### PR TITLE
feat: add createIndex and createIndexes

### DIFF
--- a/packages/i18n/src/locales/de_DE.js
+++ b/packages/i18n/src/locales/de_DE.js
@@ -836,6 +836,18 @@ const translations = {
             }
           }
         },
+        "create-indexes": {
+          "link": "https://docs.mongodb.com/manual/reference/method/db.collection.createIndexes",
+          "description": "Creates one or more indexes on a collection",
+          "example": "db.coll.db.coll.createIndexes({ category: 1 }, { name: 'index-1' })",
+          "parameters": {}
+        },
+        "create-index": {
+          "link": "https://docs.mongodb.com/manual/reference/method/db.collection.createIndex",
+          "description": "Creates one or more index on a collection",
+          "example": "db.coll.db.coll.createIndex({ category: 1 }, { name: 'index-1' })",
+          "parameters": {}
+        },
         "update-one": {
           "link": "https://docs.mongodb.com/manual/reference/method/db.collection.updateOne",
           "description": "Updates a single document within the collection based on the filter.",

--- a/packages/i18n/src/locales/en_US.js
+++ b/packages/i18n/src/locales/en_US.js
@@ -836,6 +836,18 @@ const translations = {
             }
           }
         },
+        "create-indexes": {
+          "link": "https://docs.mongodb.com/manual/reference/method/db.collection.createIndexes",
+          "description": "Creates one or more indexes on a collection",
+          "example": "db.coll.db.coll.createIndexes([{ category: 1 }], { name: 'index-1' })",
+          "parameters": {}
+        },
+        "create-index": {
+          "link": "https://docs.mongodb.com/manual/reference/method/db.collection.createIndex",
+          "description": "Creates one or more index on a collection",
+          "example": "db.coll.db.coll.createIndex({ category: 1 }, { name: 'index-1' })",
+          "parameters": {}
+        },
         "update-one": {
           "link": "https://docs.mongodb.com/manual/reference/method/db.collection.updateOne",
           "description": "Updates a single document within the collection based on the filter.",

--- a/packages/mapper/package-lock.json
+++ b/packages/mapper/package-lock.json
@@ -4,15 +4,196 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@sinonjs/commons": {
+			"version": "1.7.1",
+			"resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-1.7.1.tgz",
+			"integrity": "sha512-Debi3Baff1Qu1Unc3mjJ96MgpbwTn43S1+9yJ0llWygPwDNu2aaWBD6yc9y/Z8XDRNhx7U+u2UDg2OGQXkclUQ==",
+			"dev": true,
+			"requires": {
+				"type-detect": "4.0.8"
+			}
+		},
+		"@sinonjs/formatio": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-3.2.2.tgz",
+			"integrity": "sha512-B8SEsgd8gArBLMD6zpRw3juQ2FVSsmdd7qlevyDqzS9WTCtvF55/gAL+h6gue8ZvPYcdiPdvueM/qm//9XzyTQ==",
+			"dev": true,
+			"requires": {
+				"@sinonjs/commons": "^1",
+				"@sinonjs/samsam": "^3.1.0"
+			}
+		},
+		"@sinonjs/samsam": {
+			"version": "3.3.3",
+			"resolved": "https://registry.npmjs.org/@sinonjs/samsam/-/samsam-3.3.3.tgz",
+			"integrity": "sha512-bKCMKZvWIjYD0BLGnNrxVuw4dkWCYsLqFOUWw8VgKF/+5Y+mE7LfHWPIYoDXowH+3a9LsWDMo0uAP8YDosPvHQ==",
+			"dev": true,
+			"requires": {
+				"@sinonjs/commons": "^1.3.0",
+				"array-from": "^2.1.1",
+				"lodash": "^4.17.15"
+			}
+		},
+		"@sinonjs/text-encoding": {
+			"version": "0.7.1",
+			"resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.1.tgz",
+			"integrity": "sha512-+iTbntw2IZPb/anVDbypzfQa+ay64MW0Zo8aJ8gZPWMMK6/OubMVb6lUPMagqjOPnmtauXnFCACVl3O7ogjeqQ==",
+			"dev": true
+		},
+		"@types/chai": {
+			"version": "4.2.11",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.11.tgz",
+			"integrity": "sha512-t7uW6eFafjO+qJ3BIV2gGUyZs27egcNRkUdalkud+Qa3+kg//f129iuOFivHDXQ+vnU3fDXuwgv0cqMCbcE8sw==",
+			"dev": true
+		},
+		"@types/node": {
+			"version": "11.15.7",
+			"resolved": "https://registry.npmjs.org/@types/node/-/node-11.15.7.tgz",
+			"integrity": "sha512-3c3Kc7VIdE5UpqpmztRy7FU+turZgIurGnwpGFy/fRFOirfPc7ZnoFL83qVoqEDENJENqDhtGyQZ5fkXNQ6Qkw==",
+			"dev": true
+		},
+		"@types/sinon": {
+			"version": "7.5.2",
+			"resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-7.5.2.tgz",
+			"integrity": "sha512-T+m89VdXj/eidZyejvmoP9jivXgBDdkOSBVQjU9kF349NEx10QdPNGxHeZUaj1IlJ32/ewdyXJjnJxyxJroYwg==",
+			"dev": true
+		},
+		"@types/sinon-chai": {
+			"version": "3.2.3",
+			"resolved": "https://registry.npmjs.org/@types/sinon-chai/-/sinon-chai-3.2.3.tgz",
+			"integrity": "sha512-TOUFS6vqS0PVL1I8NGVSNcFaNJtFoyZPXZ5zur+qlhDfOmQECZZM4H4kKgca6O8L+QceX/ymODZASfUfn+y4yQ==",
+			"dev": true,
+			"requires": {
+				"@types/chai": "*",
+				"@types/sinon": "*"
+			}
+		},
+		"array-from": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/array-from/-/array-from-2.1.1.tgz",
+			"integrity": "sha1-z+nYwmYoudxa7MYqn12PHzUsEZU=",
+			"dev": true
+		},
+		"diff": {
+			"version": "3.5.0",
+			"resolved": "https://registry.npmjs.org/diff/-/diff-3.5.0.tgz",
+			"integrity": "sha512-A46qtFgd+g7pDZinpnwiRJtxbC1hpgf0uzP3iG89scHk0AUC7A1TGxf5OiiOUv/JMZR8GOt8hL900hV0bOy5xA==",
+			"dev": true
+		},
+		"has-flag": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+			"dev": true
+		},
+		"isarray": {
+			"version": "0.0.1",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+			"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8=",
+			"dev": true
+		},
+		"just-extend": {
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/just-extend/-/just-extend-4.1.0.tgz",
+			"integrity": "sha512-ApcjaOdVTJ7y4r08xI5wIqpvwS48Q0PBG4DJROcEkH1f8MdAiNFyFxz3xoL0LWAVwjrwPYZdVHHxhRHcx/uGLA==",
+			"dev": true
+		},
+		"lodash": {
+			"version": "4.17.15",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
+			"dev": true
+		},
+		"lolex": {
+			"version": "4.2.0",
+			"resolved": "https://registry.npmjs.org/lolex/-/lolex-4.2.0.tgz",
+			"integrity": "sha512-gKO5uExCXvSm6zbF562EvM+rd1kQDnB9AZBbiQVzf1ZmdDpxUSvpnAaVOP83N/31mRK8Ml8/VE8DMvsAZQ+7wg==",
+			"dev": true
+		},
+		"nise": {
+			"version": "1.5.3",
+			"resolved": "https://registry.npmjs.org/nise/-/nise-1.5.3.tgz",
+			"integrity": "sha512-Ymbac/94xeIrMf59REBPOv0thr+CJVFMhrlAkW/gjCIE58BGQdCj0x7KRCb3yz+Ga2Rz3E9XXSvUyyxqqhjQAQ==",
+			"dev": true,
+			"requires": {
+				"@sinonjs/formatio": "^3.2.1",
+				"@sinonjs/text-encoding": "^0.7.1",
+				"just-extend": "^4.0.2",
+				"lolex": "^5.0.1",
+				"path-to-regexp": "^1.7.0"
+			},
+			"dependencies": {
+				"lolex": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/lolex/-/lolex-5.1.2.tgz",
+					"integrity": "sha512-h4hmjAvHTmd+25JSwrtTIuwbKdwg5NzZVRMLn9saij4SZaepCrTCxPr35H/3bjwfMJtN+t3CX8672UIkglz28A==",
+					"dev": true,
+					"requires": {
+						"@sinonjs/commons": "^1.7.0"
+					}
+				}
+			}
+		},
+		"path-to-regexp": {
+			"version": "1.8.0",
+			"resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.8.0.tgz",
+			"integrity": "sha512-n43JRhlUKUAlibEJhPeir1ncUID16QnEjNpwzNdO3Lm4ywrBpBZ5oLD0I6br9evr1Y9JTqwRtAh7JLoOzAQdVA==",
+			"dev": true,
+			"requires": {
+				"isarray": "0.0.1"
+			}
+		},
 		"pretty-bytes": {
 			"version": "5.3.0",
 			"resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.3.0.tgz",
 			"integrity": "sha512-hjGrh+P926p4R4WbaB6OckyRtO0F0/lQBiT+0gnxjV+5kjPBrfVBFCsCLbMqVQeydvIoouYTCmmEURiH3R1Bdg=="
 		},
+		"sinon": {
+			"version": "7.5.0",
+			"resolved": "https://registry.npmjs.org/sinon/-/sinon-7.5.0.tgz",
+			"integrity": "sha512-AoD0oJWerp0/rY9czP/D6hDTTUYGpObhZjMpd7Cl/A6+j0xBE+ayL/ldfggkBXUs0IkvIiM1ljM8+WkOc5k78Q==",
+			"dev": true,
+			"requires": {
+				"@sinonjs/commons": "^1.4.0",
+				"@sinonjs/formatio": "^3.2.1",
+				"@sinonjs/samsam": "^3.3.3",
+				"diff": "^3.5.0",
+				"lolex": "^4.2.0",
+				"nise": "^1.5.2",
+				"supports-color": "^5.5.0"
+			}
+		},
+		"supports-color": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+			"dev": true,
+			"requires": {
+				"has-flag": "^3.0.0"
+			}
+		},
 		"text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
 			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+		},
+		"ts-sinon": {
+			"version": "1.0.25",
+			"resolved": "https://registry.npmjs.org/ts-sinon/-/ts-sinon-1.0.25.tgz",
+			"integrity": "sha512-G6ufQ8ELd/em6tyuhp1iKoKcwDV/zgjT0uJQWzDovRLFc33kzKvTaZZ8whshFcgHk0d8QzVTVlmwTrmy0e9F+A==",
+			"dev": true,
+			"requires": {
+				"@types/node": "^11.15.4",
+				"@types/sinon": "^7.5.1",
+				"@types/sinon-chai": "^3.2.3",
+				"sinon": "^7.5.0"
+			}
+		},
+		"type-detect": {
+			"version": "4.0.8",
+			"resolved": "https://registry.npmjs.org/type-detect/-/type-detect-4.0.8.tgz",
+			"integrity": "sha512-0fr/mIH1dlO+x7TlcMy+bIDqKPsw/70tVyeHW787goQjhmqaZe10uwLujubK9q9Lg6Fiho1KUKDYz0Z7k7g5/g==",
+			"dev": true
 		}
 	}
 }

--- a/packages/mapper/package.json
+++ b/packages/mapper/package.json
@@ -26,6 +26,9 @@
     "text-table": "^0.2.0"
   },
   "devDependencies": {
-    "@mongosh/service-provider-server": "^0.0.1-alpha.6"
+    "@mongosh/service-provider-server": "^0.0.1-alpha.6",
+    "@types/sinon": "^7.5.1",
+    "@types/sinon-chai": "^3.2.3",
+    "ts-sinon": "^1.0.25"
   }
 }

--- a/packages/mapper/src/mapper.ts
+++ b/packages/mapper/src/mapper.ts
@@ -852,4 +852,59 @@ export default class Mapper {
       size
     );
   }
+
+  /**
+   * Create indexes for a collection
+   *
+   * @param {Collection} collection
+   * @param {Document} keyPatterns - An array of documents that contains
+   *  the field and value pairs where the field is the index key and the
+   *  value describes the type of index for that field.
+   * @param {Document} options - createIndexes options (
+   *  name, background, sparse ...)
+   * @return {Promise}
+   */
+  async createIndexes(
+    collection: Collection,
+    keyPatterns: Document[],
+    options: Document = {}
+  ): Promise<any> {
+    if (typeof options !== 'object' || Array.isArray(options)) {
+      throw new Error('options must be an object');
+    }
+
+    const specs = keyPatterns.map((pattern) => ({
+      ...options, key: pattern
+    }));
+
+    return await this.serviceProvider.createIndexes(
+      collection._database,
+      collection._collection,
+      specs
+    );
+  }
+
+  /**
+   * Create index for a collection
+   *
+   * @param {Collection} collection
+   * @param {Document} keys - An document that contains
+   *  the field and value pairs where the field is the index key and the
+   *  value describes the type of index for that field.
+   * @param {Document} options - createIndexes options (
+   *  name, background, sparse ...)
+   *
+   * @return {Promise}
+   */
+  async createIndex(
+    collection: Collection,
+    keys: Document,
+    options: Document = {}
+  ): Promise<any> {
+    return await this.createIndexes(
+      collection,
+      [keys],
+      options
+    );
+  }
 }

--- a/packages/service-provider-browser/src/stitch-service-provider-browser.ts
+++ b/packages/service-provider-browser/src/stitch-service-provider-browser.ts
@@ -111,6 +111,14 @@ class StitchServiceProviderBrowser implements ServiceProvider {
       new StitchTransport<StitchAppClient, RemoteMongoClient>(stitchClient, mongoClient);
   }
 
+  getIndexes(database: string, collection: string, dbOptions?: Document): Promise<any> {
+    throw new Error("Method not implemented.");
+  }
+
+  createIndexes(database: string, collection: string, indexSpecs: Document[], options?: Document, dbOptions?: Document): Promise<any> {
+    throw new Error("Method not implemented.");
+  }
+
   convertToCapped(database: string, collection: string, size: number): Promise<any> {
     throw new Error("Method not implemented.");
   }

--- a/packages/service-provider-core/src/readable.ts
+++ b/packages/service-provider-core/src/readable.ts
@@ -151,6 +151,22 @@ interface Readable {
   isCapped(
     database: string,
     collection: string): Promise<Result>;
+
+  /**
+   * Returns an array that holds a list of documents that identify and
+   * describe the existing indexes on the collection.
+   *
+   * @param {String} database - The db name.
+   * @param {String} collection - The collection name.
+   * @param {Object} dbOptions - The database options
+   *  (i.e. readConcern, writeConcern. etc).
+   *
+   * @return {Promise}
+   */
+  getIndexes(
+    database: string,
+    collection: string,
+    dbOptions?: Document): Promise<Result>;
 }
 
 export default Readable;

--- a/packages/service-provider-core/src/writable.ts
+++ b/packages/service-provider-core/src/writable.ts
@@ -272,6 +272,23 @@ interface Writable {
     collection: string,
     size: number
   ): Promise<Result>
+
+  /**
+   * Adds new indexes to a collection.
+   *
+   * @param {String} database - The db name.
+   * @param {String} collection - The collection name.
+   * @param {Object[]} indexSpecs the spec of the intexes to be created.
+   * @param {Object} options - The command options.
+   * @param {Object} dbOptions - The database options (i.e. readConcern, writeConcern. etc).
+   * @return {Promise}
+   */
+  createIndexes(
+    database: string,
+    collection: string,
+    indexSpecs: Document[],
+    options?: Document,
+    dbOptions?: Document): Promise<Result>;
 }
 
 export default Writable;

--- a/packages/service-provider-server/src/cli-service-provider.integration.spec.ts
+++ b/packages/service-provider-server/src/cli-service-provider.integration.spec.ts
@@ -391,7 +391,7 @@ describe('CliServiceProvider [integration]', function() {
       const collName = 'coll1';
       const nativeCollection = db.collection(collName);
 
-      await nativeCollection.insertOne({ doc: 1 });
+      await db.createCollection(collName);
 
       expect(
         await nativeCollection.isCapped()
@@ -406,6 +406,50 @@ describe('CliServiceProvider [integration]', function() {
       expect(
         await nativeCollection.isCapped()
       ).to.be.true;
+    });
+  });
+
+  describe('#createIndexes', () => {
+    it('creates a new index', async() => {
+      const collName = 'coll1';
+      const nativeCollection = db.collection(collName);
+
+      await db.createCollection(collName);
+
+      expect(
+        await nativeCollection.indexExists('index-1')
+      ).to.be.false;
+
+      await serviceProvider.createIndexes(
+        dbName,
+        collName,
+        [{
+          name: 'index-1',
+          key: { x: 1 }
+        }]
+      );
+
+      expect(
+        await nativeCollection.indexExists('index-1')
+      ).to.be.true;
+    });
+  });
+
+  describe('#getIndexes', () => {
+    it('returns indexes', async() => {
+      const collName = 'coll1';
+      const nativeCollection = db.collection(collName);
+
+      await nativeCollection.createIndex('x');
+
+      const result = await serviceProvider.getIndexes(
+        dbName,
+        collName
+      );
+
+      expect(
+        result.map((spec) => spec.key)
+      ).to.deep.equal([{ _id: 1 }, { x: 1 }]);
     });
   });
 });

--- a/packages/service-provider-server/src/cli-service-provider.spec.ts
+++ b/packages/service-provider-server/src/cli-service-provider.spec.ts
@@ -504,4 +504,76 @@ describe('CliServiceProvider', () => {
       commandMock.verify();
     });
   });
+
+  describe('#createIndexes', () => {
+    let indexSpecs;
+    let nativeMethodResult;
+    let nativeMethodMock;
+
+    beforeEach(() => {
+      indexSpecs = [
+        { key: 'x' }
+      ];
+
+      nativeMethodResult = {
+        createdCollectionAutomatically: false,
+        numIndexesBefore: 2,
+        numIndexesAfter: 3,
+        ok: 1
+      };
+
+      nativeMethodMock = sinon.mock().once().withArgs(indexSpecs).
+        resolves(nativeMethodResult);
+
+      const collectionStub = sinon.createStubInstance(Collection, {
+        createIndexes: nativeMethodMock
+      });
+
+      serviceProvider = new CliServiceProvider(createClientStub(collectionStub));
+    });
+
+    it('executes the command against the database', async() => {
+      const result = await serviceProvider.createIndexes(
+        'db1',
+        'coll1',
+        indexSpecs);
+      expect(result).to.deep.equal(nativeMethodResult);
+      nativeMethodMock.verify();
+    });
+  });
+
+  describe('#getIndexes', () => {
+    let indexSpecs;
+    let nativeMethodResult;
+    let nativeMethodMock;
+
+    beforeEach(() => {
+      indexSpecs = [
+        { key: 'x' }
+      ];
+
+      nativeMethodResult = {
+        toArray: (): Promise<any[]> => Promise.resolve(indexSpecs)
+      };
+
+      nativeMethodMock = sinon.mock().once().withArgs().
+        returns(nativeMethodResult);
+
+      const collectionStub = sinon.createStubInstance(Collection, {
+        listIndexes: nativeMethodMock
+      });
+
+      serviceProvider = new CliServiceProvider(createClientStub(collectionStub));
+    });
+
+    it('executes the command against the database', async() => {
+      const result = await (serviceProvider as any).getIndexes(
+        'db1',
+        'coll1'
+      );
+
+      expect(result).to.deep.equal(indexSpecs);
+      nativeMethodMock.verify();
+    });
+  });
 });

--- a/packages/service-provider-server/src/cli-service-provider.ts
+++ b/packages/service-provider-server/src/cli-service-provider.ts
@@ -448,7 +448,8 @@ class CliServiceProvider implements ServiceProvider {
   }
 
   /**
-   * Insert many documents into the colleciton.
+   * Insert many documents into the collection. {
+   * db('db1').collection('coll1').listIndexes().toArray()}
    *
    * @param {String} database - The database name.
    * @param {String} collection - The collection name.
@@ -681,6 +682,48 @@ class CliServiceProvider implements ServiceProvider {
       ok,
       ...(ok ? { dropped: db } : {})
     };
+  }
+
+  /**
+   * Adds new indexes to a collection.
+   *
+   * @param {String} database - The db name.
+   * @param {String} collection - The collection name.
+   * @param {Object[]} indexSpecs the spec of the intexes to be created.
+   * @param {Object} options - The command options.
+   * @param {Object} dbOptions - The database options (i.e. readConcern, writeConcern. etc).
+   * @return {Promise}
+   */
+  async createIndexes(
+    database: string,
+    collection: string,
+    indexSpecs: Document[],
+    options: Document = {},
+    dbOptions: Document = {}): Promise<Result> {
+    return this.db(database, dbOptions)
+      .collection(collection)
+      .createIndexes(indexSpecs, options);
+  }
+
+  /**
+   * Returns an array that holds a list of documents that identify and
+   * describe the existing indexes on the collection.
+   *
+   * @param {String} database - The db name.
+   * @param {String} collection - The collection name.
+   * @param {Object} dbOptions - The database options
+   *  (i.e. readConcern, writeConcern. etc).
+   *
+   * @return {Promise}
+   */
+  async getIndexes(
+    database: string,
+    collection: string,
+    dbOptions: Document = {}): Promise<Result> {
+    return this.db(database, dbOptions)
+      .collection(collection)
+      .listIndexes()
+      .toArray();
   }
 }
 

--- a/packages/service-provider-server/src/cli-service-provider.ts
+++ b/packages/service-provider-server/src/cli-service-provider.ts
@@ -448,8 +448,7 @@ class CliServiceProvider implements ServiceProvider {
   }
 
   /**
-   * Insert many documents into the collection. {
-   * db('db1').collection('coll1').listIndexes().toArray()}
+   * Insert many documents into the collection.
    *
    * @param {String} database - The database name.
    * @param {String} collection - The collection name.

--- a/packages/shell-api/src/collection.spec.ts
+++ b/packages/shell-api/src/collection.spec.ts
@@ -51,8 +51,20 @@ describe('Collection', () => {
   });
 
   describe('#convertToCapped', () => {
-    it('wraps mapper.convertToCapped', async() => {
+    it('wraps mapper.convertToCapped', () => {
       testWrappedMethod('convertToCapped');
+    });
+  });
+
+  describe('#createIndexes', () => {
+    it('wraps mapper.createIndexes', () => {
+      testWrappedMethod('createIndexes');
+    });
+  });
+
+  describe('#createIndex', () => {
+    it('wraps mapper.createIndex', () => {
+      testWrappedMethod('createIndex');
     });
   });
 });

--- a/packages/shell-api/src/shell-api.js
+++ b/packages/shell-api/src/shell-api.js
@@ -268,6 +268,14 @@ class Collection {
   convertToCapped(...args) {
     return this._mapper.convertToCapped(this, ...args);
   }
+
+  createIndexes(...args) {
+    return this._mapper.createIndexes(this, ...args);
+  }
+
+  createIndex(...args) {
+    return this._mapper.createIndex(this, ...args);
+  }
 }
 
 
@@ -420,6 +428,18 @@ Collection.prototype.convertToCapped.serverVersions = ['0.0.0', '4.4.0'];
 Collection.prototype.convertToCapped.topologies = [0, 1, 2];
 Collection.prototype.convertToCapped.returnsPromise = true;
 Collection.prototype.convertToCapped.returnType = 'unknown';
+
+Collection.prototype.createIndexes.help = () => new Help({ 'help': 'shell-api.collection.help.create-indexes' });
+Collection.prototype.createIndexes.serverVersions = ['3.2.0', '4.4.0'];
+Collection.prototype.createIndexes.topologies = [0, 1, 2];
+Collection.prototype.createIndexes.returnsPromise = true;
+Collection.prototype.createIndexes.returnType = 'unknown';
+
+Collection.prototype.createIndex.help = () => new Help({ 'help': 'shell-api.collection.help.create-index' });
+Collection.prototype.createIndex.serverVersions = ['3.2.0', '4.4.0'];
+Collection.prototype.createIndex.topologies = [0, 1, 2];
+Collection.prototype.createIndex.returnsPromise = true;
+Collection.prototype.createIndex.returnType = 'unknown';
 
 
 class Cursor {

--- a/packages/shell-api/src/shell-types.js
+++ b/packages/shell-api/src/shell-types.js
@@ -51,7 +51,9 @@ const Collection = {
     update: { type: 'function', returnsPromise: true, returnType: 'unknown', serverVersions: ['0.0.0', '4.4.0'] },
     updateMany: { type: 'function', returnsPromise: true, returnType: 'unknown', serverVersions: ['3.2.0', '4.4.0'] },
     updateOne: { type: 'function', returnsPromise: true, returnType: 'unknown', serverVersions: ['3.2.0', '4.4.0'] },
-    convertToCapped: { type: 'function', returnsPromise: true, returnType: 'unknown', serverVersions: ['0.0.0', '4.4.0'] }
+    convertToCapped: { type: 'function', returnsPromise: true, returnType: 'unknown', serverVersions: ['0.0.0', '4.4.0'] },
+    createIndexes: { type: 'function', returnsPromise: true, returnType: 'unknown', serverVersions: ['3.2.0', '4.4.0'] },
+    createIndex: { type: 'function', returnsPromise: true, returnType: 'unknown', serverVersions: ['3.2.0', '4.4.0'] }
   }
 };
 const Cursor = {

--- a/packages/shell-api/yaml/Collection.yaml
+++ b/packages/shell-api/yaml/Collection.yaml
@@ -233,3 +233,19 @@ class:
             - *ServerVersions.latest
         help:
             help: 'shell-api.collection.help.convert-to-capped'
+    createIndexes:
+        <<: *__defaultMethod
+        returnsPromise: true
+        serverVersions:
+            - '3.2.0'
+            - *ServerVersions.latest
+        help:
+            help: 'shell-api.collection.help.create-indexes'
+    createIndex:
+        <<: *__defaultMethod
+        returnsPromise: true
+        serverVersions:
+            - '3.2.0'
+            - *ServerVersions.latest
+        help:
+            help: 'shell-api.collection.help.create-index'


### PR DESCRIPTION
Implements `db.coll.createIndex` and `db.coll.createIndexes`.

Changes:
- service provider: Implement `createIndexes` and `getIndexes` (used in mapper for tests)
- mapper: Implement `createIndexes` and `createIndex` as wrapper of `createIndexes` (as is currenly).  
- shell api: Add  `createIndexes` and `createIndex` specs and help

Chores:
- Use `ts-sinon` in mapper tests to mock the `ServiceProvider` interface.
