### PR TITLE
refactor: unify set ctx code and move to mapper

### DIFF
--- a/packages/browser-runtime-core/src/open-context-runtime.ts
+++ b/packages/browser-runtime-core/src/open-context-runtime.ts
@@ -5,7 +5,6 @@ import { Interpreter, InterpreterEnvironment, EvaluationResult } from './interpr
 import { Runtime } from './runtime';
 
 import Mapper from '@mongosh/mapper';
-import ShellApi from '@mongosh/shell-api';
 
 /**
  * This class is the core implementation for a runtime which is not isolated
@@ -46,20 +45,6 @@ export class OpenContextRuntime implements Runtime {
 
   private setupEvaluationContext(context: object, serviceProvider: object): void {
     const mapper = new Mapper(serviceProvider);
-    const shellApi = new ShellApi(mapper);
-
-    Object.keys(shellApi)
-      .filter(k => (!k.startsWith('_')))
-      .forEach(k => {
-        const value = shellApi[k];
-
-        if (typeof(value) === 'function') {
-          context[k] = value.bind(shellApi);
-        } else {
-          context[k] = value;
-        }
-      });
-
     mapper.setCtx(context);
   }
 }

--- a/packages/cli-repl/src/cli-repl.ts
+++ b/packages/cli-repl/src/cli-repl.ts
@@ -1,5 +1,4 @@
 import { CliServiceProvider, NodeOptions } from '@mongosh/service-provider-server';
-import ShellApi from '@mongosh/shell-api';
 import repl, { REPLServer } from 'repl';
 import CliOptions from './cli-options';
 import changeHistory from './history';
@@ -24,7 +23,6 @@ class CliRepl {
   readonly useAsync?: boolean;
   private serviceProvider: CliServiceProvider;
   private mapper: Mapper;
-  private shellApi: ShellApi;
   private mdbVersion: any;
   private repl: REPLServer;
   private options: CliOptions;
@@ -40,7 +38,6 @@ class CliRepl {
 
     this.serviceProvider = await CliServiceProvider.connect(driverUri, driverOptions);
     this.mapper = new Mapper(this.serviceProvider);
-    this.shellApi = new ShellApi(this.mapper);
     this.mdbVersion = await this.serviceProvider.getServerVersion();
     this.start();
   }
@@ -122,13 +119,13 @@ class CliRepl {
     argv.shift();
     switch(cmd) {
       case 'use':
-        return this.shellApi.use(argv[0]);
+        return this.repl.context.use(argv[0]);
       case 'show':
-        return this.shellApi.show(argv[0]);
+        return this.repl.context.show(argv[0]);
       case 'it':
-        return this.shellApi.it();
+        return this.repl.context.it();
       case 'help':
-        return this.shellApi.help();
+        return this.repl.context.help();
       case 'var':
         this.mapper.cursorAssigned = true;
       default:
@@ -231,9 +228,6 @@ class CliRepl {
       process.exit();
     });
 
-    Object.keys(this.shellApi)
-      .filter(k => (!k.startsWith('_')))
-      .forEach(k => (this.repl.context[k] = this.shellApi[k]));
     this.mapper.setCtx(this.repl.context);
   }
 }

--- a/packages/mapper/src/mapper.spec.ts
+++ b/packages/mapper/src/mapper.spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import Mapper from './mapper';
 import sinon from 'sinon';
 import { ServiceProvider } from '@mongosh/service-provider-core';
-import { Collection } from '@mongosh/shell-api';
+import { Collection, Database } from '@mongosh/shell-api';
 
 describe('Mapper', () => {
   let mapper: Mapper;
@@ -11,6 +11,26 @@ describe('Mapper', () => {
   beforeEach(() => {
     serviceProvider = {} as ServiceProvider;
     mapper = new Mapper(serviceProvider);
+  });
+
+  describe('setCtx', () => {
+    let ctx;
+    beforeEach(() => {
+      ctx = {};
+      mapper.setCtx(ctx);
+    });
+
+    it('sets shell api globals', () => {
+      expect(ctx).to.include.all.keys('it', 'help', 'show', 'use');
+    });
+
+    it('sets db', () => {
+      expect(ctx.db).to.be.instanceOf(Database);
+    });
+
+    it('sets the object as context for the mapper', () => {
+      expect((mapper as any).context).to.equal(ctx);
+    });
   });
 
   describe('commands', () => {


### PR DESCRIPTION
Moves the code that assign the ShellApi methods and attributes to the global context to the `setCtx` method of `Mapper`.

The code was present in 2 forms in both `browser-repl` and `cli-repl`.

Is that the right place to factor it?

NOTES:

1. `new ShellApi()` is moved in the `setCtx` of mapper too.
2. We run the commands directly from the context, is that ok?
3. If we keep this do we have to expose shell api? like `mapper.shellApi`?
