### PR TITLE
chore: fix missing mongodb tarball for test runner

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -1,3 +1,6 @@
+variables:
+  MONGODB_VERSION: '4.2.3'
+
 trigger:
   - master
 jobs:


### PR DESCRIPTION
Temporary fix for missing tarball in CDN.

For now we run tests against mongo 4.2.3. The latest version will be used in evergreen.

```
curl -I https://fastdl.mongodb.org/linux/mongodb-linux-x86_64-ubuntu1804-4.2.4.tgz
HTTP/2 403 
content-type: application/xml
date: Tue, 17 Mar 2020 13:16:54 GMT
server: AmazonS3
x-cache: Error from cloudfront
via: 1.1 b46ec6462593127fefb6ecac53956825.cloudfront.net (CloudFront)
x-amz-cf-pop: TXL52-C1
x-amz-cf-id: Ox-wXEgEUPp3-VAaSjFUa1fgxNEaj0kwT898aEkAaHVjy8GlvX1ryA==
```