### PR TITLE
Fix up async-writer api

### DIFF
--- a/packages/async-rewriter/local-test.js
+++ b/packages/async-rewriter/local-test.js
@@ -1,11 +1,10 @@
 /* eslint no-console:0 */
 const SymbolTable = require('./lib/symbol-table').default;
-const getWriter = require('./lib/async-writer-babel.js').default;
+const AsyncWriter = require('./lib/async-writer-babel.js').default;
 
 const { types } = require('mongosh-shell-api');
 
-const symbols = new SymbolTable({ db: types.Database }, types);
-const writer = getWriter(symbols);
+const writer = new AsyncWriter({ db: types.Database }, types);
 const input = [
   'db.coll.insertOne()',
   'y = db',
@@ -16,6 +15,6 @@ const input = [
   'x().coll.insertOne()'
 ];
 
-input.forEach((i) => console.log(`"${i}" ==> "${writer(i)}"`));
-symbols.print();
+input.forEach((i) => console.log(`"${i}" ==> "${writer.compile(i)}"`));
+writer.symbols.print();
 

--- a/packages/async-rewriter/src/async-writer-babel.ts
+++ b/packages/async-rewriter/src/async-writer-babel.ts
@@ -1,167 +1,179 @@
 /* eslint no-console:0 */
 import * as babel from '@babel/core';
 // import printAST from 'ast-pretty-print';
+import SymbolTable from './symbol-table';
 
-export default (symbols): any => {
-  const debug = (str, type?): void => {
-    str = `  ${str}${type === undefined ? '' : ` ==> ${type}`}`;
-    // console.log(str);
-  };
+const debug = (str, type?): void => {
+  str = `  ${str}${type === undefined ? '' : ` ==> ${type}`}`;
+  // console.log(str);
+};
 
-  const inferTypeVisitor = {
-    Identifier: {
-      exit(path): void {
-        const id = path.node.name;
-        let sType = symbols.lookup(id);
-        if (typeof sType === 'string') {
-          sType = symbols.types[sType];
-        }
-        path.node.shellType = sType;
-        path.findParent(()=>true).node.shellType = sType;
-        debug(`Identifier: { name: ${path.node.name} }`, sType.type);
-      }
-    },
-    MemberExpression: {
-      exit(path): void {
-        const rhs = path.node.property.name;
-        const lhsType = path.node.object.shellType;
-        let sType = symbols.types.unknown;
-        if (lhsType.attributes === undefined) {
-          sType = symbols.types.unknown;
-        } else if (rhs in lhsType.attributes) {
-          sType = lhsType.attributes[rhs];
-        } else if (lhsType.type === 'Database') {
-          sType = symbols.types.Collection;
-        }
-        path.node.shellType = sType;
-        path.findParent(()=>true).node.shellType = sType;
-        debug(`MemberExpression: { object.sType: ${lhsType.type}, property.name: ${rhs} }`, sType.type);
-      }
-    },
-    CallExpression: {
-      exit(path): void {
-        const dbg = `callee.type: ${path.node.callee.type}`;
-        const lhsType = path.node.callee.shellType;
-        const returnType = lhsType.returnType;
-        let sType = symbols.types.unknown;
-        if (lhsType.type === 'function') {
-          if (typeof returnType === 'string') {
-            sType = symbols.types[returnType];
-          } else if (returnType !== undefined) {
-            sType = returnType;
+export default class AsyncWriter {
+  public symbols: SymbolTable;
+  private inferTypeVisitor: any;
+  private plugin: any;
+
+  constructor(initialScope, types) {
+    const symbols = new SymbolTable(initialScope, types);
+    this.symbols = symbols;
+    this.inferTypeVisitor = {
+      Identifier: {
+        exit(path): void {
+          const id = path.node.name;
+          let sType = symbols.lookup(id);
+          if (typeof sType === 'string') {
+            sType = symbols.types[sType];
           }
-          if (lhsType.returnsPromise) {
-            path.replaceWith(this.t.awaitExpression(path.node));
-            path.skip();
+          path.node.shellType = sType;
+          path.findParent(() => true).node.shellType = sType;
+          debug(`Identifier: { name: ${path.node.name} }`, sType.type);
+        }
+      },
+      MemberExpression: {
+        exit(path): void {
+          const rhs = path.node.property.name;
+          const lhsType = path.node.object.shellType;
+          let sType = symbols.types.unknown;
+          if (lhsType.attributes === undefined) {
+            sType = symbols.types.unknown;
+          } else if (rhs in lhsType.attributes) {
+            sType = lhsType.attributes[rhs];
+          } else if (lhsType.type === 'Database') {
+            sType = symbols.types.Collection;
           }
+          path.node.shellType = sType;
+          path.findParent(() => true).node.shellType = sType;
+          debug(`MemberExpression: { object.sType: ${lhsType.type}, property.name: ${rhs} }`, sType.type);
         }
-        debug(`CallExpression: { ${dbg}, callee.shellType: ${lhsType.type} }`, sType.type);
-        path.node.shellType = sType;
-      }
-    },
-    VariableDeclarator: {
-      exit(path): void {
-        let sType = symbols.types.unknown;
-        if (path.node.init !== null) {
-          sType = path.node.init.shellType;
-        }
-        path.node.shellType = symbols.types.unknown;
-        symbols.update(path.node.id.name, sType);
-        debug(`VariableDeclarator: { id.name: ${path.node.id.name}, init.shellType: ${
-          path.node.init === null ? 'null' : sType.type
-        }`, 'unknown'); // id must be a identifier
-      }
-    },
-    AssignmentExpression: {
-      exit(path): void {
-        const sType = path.node.right.shellType;
-        symbols.update(path.node.left.name, sType);
-        path.node.shellType = sType; // assignment returns value unlike decl
-        debug(`AssignmentExpression: { left.name: ${path.node.left.name}, right.type: ${path.node.right.type} }`, sType.type); // id must be a identifier
-      }
-    },
-    Function: {
-      enter(): void {
-        symbols.pushScope();
       },
-      exit(path): void {
-        symbols.popScope();
-        const rType = path.node.body.shellType; // should always be set
-        const sType = { type: 'function', returnsPromise: false, returnType: rType };
-        if (path.node.id !== null) {
-          symbols.add(path.node.id.name, sType);
+      CallExpression: {
+        exit(path): void {
+          const dbg = `callee.type: ${path.node.callee.type}`;
+          const lhsType = path.node.callee.shellType;
+          const returnType = lhsType.returnType;
+          let sType = symbols.types.unknown;
+          if (lhsType.type === 'function') {
+            if (typeof returnType === 'string') {
+              sType = symbols.types[returnType];
+            } else if (returnType !== undefined) {
+              sType = returnType;
+            }
+            if (lhsType.returnsPromise) {
+              path.replaceWith(this.t.awaitExpression(path.node));
+              path.skip();
+            }
+          }
+          debug(`CallExpression: { ${dbg}, callee.shellType: ${lhsType.type} }`, sType.type);
+          path.node.shellType = sType;
         }
-        path.node.shellType = sType;
-        debug(`Function: { id: ${path.node.id === null ? '<lambda>' : path.node.id.name} }`, `${sType.type}<${rType.type}>`);
-      }
-    },
-    BlockStatement: {
-      enter(): void {
-        this.toRet.push([]);
       },
-      exit(path): void {
-        const returnTypes = this.toRet.pop();
-        let dbg;
-        if (returnTypes.length === 0) { // no return value, take last or unknown
-          if (path.node.body.length === 0) {
-            dbg = 'empty stmt';
-            path.node.shellType = symbols.types.unknown;
+      VariableDeclarator: {
+        exit(path): void {
+          let sType = symbols.types.unknown;
+          if (path.node.init !== null) {
+            sType = path.node.init.shellType;
+          }
+          path.node.shellType = symbols.types.unknown;
+          symbols.update(path.node.id.name, sType);
+          debug(`VariableDeclarator: { id.name: ${path.node.id.name}, init.shellType: ${
+            path.node.init === null ? 'null' : sType.type
+          }`, 'unknown'); // id must be a identifier
+        }
+      },
+      AssignmentExpression: {
+        exit(path): void {
+          const sType = path.node.right.shellType;
+          symbols.update(path.node.left.name, sType);
+          path.node.shellType = sType; // assignment returns value unlike decl
+          debug(`AssignmentExpression: { left.name: ${path.node.left.name}, right.type: ${path.node.right.type} }`, sType.type); // id must be a identifier
+        }
+      },
+      Function: {
+        enter(): void {
+          symbols.pushScope();
+        },
+        exit(path): void {
+          symbols.popScope();
+          const rType = path.node.body.shellType; // should always be set
+          const sType = { type: 'function', returnsPromise: false, returnType: rType };
+          if (path.node.id !== null) {
+            symbols.add(path.node.id.name, sType);
+          }
+          path.node.shellType = sType;
+          debug(`Function: { id: ${path.node.id === null ? '<lambda>' : path.node.id.name} }`, `${sType.type}<${rType.type}>`);
+        }
+      },
+      BlockStatement: {
+        enter(): void {
+          this.toRet.push([]);
+        },
+        exit(path): void {
+          const returnTypes = this.toRet.pop();
+          let dbg;
+          if (returnTypes.length === 0) { // no return value, take last or unknown
+            if (path.node.body.length === 0) {
+              dbg = 'empty stmt';
+              path.node.shellType = symbols.types.unknown;
+            } else {
+              dbg = 'last stmt';
+              path.node.shellType = path.node.body[0].shellType || symbols.types.unknown;
+            }
           } else {
-            dbg = 'last stmt';
-            path.node.shellType = path.node.body[0].shellType || symbols.types.unknown;
+            // TODO: if any of the return statements are shell types, return shell type as to add async. Can add user warning, but for now take last return.
+            path.node.shellType = returnTypes[returnTypes.length - 1];
+            dbg = 'return stmt';
           }
-        } else {
-          // TODO: if any of the return statements are shell types, return shell type as to add async. Can add user warning, but for now take last return.
-          path.node.shellType = returnTypes[returnTypes.length - 1];
-          dbg = 'return stmt';
+          debug(`BlockStatement: ${dbg}`, path.node.shellType.type);
         }
-        debug(`BlockStatement: ${dbg}`, path.node.shellType.type);
-      }
-    },
-    ReturnStatement: {
-      exit(path, state): void {
-        const sType = path.node.argument === null ? symbols.types.unknown : path.node.argument.shellType;
-        path.node.shellType = sType;
-        state.toRet[state.toRet.length - 1].push(sType);
-        debug('ReturnStatement', sType.type);
-      }
-    },
-    exit(path): void {
-      const type = path.node.shellType || symbols.types.unknown;
-      if (this.skip.some((t) => (this.t[t](path.node)))) { // TODO: nicer?
-        debug(`${path.node.type}`);
-        return;
-      }
-      path.node.shellType = type; // TODO: set all types?
-      debug(`*${path.node.type}`, type.type);
-    }
-  };
-
-  const plugin = ({ types: t }): any => {
-    const skips = Object.keys(inferTypeVisitor).filter(s => /^[A-Z]/.test(s[0])).map(s => `is${s}`);
-    return {
-      // post(state): void {
-      //   console.log('transformed AST:');
-      //   console.log(printAST(state.ast));
-      // },
-      visitor: {
-        Program: {
-          exit(path): void {
-            path.traverse(inferTypeVisitor, {
-              t: t,
-              skip: skips,
-              toRet: []
-            });
-          }
+      },
+      ReturnStatement: {
+        exit(path, state): void {
+          const sType = path.node.argument === null ? symbols.types.unknown : path.node.argument.shellType;
+          path.node.shellType = sType;
+          state.toRet[state.toRet.length - 1].push(sType);
+          debug('ReturnStatement', sType.type);
         }
+      },
+      exit(path): void {
+        const type = path.node.shellType || symbols.types.unknown;
+        if (this.skip.some((t) => (this.t[t](path.node)))) { // TODO: nicer?
+          debug(`${path.node.type}`);
+          return;
+        }
+        path.node.shellType = type; // TODO: set all types?
+        debug(`*${path.node.type}`, type.type);
       }
     };
-  };
-  return (code): string => {
+    this.symbols = symbols;
+
+    this.plugin = ({ types: t }): any => {
+      const visitor = this.inferTypeVisitor;
+      const skips = Object.keys(visitor).filter(s => /^[A-Z]/.test(s[0])).map(s => `is${s}`);
+      return {
+        // post(state): void {
+        //   console.log('transformed AST:');
+        //   console.log(printAST(state.ast));
+        // },
+        visitor: {
+          Program: {
+            exit(path): void {
+              path.traverse(visitor, {
+                t: t,
+                skip: skips,
+                toRet: []
+              });
+            }
+          }
+        }
+      };
+    };
+  }
+
+  compile(code): string {
     return babel.transform(code, {
-      plugins: [plugin],
+      plugins: [this.plugin],
       code: true,
       ast: true
     }).code;
-  };
-};
+  }
+}

--- a/packages/async-rewriter/src/index.ts
+++ b/packages/async-rewriter/src/index.ts
@@ -1,5 +1,2 @@
 import AsyncWriter from './async-writer-babel';
-import SymbolTable from './symbol-table';
-
-export { SymbolTable };
 export default AsyncWriter;

--- a/packages/async-rewriter/src/symbol-table.ts
+++ b/packages/async-rewriter/src/symbol-table.ts
@@ -13,6 +13,7 @@ export default class SymbolTable {
   readonly scopeStack: any;
   public types: any;
   constructor(initialScope, types) {
+    initialScope.global = true;
     this.scopeStack = [initialScope];
     this.types = types;
     Object.keys(types).forEach(s => {
@@ -41,6 +42,7 @@ export default class SymbolTable {
     return this.add(item, value);
   }
   popScope(): void {
+    if (this.scopeStack[this.scopeStack.length - 1].global) return;
     this.scopeStack.pop();
   }
   pushScope(): void {

--- a/packages/cli-repl/src/cli-repl.ts
+++ b/packages/cli-repl/src/cli-repl.ts
@@ -194,7 +194,7 @@ class CliRepl {
       try {
         let str;
         if (this.useAsync) {
-          const syncStr = this.mapper.asyncWriter(input);
+          const syncStr = this.mapper.asyncWriter.compile(input);
           console.log(`DEBUG: rewrote input "${input.trim()}" to "${syncStr.trim()}"`);
           str = await this.evaluateAndResolveApiType(originalEval, syncStr, context, filename);
         } else {

--- a/packages/mapper/src/mapper.ts
+++ b/packages/mapper/src/mapper.ts
@@ -26,7 +26,7 @@ export default class Mapper {
 
   public context: any;
   public cursorAssigned: any;
-  public asyncWriter: any;
+  public asyncWriter: AsyncWriter;
 
   constructor(serviceProvider) {
     this.serviceProvider = serviceProvider;

--- a/packages/mapper/src/mapper.ts
+++ b/packages/mapper/src/mapper.ts
@@ -17,13 +17,12 @@ import {
   types
 } from 'mongosh-shell-api';
 
-import getWriter, { SymbolTable } from 'mongosh-async-rewriter';
+import AsyncWriter from 'mongosh-async-rewriter';
 
 export default class Mapper {
   private serviceProvider: any;
   private currentCursor: Cursor | AggregationCursor;
   private databases: any;
-  private symbols: SymbolTable;
 
   public context: any;
   public cursorAssigned: any;
@@ -36,11 +35,9 @@ export default class Mapper {
     this.currentCursor = null;
     this.cursorAssigned = false;
     this.databases = { test: new Database(this, 'test') };
-    this.symbols = new SymbolTable({ db: types.Database }, types);
-    this.asyncWriter = getWriter(this.symbols);
+    this.asyncWriter = new AsyncWriter({ db: types.Database }, types); // TODO: this will go in context object
   }
 
-  // TODO: rename to initializeContext
   setCtx(ctx): void {
     this.context = ctx;
     this.context.db = this.databases.test;


### PR DESCRIPTION
NOTE: this doesn't include any implementation changes, only changing the packge to return a class instead of a function.

This is my suggestion for what the async writer API should look like. The major change is that the mapper doesn't have to construct the SymbolTable separately, it's initialized and stored within the AsyncWriter class. So to use from the mapper:

```
import { types } from 'shell-api'; // this will be an argument when the context object PR is merged
const globalScope = { db: types.Database };

const writer = new AsyncWriter(globalScope, types); // initialize
const rewrittenCode = writer.compile('code'); // use
```
The `globalScope` argument is the set of global variables (like `db`) and their types. The `types` argument is the ShellApi types from `shell-api-types` and is passed as an argument in order to not add an extra dependency to async-rewriter package (also because in theory this package can be used independently of the shell itself).

There is a little bit of weirdness in the async-writer class because of how babel's plugins work. The `InferTypeVisitor` has to be it's own class, yet it requires access to the symbol table, but I cannot modify the constructor or pass it any arguments/options. I don't like defining the visitor within the constructor but that's the only way I could think to do it. Open to suggestions if you think it can be improved!