### PR TITLE
feat: getIndexes, getIndexSpecs, getIndexKeys, getIndices

### DIFF
--- a/packages/i18n/src/locales/en_US.js
+++ b/packages/i18n/src/locales/en_US.js
@@ -866,6 +866,12 @@ const translations = {
           "example": "",
           "parameters": {}
         },
+        "get-indices": {
+          "link": "",
+          "description": "",
+          "example": "",
+          "parameters": {}
+        },
         "get-index-specs": {
           "link": "",
           "description": "",

--- a/packages/i18n/src/locales/en_US.js
+++ b/packages/i18n/src/locales/en_US.js
@@ -854,6 +854,24 @@ const translations = {
           "example": "db.coll.db.coll.ensureIndex({ category: 1 }, { name: 'index-1' })",
           "parameters": {}
         },
+        "get-indexes": {
+          "link": "",
+          "description": "",
+          "example": "",
+          "parameters": {}
+        },
+        "get-index-keys": {
+          "link": "",
+          "description": "",
+          "example": "",
+          "parameters": {}
+        },
+        "get-index-specs": {
+          "link": "",
+          "description": "",
+          "example": "",
+          "parameters": {}
+        },
         "update-one": {
           "link": "https://docs.mongodb.com/manual/reference/method/db.collection.updateOne",
           "description": "Updates a single document within the collection based on the filter.",

--- a/packages/mapper/src/mapper.integration.spec.ts
+++ b/packages/mapper/src/mapper.integration.spec.ts
@@ -202,6 +202,40 @@ describe('Mapper (integration)', function() {
         )).map((spec) => spec.name)).to.contain('index-1');
       });
     });
+
+    describe('getIndexes', () => {
+      let result;
+
+      beforeEach(async() => {
+        await serviceProvider.insertOne(dbName, collectionName, { doc: 1 });
+        await serviceProvider.createIndexes(dbName, collectionName, [
+          { key: { x: 1 } }
+        ]);
+
+        result = await mapper.getIndexes(collection);
+      });
+
+      it('returns indexes for the collection', () => {
+        expect(result).to.deep.equal([
+          {
+            key: {
+              _id: 1
+            },
+            name: '_id_',
+            ns: `${dbName}.${collectionName}`,
+            v: 2
+          },
+          {
+            key: {
+              x: 1
+            },
+            name: 'x_1',
+            ns: `${dbName}.${collectionName}`,
+            v: 2
+          }
+        ]);
+      });
+    });
   });
 });
 

--- a/packages/mapper/src/mapper.spec.ts
+++ b/packages/mapper/src/mapper.spec.ts
@@ -289,5 +289,60 @@ db3  30 kB`;
       });
     });
   });
+
+  ['getIndexes', 'getIndexSpecs'].forEach((method) => {
+    describe(method, () => {
+      let collection;
+      let result;
+      beforeEach(async() => {
+        result = [{
+          v: 2,
+          key: {
+            _id: 1
+          },
+          name: '_id_',
+          ns: 'test.coll1'
+        }];
+        collection = new Collection(mapper, 'db1', 'coll1');
+        serviceProvider.getIndexes.resolves(result);
+      });
+
+      it('returns serviceProvider.getIndexes using keys', async() => {
+        expect(await mapper[method](collection)).to.deep.equal(result);
+      });
+    });
+  });
+
+  describe('getIndexKeys', () => {
+    let collection;
+    let result;
+    beforeEach(async() => {
+      result = [{
+        v: 2,
+        key: {
+          _id: 1
+        },
+        name: '_id_',
+        ns: 'test.coll1'
+      },
+      {
+        v: 2,
+        key: {
+          name: 1
+        },
+        name: '_name_',
+        ns: 'test.coll1'
+      }];
+      collection = new Collection(mapper, 'db1', 'coll1');
+      serviceProvider.getIndexes.resolves(result);
+    });
+
+    it('returns only indexes keys', async() => {
+      expect(await mapper.getIndexKeys(collection)).to.deep.equal([
+        { _id: 1 },
+        { name: 1 }
+      ]);
+    });
+  });
 });
 

--- a/packages/mapper/src/mapper.spec.ts
+++ b/packages/mapper/src/mapper.spec.ts
@@ -290,7 +290,7 @@ db3  30 kB`;
     });
   });
 
-  ['getIndexes', 'getIndexSpecs'].forEach((method) => {
+  ['getIndexes', 'getIndexSpecs', 'getIndices'].forEach((method) => {
     describe(method, () => {
       let collection;
       let result;

--- a/packages/mapper/src/mapper.ts
+++ b/packages/mapper/src/mapper.ts
@@ -964,8 +964,7 @@ export default class Mapper {
   }
 
   /**
-   * Returns an array that holds a list of documents that identify
-   * key patters for the indexes defined on the collection.
+   * Returns an array of key patters for the indexes defined on the collection.
    *
    * @param {Collection} collection
    *

--- a/packages/mapper/src/mapper.ts
+++ b/packages/mapper/src/mapper.ts
@@ -964,6 +964,20 @@ export default class Mapper {
   }
 
   /**
+   * Returns an array that holds a list of documents that identify and
+   * describe the existing indexes on the collection. (alias for getIndexes)
+   *
+   * @param {Collection} collection
+   *
+   * @return {Promise}
+   */
+  async getIndices(
+    collection: Collection,
+  ): Promise<any> {
+    return await this.getIndexes(collection);
+  }
+
+  /**
    * Returns an array of key patters for the indexes defined on the collection.
    *
    * @param {Collection} collection

--- a/packages/mapper/src/mapper.ts
+++ b/packages/mapper/src/mapper.ts
@@ -931,4 +931,49 @@ export default class Mapper {
       options
     );
   }
+
+  /**
+   * Returns an array that holds a list of documents that identify and
+   * describe the existing indexes on the collection.
+   *
+   * @param {Collection} collection
+   *
+   * @return {Promise}
+   */
+  async getIndexes(
+    collection: Collection,
+  ): Promise<any> {
+    return await this.serviceProvider.getIndexes(
+      collection._database,
+      collection._collection
+    );
+  }
+
+  /**
+   * Returns an array that holds a list of documents that identify and
+   * describe the existing indexes on the collection. (alias for getIndexes)
+   *
+   * @param {Collection} collection
+   *
+   * @return {Promise}
+   */
+  async getIndexSpecs(
+    collection: Collection,
+  ): Promise<any> {
+    return await this.getIndexes(collection);
+  }
+
+  /**
+   * Returns an array that holds a list of documents that identify
+   * key patters for the indexes defined on the collection.
+   *
+   * @param {Collection} collection
+   *
+   * @return {Promise}
+   */
+  async getIndexKeys(
+    collection: Collection,
+  ): Promise<any> {
+    return (await this.getIndexes(collection)).map(i => i.key);
+  }
 }

--- a/packages/shell-api/src/collection.spec.ts
+++ b/packages/shell-api/src/collection.spec.ts
@@ -86,6 +86,12 @@ describe('Collection', () => {
     });
   });
 
+  describe('#getIndices', () => {
+    it('wraps mapper.getIndices', () => {
+      testWrappedMethod('getIndices');
+    });
+  });
+
   describe('#getIndexKeys', () => {
     it('wraps mapper.getIndexKeys', () => {
       testWrappedMethod('getIndexKeys');

--- a/packages/shell-api/src/collection.spec.ts
+++ b/packages/shell-api/src/collection.spec.ts
@@ -73,4 +73,22 @@ describe('Collection', () => {
       testWrappedMethod('ensureIndex');
     });
   });
+
+  describe('#getIndexes', () => {
+    it('wraps mapper.getIndexes', () => {
+      testWrappedMethod('getIndexes');
+    });
+  });
+
+  describe('#getIndexSpecs', () => {
+    it('wraps mapper.getIndexSpecs', () => {
+      testWrappedMethod('getIndexSpecs');
+    });
+  });
+
+  describe('#getIndexKeys', () => {
+    it('wraps mapper.getIndexKeys', () => {
+      testWrappedMethod('getIndexKeys');
+    });
+  });
 });

--- a/packages/shell-api/src/shell-api.js
+++ b/packages/shell-api/src/shell-api.js
@@ -280,6 +280,22 @@ class Collection {
   ensureIndex(...args) {
     return this._mapper.ensureIndex(this, ...args);
   }
+
+  getIndexes(...args) {
+    return this._mapper.getIndexes(this, ...args);
+  }
+
+  getIndexSpecs(...args) {
+    return this._mapper.getIndexSpecs(this, ...args);
+  }
+
+  getIndexKeys(...args) {
+    return this._mapper.getIndexKeys(this, ...args);
+  }
+
+  getIndices(...args) {
+    return this._mapper.getIndices(this, ...args);
+  }
 }
 
 
@@ -450,6 +466,30 @@ Collection.prototype.ensureIndex.serverVersions = ['0.0.0', '4.4.0'];
 Collection.prototype.ensureIndex.topologies = [0, 1, 2];
 Collection.prototype.ensureIndex.returnsPromise = true;
 Collection.prototype.ensureIndex.returnType = 'unknown';
+
+Collection.prototype.getIndexes.help = () => new Help({ 'help': 'shell-api.collection.help.get-indexes' });
+Collection.prototype.getIndexes.serverVersions = ['3.2.0', '4.4.0'];
+Collection.prototype.getIndexes.topologies = [0, 1, 2];
+Collection.prototype.getIndexes.returnsPromise = true;
+Collection.prototype.getIndexes.returnType = 'unknown';
+
+Collection.prototype.getIndexSpecs.help = () => new Help({ 'help': 'shell-api.collection.help.get-index-specs' });
+Collection.prototype.getIndexSpecs.serverVersions = ['3.2.0', '4.4.0'];
+Collection.prototype.getIndexSpecs.topologies = [0, 1, 2];
+Collection.prototype.getIndexSpecs.returnsPromise = true;
+Collection.prototype.getIndexSpecs.returnType = 'unknown';
+
+Collection.prototype.getIndexKeys.help = () => new Help({ 'help': 'shell-api.collection.help.get-index-keys' });
+Collection.prototype.getIndexKeys.serverVersions = ['3.2.0', '4.4.0'];
+Collection.prototype.getIndexKeys.topologies = [0, 1, 2];
+Collection.prototype.getIndexKeys.returnsPromise = true;
+Collection.prototype.getIndexKeys.returnType = 'unknown';
+
+Collection.prototype.getIndices.help = () => new Help({ 'help': 'shell-api.collection.help.get-indices' });
+Collection.prototype.getIndices.serverVersions = ['3.2.0', '4.4.0'];
+Collection.prototype.getIndices.topologies = [0, 1, 2];
+Collection.prototype.getIndices.returnsPromise = true;
+Collection.prototype.getIndices.returnType = 'unknown';
 
 
 class Cursor {

--- a/packages/shell-api/src/shell-types.js
+++ b/packages/shell-api/src/shell-types.js
@@ -54,7 +54,11 @@ const Collection = {
     convertToCapped: { type: 'function', returnsPromise: true, returnType: 'unknown', serverVersions: ['0.0.0', '4.4.0'] },
     createIndexes: { type: 'function', returnsPromise: true, returnType: 'unknown', serverVersions: ['3.2.0', '4.4.0'] },
     createIndex: { type: 'function', returnsPromise: true, returnType: 'unknown', serverVersions: ['0.0.0', '4.4.0'] },
-    ensureIndex: { type: 'function', returnsPromise: true, returnType: 'unknown', serverVersions: ['0.0.0', '4.4.0'] }
+    ensureIndex: { type: 'function', returnsPromise: true, returnType: 'unknown', serverVersions: ['0.0.0', '4.4.0'] },
+    getIndexes: { type: 'function', returnsPromise: true, returnType: 'unknown', serverVersions: ['3.2.0', '4.4.0'] },
+    getIndexSpecs: { type: 'function', returnsPromise: true, returnType: 'unknown', serverVersions: ['3.2.0', '4.4.0'] },
+    getIndexKeys: { type: 'function', returnsPromise: true, returnType: 'unknown', serverVersions: ['3.2.0', '4.4.0'] },
+    getIndices: { type: 'function', returnsPromise: true, returnType: 'unknown', serverVersions: ['3.2.0', '4.4.0'] }
   }
 };
 const Cursor = {

--- a/packages/shell-api/yaml/Collection.yaml
+++ b/packages/shell-api/yaml/Collection.yaml
@@ -281,3 +281,11 @@ class:
             - *ServerVersions.latest
         help:
             help: 'shell-api.collection.help.get-index-keys'
+    getIndices:
+        <<: *__defaultMethod
+        returnsPromise: true
+        serverVersions:
+            - '3.2.0'
+            - *ServerVersions.latest
+        help:
+            help: 'shell-api.collection.help.get-indices'

--- a/packages/shell-api/yaml/Collection.yaml
+++ b/packages/shell-api/yaml/Collection.yaml
@@ -257,3 +257,27 @@ class:
             - *ServerVersions.latest
         help:
             help: 'shell-api.collection.help.ensure-index'
+    getIndexes:
+        <<: *__defaultMethod
+        returnsPromise: true
+        serverVersions:
+            - '3.2.0'
+            - *ServerVersions.latest
+        help:
+            help: 'shell-api.collection.help.get-indexes'
+    getIndexSpecs:
+        <<: *__defaultMethod
+        returnsPromise: true
+        serverVersions:
+            - '3.2.0'
+            - *ServerVersions.latest
+        help:
+            help: 'shell-api.collection.help.get-index-specs'
+    getIndexKeys:
+        <<: *__defaultMethod
+        returnsPromise: true
+        serverVersions:
+            - '3.2.0'
+            - *ServerVersions.latest
+        help:
+            help: 'shell-api.collection.help.get-index-keys'


### PR DESCRIPTION
- Implement collection.getIndexes,
- Implement collection.getIndexSpecs (alias to getIndexes)
- Implement collection.getIndexKeys
- Implement collection.getIndices (alias to getIndexes)

```
$ mongosh > db.coll1.getIndexes()
[
  { v: 2, key: { _id: 1 }, name: '_id_', ns: 'test.coll1' },
  { v: 2, key: { y: 1 }, name: 'y_1', ns: 'test.coll1' },
  { v: 2, key: { z: 1 }, name: 'bla', ns: 'test.coll1' },
  { v: 2, key: { k: 1 }, name: 'k_1', ns: 'test.coll1' }
]
$ mongosh > db.coll1.getIndices()
[
  { v: 2, key: { _id: 1 }, name: '_id_', ns: 'test.coll1' },
  { v: 2, key: { y: 1 }, name: 'y_1', ns: 'test.coll1' },
  { v: 2, key: { z: 1 }, name: 'bla', ns: 'test.coll1' },
  { v: 2, key: { k: 1 }, name: 'k_1', ns: 'test.coll1' }
]
$ mongosh > db.coll1.getIndexSpecs()
[
  { v: 2, key: { _id: 1 }, name: '_id_', ns: 'test.coll1' },
  { v: 2, key: { y: 1 }, name: 'y_1', ns: 'test.coll1' },
  { v: 2, key: { z: 1 }, name: 'bla', ns: 'test.coll1' },
  { v: 2, key: { k: 1 }, name: 'k_1', ns: 'test.coll1' }
]
$ mongosh > db.coll1.getIndexKeys()
[ { _id: 1 }, { y: 1 }, { z: 1 }, { k: 1 } ]
```