### PR TITLE
fix multiline input

### DIFF
--- a/packages/cli-repl/src/cli-repl.ts
+++ b/packages/cli-repl/src/cli-repl.ts
@@ -86,7 +86,7 @@ class CliRepl {
       input,
       context,
       filename
-    ).catch((err) => err);
+    )
 
     if (this.isShellApiType(evaluationResult)) {
       return {
@@ -108,7 +108,7 @@ class CliRepl {
     // The writer gets called immediately by the internal `this.repl.eval`
     // in case of errors.
     if (result && result.message && typeof result.stack === 'string') {
-      return formatOutput({value: result});
+      return formatOutput({type: 'Error', value: result});
     }
 
     return formatOutput(result);
@@ -138,7 +138,7 @@ class CliRepl {
    * The greeting for the shell.
    */
   greet(): void {
-    console.log(`Using MongoDB: ${this.mdbVersion}`);
+    console.log(`Using MongoDB: ${this.mdbVersion} \n`);
   }
 
   /**
@@ -213,7 +213,7 @@ class CliRepl {
         }
         callback(null, str);
       } catch (err) {
-        console.log('Catch callback:', err);
+        // console.log('Catch callback:', err);
         callback(err, null);
       } finally {
         this.mapper.cursorAssigned = false;

--- a/packages/cli-repl/src/constants.ts
+++ b/packages/cli-repl/src/constants.ts
@@ -6,6 +6,7 @@ export const USAGE = `
   ${clr(i18n.__('cli-repl.args.usage'), 'bold')}
 
   ${clr(i18n.__('cli-repl.args.options'), ['bold', 'yellow'])}
+
     -h, --help                                 ${i18n.__('cli-repl.args.help')} 
         --ipv6                                 ${i18n.__('cli-repl.args.ipv6')}
         --host [arg]                           ${i18n.__('cli-repl.args.host')}

--- a/packages/cli-repl/src/format-output.ts
+++ b/packages/cli-repl/src/format-output.ts
@@ -31,6 +31,10 @@ export default function formatOutput(evaluationResult: EvaluationResult): string
     return formatHelp(value);
   }
 
+  if (type === 'Error') {
+    return formatError(value)
+  }
+
   return formatSimpleType(value);
 }
 
@@ -40,6 +44,10 @@ function formatSimpleType(output) {
   }
 
   return inspect(output);
+}
+
+function formatError(error) {
+  return inspect(error)
 }
 
 function inspect(output) {


### PR DESCRIPTION
## Description
Callback on `this.evaluate` was catching and printing recoverable errors that happen when you type in multiline input. This PR removes the catch, and lets original node eval deal with multiline, and just pass on the result over to `writer` and then `formatOutput`. 