### PR TITLE
set context in mapper (also fixes shell api commands not working in browser)

### DIFF
--- a/packages/browser-runtime-core/src/open-context-runtime.ts
+++ b/packages/browser-runtime-core/src/open-context-runtime.ts
@@ -5,7 +5,7 @@ import { Interpreter, InterpreterEnvironment, EvaluationResult } from './interpr
 import { Runtime } from './runtime';
 
 import Mapper from 'mongosh-mapper';
-import ShellApi from 'mongosh-shell-api';
+import ShellApi, { types } from 'mongosh-shell-api';
 
 /**
  * This class is the core implementation for a runtime which is not isolated
@@ -48,15 +48,20 @@ export class OpenContextRuntime implements Runtime {
     const mapper = new Mapper(serviceProvider);
     const shellApi = new ShellApi(mapper);
 
-    Object.keys(shellApi)
-      .filter(k => (!k.startsWith('_')))
-      .forEach(k => {
-        const value = shellApi[k];
+    const attributes = Object.keys(types.ShellApi.attributes);
+    const ownProperties = Object.getOwnPropertyNames(shellApi);
 
-        if (typeof(value) === 'function') {
-          context[k] = value.bind(shellApi);
+    [
+      ...attributes,
+      ...ownProperties
+    ]
+      .filter((name) => (!name.startsWith('_')))
+      .forEach((name) => {
+        const attribute = shellApi[name];
+        if (typeof(attribute) === 'function') {
+          context[name] = attribute.bind(shellApi);
         } else {
-          context[k] = value;
+          context[name] = attribute;
         }
       });
 

--- a/packages/browser-runtime-core/src/open-context-runtime.ts
+++ b/packages/browser-runtime-core/src/open-context-runtime.ts
@@ -5,7 +5,6 @@ import { Interpreter, InterpreterEnvironment, EvaluationResult } from './interpr
 import { Runtime } from './runtime';
 
 import Mapper from 'mongosh-mapper';
-import ShellApi, { types } from 'mongosh-shell-api';
 
 /**
  * This class is the core implementation for a runtime which is not isolated
@@ -46,25 +45,6 @@ export class OpenContextRuntime implements Runtime {
 
   private setupEvaluationContext(context: object, serviceProvider: object): void {
     const mapper = new Mapper(serviceProvider);
-    const shellApi = new ShellApi(mapper);
-
-    const attributes = Object.keys(types.ShellApi.attributes);
-    const ownProperties = Object.getOwnPropertyNames(shellApi);
-
-    [
-      ...attributes,
-      ...ownProperties
-    ]
-      .filter((name) => (!name.startsWith('_')))
-      .forEach((name) => {
-        const attribute = shellApi[name];
-        if (typeof(attribute) === 'function') {
-          context[name] = attribute.bind(shellApi);
-        } else {
-          context[name] = attribute;
-        }
-      });
-
     mapper.setCtx(context);
   }
 }

--- a/packages/browser-runtime-electron/package.json
+++ b/packages/browser-runtime-electron/package.json
@@ -17,7 +17,9 @@
   },
   "author": "",
   "license": "SSPL",
-  "devDependencies": {},
+  "devDependencies": {
+    "mongosh-service-provider-server": "file:../service-provider-server"
+  },
   "dependencies": {
     "mongosh-browser-runtime-core": "file:../browser-runtime-core"
   }

--- a/packages/browser-runtime-electron/src/electron-runtime.spec.ts
+++ b/packages/browser-runtime-electron/src/electron-runtime.spec.ts
@@ -1,0 +1,46 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import { CliServiceProvider } from 'mongosh-service-provider-server';
+import { ElectronRuntime } from './electron-runtime';
+
+describe('Mapper (integration)', function() {
+  let serviceProvider: CliServiceProvider;
+  let electronRuntime: ElectronRuntime;
+
+  beforeEach(async() => {
+    serviceProvider = sinon.createStubInstance(CliServiceProvider);
+    electronRuntime = new ElectronRuntime(serviceProvider);
+  });
+
+  it('can evaluate simple js', async() => {
+    const result = await electronRuntime.evaluate('2 + 2');
+    expect(result.value).to.equal(4);
+  });
+
+  it('can run help', async() => {
+    const result = await electronRuntime.evaluate('help');
+    expect(result.shellApiType).to.equal('Help');
+  });
+
+  it('can run show', async() => {
+    (serviceProvider.listDatabases as sinon.Stub).resolves({
+      databases: []
+    });
+
+    const result = await electronRuntime.evaluate('show dbs');
+    expect(result.shellApiType).to.equal('CommandResult');
+  });
+
+  it('can switch database', async() => {
+    expect(
+      (await electronRuntime.evaluate('db')).value
+    ).not.to.equal('db1');
+
+    await electronRuntime.evaluate('use db1');
+
+    expect(
+      (await electronRuntime.evaluate('db')).value
+    ).to.equal('db1');
+  });
+});

--- a/packages/cli-repl/src/cli-repl.ts
+++ b/packages/cli-repl/src/cli-repl.ts
@@ -1,7 +1,6 @@
 import { CliServiceProvider } from 'mongosh-service-provider-server';
 import { NodeOptions } from 'mongosh-transport-server';
 import { compile } from 'mongosh-mapper';
-import ShellApi from 'mongosh-shell-api';
 import repl, { REPLServer } from 'repl';
 import CliOptions from './cli-options';
 import changeHistory from './history';
@@ -26,7 +25,6 @@ class CliRepl {
   private useAntlr?: boolean;
   private serviceProvider: CliServiceProvider;
   private mapper: Mapper;
-  private shellApi: ShellApi;
   private mdbVersion: any;
   private repl: REPLServer;
   private options: CliOptions;
@@ -42,7 +40,6 @@ class CliRepl {
 
     this.serviceProvider = await CliServiceProvider.connect(driverUri, driverOptions);
     this.mapper = new Mapper(this.serviceProvider);
-    this.shellApi = new ShellApi(this.mapper);
     this.mdbVersion = await this.serviceProvider.getServerVersion();
     this.start();
   }
@@ -123,13 +120,13 @@ class CliRepl {
     argv.shift();
     switch(cmd) {
       case 'use':
-        return this.shellApi.use(argv[0]);
+        return this.repl.context.use(argv[0]);
       case 'show':
-        return this.shellApi.show(argv[0]);
+        return this.repl.context.show(argv[0]);
       case 'it':
-        return this.shellApi.it();
+        return this.repl.context.it();
       case 'help':
-        return this.shellApi.help();
+        return this.repl.context.help();
       case 'var':
         this.mapper.cursorAssigned = true;
       default:
@@ -245,9 +242,6 @@ class CliRepl {
       process.exit();
     });
 
-    Object.keys(this.shellApi)
-      .filter(k => (!k.startsWith('_')))
-      .forEach(k => (this.repl.context[k] = this.shellApi[k]));
     this.mapper.setCtx(this.repl.context);
   }
 }

--- a/packages/mapper/src/mapper.spec.ts
+++ b/packages/mapper/src/mapper.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from 'chai';
 import Mapper from './mapper';
+import { Database } from 'mongosh-shell-api';
 
 describe('Mapper', () => {
   let mapper;
@@ -8,6 +9,26 @@ describe('Mapper', () => {
   beforeEach(() => {
     serviceProvider = {};
     mapper = new Mapper(serviceProvider);
+  });
+
+  describe('setCtx', () => {
+    let ctx;
+    beforeEach(() => {
+      ctx = {};
+      mapper.setCtx(ctx);
+    });
+
+    it('sets shell api globals', () => {
+      expect(ctx).to.include.all.keys('it', 'help', 'show', 'use');
+    });
+
+    it('sets db', () => {
+      expect(ctx.db).to.be.instanceOf(Database);
+    });
+
+    it('sets the object as context for the mapper', () => {
+      expect((mapper as any).context).to.equal(ctx);
+    });
   });
 
   describe('commands', () => {

--- a/packages/mapper/src/mapper.ts
+++ b/packages/mapper/src/mapper.ts
@@ -101,7 +101,7 @@ export default class Mapper {
     this.context = contextObject;
   }
 
-  use(_, db): any {
+  use(db): any {
     if (!(db in this.databases)) {
       this.databases[db] = new Database(this, db);
     }
@@ -109,7 +109,7 @@ export default class Mapper {
     return `switched to db ${db}`;
   }
 
-  async show(_, arg): Promise<any> {
+  async show(arg): Promise<any> {
     switch (arg) {
       case 'databases':
       case 'dbs':

--- a/packages/shell-api/src/shell-api.js
+++ b/packages/shell-api/src/shell-api.js
@@ -999,15 +999,15 @@ class ShellApi {
   }
 
   use(...args) {
-    return this._mapper.use(this, ...args);
+    return this._mapper.use(...args);
   }
 
   it(...args) {
-    return this._mapper.it(this, ...args);
+    return this._mapper.it(...args);
   }
 
   show(...args) {
-    return this._mapper.show(this, ...args);
+    return this._mapper.show(...args);
   }
 }
 

--- a/packages/shell-api/yaml/ShellApi.yaml
+++ b/packages/shell-api/yaml/ShellApi.yaml
@@ -2,6 +2,9 @@ class:
     <<: *__defaultClass
     __constructorArgs:
         - _mapper
+    __methods:
+        wrappee: '_mapper'
+        firstArg: ''
     help:
         help: 'shell-api.help.description'
         docs: 'https://docs.mongodb.com/manual/reference/method'


### PR DESCRIPTION
Remove duplicated code to set the context by moving it inside the mapper.