### PR TITLE
CLI help output formatting

### DIFF
--- a/packages/cli-repl/package.json
+++ b/packages/cli-repl/package.json
@@ -11,6 +11,7 @@
     "check": "mongodb-js-precommit './lib/**/*{.js}' './test/**/*.js'"
   },
   "dependencies": {
+    "ansi-escape-sequences": "^5.1.2",
     "mongosh-mapper": "file:../mapper",
     "mongosh-service-provider-server": "file:../service-provider-server",
     "mongosh-shell-api": "file:../shell-api"

--- a/packages/shell-api/compile-shell-api.js
+++ b/packages/shell-api/compile-shell-api.js
@@ -31,6 +31,7 @@ const attrTemplate = (attrName, lib, base = '') => {
   const lhs = `    this${base}.${attrName}`;
 
   if (attrName === 'help') {
+    let helpObj = { attr };
     let attributesToList = Object.keys(lib).filter(
       (a) => (!a.startsWith('__') && a !== 'help')
     );
@@ -38,11 +39,10 @@ const attrTemplate = (attrName, lib, base = '') => {
       const constructorArgs = lib.__constructorArgs.filter((a) => (!a.startsWith('_')));
       attributesToList = attributesToList.concat(constructorArgs);
     }
-    const helpValue = `${attr}
-Attributes: ${attributesToList.join(', ')}`;
+    helpObj.attributesList = attributesToList;
 
-    return `${lhs} = () => (${JSON.stringify(helpValue)});
-${lhs}.toReplString = () => (${JSON.stringify(helpValue)});`
+    return `${lhs} = () => (${JSON.stringify(helpObj)});
+${lhs}.toReplString = () => (${JSON.stringify(helpObj)});`
   }
 
   return `${lhs} = ${JSON.stringify(attr)};`;


### PR DESCRIPTION
Hello! 

I am thinking of changing up the way help output is getting generated. I'd like to input some additional information about each command and have links to docs, if applicable. 

I am thinking shell-api should output an object that then can be formatted by the CLI or the browser packages. Since colouring and spacing will have to be done differently for the browser and terminal, it also doesn't make a lot of sense to do it directly in shell packages. What do y'all think?

here is the object I am thinking of outputting:
_Edit: simplified the arguments object to not have the top level array_
```js
var arguments ={
      help: "Top Level Commands", // what's currently listed under 'help' in yaml file
      docs: "https://docs.mongodb.com/manual/reference/mongo-shell/#command-helpers",
      attr: [
        { "use": "Set current database" },
        { "it": "Result of the last line evaluated; use to further iterate" },
        { ".exit": "Quit the mongo shell" },
        { "db.help()": "Help on db methods" },
        { "db.mycoll.help()": "Help on collection methods" },
        { "sh.help()": "Sharding helpers" },
        { "rs.help()": "Replica set helpers" },
        { "help admin": "Administrative help" }
      ]   
}
```

I've hard coded something for the top-level `help()` to play around with formatting. Here is what ^ that info (+ more) would look like: 
![Untitled](https://user-images.githubusercontent.com/8107784/72273034-ea426400-3629-11ea-9a63-f20d837b7e8f.png)

@durran @aherlihy what do you think?
