### PR TITLE
feat: ensureIndex

### DIFF
--- a/packages/i18n/src/locales/en_US.js
+++ b/packages/i18n/src/locales/en_US.js
@@ -844,8 +844,14 @@ const translations = {
         },
         "create-index": {
           "link": "https://docs.mongodb.com/manual/reference/method/db.collection.createIndex",
-          "description": "Creates one or more index on a collection",
+          "description": "Creates one index on a collection",
           "example": "db.coll.db.coll.createIndex({ category: 1 }, { name: 'index-1' })",
+          "parameters": {}
+        },
+        "ensure-index": {
+          "link": "https://docs.mongodb.com/manual/reference/method/db.collection.ensureIndex",
+          "description": "Creates one index on a collection",
+          "example": "db.coll.db.coll.ensureIndex({ category: 1 }, { name: 'index-1' })",
           "parameters": {}
         },
         "update-one": {

--- a/packages/mapper/src/mapper.spec.ts
+++ b/packages/mapper/src/mapper.spec.ts
@@ -245,45 +245,47 @@ db3  30 kB`;
     });
   });
 
-  describe('createIndex', () => {
-    let collection;
-    beforeEach(async() => {
-      collection = new Collection(mapper, 'db1', 'coll1');
-      serviceProvider.createIndexes.resolves({ ok: 1 });
-    });
-
-    context('when options is not passed', () => {
-      it('calls serviceProvider.createIndexes using keys', async() => {
-        await mapper.createIndex(collection, { x: 1 });
-
-        expect(serviceProvider.createIndexes).to.have.been.calledWith(
-          'db1',
-          'coll1',
-          [{ key: { x: 1 } }]
-        );
+  ['ensureIndex', 'createIndex'].forEach((method) => {
+    describe(method, () => {
+      let collection;
+      beforeEach(async() => {
+        collection = new Collection(mapper, 'db1', 'coll1');
+        serviceProvider.createIndexes.resolves({ ok: 1 });
       });
-    });
 
-    context('when options is an object', () => {
-      it('calls serviceProvider.createIndexes merging options', async() => {
-        await mapper.createIndex(collection, { x: 1 }, { name: 'index-1' });
+      context('when options is not passed', () => {
+        it('calls serviceProvider.createIndexes using keys', async() => {
+          await mapper[method](collection, { x: 1 });
 
-        expect(serviceProvider.createIndexes).to.have.been.calledWith(
-          'db1',
-          'coll1',
-          [{ key: { x: 1 }, name: 'index-1' }]
-        );
+          expect(serviceProvider.createIndexes).to.have.been.calledWith(
+            'db1',
+            'coll1',
+            [{ key: { x: 1 } }]
+          );
+        });
       });
-    });
 
-    context('when options is not an object', () => {
-      it('throws an error', async() => {
-        const error = await mapper.createIndex(
-          collection, { x: 1 }, 'unsupported' as any
-        ).catch(e => e);
+      context('when options is an object', () => {
+        it('calls serviceProvider.createIndexes merging options', async() => {
+          await mapper[method](collection, { x: 1 }, { name: 'index-1' });
 
-        expect(error).to.be.instanceOf(Error);
-        expect(error.message).to.equal('options must be an object');
+          expect(serviceProvider.createIndexes).to.have.been.calledWith(
+            'db1',
+            'coll1',
+            [{ key: { x: 1 }, name: 'index-1' }]
+          );
+        });
+      });
+
+      context('when options is not an object', () => {
+        it('throws an error', async() => {
+          const error = await mapper[method](
+            collection, { x: 1 }, 'unsupported' as any
+          ).catch(e => e);
+
+          expect(error).to.be.instanceOf(Error);
+          expect(error.message).to.equal('options must be an object');
+        });
       });
     });
   });

--- a/packages/mapper/src/mapper.ts
+++ b/packages/mapper/src/mapper.ts
@@ -907,4 +907,28 @@ export default class Mapper {
       options
     );
   }
+
+  /**
+   * Create index for a collection (alias for createIndex)
+   *
+   * @param {Collection} collection
+   * @param {Document} keys - An document that contains
+   *  the field and value pairs where the field is the index key and the
+   *  value describes the type of index for that field.
+   * @param {Document} options - createIndexes options (
+   *  name, background, sparse ...)
+   *
+   * @return {Promise}
+   */
+  async ensureIndex(
+    collection: Collection,
+    keys: Document,
+    options: Document
+  ): Promise<any> {
+    return await this.createIndex(
+      collection,
+      keys,
+      options
+    );
+  }
 }

--- a/packages/shell-api/src/collection.spec.ts
+++ b/packages/shell-api/src/collection.spec.ts
@@ -67,4 +67,10 @@ describe('Collection', () => {
       testWrappedMethod('createIndex');
     });
   });
+
+  describe('#ensureIndex', () => {
+    it('wraps mapper.ensureIndex', () => {
+      testWrappedMethod('ensureIndex');
+    });
+  });
 });

--- a/packages/shell-api/src/shell-api.js
+++ b/packages/shell-api/src/shell-api.js
@@ -276,6 +276,10 @@ class Collection {
   createIndex(...args) {
     return this._mapper.createIndex(this, ...args);
   }
+
+  ensureIndex(...args) {
+    return this._mapper.ensureIndex(this, ...args);
+  }
 }
 
 
@@ -436,10 +440,16 @@ Collection.prototype.createIndexes.returnsPromise = true;
 Collection.prototype.createIndexes.returnType = 'unknown';
 
 Collection.prototype.createIndex.help = () => new Help({ 'help': 'shell-api.collection.help.create-index' });
-Collection.prototype.createIndex.serverVersions = ['3.2.0', '4.4.0'];
+Collection.prototype.createIndex.serverVersions = ['0.0.0', '4.4.0'];
 Collection.prototype.createIndex.topologies = [0, 1, 2];
 Collection.prototype.createIndex.returnsPromise = true;
 Collection.prototype.createIndex.returnType = 'unknown';
+
+Collection.prototype.ensureIndex.help = () => new Help({ 'help': 'shell-api.collection.help.ensure-index' });
+Collection.prototype.ensureIndex.serverVersions = ['0.0.0', '4.4.0'];
+Collection.prototype.ensureIndex.topologies = [0, 1, 2];
+Collection.prototype.ensureIndex.returnsPromise = true;
+Collection.prototype.ensureIndex.returnType = 'unknown';
 
 
 class Cursor {

--- a/packages/shell-api/src/shell-types.js
+++ b/packages/shell-api/src/shell-types.js
@@ -53,7 +53,8 @@ const Collection = {
     updateOne: { type: 'function', returnsPromise: true, returnType: 'unknown', serverVersions: ['3.2.0', '4.4.0'] },
     convertToCapped: { type: 'function', returnsPromise: true, returnType: 'unknown', serverVersions: ['0.0.0', '4.4.0'] },
     createIndexes: { type: 'function', returnsPromise: true, returnType: 'unknown', serverVersions: ['3.2.0', '4.4.0'] },
-    createIndex: { type: 'function', returnsPromise: true, returnType: 'unknown', serverVersions: ['3.2.0', '4.4.0'] }
+    createIndex: { type: 'function', returnsPromise: true, returnType: 'unknown', serverVersions: ['0.0.0', '4.4.0'] },
+    ensureIndex: { type: 'function', returnsPromise: true, returnType: 'unknown', serverVersions: ['0.0.0', '4.4.0'] }
   }
 };
 const Cursor = {

--- a/packages/shell-api/yaml/Collection.yaml
+++ b/packages/shell-api/yaml/Collection.yaml
@@ -245,7 +245,15 @@ class:
         <<: *__defaultMethod
         returnsPromise: true
         serverVersions:
-            - '3.2.0'
+            - *ServerVersions.earliest
             - *ServerVersions.latest
         help:
             help: 'shell-api.collection.help.create-index'
+    ensureIndex:
+        <<: *__defaultMethod
+        returnsPromise: true
+        serverVersions:
+            - *ServerVersions.earliest
+            - *ServerVersions.latest
+        help:
+            help: 'shell-api.collection.help.ensure-index'


### PR DESCRIPTION
NOTE:

The previous implementation wraps `createIndex` and changes the output:

When `writeMode` is `legacy` it returns: nothing in case of success, and `getLastErrorObj()` if  there was an error.

Since the documentation does not mention anything about that, I just did an alias to `createIndex`. Added a note in jira about that.

This is the old code:

```
> db.coll.ensureIndex
function(keys, options) {
    var result = this.createIndex(keys, options);

    if (this.getMongo().writeMode() != "legacy") {
        return result;
    }

    err = this.getDB().getLastErrorObj();
    if (err.err) {
        return err;
    }
    // nothing returned on success
}
```