### PR TITLE
MONGOSH-105: add autocompletions for find and aggregation queries

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10231,6 +10231,21 @@
         "saslprep": "^1.0.0"
       }
     },
+    "mongodb-ace-autocompleter": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/mongodb-ace-autocompleter/-/mongodb-ace-autocompleter-0.4.1.tgz",
+      "integrity": "sha512-zirVyvAu7CMGcbos9Ibrg2Pxq2V7tjMESWRcy9WQHdLXzAp1L/tHuFsn2Rx5l9vV1biEjPDm4KHJzKJhuhA2cg==",
+      "requires": {
+        "semver": "^7.1.1"
+      },
+      "dependencies": {
+        "semver": {
+          "version": "7.1.3",
+          "resolved": "https://registry.npmjs.org/semver/-/semver-7.1.3.tgz",
+          "integrity": "sha512-ekM0zfiA9SCBlsKa2X1hxyxiI4L3B6EbVJkkdgQXnSEEaHlGdvyodMruTiulSRWMMB4NeIuYNMC9rTKTz97GxA=="
+        }
+      }
+    },
     "mongodb-core": {
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/mongodb-core/-/mongodb-core-3.2.2.tgz",
@@ -10945,6 +10960,7 @@
         "ansi-escape-sequences": "^5.1.2",
         "lodash.set": "^4.3.2",
         "minimist": "^1.2.0",
+        "mongodb-ace-autocompleter": "^0.4.1",
         "mongodb-redact": "^0.2.0",
         "mongosh-i18n": "file:packages/i18n",
         "mongosh-mapper": "file:packages/mapper",

--- a/packages/cli-repl/package.json
+++ b/packages/cli-repl/package.json
@@ -22,6 +22,7 @@
     "ansi-escape-sequences": "^5.1.2",
     "lodash.set": "^4.3.2",
     "minimist": "^1.2.0",
+    "mongodb-ace-autocompleter": "^0.4.1",
     "mongodb-redact": "^0.2.0",
     "mongosh-i18n": "file:../i18n",
     "mongosh-mapper": "file:../mapper",

--- a/packages/cli-repl/src/completer.spec.ts
+++ b/packages/cli-repl/src/completer.spec.ts
@@ -98,6 +98,50 @@ describe('completer.completer', () => {
     });
   });
 
+  context('when context is aggregation query', () => {
+    it('has several matches', () => {
+      const i = 'db.shipwrecks.aggregate([ { $so';
+      expect(completer('4.4.0', i)).to.deep.equal([
+        ['db.shipwrecks.aggregate([ { $sort',
+         'db.shipwrecks.aggregate([ { $sortByCount'], i]);
+    });
+
+    it('does not have a match', () => {
+      const i = 'db.shipwrecks.aggregate([ { $cat';
+      expect(completer('4.4.0', i)).to.deep.equal([[], i]);
+    });
+
+    it('matches an aggregation stage', () => {
+      const i = 'db.shipwrecks.aggregate([ { $proj';
+      expect(completer('4.4.0', i)).to.deep.equal([
+        [ 'db.shipwrecks.aggregate([ { $project' ], i]);
+    });
+  });
+
+  context('when context is a collection query', () => {
+    it('has several matches', () => {
+      const i = 'db.bios.find({ birth: { $g';
+      expect(completer('4.4.0', i)).to.deep.equal([
+        [
+          'db.bios.find({ birth: { $geoIntersects',
+          'db.bios.find({ birth: { $geoWithin',
+          'db.bios.find({ birth: { $gt',
+          'db.bios.find({ birth: { $gte',
+        ], i]);
+    });
+
+    it('does not have a match', () => {
+      const i = 'db.bios.find({ field: { $cat';
+      expect(completer('4.4.0', i)).to.deep.equal([[], i]);
+    });
+
+    it('matches an aggregation stage', () => {
+      const i = 'db.bios.find({ field: { $exis';
+      expect(completer('4.4.0', i)).to.deep.equal([
+        [ 'db.bios.find({ field: { $exists' ], i]);
+    });
+  });
+
   context('when context is collections and collection cursor', () => {
     it('matches a collection cursor command', () => {
       const i = 'db.shipwrecks.find({feature_type: "Wrecks - Visible"}).for';

--- a/packages/cli-repl/src/completer.ts
+++ b/packages/cli-repl/src/completer.ts
@@ -78,20 +78,25 @@ function completer(mdbVersion: string, line: string): [string[], string] {
         mdbVersion, COLL_CURSOR_COMPLETIONS, elToComplete, splitLine);
       return [hits.length ? hits : [], line];
     }
-    // complete aggregation queries/stages
-    if (splitLine[2].includes('aggregate') && splitLine[2].includes('([')) {
-      const expressions = BASE_COMPLETIONS.concat(accumulators(
-        elToComplete, mdbVersion));
+
+    // complete aggregation and collection  queries/stages
+    if (splitLine[2].includes('([') || splitLine[2].includes('({')) {
+      let expressions;
+      if (splitLine[2].includes('aggregate')) {
+        // aggregation needs extra accumulators to autocomplete properly
+        expressions = BASE_COMPLETIONS.concat(accumulators(
+          elToComplete, mdbVersion));
+      } else {
+        // collection quering just needs MATCH COMPLETIONS
+        expressions = MATCH_COMPLETIONS;
+      }
       // split on {, as a stage/query will always follow an open curly brace
-      const preAggQuery = line.split("{");
-      const prefix = preAggQuery.pop().trim();
+      const splitQuery = line.split("{");
+      const prefix = splitQuery.pop().trim();
       const command = line.split(prefix).shift();
       const hits = filterQueries(mdbVersion, expressions, prefix, command);
       return [hits.length ? hits: [], line]
     }
-
-    // if splitLine[2].contains(any of the COLL_COMPLETIONS), and
-    // .contains('({'), suggest query operators from 'ace-autocompleter'
 
     const hits = filterShellAPI(
       mdbVersion, COLL_COMPLETIONS, elToComplete, splitLine);

--- a/packages/cli-repl/src/completer.ts
+++ b/packages/cli-repl/src/completer.ts
@@ -116,18 +116,18 @@ function completer(mdbVersion: string, line: string): [string[], string] {
 
 // stage completions based on current stage string.
 function accumulators(stage: string, mdbVersion: string) {
-	if (stage !== '') {
-		if (stage.includes(PROJECT)) {
-			return ACCUMULATORS.filter(acc => {
-				return (
-					acc.projectVersion && semver.gte(mdbVersion, acc.projectVersion)
-				);
-			});
-		} else if (stage.includes(GROUP)) {
-			return ACCUMULATORS;
-		}
-	}
-	return [];
+  if (stage !== '') {
+    if (stage.includes(PROJECT)) {
+      return ACCUMULATORS.filter(acc => {
+        return (
+          acc.projectVersion && semver.gte(mdbVersion, acc.projectVersion)
+        );
+      });
+    } else if (stage.includes(GROUP)) {
+      return ACCUMULATORS;
+    }
+  }
+  return [];
 }
 
 function filterQueries(mdbVersion: string, completions: any, prefix: string, split: string) {

--- a/packages/cli-repl/src/completer.ts
+++ b/packages/cli-repl/src/completer.ts
@@ -84,7 +84,7 @@ function completer(mdbVersion: string, line: string): [string[], string] {
       let expressions;
       if (splitLine[2].includes('aggregate')) {
         // aggregation needs extra accumulators to autocomplete properly
-        expressions = BASE_COMPLETIONS.concat(accumulators(
+        expressions = BASE_COMPLETIONS.concat(getStageAccumulators(
           elToComplete, mdbVersion));
       } else {
         // collection quering just needs MATCH COMPLETIONS
@@ -115,19 +115,18 @@ function completer(mdbVersion: string, line: string): [string[], string] {
 }
 
 // stage completions based on current stage string.
-function accumulators(stage: string, mdbVersion: string) {
-  if (stage !== '') {
-    if (stage.includes(PROJECT)) {
-      return ACCUMULATORS.filter(acc => {
-        return (
-          acc.projectVersion && semver.gte(mdbVersion, acc.projectVersion)
-        );
-      });
-    } else if (stage.includes(GROUP)) {
-      return ACCUMULATORS;
-    }
+function getStageAccumulators(stage: string, mdbVersion: string) {
+  if (stage !== '') return [] ;
+
+  if (stage.includes(PROJECT)) {
+    return ACCUMULATORS.filter(acc => {
+      return (
+        acc.projectVersion && semver.gte(mdbVersion, acc.projectVersion)
+      );
+    });
+  } else if (stage.includes(GROUP)) {
+    return ACCUMULATORS;
   }
-  return [];
 }
 
 function filterQueries(mdbVersion: string, completions: any, prefix: string, split: string) {


### PR DESCRIPTION
## Description
Preloads autocompletions from `[ace-autocompleter](https://github.com/mongodb-js/ace-autocompleter)` for all collection and aggergation queries. 

## Open Questions
I am feeling this module is getting a bit unruly, and getting quite hacky with all the `.pop()`s, `.split()`s and `.trim()`s.

I think in the future (maybe after mongodb world), we can consider writing a parser to have a PT with a bit of context to give the necessary information for more accurate suggestions. This would also allow for queries that look like this, that are currently not possible to autocomplete:

```js
var cat = "Nori"; db.cats.aggregate([ {$mat
```