### PR TITLE
fix: shell api commands not working in browser

### DIFF
--- a/packages/browser-runtime-core/src/open-context-runtime.ts
+++ b/packages/browser-runtime-core/src/open-context-runtime.ts
@@ -5,7 +5,7 @@ import { Interpreter, InterpreterEnvironment, EvaluationResult } from './interpr
 import { Runtime } from './runtime';
 
 import Mapper from 'mongosh-mapper';
-import ShellApi from 'mongosh-shell-api';
+import ShellApi, { types } from 'mongosh-shell-api';
 
 /**
  * This class is the core implementation for a runtime which is not isolated
@@ -48,15 +48,20 @@ export class OpenContextRuntime implements Runtime {
     const mapper = new Mapper(serviceProvider);
     const shellApi = new ShellApi(mapper);
 
-    Object.keys(shellApi)
-      .filter(k => (!k.startsWith('_')))
-      .forEach(k => {
-        const value = shellApi[k];
+    const attributes = Object.keys(types.ShellApi.attributes);
+    const ownProperties = Object.getOwnPropertyNames(shellApi);
 
-        if (typeof(value) === 'function') {
-          context[k] = value.bind(shellApi);
+    [
+      ...attributes,
+      ...ownProperties
+    ]
+      .filter((name) => (!name.startsWith('_')))
+      .forEach((name) => {
+        const attribute = shellApi[name];
+        if (typeof(attribute) === 'function') {
+          context[name] = attribute.bind(shellApi);
         } else {
-          context[k] = value;
+          context[name] = attribute;
         }
       });
 

--- a/packages/browser-runtime-electron/package.json
+++ b/packages/browser-runtime-electron/package.json
@@ -17,7 +17,9 @@
   },
   "author": "",
   "license": "SSPL",
-  "devDependencies": {},
+  "devDependencies": {
+    "mongosh-service-provider-server": "file:../service-provider-server"
+  },
   "dependencies": {
     "mongosh-browser-runtime-core": "file:../browser-runtime-core"
   }

--- a/packages/browser-runtime-electron/src/electron-runtime.spec.ts
+++ b/packages/browser-runtime-electron/src/electron-runtime.spec.ts
@@ -1,0 +1,46 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { CliServiceProvider } from 'mongosh-service-provider-server';
+import { ElectronRuntime } from './electron-runtime';
+
+describe('Mapper (integration)', function() {
+  let serviceProvider: CliServiceProvider;
+  let electronRuntime: ElectronRuntime;
+
+  beforeEach(async() => {
+    serviceProvider = sinon.createStubInstance(CliServiceProvider);
+    electronRuntime = new ElectronRuntime(serviceProvider);
+  });
+
+  it('can evaluate simple js', async() => {
+    const result = await electronRuntime.evaluate('2 + 2');
+    expect(result.value).to.equal(4);
+  });
+
+  it('can run help', async() => {
+    const result = await electronRuntime.evaluate('help');
+    expect(result.shellApiType).to.equal('Help');
+  });
+
+  it('can run show', async() => {
+    (serviceProvider.listDatabases as sinon.Stub).resolves({
+      databases: []
+    });
+
+    const result = await electronRuntime.evaluate('show dbs');
+    expect(result.shellApiType).to.equal('CommandResult');
+  });
+
+  it('can switch database', async() => {
+    expect(
+      (await electronRuntime.evaluate('db')).value
+    ).not.to.equal('db1');
+
+    await electronRuntime.evaluate('use db1');
+
+    expect(
+      (await electronRuntime.evaluate('db')).value
+    ).to.equal('db1');
+  });
+});


### PR DESCRIPTION
Creates context with shell api attributes so that it will contain attributes of shell api that are non own properties.

Fixes an issue where commands like `show` and `use` where not accessible from the browser repl.