### PR TITLE
chore: add timeout to mocha

### DIFF
--- a/config/karma.conf.base.js
+++ b/config/karma.conf.base.js
@@ -40,7 +40,12 @@ const configure = (config) => {
       },
     },
     browsers: [ 'ChromeHeadless' ],
-    singleRun: true
+    singleRun: true,
+    client: {
+      mocha: {
+        timeout: 15000
+      }
+    }
   });
 };
 

--- a/packages/async-rewriter/package.json
+++ b/packages/async-rewriter/package.json
@@ -4,8 +4,8 @@
   "description": "MongoDB Shell Async Rewriter Package",
   "main": "./lib/index.js",
   "scripts": {
-    "test": "mocha --colors -r ts-node/register \"./{src,lib}/**/*.spec.ts\"",
-    "test-ci": "mocha -r ts-node/register \"./{src,lib}/**/*.spec.ts\"",
+    "test": "mocha --timeout 15000 --colors -r ts-node/register \"./{src,lib}/**/*.spec.ts\"",
+    "test-ci": "mocha --timeout 15000 -r ts-node/register \"./{src,lib}/**/*.spec.ts\"",
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
     "check": "npm run lint",
     "compile-ts": "tsc -p tsconfig.json",

--- a/packages/browser-repl/config/karma.conf.js
+++ b/packages/browser-repl/config/karma.conf.js
@@ -37,6 +37,11 @@ module.exports = (config) => {
       'mocha'
     ],
     browsers: [ 'ChromeHeadless' ],
-    singleRun: true
+    singleRun: true,
+    client: {
+      mocha: {
+        timeout: 15000
+      }
+    }
   });
 };

--- a/packages/browser-runtime-core/package.json
+++ b/packages/browser-runtime-core/package.json
@@ -8,8 +8,8 @@
     "node": "^12.4.0"
   },
   "scripts": {
-    "test": "mocha --colors -r ts-node/register \"./{src,lib}/**/*.spec.ts\"",
-    "test-ci": "mocha -r ts-node/register \"./{src,lib}/**/*.spec.ts\"",
+    "test": "mocha --timeout 15000 --colors -r ts-node/register \"./{src,lib}/**/*.spec.ts\"",
+    "test-ci": "mocha --timeout 15000 -r ts-node/register \"./{src,lib}/**/*.spec.ts\"",
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
     "check": "npm run lint",
     "prepublish": "rm -rf ./lib && npm run compile-ts",

--- a/packages/browser-runtime-electron/package.json
+++ b/packages/browser-runtime-electron/package.json
@@ -8,8 +8,8 @@
     "node": "^12.4.0"
   },
   "scripts": {
-    "test": "mocha --colors -r ts-node/register \"./{src,lib}/**/*.spec.ts\"",
-    "test-ci": "mocha -r ts-node/register \"./{src,lib}/**/*.spec.ts\"",
+    "test": "mocha --timeout 15000 --colors -r ts-node/register \"./{src,lib}/**/*.spec.ts\"",
+    "test-ci": "mocha --timeout 15000 -r ts-node/register \"./{src,lib}/**/*.spec.ts\"",
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
     "check": "npm run lint",
     "prepublish": "rm -rf ./lib && npm run compile-ts",

--- a/packages/cli-repl/package.json
+++ b/packages/cli-repl/package.json
@@ -11,8 +11,8 @@
     "compile-ts": "tsc -p tsconfig.json",
     "start": "node --experimental-repl-await bin/mongosh.js start",
     "start-async": "node --experimental-repl-await bin/mongosh.js start --async",
-    "test": "mocha --colors -r ts-node/register \"./src/**/*.spec.ts\"",
-    "test-ci": "mocha -r ts-node/register \"./src/**/*.spec.ts\"",
+    "test": "mocha --timeout 15000 --colors -r ts-node/register \"./src/**/*.spec.ts\"",
+    "test-ci": "mocha --timeout 15000 -r ts-node/register \"./src/**/*.spec.ts\"",
     "prepublish": "npm run compile-ts"
   },
   "license": "SSPL",

--- a/packages/compass-shell/karma.conf.js
+++ b/packages/compass-shell/karma.conf.js
@@ -13,7 +13,12 @@ module.exports = (config) => {
     webpackMiddleware: { noInfo: true, stats: 'errors-only' },
     // DEV: `useIframe: false` is for launching a new window instead of using an iframe
     // In Electron, iframes don't get `nodeIntegration` priveleges yet windows do.
-    client: { useIframe: false },
+    client: {
+      useIframe: false,
+      mocha: {
+        timeout: 15000
+      }
+    },
     logLevel: config.LOG_ERROR
   });
 };

--- a/packages/history/package.json
+++ b/packages/history/package.json
@@ -4,8 +4,8 @@
   "description": "MongoDB Shell History Package",
   "main": "./lib/index.js",
   "scripts": {
-    "test": "mocha --colors -r ts-node/register \"./{src,lib}/**/*.spec.ts\"",
-    "test-ci": "mocha -r ts-node/register \"./{src,lib}/**/*.spec.ts\"",
+    "test": "mocha --timeout 15000 --colors -r ts-node/register \"./{src,lib}/**/*.spec.ts\"",
+    "test-ci": "mocha --timeout 15000 -r ts-node/register \"./{src,lib}/**/*.spec.ts\"",
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
     "check": "npm run lint",
     "compile-ts": "tsc -p tsconfig.json",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -7,8 +7,8 @@
   "scripts": {
     "compile-ts": "tsc -p tsconfig.json",
     "prepublish": "npm run compile-ts",
-    "test": "mocha --colors -r ts-node/register \"./src/**/*.spec.ts\"",
-    "test-ci": "mocha -r ts-node/register \"./src/**/*.spec.ts\""
+    "test": "mocha --timeout 15000 --colors -r ts-node/register \"./src/**/*.spec.ts\"",
+    "test-ci": "mocha --timeout 15000 -r ts-node/register \"./src/**/*.spec.ts\""
   },
   "license": "SSPL",
   "publishConfig": {

--- a/packages/mapper/package.json
+++ b/packages/mapper/package.json
@@ -4,8 +4,8 @@
   "description": "MongoDB Shell Mapper Package",
   "main": "./lib/index.js",
   "scripts": {
-    "test": "mocha --colors -r ts-node/register \"./{src,lib}/**/*.spec.ts\"",
-    "test-ci": "mocha -r ts-node/register \"./{src,lib}/**/*.spec.ts\"",
+    "test": "mocha --timeout 15000 --colors -r ts-node/register \"./{src,lib}/**/*.spec.ts\"",
+    "test-ci": "mocha --timeout 15000 -r ts-node/register \"./{src,lib}/**/*.spec.ts\"",
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
     "check": "npm run lint",
     "compile-ts": "tsc -p tsconfig.json",

--- a/packages/service-provider-server/package.json
+++ b/packages/service-provider-server/package.json
@@ -6,8 +6,8 @@
   "types": "lib/index.d.ts",
   "scripts": {
     "compile-ts": "tsc -p tsconfig.json",
-    "test": "mocha --colors -r ts-node/register \"./src/**/*.spec.ts\"",
-    "test-ci": "mocha -r ts-node/register \"./src/**/*.spec.ts\"",
+    "test": "mocha --timeout 15000 --colors -r ts-node/register \"./src/**/*.spec.ts\"",
+    "test-ci": "mocha --timeout 15000 -r ts-node/register \"./src/**/*.spec.ts\"",
     "prepublish": "npm run compile-ts",
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
     "check": "npm run lint"

--- a/packages/shell-api/package.json
+++ b/packages/shell-api/package.json
@@ -11,8 +11,8 @@
     "pretest": "npm run compile-api",
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
     "check": "npm run lint",
-    "test": "mocha --colors -r ts-node/register \"./src/**/*.spec.ts\"",
-    "test-ci": "mocha -r ts-node/register \"./src/**/*.spec.ts\"",
+    "test": "mocha --timeout 15000 --colors -r ts-node/register \"./src/**/*.spec.ts\"",
+    "test-ci": "mocha --timeout 15000 -r ts-node/register \"./src/**/*.spec.ts\"",
     "prepublish": "npm run compile-ts"
   },
   "license": "SSPL",


### PR DESCRIPTION
Use longer timeout for mocha to prevent tests with slow setup from failing.  