### PR TITLE
update minimist to latest - 1.2.5

### DIFF
--- a/packages/cli-repl/package.json
+++ b/packages/cli-repl/package.json
@@ -23,20 +23,19 @@
     "node": "^12.4.0"
   },
   "dependencies": {
+    "@mongosh/history": "^0.0.1-alpha.6",
     "@mongosh/i18n": "^0.0.1-alpha.6",
     "@mongosh/mapper": "^0.0.1-alpha.6",
     "@mongosh/service-provider-server": "^0.0.1-alpha.6",
     "@mongosh/shell-api": "^0.0.1-alpha.6",
-    "@mongosh/history": "^0.0.1-alpha.6",
     "ansi-escape-sequences": "^5.1.2",
     "lodash.set": "^4.3.2",
-    "minimist": "^1.2.0",
+    "minimist": "^1.2.5",
     "mongodb-ace-autocompleter": "^0.4.1",
     "nanobus": "^4.4.0",
     "pino": "^5.16.0",
     "read": "^1.0.7",
     "semver": "^7.1.2"
   },
-  "devDependencies": {
-  }
+  "devDependencies": {}
 }


### PR DESCRIPTION
we were using an older version of minimist that has a bit of a bug with
prototype pollution, it [was fixed in](https://github.com/substack/minimist/commit/4cf1354839cb972e38496d35e12f806eea92c11f) and we should update.