### PR TITLE
MONGOSH-72: implement commands

### DIFF
--- a/packages/browser-repl/src/lib/interpreter/interpreter.spec.ts
+++ b/packages/browser-repl/src/lib/interpreter/interpreter.spec.ts
@@ -19,15 +19,17 @@ describe('Interpreter', () => {
   let interpreter;
   let testEvaluate;
   let iframe;
+  let testEnvironment;
 
   beforeEach(async() => {
     document.body.innerHTML = '';
     iframe = await createTestIframe();
+    const contentWindow = iframe.contentWindow as any;
 
-    const testEnvironment = {
-      sloppyEval: (iframe.contentWindow as any).eval,
-      getGlobal: (name): any => iframe.contentWindow[name],
-      setGlobal: (name, value): void => { iframe.contentWindow[name] = value; }
+    testEnvironment = {
+      sloppyEval: contentWindow.eval,
+      getGlobal: (name): any => contentWindow[name],
+      setGlobal: (name, value): void => { contentWindow[name] = value; }
     };
 
     interpreter = new Interpreter(testEnvironment);
@@ -231,6 +233,46 @@ describe('Interpreter', () => {
 
       expect(error.message)
         .to.contain('\'return\' outside of function');
+    });
+
+    it('allows to invoke the help command', async() => {
+      testEnvironment.setGlobal('help', () => 'help invoked');
+
+      expect(
+        await testEvaluate(
+          'help'
+        )
+      ).to.equal('help invoked');
+    });
+
+    it('allows to invoke the it command', async() => {
+      testEnvironment.setGlobal('it', () => 'it invoked');
+
+      expect(
+        await testEvaluate(
+          'it'
+        )
+      ).to.equal('it invoked');
+    });
+
+    it('allows to invoke the show command', async() => {
+      testEnvironment.setGlobal('show', () => 'show invoked');
+
+      expect(
+        await testEvaluate(
+          'show'
+        )
+      ).to.equal('show invoked');
+    });
+
+    it('allows to invoke the use command', async() => {
+      testEnvironment.setGlobal('use', () => 'use invoked');
+
+      expect(
+        await testEvaluate(
+          'use'
+        )
+      ).to.equal('use invoked');
     });
   });
 });

--- a/packages/browser-repl/src/lib/interpreter/preprocessor/preprocessor.ts
+++ b/packages/browser-repl/src/lib/interpreter/preprocessor/preprocessor.ts
@@ -17,6 +17,14 @@ import {
   saveAndRestoreLexicalContext
 } from './save-and-restore-lexical-context';
 
+import {
+  transformCommandInvocation
+} from './transform-command-invocation';
+
+const SUPPORTED_COMMANDS = [
+  'help', 'use', 'it', 'show'
+];
+
 export class Preprocessor {
   private lexicalContext = {};
   private lastExpressionCallbackFunctionName: string;
@@ -32,7 +40,9 @@ export class Preprocessor {
 
   preprocess(code: string): string {
     let ast;
-    ast = parse(wrapObjectLiteral(code), {allowAwaitOutsideFunction: true});
+    code = wrapObjectLiteral(code);
+    code = transformCommandInvocation(code, SUPPORTED_COMMANDS);
+    ast = parse(code, {allowAwaitOutsideFunction: true});
     ast = injectLastExpressionCallback(this.lastExpressionCallbackFunctionName, ast);
 
     const {
@@ -51,5 +61,4 @@ export class Preprocessor {
     return newCode;
   }
 }
-
 

--- a/packages/browser-repl/src/lib/interpreter/preprocessor/transform-command-invocation.spec.ts
+++ b/packages/browser-repl/src/lib/interpreter/preprocessor/transform-command-invocation.spec.ts
@@ -1,0 +1,22 @@
+import { expect } from '../../../../testing/chai';
+import { transformCommandInvocation } from './transform-command-invocation';
+
+describe('transformCommandInvocation', () => {
+  it('transforms a command from code if is the first token', () => {
+    expect(transformCommandInvocation('help', ['help'])).to.equal('help()');
+    expect(transformCommandInvocation('  help', ['help'])).to.equal('help()');
+  });
+
+  it('does not transform command from code if not first token', () => {
+    expect(transformCommandInvocation('; help', ['help'])).to.equal('; help');
+  });
+
+  it('does not transform command from code if command is not available', () => {
+    expect(transformCommandInvocation('help', [])).to.equal('help');
+  });
+
+  it('transforms arguments', () => {
+    expect(transformCommandInvocation('show collections', ['show']))
+      .to.equal('show("collections")');
+  });
+});

--- a/packages/browser-repl/src/lib/interpreter/preprocessor/transform-command-invocation.ts
+++ b/packages/browser-repl/src/lib/interpreter/preprocessor/transform-command-invocation.ts
@@ -1,0 +1,15 @@
+export function transformCommandInvocation(code: string, availableCommands: string[]): string {
+  const tokens = code.trim().split(/\s+/);
+  const command = tokens[0];
+  if (!availableCommands.includes(command)) {
+    return code;
+  }
+
+  tokens.shift();
+
+  const args = tokens
+    .map(token => JSON.stringify(token))
+    .join(',');
+
+  return `${command}(${args})`;
+}

--- a/packages/browser-repl/src/lib/runtime-helpers/setup-evaluation-context.ts
+++ b/packages/browser-repl/src/lib/runtime-helpers/setup-evaluation-context.ts
@@ -7,6 +7,15 @@ export function setupEvaluationContext(context: object, serviceProvider: object)
 
   Object.keys(shellApi)
     .filter(k => (!k.startsWith('_')))
-    .forEach(k => (context[k] = shellApi[k]));
+    .forEach(k => {
+      const value = shellApi[k];
+
+      if (typeof(value) === 'function') {
+        context[k] = value.bind(shellApi);
+      } else {
+        context[k] = value;
+      }
+    });
+
   mapper.setCtx(context);
 }


### PR DESCRIPTION
Allows to run commands like 'use', 'it', 'show' and 'help'.

NOTES:
- the `show` command does not seem to be available in shell api.
- Would be nice to have a more robust parsing for commands.
- The output of the commands is currently rendered as "stringified" string with quotes. We need the object model for commands in order to fix that. 