### PR TITLE
MONGOSH-55: use minimist to parse arguments and commands

### DIFF
--- a/packages/cli-repl/README.md
+++ b/packages/cli-repl/README.md
@@ -1,0 +1,87 @@
+# Mongosh CLI
+
+## Usage
+```
+  $ mongosh [options] [db address] [file names]
+
+  Options:
+
+    --ipv6                                 Enable IPv6 support (disabled by default)
+    --host [arg]                           Server to connect to
+    --port [arg]                           Port to connect to
+    -h, --help                             Show this usage information
+    --version                              Show version information
+    --verbose                              Increase verbosity
+    --shell                                Run the shell after executing files
+    --nodb                                 Don't connect to mongod on startup - no 'db address' [arg] expected
+    --norc                                 Will not run the ".mongorc.js" file on start up
+    --quiet                                Be less chatty
+    --eval [arg]                           Evaluate javascript
+    --disableJavaScriptJIT                 Disable the Javascript Just In Time compiler
+    --enableJavaScriptJIT                  Enable the Javascript Just In Time compiler
+    --disableJavaScriptProtection          Allow automatic JavaScript function marshalling
+    --retryWrites                          Automatically retry write operations upon transient network errors
+    --disableImplicitSessions              Do not automatically create and use implicit sessions
+    --jsHeapLimitMB [arg]                  Set the js scope's heap size limit
+
+  Authentication Options:
+
+    -u, --username [arg]                   Username for authentication
+    -p, --password [arg]                   Password for authentication
+    --authenticationDatabase [arg]         User source (defaults to dbname)
+    --authenticationMechanism [arg]        Authentication mechanism
+    --gssapiServiceName [arg] (=mongodb)   Service name to use when authenticating using GSSAPI/Kerberos
+    --gssapiHostName [arg]                 Remote host name to use for purpose of GSSAPI/Kerberos authentication
+
+  TLS Options:
+
+    --tls                                  Use TLS for all connections
+    --tlsCertificateKeyFile [arg]          PEM certificate/key file for TLS
+    --tlsCertificateKeyFilePassword [arg]  Password for key in PEM file for TLS
+    --tlsCAFile [arg]                      Certificate Authority file for TLS
+    --tlsCRLFile [arg]                     Certificate Revocation List file for TLS
+    --tlsAllowInvalidHostnames             Allow connections to servers with non-matching hostnames
+    --tlsAllowInvalidCertificates          Allow connections to servers with invalid certificates
+    --tlsFIPSMode                          Activate FIPS 140-2 mode at startup
+    --tlsCertificateSelector [arg]         TLS Certificate in system store
+    --tlsDisabledProtocols [arg]           Comma separated list of TLS protocols to disable [TLS1_0,TLS1_1,TLS1_2]
+
+  FLE AWS Options:
+
+    --awsAccessKeyId [arg]                 AWS Access Key for FLE Amazon KMS
+    --awsSecretAccessKey [arg]             AWS Secret Key for FLE Amazon KMS
+    --awsSessionToken [arg]                Optional AWS Session Token ID
+    --keyVaultNamespace [arg]              database.collection to store encrypted FLE parameters
+    --kmsURL [arg]                         Test parameter to override the URL for KMS
+
+  DB Address:
+
+    foo                                    Foo database on local machine
+    192.168.0.5/foo                        Foo database on 192.168.0.5 machine
+    192.168.0.5:9999/foo                   Foo database on 192.168.0.5 machine on port 9999
+    mongodb://192.168.0.5:9999/foo         Connection string URI can also be used
+
+  File Names:
+
+    A list of files to run. Files must end in .js and will exit after unless --shell is specified.
+
+  Examples:
+
+    Start mongosh using IPV6, running a local file:
+    $ mongosh --ipv6 --shell index.js
+```
+
+## Development
+To use locally link this package from `./cli-repl` directory:
+```
+npm link
+```
+
+and run locally using:
+```
+mongosh
+```
+or to start mongosh with antlr:
+```
+mongosh start-antlr
+```

--- a/packages/cli-repl/bin.js
+++ b/packages/cli-repl/bin.js
@@ -1,0 +1,136 @@
+#!/usr/bin/env node
+
+process.title = 'mongosh'
+
+require('v8-compile-cache') //speed up initial cli load time
+
+const ansi = require('ansi-escape-sequences')
+const minimist = require('minimist')
+const path = require('path')
+
+const USAGE = `
+  $ ${clr('mongosh', 'bold')} ${clr('[options]', 'green')} [db address] [file names]
+
+  ${clr('Options:', 'bold')}
+
+    --ipv6                                 Enable IPv6 support (disabled by default)
+    --host [arg]                           Server to connect to
+    --port [arg]                           Port to connect to
+    -h, --help                             Show this usage information
+    --version                              Show version information
+    --verbose                              Increase verbosity
+    --shell                                Run the shell after executing files
+    --nodb                                 Don't connect to mongod on startup - no 'db address' [arg] expected
+    --norc                                 Will not run the ".mongorc.js" file on start up
+    --quiet                                Be less chatty
+    --eval [arg]                           Evaluate javascript
+    --disableJavaScriptJIT                 Disable the Javascript Just In Time compiler
+    --enableJavaScriptJIT                  Enable the Javascript Just In Time compiler
+    --disableJavaScriptProtection          Allow automatic JavaScript function marshalling
+    --retryWrites                          Automatically retry write operations upon transient network errors
+    --disableImplicitSessions              Do not automatically create and use implicit sessions
+    --jsHeapLimitMB [arg]                  Set the js scope's heap size limit
+
+  ${clr('Authentication Options:', 'bold')}
+
+    -u, --username [arg]                   Username for authentication
+    -p, --password [arg]                   Password for authentication
+    --authenticationDatabase [arg]         User source (defaults to dbname)
+    --authenticationMechanism [arg]        Authentication mechanism
+    --gssapiServiceName [arg] (=mongodb)   Service name to use when authenticating using GSSAPI/Kerberos
+    --gssapiHostName [arg]                 Remote host name to use for purpose of GSSAPI/Kerberos authentication
+
+  ${clr('TLS Options:', 'bold')}
+
+    --tls                                  Use TLS for all connections
+    --tlsCertificateKeyFile [arg]          PEM certificate/key file for TLS
+    --tlsCertificateKeyFilePassword [arg]  Password for key in PEM file for TLS
+    --tlsCAFile [arg]                      Certificate Authority file for TLS
+    --tlsCRLFile [arg]                     Certificate Revocation List file for TLS
+    --tlsAllowInvalidHostnames             Allow connections to servers with non-matching hostnames
+    --tlsAllowInvalidCertificates          Allow connections to servers with invalid certificates
+    --tlsFIPSMode                          Activate FIPS 140-2 mode at startup
+    --tlsCertificateSelector [arg]         TLS Certificate in system store
+    --tlsDisabledProtocols [arg]           Comma separated list of TLS protocols to disable [TLS1_0,TLS1_1,TLS1_2]
+
+  ${clr('FLE AWS Options:', 'bold')}
+
+    --awsAccessKeyId [arg]                 AWS Access Key for FLE Amazon KMS
+    --awsSecretAccessKey [arg]             AWS Secret Key for FLE Amazon KMS
+    --awsSessionToken [arg]                Optional AWS Session Token ID
+    --keyVaultNamespace [arg]              database.collection to store encrypted FLE parameters
+    --kmsURL [arg]                         Test parameter to override the URL for KMS
+
+  ${clr('DB Address:', 'bold')}
+
+    foo                                    Foo database on local machine
+    192.168.0.5/foo                        Foo database on 192.168.0.5 machine
+    192.168.0.5:9999/foo                   Foo database on 192.168.0.5 machine on port 9999
+    mongodb://192.168.0.5:9999/foo         Connection string URI can also be used
+
+  ${clr('File Names:', 'bold')}
+
+    A list of files to run. Files must end in ${clr('.js', 'bold')} and will exit after unless ${clr('--shell', 'bold')} is specified.
+
+  ${clr('Examples:', 'bold')}
+
+    Start mongosh using IPV6, running a local file:
+    ${clr('$ mongosh --ipv6 --shell index.js', 'green')}
+
+`.replace(/\n$/, '').replace(/^\n/, '')
+
+const optionString =
+[
+  'ipv6', 'host', 'port', 'verbose', 'shell', 'nodb', 'norc', 'eval', 'disableJavaScriptJIT',
+  'enableJavaScriptJIT', 'disableJavaScriptProtection', 'retryWrites', 'disableImplicitSessions',
+  'jsHeapLimitMB', 'username', 'password', 'authenticationDatabase', 'authenticationMechanism',
+  'gssapiServiceName', 'gssapiHostName', 'tls', 'tlsCertificateKeyFile', 'tlsCertificateKeyFilePassword',
+  'tlsCAFile', 'tlsCRLFile', 'tlsAllowInvalidHostnames', 'tlsAllowInvalidCertificates',
+  'tlsFIPSMode', 'tlsCertificateSelector', 'tlsDisabledProtocols', 'awsAccessKeyID',
+  'awsSecretAccessKey', 'keyVaultNamespace', 'kmsURL'
+]
+
+
+const argv = minimist(process.argv.slice(2), {
+  alias: {
+    help: 'h',
+    username: 'u',
+    password: 'p',
+    version: 'v',
+  },
+  strings: optionString,
+  default: {
+    ipv6: false
+    // authenticationDatabase should be defaulted to current dbname
+  },
+  boolean: [
+    'help',
+    'quiet',
+    'version'
+  ]
+})
+
+;(function main (argv) {
+  const cmd = argv._[0] //lrlna: not sure if we will have any commands in the future? might not even need this
+  // TODO: lrlna: extract db address and .js file name
+
+
+  const CliRepl = require('./lib/cli-repl.js');
+
+  if (argv.help) {
+    console.log(USAGE)
+  } else if (argv.version) {
+    console.log(require('./package.json').version)
+  } else if (cmd === 'start-antlr') {
+    new CliRepl(true)
+  } else if (argv.ipv6) {
+    // TODO: lrlna handle various options ideally in a separate module.exports
+    // file that could also be used by the browser 'repl'
+  } else {
+    new CliRepl();
+  }
+})(argv)
+
+function clr (text, color) {
+  return process.stdout.isTTY ? ansi.format(text, color) : text
+}

--- a/packages/cli-repl/bin.js
+++ b/packages/cli-repl/bin.js
@@ -1,12 +1,12 @@
 #!/usr/bin/env node
 
-process.title = 'mongosh'
+process.title = 'mongosh';
 
-require('v8-compile-cache') //speed up initial cli load time
+require('v8-compile-cache'); //speed up initial cli load time
 
-const ansi = require('ansi-escape-sequences')
-const minimist = require('minimist')
-const path = require('path')
+const ansi = require('ansi-escape-sequences');
+const minimist = require('minimist');
+const path = require('path');
 
 const USAGE = `
   $ ${clr('mongosh', 'bold')} ${clr('[options]', 'green')} [db address] [file names]
@@ -77,7 +77,7 @@ const USAGE = `
     Start mongosh using IPV6, running a local file:
     ${clr('$ mongosh --ipv6 --shell index.js', 'green')}
 
-`.replace(/\n$/, '').replace(/^\n/, '')
+`.replace(/\n$/, '').replace(/^\n/, '');
 
 const optionString =
 [
@@ -88,7 +88,7 @@ const optionString =
   'tlsCAFile', 'tlsCRLFile', 'tlsAllowInvalidHostnames', 'tlsAllowInvalidCertificates',
   'tlsFIPSMode', 'tlsCertificateSelector', 'tlsDisabledProtocols', 'awsAccessKeyID',
   'awsSecretAccessKey', 'keyVaultNamespace', 'kmsURL'
-]
+];
 
 
 const argv = minimist(process.argv.slice(2), {
@@ -108,29 +108,29 @@ const argv = minimist(process.argv.slice(2), {
     'quiet',
     'version'
   ]
-})
+});
 
 ;(function main (argv) {
-  const cmd = argv._[0] //lrlna: not sure if we will have any commands in the future? might not even need this
+  const cmd = argv._[0]; //lrlna: not sure if we will have any commands in the future? might not even need this
   // TODO: lrlna: extract db address and .js file name
 
 
   const CliRepl = require('./lib/cli-repl.js');
 
   if (argv.help) {
-    console.log(USAGE)
+    console.log(USAGE);
   } else if (argv.version) {
-    console.log(require('./package.json').version)
+    console.log(require('./package.json').version);
   } else if (cmd === 'start-antlr') {
-    new CliRepl(true)
+    new CliRepl(true);
   } else if (argv.ipv6) {
     // TODO: lrlna handle various options ideally in a separate module.exports
     // file that could also be used by the browser 'repl'
   } else {
     new CliRepl();
   }
-})(argv)
+})(argv);
 
 function clr (text, color) {
-  return process.stdout.isTTY ? ansi.format(text, color) : text
+  return process.stdout.isTTY ? ansi.format(text, color) : text;
 }

--- a/packages/cli-repl/index.js
+++ b/packages/cli-repl/index.js
@@ -1,6 +1,3 @@
-const CliRepl = require('./lib/cli-repl.js');
+const CliRepl = require('./lib/cli-repl.js')
 
-if (process.argv[2] === 'start') new CliRepl();
-if (process.argv[2] === 'start-antlr') new CliRepl(true);
-
-module.exports = CliRepl;
+module.exports = CliRepl

--- a/packages/cli-repl/lib/cli-repl.js
+++ b/packages/cli-repl/lib/cli-repl.js
@@ -21,7 +21,8 @@ class CliRepl {
     this.options.cwd = colorize(COLORS.YELLOW, this.options.cwd);
   }
 
-  constructor(useAntlr) {
+  constructor(useAntlr, argv) {
+    argv = argv || {};
     this.processCmdArgs({});
 
     this.useAntlr = !!useAntlr;
@@ -75,7 +76,7 @@ class CliRepl {
     this.greet();
 
     this.repl = repl.start({
-      prompt: `$${this.options.user} > `,
+      prompt: `$ ${this.options.user} > `,
       ignoreUndefined: true,
       writer: this.writer
     });

--- a/packages/cli-repl/package.json
+++ b/packages/cli-repl/package.json
@@ -1,18 +1,24 @@
 {
-  "name": "mongosh-cli-repl",
+  "name": "mongosh",
   "version": "0.0.0",
   "description": "MongoDB Shell CLI REPL Package",
   "main": "index.js",
   "scripts": {
-    "start": "node --experimental-repl-await index.js start",
-    "start-antlr": "node --experimental-repl-await index.js start-antlr",
+    "start": "node --experimental-repl-await bin.js start",
+    "start-antlr": "node --experimental-repl-await bin.js start-antlr",
     "test": "mocha --recursive --color",
     "test-ci": "mocha --recursive",
     "check": "mongodb-js-precommit './lib/**/*{.js}' './test/**/*.js'"
   },
+  "bin": {
+    "mongosh": "bin.js"
+  },
   "dependencies": {
-    "mongosh-mapper": "file:../mapper",
-    "mongosh-service-provider-server": "file:../service-provider-server",
-    "mongosh-shell-api": "file:../shell-api"
+    "ansi-escape-sequences": "^5.1.2",
+    "minimist": "^1.2.0",
+    "mongosh-mapper": "../mapper",
+    "mongosh-service-provider-server": "../service-provider-server",
+    "mongosh-shell-api": "../shell-api",
+    "v8-compile-cache": "^2.1.0"
   }
 }


### PR DESCRIPTION
## Description

- adds minimist as a dependancy to help with argument parsing
- adds "UI" for `mongosh --help` command with all the available options
- adds a `bin` field to `package.json` to allow this to be run via command line as `mongosh`

Using minimist for now since it's nice to have certain defaults and aliases. If we will like we need something more elaborate, we can switch over to yargs. I just feel like it might be too big of a package for the moment. 

_Not yet complete_: passing arguments down to `CliRepl` constructor and hooking them up to DB calls.  