### PR TITLE
feat: BulkWriteResult

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11293,6 +11293,7 @@
       "version": "file:packages/mapper",
       "requires": {
         "mongosh-async-rewriter": "file:packages/async-rewriter",
+        "mongosh-service-provider-core": "file:packages/service-provider-core",
         "mongosh-shell-api": "file:packages/shell-api",
         "pretty-bytes": "^5.3.0",
         "text-table": "^0.2.0"

--- a/packages/mapper/package.json
+++ b/packages/mapper/package.json
@@ -17,11 +17,11 @@
   "dependencies": {
     "mongosh-shell-api": "file:../shell-api",
     "mongosh-async-rewriter": "file:../async-rewriter",
+    "mongosh-service-provider-core": "file:../service-provider-core",
     "pretty-bytes": "^5.3.0",
     "text-table": "^0.2.0"
   },
   "devDependencies": {
-    "mongosh-service-provider-core": "file:../service-provider-core",
     "mongosh-service-provider-server": "file:../service-provider-server"
   }
 }

--- a/packages/mapper/package.json
+++ b/packages/mapper/package.json
@@ -21,6 +21,7 @@
     "text-table": "^0.2.0"
   },
   "devDependencies": {
+    "mongosh-service-provider-core": "file:../service-provider-core",
     "mongosh-service-provider-server": "file:../service-provider-server"
   }
 }

--- a/packages/mapper/src/mapper.spec.ts
+++ b/packages/mapper/src/mapper.spec.ts
@@ -1,12 +1,15 @@
 import { expect } from 'chai';
 import Mapper from './mapper';
+import sinon from 'sinon';
+import { ServiceProvider } from 'mongosh-service-provider-core';
+import { Collection } from 'mongosh-shell-api';
 
 describe('Mapper', () => {
-  let mapper;
-  let serviceProvider;
+  let mapper: Mapper;
+  let serviceProvider: ServiceProvider;
 
   beforeEach(() => {
-    serviceProvider = {};
+    serviceProvider = {} as ServiceProvider;
     mapper = new Mapper(serviceProvider);
   });
 
@@ -92,6 +95,59 @@ db3  30 kB`;
             const result = await mapper.it();
             expect(result.shellApiType()).to.equal('CursorIterationResult');
             expect(result).to.have.lengthOf(0);
+          });
+        });
+      });
+    });
+
+    describe('collection', () => {
+      describe('bulkWrite', () => {
+        let collection;
+        let requests;
+        beforeEach(async() => {
+          collection = new Collection(mapper, 'db1', 'coll1');
+          requests = [
+            { insertOne: { 'document': { doc: 1 } } }
+          ];
+        });
+
+        it('calls service provider bulkWrite', async() => {
+          serviceProvider.bulkWrite = sinon.spy(() => Promise.resolve({
+            result: { ok: 1 }
+          }));
+
+          await mapper.bulkWrite(collection, requests);
+
+          expect((serviceProvider.bulkWrite as sinon.Spy).calledWith(
+            'db1',
+            'coll1',
+            requests
+          ));
+        });
+
+        it('adapts the result', async() => {
+          serviceProvider.bulkWrite = sinon.spy(() => Promise.resolve({
+            result: { ok: 1 },
+            insertedCount: 1,
+            matchedCount: 2,
+            modifiedCount: 3,
+            deletedCount: 4,
+            upsertedCount: 5,
+            insertedIds: [ 6 ],
+            upsertedIds: [ 7 ]
+          }));
+
+          const result = await mapper.bulkWrite(collection, requests);
+
+          expect(await result.toReplString()).to.be.deep.equal({
+            ackowledged: true,
+            insertedCount: 1,
+            matchedCount: 2,
+            modifiedCount: 3,
+            deletedCount: 4,
+            upsertedCount: 5,
+            insertedIds: [ 6 ],
+            upsertedIds: [ 7 ]
           });
         });
       });

--- a/packages/mapper/src/mapper.ts
+++ b/packages/mapper/src/mapper.ts
@@ -14,13 +14,19 @@ import {
   UpdateResult,
   CursorIterationResult,
   CommandResult,
-  types
+  types,
+  Collection
 } from 'mongosh-shell-api';
+
+import {
+  ServiceProvider,
+  Document
+} from 'mongosh-service-provider-core';
 
 import AsyncWriter from 'mongosh-async-rewriter';
 
 export default class Mapper {
-  private serviceProvider: any;
+  private serviceProvider: ServiceProvider;
   private currentCursor: Cursor | AggregationCursor;
   private databases: any;
 
@@ -165,7 +171,11 @@ export default class Mapper {
    *
    * @returns {BulkWriteResult} The promise of the result.
    */
-  async bulkWrite(collection, operations, options: any = {}): Promise<any> {
+  async bulkWrite(
+    collection: Collection,
+    operations: Document,
+    options: Document = {}
+  ): Promise<BulkWriteResult> {
     const dbOptions: any = {};
     if ('writeConcern' in options) {
       dbOptions.writeConcern = options.writeConcern;
@@ -179,11 +189,15 @@ export default class Mapper {
       dbOptions
     );
 
-    // TODO: implement BulkWriteResult and remove ts ignore
-    // eslint-disable-next-line @typescript-eslint/ban-ts-ignore
-    // @ts-ignore
     return new BulkWriteResult(
-      result.result.ok // TODO
+      !!result.result.ok, // ackowledged
+      result.insertedCount,
+      result.insertedIds,
+      result.matchedCount,
+      result.modifiedCount,
+      result.deletedCount,
+      result.upsertedCount,
+      result.upsertedIds
     );
   }
 

--- a/packages/service-provider-browser/src/stitch-service-provider-browser.ts
+++ b/packages/service-provider-browser/src/stitch-service-provider-browser.ts
@@ -1,4 +1,4 @@
-import { ServiceProvider, Result, Document, Cursor } from 'mongosh-service-provider-core';
+import { ServiceProvider, Result, BulkWriteResult, Document, Cursor } from 'mongosh-service-provider-core';
 import StitchTransport from './stitch-transport';
 
 import i18n from 'mongosh-i18n';
@@ -74,7 +74,7 @@ class StitchServiceProviderBrowser implements ServiceProvider {
    *
    * @returns {Promise} The rejected promise.
    */
-  bulkWrite() : Promise<Result> {
+  bulkWrite() : Promise<BulkWriteResult> {
     return this.stitchTransport.bulkWrite();
   }
 
@@ -109,6 +109,18 @@ class StitchServiceProviderBrowser implements ServiceProvider {
       getServiceClient(RemoteMongoClient.factory, serviceName);
     this.stitchTransport =
       new StitchTransport<StitchAppClient, RemoteMongoClient>(stitchClient, mongoClient);
+  }
+
+  listDatabases(database: string): Promise<any> {
+    throw new Error("Method not implemented.");
+  }
+
+  isCapped(database: string, collection: string): Promise<any> {
+    throw new Error("Method not implemented.");
+  }
+
+  remove(database: string, collection: string, query: Document, options?: Document, dbOptions?: Document): Promise<any> {
+    throw new Error("Method not implemented.");
   }
 
   save(database: string, collection: string, doc: Document, options?: Document, dbOptions?: Document): Promise<any> {

--- a/packages/service-provider-core/src/bulk-write-result.ts
+++ b/packages/service-provider-core/src/bulk-write-result.ts
@@ -1,0 +1,40 @@
+export default interface BulkWriteResult {
+  result: {
+    ok: number
+  };
+
+  /**
+   * The number of documents inserted.
+   */
+  insertedCount: number;
+
+  /**
+   * The number of existing documents selected for update or replacement.
+   */
+  matchedCount: number;
+
+  /**
+   * The number of existing documents updated or replaced.
+   */
+  modifiedCount: number;
+
+  /**
+   * The number of documents removed.
+   */
+  deletedCount: number;
+
+  /**
+   * The number of upserted documents.
+   */
+  upsertedCount: number;
+
+  /**
+   * Ids of upserted documents.
+   */
+  upsertedIds: {[index: number]: any}
+
+  /**
+   * Ids of inserted documents.
+   */
+  insertedIds: {[index: number]: any}
+}

--- a/packages/service-provider-core/src/index.ts
+++ b/packages/service-provider-core/src/index.ts
@@ -2,9 +2,11 @@ import ServiceProvider from './service-provider';
 import Document from './document';
 import Cursor from './cursor';
 import Result from './result';
+import BulkWriteResult from './bulk-write-result';
 
 export {
   ServiceProvider,
+  BulkWriteResult,
   Document,
   Cursor,
   Result

--- a/packages/service-provider-core/src/readable.ts
+++ b/packages/service-provider-core/src/readable.ts
@@ -131,6 +131,26 @@ interface Readable {
    * @returns {Promise} The server version.
    */
   getServerVersion(): Promise<string>;
+
+  /**
+   * list databases.
+   *
+   * @param {String} database - The database name.
+   *
+   * @returns {Promise} The promise of command results.
+   */
+  listDatabases(database: string): Promise<Result>;
+
+  /**
+   * Is the collection capped?
+   *
+   * @param {String} database - The database name.
+   * @param {String} collection - The collection name.
+   * @returns {Promise} The promise of the result.
+   */
+  isCapped(
+    database: string,
+    collection: string): Promise<Result>;
 }
 
 export default Readable;

--- a/packages/service-provider-core/src/writable.ts
+++ b/packages/service-provider-core/src/writable.ts
@@ -1,5 +1,6 @@
 import Document from './document';
 import Result from './result';
+import BulkWriteResult from './bulk-write-result';
 
 /**
  * Interface for write operations in the CRUD specification.
@@ -20,7 +21,7 @@ interface Writable {
     collection: string,
     requests: Document,
     options?: Document,
-    dbOptions?: Document) : Promise<Result>;
+    dbOptions?: Document) : Promise<BulkWriteResult>;
 
   /**
    * Delete multiple documents from the collection.
@@ -121,8 +122,9 @@ interface Writable {
   insertMany(
     database: string,
     collection: string,
-    docs: object[],
-    options?: object) : Promise<Result>;
+    docs: Document[],
+    options?: Document,
+    dbOptions?: Document) : Promise<Result>;
 
   /**
    * Insert one document into the collection.
@@ -137,8 +139,9 @@ interface Writable {
   insertOne(
     database: string,
     collection: string,
-    doc: object,
-    options?: object) : Promise<Result>;
+    doc: Document,
+    options?: Document,
+    dbOptions?: Document) : Promise<Result>;
 
   /**
    * Replace a document with another.
@@ -237,6 +240,22 @@ interface Writable {
     database: string,
     writeConcern?: Document
   ) : Promise<Result>;
+
+  /**
+   * Deprecated remove command.
+   *
+   * @param {String} database - The db name.
+   * @param {String} collection - The collection name.
+   * @param {Object} query - The query.
+   * @param {Object} options - The options.
+   * @return {Promise}
+   */
+  remove(
+    database: string,
+    collection: string,
+    query: Document,
+    options?: Document,
+    dbOptions?: Document): Promise<Result>;
 }
 
 export default Writable;

--- a/packages/service-provider-server/src/cli-service-provider.ts
+++ b/packages/service-provider-server/src/cli-service-provider.ts
@@ -4,7 +4,8 @@ import {
   ServiceProvider,
   Document,
   Cursor,
-  Result
+  Result,
+  BulkWriteResult
 } from 'mongosh-service-provider-core';
 
 import NodeOptions from './node/node-options';
@@ -166,9 +167,10 @@ class CliServiceProvider implements ServiceProvider {
     collection: string,
     requests,
     options: Document = {},
-    dbOptions: Document = {}): Promise<Result> {
-    return this.db(database, dbOptions).collection(collection).
-      bulkWrite(requests as any[], options);
+    dbOptions: Document = {}): Promise<BulkWriteResult> {
+    return this.db(database, dbOptions)
+      .collection(collection)
+      .bulkWrite(requests as any[], options);
   }
 
   /**

--- a/packages/shell-api/src/shell-api.js
+++ b/packages/shell-api/src/shell-api.js
@@ -131,12 +131,12 @@ AggregationCursor.prototype.toArray.returnType = 'unknown';
 
 
 class BulkWriteResult {
-  constructor(ackowledged, insertedCount, insertedIds, matchedCount, modifedCount, deletedCount, upsertedCount, upsertedIds) {
+  constructor(ackowledged, insertedCount, insertedIds, matchedCount, modifiedCount, deletedCount, upsertedCount, upsertedIds) {
     this.ackowledged = ackowledged;
     this.insertedCount = insertedCount;
     this.insertedIds = insertedIds;
     this.matchedCount = matchedCount;
-    this.modifedCount = modifedCount;
+    this.modifiedCount = modifiedCount;
     this.deletedCount = deletedCount;
     this.upsertedCount = upsertedCount;
     this.upsertedIds = upsertedIds;

--- a/packages/shell-api/yaml/BulkWriteResult.yaml
+++ b/packages/shell-api/yaml/BulkWriteResult.yaml
@@ -7,7 +7,7 @@ class:
         - insertedCount
         - insertedIds
         - matchedCount
-        - modifedCount
+        - modifiedCount
         - deletedCount
         - upsertedCount
         - upsertedIds


### PR DESCRIPTION
Implement `BulkWriteResult` and fixes typing issues encountered while doing so.

Changes:
- fix a typo in shell api yaml for `BulkWriteResult`
- add `BulkWriteResult` to `service-provider-core` to establish the `bulkWrite` interface the implementations has to conform to (is the node.js driver one)
- map `BulkWriteResult` in the mapper to the expected result for shell bulkWrite
- add missing typings for `listDatabases`, `isCapped`, `remove` so it compiles
