### PR TITLE
MONGOSH-108: log file for individual sessions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,9 +13,9 @@
       }
     },
     "@babel/generator": {
-      "version": "7.9.3",
-      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.3.tgz",
-      "integrity": "sha512-RpxM252EYsz9qLUIq6F7YJyK1sv0wWDBFuztfDGWaQKzHjqDHysxSiRUpA/X9jmfqo+WzkAVKFaUily5h+gDCQ==",
+      "version": "7.9.4",
+      "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.4.tgz",
+      "integrity": "sha512-rjP8ahaDy/ouhrvCoU1E5mqaitWrxwuNGU+dy1EpaoK48jZay4MdkskKGIMHLZNewg8sAsqpGSREJwP0zH3YQA==",
       "dev": true,
       "requires": {
         "@babel/types": "^7.9.0",
@@ -71,9 +71,9 @@
       }
     },
     "@babel/parser": {
-      "version": "7.9.3",
-      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.3.tgz",
-      "integrity": "sha512-E6SpIDJZ0cZAKoCNk+qSDd0ChfTnpiJN9FfNf3RZ20dzwA2vL2oq5IX1XTVT+4vDmRlta2nGk5HGMMskJAR+4A==",
+      "version": "7.9.4",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.4.tgz",
+      "integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA==",
       "dev": true
     },
     "@babel/runtime": {
@@ -1712,45 +1712,45 @@
       "dev": true
     },
     "@typescript-eslint/eslint-plugin": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.24.0.tgz",
-      "integrity": "sha512-wJRBeaMeT7RLQ27UQkDFOu25MqFOBus8PtOa9KaT5ZuxC1kAsd7JEHqWt4YXuY9eancX0GK9C68i5OROnlIzBA==",
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-2.25.0.tgz",
+      "integrity": "sha512-W2YyMtjmlrOjtXc+FtTelVs9OhuR6OlYc4XKIslJ8PUJOqgYYAPRJhAqkYRQo3G4sjvG8jSodsNycEn4W2gHUw==",
       "dev": true,
       "requires": {
-        "@typescript-eslint/experimental-utils": "2.24.0",
-        "eslint-utils": "^1.4.3",
+        "@typescript-eslint/experimental-utils": "2.25.0",
         "functional-red-black-tree": "^1.0.1",
         "regexpp": "^3.0.0",
         "tsutils": "^3.17.1"
       }
     },
     "@typescript-eslint/experimental-utils": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.24.0.tgz",
-      "integrity": "sha512-DXrwuXTdVh3ycNCMYmWhUzn/gfqu9N0VzNnahjiDJvcyhfBy4gb59ncVZVxdp5XzBC77dCncu0daQgOkbvPwBw==",
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/experimental-utils/-/experimental-utils-2.25.0.tgz",
+      "integrity": "sha512-0IZ4ZR5QkFYbaJk+8eJ2kYeA+1tzOE1sBjbwwtSV85oNWYUBep+EyhlZ7DLUCyhMUGuJpcCCFL0fDtYAP1zMZw==",
       "dev": true,
       "requires": {
         "@types/json-schema": "^7.0.3",
-        "@typescript-eslint/typescript-estree": "2.24.0",
-        "eslint-scope": "^5.0.0"
+        "@typescript-eslint/typescript-estree": "2.25.0",
+        "eslint-scope": "^5.0.0",
+        "eslint-utils": "^2.0.0"
       }
     },
     "@typescript-eslint/parser": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.24.0.tgz",
-      "integrity": "sha512-H2Y7uacwSSg8IbVxdYExSI3T7uM1DzmOn2COGtCahCC3g8YtM1xYAPi2MAHyfPs61VKxP/J/UiSctcRgw4G8aw==",
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-2.25.0.tgz",
+      "integrity": "sha512-mccBLaBSpNVgp191CP5W+8U1crTyXsRziWliCqzj02kpxdjKMvFHGJbK33NroquH3zB/gZ8H511HEsJBa2fNEg==",
       "dev": true,
       "requires": {
         "@types/eslint-visitor-keys": "^1.0.0",
-        "@typescript-eslint/experimental-utils": "2.24.0",
-        "@typescript-eslint/typescript-estree": "2.24.0",
+        "@typescript-eslint/experimental-utils": "2.25.0",
+        "@typescript-eslint/typescript-estree": "2.25.0",
         "eslint-visitor-keys": "^1.1.0"
       }
     },
     "@typescript-eslint/typescript-estree": {
-      "version": "2.24.0",
-      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.24.0.tgz",
-      "integrity": "sha512-RJ0yMe5owMSix55qX7Mi9V6z2FDuuDpN6eR5fzRJrp+8in9UF41IGNQHbg5aMK4/PjVaEQksLvz0IA8n+Mr/FA==",
+      "version": "2.25.0",
+      "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-2.25.0.tgz",
+      "integrity": "sha512-VUksmx5lDxSi6GfmwSK7SSoIKSw9anukWWNitQPqt58LuYrKalzsgeuignbqnB+rK/xxGlSsCy8lYnwFfB6YJg==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
@@ -2671,9 +2671,9 @@
       }
     },
     "bson": {
-      "version": "1.1.3",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.3.tgz",
-      "integrity": "sha512-TdiJxMVnodVS7r0BdL42y/pqC9cL2iKynVwA0Ho3qbsQYr428veL3l7BQyuqiw+Q5SqqoT0m4srSY/BlZ9AxXg==",
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.4.tgz",
+      "integrity": "sha512-S/yKGU1syOMzO86+dGpg2qGoDL0zvzcb262G+gqEy6TgP6rt6z6qxSFX/8X6vLC91P7G7C3nLs0+bvDzmvBA3Q==",
       "dev": true
     },
     "btoa-lite": {
@@ -2763,9 +2763,9 @@
       "dev": true
     },
     "cacache": {
-      "version": "12.0.3",
-      "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.3.tgz",
-      "integrity": "sha512-kqdmfXEGFepesTuROHMs3MpFLWrPkSSpRqOw80RCflZXy/khxaArvFrQ7uJxSUduzAufc6G0g1VUCOZXxWavPw==",
+      "version": "12.0.4",
+      "resolved": "https://registry.npmjs.org/cacache/-/cacache-12.0.4.tgz",
+      "integrity": "sha512-a0tMB40oefvuInr4Cwb3GerbL9xTj1D5yg0T5xrjGCGyfvbxseIXX7BAO/u/hIXdafzOI5JC3wDwHyf24buOAQ==",
       "dev": true,
       "requires": {
         "bluebird": "^3.5.5",
@@ -5691,6 +5691,15 @@
             }
           }
         },
+        "eslint-utils": {
+          "version": "1.4.3",
+          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
+          "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
+          "dev": true,
+          "requires": {
+            "eslint-visitor-keys": "^1.1.0"
+          }
+        },
         "path-key": {
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/path-key/-/path-key-2.0.1.tgz",
@@ -5833,6 +5842,15 @@
           "requires": {
             "esrecurse": "^4.1.0",
             "estraverse": "^4.1.1"
+          }
+        },
+        "eslint-utils": {
+          "version": "1.4.3",
+          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
+          "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
+          "dev": true,
+          "requires": {
+            "eslint-visitor-keys": "^1.1.0"
           }
         },
         "espree": {
@@ -6019,17 +6037,6 @@
       "requires": {
         "eslint-utils": "^2.0.0",
         "ramda": "^0.27.0"
-      },
-      "dependencies": {
-        "eslint-utils": {
-          "version": "2.0.0",
-          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.0.0.tgz",
-          "integrity": "sha512-0HCPuJv+7Wv1bACm8y5/ECVfYdfsAm9xmVb7saeFlxjPYALefjhbYoCkBjPdPzGH8wWyTpAez82Fh3VKYEZ8OA==",
-          "dev": true,
-          "requires": {
-            "eslint-visitor-keys": "^1.1.0"
-          }
-        }
       }
     },
     "eslint-plugin-react": {
@@ -6074,9 +6081,9 @@
       }
     },
     "eslint-utils": {
-      "version": "1.4.3",
-      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
-      "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-2.0.0.tgz",
+      "integrity": "sha512-0HCPuJv+7Wv1bACm8y5/ECVfYdfsAm9xmVb7saeFlxjPYALefjhbYoCkBjPdPzGH8wWyTpAez82Fh3VKYEZ8OA==",
       "dev": true,
       "requires": {
         "eslint-visitor-keys": "^1.1.0"
@@ -9881,9 +9888,9 @@
       }
     },
     "mkdirp": {
-      "version": "0.5.3",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.3.tgz",
-      "integrity": "sha512-P+2gwrFqx8lhew375MQHHeTlY8AuOJSrGf0R5ddkEndUkmwpgUob/vQuBD1V22/Cw1/lJr4x+EjllSezBThzBg==",
+      "version": "0.5.4",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.4.tgz",
+      "integrity": "sha512-iG9AK/dJLtJ0XNgTuDbSyNS3zECqDlAhnQW4CsNxBG3LQJBbHmRX1egw39DmtOdCAqY+dKXV+sgPgilNWUKMVw==",
       "dev": true,
       "requires": {
         "minimist": "^1.2.5"
@@ -10431,6 +10438,15 @@
           "requires": {
             "esrecurse": "^4.1.0",
             "estraverse": "^4.1.1"
+          }
+        },
+        "eslint-utils": {
+          "version": "1.4.3",
+          "resolved": "https://registry.npmjs.org/eslint-utils/-/eslint-utils-1.4.3.tgz",
+          "integrity": "sha512-fbBN5W2xdY45KulGXmLHZ3c3FHfVYmKg0IrAKGOkT/464PQsx2UeIzfz1RmEci+KLm1bBaAzZAh8+/E+XAeZ8Q==",
+          "dev": true,
+          "requires": {
+            "eslint-visitor-keys": "^1.1.0"
           }
         },
         "espree": {

--- a/packages/cli-repl/package-lock.json
+++ b/packages/cli-repl/package-lock.json
@@ -47,6 +47,11 @@
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
 			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
 		},
+		"mkdirp": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.3.tgz",
+			"integrity": "sha512-6uCP4Qc0sWsgMLy1EOqqS/3rjDHOEnsStVr/4vtAIK2Y5i2kA7lFFejYrpIyiN9w0pYf4ckeCYT9f1r1P9KX5g=="
+		},
 		"mongodb-ace-autocompleter": {
 			"version": "0.4.8",
 			"resolved": "https://registry.npmjs.org/mongodb-ace-autocompleter/-/mongodb-ace-autocompleter-0.4.8.tgz",
@@ -140,6 +145,19 @@
 			"requires": {
 				"atomic-sleep": "^1.0.0",
 				"flatstr": "^1.0.12"
+			}
+		},
+		"uuid": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.2.tgz",
+			"integrity": "sha512-vy9V/+pKG+5ZTYKf+VcphF5Oc6EFiu3W8Nv3P3zIh0EqVI80ZxOzuPfe9EHjkFNvf8+xuTHVeei4Drydlx4zjw=="
+		},
+		"uuidv4": {
+			"version": "6.0.6",
+			"resolved": "https://registry.npmjs.org/uuidv4/-/uuidv4-6.0.6.tgz",
+			"integrity": "sha512-10YcruyGJtsG5SJnPG+8atr8toJa7xAOrcO7B7plYYiwpH1mQ8UZHjNSa2MrwGi6KWuyVrXGHr+Rce22F9UAiw==",
+			"requires": {
+				"uuid": "7.0.2"
 			}
 		}
 	}

--- a/packages/cli-repl/package.json
+++ b/packages/cli-repl/package.json
@@ -31,11 +31,13 @@
     "ansi-escape-sequences": "^5.1.2",
     "lodash.set": "^4.3.2",
     "minimist": "^1.2.5",
+    "mkdirp": "^1.0.3",
     "mongodb-ace-autocompleter": "^0.4.1",
     "nanobus": "^4.4.0",
     "pino": "^5.16.0",
     "read": "^1.0.7",
-    "semver": "^7.1.2"
+    "semver": "^7.1.2",
+    "uuidv4": "^6.0.6"
   },
   "devDependencies": {}
 }

--- a/packages/cli-repl/src/logger.ts
+++ b/packages/cli-repl/src/logger.ts
@@ -1,43 +1,45 @@
-import pino from 'pino'
-import path from 'path'
-import os from 'os'
+import { uuid } from 'uuidv4';
+import pino from 'pino';
+import path from 'path';
+import os from 'os';
 
-function logger (bus) {
-  const dest = path.join(os.homedir(), './.mongosh_log')
-  const log = pino({ name: 'monogsh' }, pino.destination(dest))
+function logger (bus: any, logDir: string) {
+  const time = Date.now();
+  const dest = path.join(os.homedir(), logDir, `${time}_log`);
+  const log = pino({ name: 'monogsh' }, pino.destination(dest));
+  const sessionID = uuid();
 
-  bus.on('*', function() {
-    // log info from all events
-  })
+  bus.on('*', function() {});
 
   bus.on('connect', function(info) {
-    log.info('connect', info)
-  })
+    const params = { sessionID, info }
+    log.info('connect', params)
+  });
 
   bus.on('error', function(error) {
-    log.error(error)
-  })
+    log.error(error);
+  });
 
   bus.on('cmd:help', function() {
-    log.info('cmd:help')
-  })
+    log.info('cmd:help');
+  });
 
   bus.on('cmd:use', function(database) {
-    log.info('cmd:use', database)
-  })
+    log.info('cmd:use', database);
+  });
 
   bus.on('cmd:show', function(databases) {
-    log.info('cmd:show', databases)
-  })
+    log.info('cmd:show', databases);
+  });
 
   bus.on('cmd:it', function(info) {
-    log.info('cmd:it', info)
-  })
+    log.info('cmd:it', info);
+  });
 
   bus.on('method:aggregate', function(collection, pipeline) {
-    const params = { collection, pipeline }
-    log.info('method:aggregate', params)
-  })
+    const params = { collection, pipeline };
+    log.info('method:aggregate', params);
+  });
 
   bus.on('method:bulkWrite', function(collection, operations) {
     const params = { collection, operations }

--- a/packages/cli-repl/src/logger.ts
+++ b/packages/cli-repl/src/logger.ts
@@ -12,8 +12,8 @@ function logger (bus: any, logDir: string) {
   bus.on('*', function() {});
 
   bus.on('connect', function(info) {
-    const params = { sessionID, info }
-    log.info('connect', params)
+    const params = { sessionID, info };
+    log.info('connect', params);
   });
 
   bus.on('error', function(error) {
@@ -42,119 +42,119 @@ function logger (bus: any, logDir: string) {
   });
 
   bus.on('method:bulkWrite', function(collection, operations) {
-    const params = { collection, operations }
-    log.info('method:bulkWrite', params)
-  })
+    const params = { collection, operations };
+    log.info('method:bulkWrite', params);
+  });
 
   bus.on('method:count', function(collection, query = {}) {
-    const params = { collection, query }
-    log.info('method:count', params)
-  })
+    const params = { collection, query };
+    log.info('method:count', params);
+  });
 
   bus.on('method:countDocuments', function(collection, query = {}, options) {
-    const params = { collection, query, options }
-    log.info('method:countDocument', params)
-  })
+    const params = { collection, query, options };
+    log.info('method:countDocument', params);
+  });
 
   bus.on('method:deleteMany', function(collection, filter) {
-    const params = { collection, filter }
-    log.info('method:deleteMany', params)
-  })
+    const params = { collection, filter };
+    log.info('method:deleteMany', params);
+  });
 
   bus.on('method:deleteOne', function(collection, filter) {
-    const params = { collection, filter }
-    log.info('method:deleteOne', params)
-  })
+    const params = { collection, filter };
+    log.info('method:deleteOne', params);
+  });
 
   bus.on('method:distinct', function(collection, field, query = {}) {
-    const params = { collection, field, query }
-    log.info('method:distinct', params)
-  })
+    const params = { collection, field, query };
+    log.info('method:distinct', params);
+  });
 
   bus.on('method:estimatedDocumentCount', function(collection) {
-    const params = { collection }
-    log.info('method:estimatedDocumentCount', params)
-  })
+    const params = { collection };
+    log.info('method:estimatedDocumentCount', params);
+  });
 
   bus.on('method:find', function(collection, query = {}, projection = {}) {
-    const params = { collection, query, projection }
-    log.info('method:find', params)
-  })
+    const params = { collection, query, projection };
+    log.info('method:find', params);
+  });
 
   bus.on('method:findOne', function(collection, query = {}, projection = {}) {
-    const params = { collection, query, projection }
-    log.info('method:findOne', params)
-  })
+    const params = { collection, query, projection };
+    log.info('method:findOne', params);
+  });
 
   bus.on('method:findOneAndDelete', function(collection, filter = {}) {
-    const params = { collection, filter }
-    log.info('method:findOneAndDelete', params)
-  })
+    const params = { collection, filter };
+    log.info('method:findOneAndDelete', params);
+  });
 
   bus.on('method:findOneAndReplace', function(collection, filter) {
-    const params = { collection, filter }
-    log.info('method:findOneAndReplace', params)
-  })
+    const params = { collection, filter };
+    log.info('method:findOneAndReplace', params);
+  });
 
   bus.on('method:findOneAndUpdate', function(collection, filter) {
-    const params = { collection, filter }
-    log.info('method:findOneAndUpdate', params)
-  })
+    const params = { collection, filter };
+    log.info('method:findOneAndUpdate', params);
+  });
 
   bus.on('method:insert', function(collection, docs) {
-    const params = { collection, docs }
-    log.info('method:insert', params)
-  })
+    const params = { collection, docs };
+    log.info('method:insert', params);
+  });
 
   bus.on('method:insertMany', function(collection, docs) {
-    const params = { collection, docs }
-    log.info('method:insertMany', params)
-  })
+    const params = { collection, docs };
+    log.info('method:insertMany', params);
+  });
 
   bus.on('method:insertOne', function(collection, doc) {
-    const params = { collection, doc }
-    log.info('method:insertOne', params)
-  })
+    const params = { collection, doc };
+    log.info('method:insertOne', params);
+  });
 
   bus.on('method:isCapped', function(collection) {
-    const params = { collection }
-    log.info('method:isCapped', params)
-  })
+    const params = { collection };
+    log.info('method:isCapped', params);
+  });
 
   bus.on('method:remove', function(collection, query = {}) {
-    const params = { collection, query }
-    log.info('method:remove', params)
-  })
+    const params = { collection, query };
+    log.info('method:remove', params);
+  });
 
   bus.on('method:save', function(collection, doc) {
-    const params = { collection, doc }
-    log.info('method:save', params)
-  })
+    const params = { collection, doc };
+    log.info('method:save', params);
+  });
 
   bus.on('method:replaceOne', function(collection, filter) {
-    const params = { collection, filter }
-    log.info('method:replaceOne', params)
-  })
+    const params = { collection, filter };
+    log.info('method:replaceOne', params);
+  });
 
   bus.on('method:runCommand', function(database, cmd) {
-    const params = { database, cmd }
-    log.info('method:runCommand', params)
-  })
+    const params = { database, cmd };
+    log.info('method:runCommand', params);
+  });
 
   bus.on('method:update', function(collection, filter) {
-    const params = { collection, filter }
-    log.info('method:update', params)
-  })
+    const params = { collection, filter };
+    log.info('method:update', params);
+  });
 
   bus.on('method:updateMany', function(collection, filter) {
-    const params = { collection, filter }
-    log.info('method:updateMany', params)
-  })
+    const params = { collection, filter };
+    log.info('method:updateMany', params);
+  });
 
   bus.on('method:updateOne', function(collection, filter) {
-    const params = { collection, filter }
-    log.info('method:updateOne', params)
-  })
+    const params = { collection, filter };
+    log.info('method:updateOne', params);
+  });
 }
 
 export default logger;


### PR DESCRIPTION
## Description
This PR adds a directory (if doesn't exist) `~/.mongodb/mongosh` to use to store history, logs, and soon to be config files.

Logs are now stored per session. So if multiple sessions are running, they will be written to separate files. Log file names are based on a timestamp `Date.now()`. I've tried `performance.now` which is quite a bit more precise, but the timestamps are not as easy to read and a tad more complicated to format. If we prefer that, happy to do some formatting though!

sessionID is created from `uuidv4` and is written on `'connect'` event of each individual log file. Once telemetry is hooked up, it will be written to every telemetry event we will be sending and will be consistent to a local log file. 

