### PR TITLE
shell can redact and omit sensitive info, as a treat

### DIFF
--- a/packages/cli-repl/package.json
+++ b/packages/cli-repl/package.json
@@ -18,6 +18,7 @@
   "dependencies": {
     "lodash.set": "^4.3.2",
     "minimist": "^1.2.0",
+    "mongodb-redact": "^0.2.0",
     "mongosh-mapper": "file:../mapper",
     "mongosh-service-provider-server": "file:../service-provider-server",
     "mongosh-shell-api": "file:../shell-api",

--- a/packages/cli-repl/src/arg-parser.ts
+++ b/packages/cli-repl/src/arg-parser.ts
@@ -46,6 +46,7 @@ const OPTIONS = {
     'nodb',
     'norc',
     'quiet',
+    'redactInfo',
     'retryWrites',
     'shell',
     'tls',

--- a/packages/cli-repl/src/cli-options.ts
+++ b/packages/cli-repl/src/cli-options.ts
@@ -26,6 +26,7 @@ interface CliOptions {
   password?: string;
   port?: string;
   quiet?: boolean;
+  redactInfo?: boolean;
   retryWrites?: boolean;
   shell?: boolean;
   tls?: boolean;

--- a/packages/cli-repl/src/cli-repl.ts
+++ b/packages/cli-repl/src/cli-repl.ts
@@ -25,6 +25,7 @@ class CliRepl {
   private mapper: Mapper;
   private shellApi: ShellApi;
   private repl: REPLServer;
+  private options: CliOptions;
 
   /**
    * Connect to the cluster.
@@ -47,6 +48,7 @@ class CliRepl {
    */
   constructor(driverUri: string, driverOptions: NodeOptions, options: CliOptions) {
     this.useAntlr = !!options.antlr;
+    this.options = options;
 
     if (this.isPasswordMissing(driverOptions)) {
       this.requirePassword(driverUri, driverOptions);
@@ -169,6 +171,7 @@ class CliRepl {
     this.repl.eval = customEval;
     
     const historyFile = path.join(os.homedir(), '.mongosh_repl_history');
+    const redactInfo = this.options.redactInfo;
     this.repl.setupHistory(historyFile, function(err, repl) {
       // TODO: @lrlna format this error
       if (err) console.log(err);
@@ -178,7 +181,7 @@ class CliRepl {
       // sensitive.
       repl.on('flushHistory', function() {
         // @ts-ignore
-        changeHistory(repl.history, false);
+        changeHistory(repl.history, redactInfo);
       })
     })
 

--- a/packages/cli-repl/src/cli-repl.ts
+++ b/packages/cli-repl/src/cli-repl.ts
@@ -4,6 +4,7 @@ import { compile } from 'mongosh-mapper';
 import ShellApi from 'mongosh-shell-api';
 import repl, { REPLServer } from 'repl';
 import CliOptions from './cli-options';
+import changeHistory from './history';
 import Mapper from 'mongosh-mapper';
 import completer from './completer';
 import { Transform } from 'stream';
@@ -171,6 +172,14 @@ class CliRepl {
     this.repl.setupHistory(historyFile, function(err, repl) {
       // TODO: @lrlna format this error
       if (err) console.log(err);
+
+      // repl.history is an array of previous commands. We need to hijack the
+      // value we just typed, and shift it off the history array if the info is
+      // sensitive.
+      repl.on('flushHistory', function() {
+        // @ts-ignore
+        changeHistory(repl.history, false);
+      })
     })
 
     this.repl.on('exit', () => {

--- a/packages/cli-repl/src/history.spec.ts
+++ b/packages/cli-repl/src/history.spec.ts
@@ -1,0 +1,69 @@
+import changeHistory from './history';
+
+import { expect } from 'chai';
+
+describe('changeHistory', () => {
+  const history = ['db.shipwrecks.findOne()', 'use ships'];
+
+  context('when redact option is not used', () => {
+    it('removes sensitive commands from history', () => {
+      const i = ['db.createUser({ user: "reportUser256" })', 'db.shipwrecks.findOne()', 'use ships'];
+      changeHistory(i);
+      expect(i).to.deep.equal(history);
+    });
+
+    it('leaves history as is if command is not sensitive', () => {
+      const i = ['db.shipwrecks.find({quasou: "depth unknown"})', 'db.shipwrecks.findOne()', 'use ships'];
+      const cloned = Array.from(i);
+      changeHistory(cloned);
+      expect(cloned).to.deep.equal(i);
+    });
+  });
+
+  context('when redact option is false', () => {
+    it('removes sensitive commands from history', () => {
+      const i = ['db.createUser({ user: "reportUser256" })', 'db.shipwrecks.findOne()', 'use ships'];
+      changeHistory(i, false);
+      expect(i).to.deep.equal(history);
+    });
+
+    it('leaves history as is if command is not sensitive', () => {
+      const i = ['db.shipwrecks.find({quasou: "depth unknown"})', 'db.shipwrecks.findOne()', 'use ships'];
+      const cloned = Array.from(i);
+      changeHistory(cloned, false);
+      expect(cloned).to.deep.equal(i);
+    });
+  });
+
+  context('when redact option is true', () => {
+    it('removes sensitive commands from history', () => {
+      const i = ['db.createUser({ user: "reportUser256" })', 'db.shipwrecks.findOne()', 'use ships'];
+      changeHistory(i, true);
+      expect(i).to.deep.equal(history);
+    });
+
+    it('leaves history as is if command is not sensitive', () => {
+      const i = ['db.shipwrecks.find({quasou: "depth unknown"})', 'db.shipwrecks.findOne()', 'use ships'];
+      const cloned = Array.from(i);
+      changeHistory(cloned, true);
+      expect(cloned).to.deep.equal(i);
+    });
+
+    it('removes command from history and does not redact even if info in command is redactable', () => {
+      const i = ['db.createUser( { user: "restricted", pwd: passwordPrompt(),      // Or  "<cleartext password>" roles: [ { role: "readWrite", db: "reporting" } ], authenticationRestrictions: [ { clientSource: ["192.0.2.0"], serverAddress: ["198.51.100.0"] } ] })',
+        'db.shipwrecks.findOne()', 'use ships'];
+      changeHistory(i, true);
+      expect(i).to.deep.equal(history);
+    });
+
+    it('does not remove from history, but redacts info if redact is true', () => {
+      const i = ['db.supplies.find({email: "cat@cat.cat"})',
+        'db.supplies.findOne()', 'use sales'];
+      const redacted = ['db.supplies.find({email: "<email>"})',
+        'db.supplies.findOne()', 'use sales'];
+      const cloned = Array.from(i);
+      changeHistory(cloned, true);
+      expect(cloned).to.deep.equal(redacted);
+    });
+  });
+});

--- a/packages/cli-repl/src/history.ts
+++ b/packages/cli-repl/src/history.ts
@@ -11,9 +11,9 @@ import redactInfo from 'mongodb-redact';
  */
 function changeHistory(history: string[], redact: boolean = false) {
   const hiddenCommands =
-    RegExp('createUser|auth|updateUser|changeUserPassword', 'ig');
+    RegExp('createUser|auth|updateUser|changeUserPassword', 'g');
 
-  if (hiddenCommands.test(history[0])) history.shift();
+  if (hiddenCommands.test(history[0])) return history.shift();
   if (redact) history[0] = redactInfo(history[0]);
 }
 

--- a/packages/cli-repl/src/history.ts
+++ b/packages/cli-repl/src/history.ts
@@ -1,0 +1,19 @@
+/**
+ * Modifies command history array based on sensitive information.
+ * If redact option is passed, also redacts sensitive info.
+ *
+ * @param {array} History - Array of commands, where the first command is the
+ * most recent.
+ *
+ * @param {boolean} Redact - Option to redact sensitive info.
+ */
+function changeHistory(history: string[], redact: boolean = false) {
+  const hiddenCommands =
+    RegExp('createUser|auth|updateUser|changeUserPassword', 'ig');
+
+  if (hiddenCommands.test(history[0])) {
+    history.shift();
+  }
+}
+
+export default changeHistory;

--- a/packages/cli-repl/src/history.ts
+++ b/packages/cli-repl/src/history.ts
@@ -1,3 +1,5 @@
+import redactInfo from 'mongodb-redact';
+
 /**
  * Modifies command history array based on sensitive information.
  * If redact option is passed, also redacts sensitive info.
@@ -11,9 +13,8 @@ function changeHistory(history: string[], redact: boolean = false) {
   const hiddenCommands =
     RegExp('createUser|auth|updateUser|changeUserPassword', 'ig');
 
-  if (hiddenCommands.test(history[0])) {
-    history.shift();
-  }
+  if (hiddenCommands.test(history[0])) history.shift();
+  if (redact) history[0] = redactInfo(history[0]);
 }
 
 export default changeHistory;

--- a/packages/cli-repl/src/index.ts
+++ b/packages/cli-repl/src/index.ts
@@ -2,6 +2,8 @@ import CliRepl from './cli-repl';
 import parseCliArgs from './arg-parser';
 import mapCliToDriver from './arg-mapper';
 import generateUri from './uri-generator';
+import completer from './completer';
+import changeHistory from './history';
 
 export default CliRepl;
-export { CliRepl, parseCliArgs, mapCliToDriver, generateUri };
+export { CliRepl, parseCliArgs, mapCliToDriver, generateUri, completer, changeHistory };


### PR DESCRIPTION
## Description
This PR adds a flag to redact information in user's command history using [mongodb-redact](https://github.com/mongodb-js/redact) module. This is based on a flag(`--redactInfo`) when user starts the shell. The default for this flag is `false` to keep it compatible with the current shell. 

This PR also automatically removes user management commands from history (entirely). 

Example of starting shell without `--redactInfo`:
![lF30gBfAuY](https://user-images.githubusercontent.com/8107784/73458036-ed04bf00-4374-11ea-80b9-822e1803a252.gif)

Example of starting shell with `--redactInfo`:
![0jpSixzEN9](https://user-images.githubusercontent.com/8107784/73458087-0148bc00-4375-11ea-8de6-c30fb41f9379.gif)

## Open Questions
Any other commands I should be omitting? I just copied the ones from [this line in current mongodb shell](https://github.com/mongodb/mongo/blob/master/src/mongo/shell/dbshell.cpp#L308).

Thanks! ✨ 