### PR TITLE
feat(cli-repl): add name and version to metadata

### DIFF
--- a/packages/cli-repl/bin/mongosh.js
+++ b/packages/cli-repl/bin/mongosh.js
@@ -5,15 +5,18 @@ process.title = 'mongosh';
 
 try {
   const options = parseCliArgs(process.argv);
+  const { version } = require('../package.json');
 
   if (options.help) {
     console.log(USAGE);
   } else if (options.version) {
-    console.log(require('../package.json').version);
+    console.log(version);
   } else {
     const driverOptions = mapCliToDriver(options);
     const driverUri = generateUri(options);
-    new CliRepl(driverUri, driverOptions, options);
+    const appname = `${process.title} ${version}`;
+
+    new CliRepl(driverUri, {appname, ...driverOptions}, options);
   }
 } catch (e) {
   console.log(e.message);


### PR DESCRIPTION
```
2020-03-02T16:17:52.684+0000 I  NETWORK  [conn438] received client metadata from 172.17.0.1:45714 conn438: { driver: { name: "nodejs", version: "3.5.4" }, os: { type: "Darwin", name: "darwin", architecture: "x64", version: "18.7.0" }, platform: "'Node.js v12.14.1, LE (unified)", application: { name: "mongosh 0.0.0" } }
```