### PR TITLE
Show collection and related api methods

### DIFF
--- a/packages/cli-repl/src/logger.ts
+++ b/packages/cli-repl/src/logger.ts
@@ -205,6 +205,16 @@ function logger(bus: any, logDir: string) {
     const params = { collection, index };
     log.info('method:dropIndex', params);
   });
+
+  bus.on('method:getCollectionInfos', function(database, filter, options) {
+    const params = { database, filter, options };
+    log.info('method:getCollectionInfos', params);
+  });
+
+  bus.on('method:getCollectionNames', function(database) {
+    const params = { database };
+    log.info('method:getCollectionNames', params);
+  });
 }
 
 export default logger;

--- a/packages/i18n/src/locales/en_US.js
+++ b/packages/i18n/src/locales/en_US.js
@@ -988,7 +988,19 @@ const translations = {
     "database": {
       "description": "Database Class",
       "help": {
-        "run-command": "Runs an arbitrary command on the database."
+        "run-command": "Runs an arbitrary command on the database.",
+        "get-collection-infos": {
+          "link": "https://docs.mongodb.com/manual/reference/method/db.getCollectionInfos",
+          "description": "Returns an array of documents with collection information, i.e. collection name and options, for the current database.",
+          "example": "",
+          "parameters": {}
+        },
+        "get-collection-names": {
+          "link": "https://docs.mongodb.com/manual/reference/method/db.getCollectionNames",
+          "description": "Returns an array containing the names of all collections in the current database.",
+          "example": "",
+          "parameters": {}
+        }
       }
     },
     "replica-set": {

--- a/packages/mapper/src/mapper.spec.ts
+++ b/packages/mapper/src/mapper.spec.ts
@@ -41,6 +41,10 @@ describe('Mapper', () => {
   });
 
   describe('commands', () => {
+    beforeEach(() => {
+      mapper.setCtx({});
+    });
+
     describe('show databases', () => {
       it('lists databases', async() => {
         serviceProvider.listDatabases.resolves({
@@ -64,6 +68,22 @@ db3  30 kB`;
         expect(
           (await mapper.show(null, 'databases')).toReplString()
         ).to.equal(expectedOutput);
+      });
+
+      describe('show collections', () => {
+        it('lists collection names', async() => {
+          serviceProvider.listCollections.resolves([
+            { name: 'coll1' },
+            { name: 'coll2' }
+          ]);
+
+          const expectedOutput = `coll1
+coll2`;
+
+          expect(
+            (await mapper.show(null, 'collections')).toReplString()
+          ).to.equal(expectedOutput);
+        });
       });
     });
 

--- a/packages/mapper/src/mapper.spec.ts
+++ b/packages/mapper/src/mapper.spec.ts
@@ -440,5 +440,39 @@ db3  30 kB`;
       });
     });
   });
+
+  describe('getCollectionInfos', () => {
+    it('returns the result of serviceProvider.listCollections', async() => {
+      const database = new Database(mapper, 'db1');
+
+      const filter = { name: 'abc' };
+      const options = { nameOnly: true };
+      const result = [{ name: 'coll1' }];
+
+      serviceProvider.listCollections.resolves(result);
+
+      expect(await mapper.getCollectionInfos(
+        database,
+        filter,
+        options)).to.deep.equal(result);
+
+      expect(serviceProvider.listCollections).to.have.been.calledOnceWith('db1', filter, options);
+    });
+  });
+
+  describe('getCollectionNames', () => {
+    it('returns the result of serviceProvider.listCollections', async() => {
+      const database = new Database(mapper, 'db1');
+      const result = [{ name: 'coll1' }];
+
+      serviceProvider.listCollections.resolves(result);
+
+      expect(await mapper.getCollectionNames(
+        database)).to.deep.equal(['coll1']);
+
+      expect(serviceProvider.listCollections).to.have.been.calledOnceWith(
+        'db1', {}, { nameOnly: true });
+    });
+  });
 });
 

--- a/packages/mapper/src/mapper.ts
+++ b/packages/mapper/src/mapper.ts
@@ -115,6 +115,10 @@ export default class Mapper {
         const table = formatTable(tableEntries);
 
         return new CommandResult({ value: table });
+      case 'collections':
+        const collectionNames = await this.getCollectionNames(this.context.db);
+
+        return new CommandResult({ value: collectionNames.join('\n') });
       default:
         const err = new Error(`Error: don't know how to show ${arg}`); // TODO: which error obj
         this.messageBus.emit('error', err);

--- a/packages/mapper/src/mapper.ts
+++ b/packages/mapper/src/mapper.ts
@@ -1155,4 +1155,45 @@ export default class Mapper {
 
     return await this.dropIndexes(collection, index);
   }
+
+  /**
+   * Returns an array of collection infos
+   *
+   * @param {String} database - The database.
+   * @param {Document} filter - The filter.
+   * @param {Document} options - The options.
+   *
+   * @return {Promise}
+   */
+  async getCollectionInfos(
+    database: Database,
+    filter: Document = {},
+    options: Document = {}): Promise<any> {
+    return await this.serviceProvider.listCollections(
+      database._database,
+      filter,
+      options
+    );
+  }
+
+  /**
+   * Returns an array of collection names
+   *
+   * @param {String} database - The database.
+   * @param {Document} filter - The filter.
+   * @param {Document} options - The options.
+   *
+   * @return {Promise}
+   */
+  async getCollectionNames(
+    database: Database
+  ): Promise<any> {
+    const infos = await this.getCollectionInfos(
+      database,
+      {},
+      { nameOnly: true }
+    );
+
+    return infos.map(collection => collection.name);
+  }
 }

--- a/packages/mapper/src/mapper.ts
+++ b/packages/mapper/src/mapper.ts
@@ -1169,6 +1169,13 @@ export default class Mapper {
     database: Database,
     filter: Document = {},
     options: Document = {}): Promise<any> {
+    this.messageBus.emit(
+      'method:getCollectionInfos',
+      database._database,
+      filter,
+      options
+    );
+
     return await this.serviceProvider.listCollections(
       database._database,
       filter,
@@ -1188,6 +1195,11 @@ export default class Mapper {
   async getCollectionNames(
     database: Database
   ): Promise<any> {
+    this.messageBus.emit(
+      'method:getCollectionNames',
+      database._database
+    );
+
     const infos = await this.getCollectionInfos(
       database,
       {},

--- a/packages/service-provider-browser/src/stitch-service-provider-browser.ts
+++ b/packages/service-provider-browser/src/stitch-service-provider-browser.ts
@@ -111,7 +111,7 @@ class StitchServiceProviderBrowser implements ServiceProvider {
       new StitchTransport<StitchAppClient, RemoteMongoClient>(stitchClient, mongoClient);
   }
 
-  listCollections(database: string, dbOptions?: Document): Promise<any> {
+  listCollections(database: string, filter?: Document, options?: Document, dbOptions?: Document): Promise<any> {
     throw new Error("Method not implemented.");
   }
 

--- a/packages/service-provider-browser/src/stitch-service-provider-browser.ts
+++ b/packages/service-provider-browser/src/stitch-service-provider-browser.ts
@@ -111,6 +111,10 @@ class StitchServiceProviderBrowser implements ServiceProvider {
       new StitchTransport<StitchAppClient, RemoteMongoClient>(stitchClient, mongoClient);
   }
 
+  listCollections(database: string, dbOptions?: Document): Promise<any> {
+    throw new Error("Method not implemented.");
+  }
+
   dropIndexes(database: string, collection: string, indexes: string|string[]|Document|Document[], options?: Document, dbOptions?: Document): Promise<any> {
     throw new Error("Method not implemented.");
   }

--- a/packages/service-provider-core/src/readable.ts
+++ b/packages/service-provider-core/src/readable.ts
@@ -167,6 +167,20 @@ interface Readable {
     database: string,
     collection: string,
     dbOptions?: Document): Promise<Result>;
+
+  /**
+   * Returns an array of collection infos
+   *
+   * @param {String} database - The db name.
+   * @param {String} collection - The collection name.
+   * @param {Object} dbOptions - The database options
+   *  (i.e. readConcern, writeConcern. etc).
+   *
+   * @return {Promise}
+   */
+  listCollections(
+    database: string,
+    dbOptions?: Document): Promise<Result>;
 }
 
 export default Readable;

--- a/packages/service-provider-core/src/readable.ts
+++ b/packages/service-provider-core/src/readable.ts
@@ -172,7 +172,8 @@ interface Readable {
    * Returns an array of collection infos
    *
    * @param {String} database - The db name.
-   * @param {String} collection - The collection name.
+   * @param {Document} filter - The filter.
+   * @param {Document} options - The command options.
    * @param {Object} dbOptions - The database options
    *  (i.e. readConcern, writeConcern. etc).
    *
@@ -180,6 +181,8 @@ interface Readable {
    */
   listCollections(
     database: string,
+    filter?: Document,
+    options?: Document,
     dbOptions?: Document): Promise<Result>;
 }
 

--- a/packages/service-provider-server/src/cli-service-provider.integration.spec.ts
+++ b/packages/service-provider-server/src/cli-service-provider.integration.spec.ts
@@ -490,4 +490,14 @@ describe('CliServiceProvider [integration]', function() {
     expect(error.ok).to.equal(0);
     expect(error.codeName).to.equal('IndexNotFound');
   });
+
+  describe('#listCollections', () => {
+    it('returns the list of collections', async() => {
+      await db.createCollection('coll1');
+
+      expect(
+        (await serviceProvider.listCollections(dbName)).map((c) => c.name)
+      ).to.deep.equal(['coll1']);
+    });
+  });
 });

--- a/packages/service-provider-server/src/cli-service-provider.integration.spec.ts
+++ b/packages/service-provider-server/src/cli-service-provider.integration.spec.ts
@@ -499,5 +499,32 @@ describe('CliServiceProvider [integration]', function() {
         (await serviceProvider.listCollections(dbName)).map((c) => c.name)
       ).to.deep.equal(['coll1']);
     });
+
+    it('filter the list of collections', async() => {
+      await db.createCollection('coll1');
+      await db.createCollection('coll2');
+
+      expect(
+        (await serviceProvider.listCollections(dbName, { name: 'coll2' })).map((c) => c.name)
+      ).to.deep.equal(['coll2']);
+    });
+
+    it('allows options', async() => {
+      await db.createCollection('coll1');
+      await db.createCollection('coll2');
+
+      expect(
+        await serviceProvider.listCollections(dbName, {}, { nameOnly: true })
+      ).to.deep.equal([
+        {
+          name: 'coll1',
+          type: 'collection'
+        },
+        {
+          name: 'coll2',
+          type: 'collection'
+        }
+      ]);
+    });
   });
 });

--- a/packages/service-provider-server/src/cli-service-provider.integration.spec.ts
+++ b/packages/service-provider-server/src/cli-service-provider.integration.spec.ts
@@ -513,18 +513,21 @@ describe('CliServiceProvider [integration]', function() {
       await db.createCollection('coll1');
       await db.createCollection('coll2');
 
+      const collections = await serviceProvider.listCollections(dbName, {}, { nameOnly: true });
+
       expect(
-        await serviceProvider.listCollections(dbName, {}, { nameOnly: true })
-      ).to.deep.equal([
-        {
-          name: 'coll1',
-          type: 'collection'
-        },
-        {
-          name: 'coll2',
-          type: 'collection'
-        }
-      ]);
+        collections
+      ).to.deep.contain({
+        name: 'coll1',
+        type: 'collection'
+      });
+
+      expect(
+        collections
+      ).to.deep.contain({
+        name: 'coll2',
+        type: 'collection'
+      });
     });
   });
 });

--- a/packages/service-provider-server/src/cli-service-provider.spec.ts
+++ b/packages/service-provider-server/src/cli-service-provider.spec.ts
@@ -609,4 +609,50 @@ describe('CliServiceProvider', () => {
       commandMock.verify();
     });
   });
+
+  describe('#listCollections', () => {
+    let commandMock;
+    let dbMock;
+    let clientStub: MongoClient;
+
+    beforeEach(() => {
+      commandMock = sinon.mock()
+        .withArgs()
+        .returns({
+          toArray: () => {
+            return Promise.resolve([
+              {
+                name: 'coll1'
+              }
+            ]);
+          }
+        });
+
+      const dbStub = sinon.createStubInstance(Db, {
+        listCollections: commandMock
+      });
+
+      dbMock = sinon.mock()
+        .withArgs('db1')
+        .returns(dbStub);
+
+      clientStub = sinon.createStubInstance(MongoClient, {
+        db: dbMock
+      });
+
+      serviceProvider = new CliServiceProvider(clientStub);
+    });
+
+    it('executes the command', async() => {
+      const result = await serviceProvider.listCollections('db1');
+      expect(result).to.deep.equal([
+        {
+          name: 'coll1'
+        }
+      ]);
+
+      dbMock.verify();
+      commandMock.verify();
+    });
+  });
 });

--- a/packages/service-provider-server/src/cli-service-provider.spec.ts
+++ b/packages/service-provider-server/src/cli-service-provider.spec.ts
@@ -617,7 +617,7 @@ describe('CliServiceProvider', () => {
 
     beforeEach(() => {
       commandMock = sinon.mock()
-        .withArgs()
+        .withArgs({}, {})
         .returns({
           toArray: () => {
             return Promise.resolve([

--- a/packages/service-provider-server/src/cli-service-provider.ts
+++ b/packages/service-provider-server/src/cli-service-provider.ts
@@ -754,7 +754,8 @@ class CliServiceProvider implements ServiceProvider {
    * Returns an array of collection infos
    *
    * @param {String} database - The db name.
-   * @param {String} collection - The collection name.
+   * @param {Document} filter - The filter.
+   * @param {Document} options - The command options.
    * @param {Object} dbOptions - The database options
    *  (i.e. readConcern, writeConcern. etc).
    *
@@ -762,8 +763,12 @@ class CliServiceProvider implements ServiceProvider {
    */
   async listCollections(
     database: string,
+    filter: Document = {},
+    options: Document = {},
     dbOptions: Document = {}): Promise<Result> {
-    return await this.db(database, dbOptions).listCollections().toArray();
+    return await this.db(database, dbOptions).listCollections(
+      filter, options
+    ).toArray();
   }
 }
 

--- a/packages/service-provider-server/src/cli-service-provider.ts
+++ b/packages/service-provider-server/src/cli-service-provider.ts
@@ -749,6 +749,22 @@ class CliServiceProvider implements ServiceProvider {
       index: indexes,
     }, options, dbOptions);
   }
+
+  /**
+   * Returns an array of collection infos
+   *
+   * @param {String} database - The db name.
+   * @param {String} collection - The collection name.
+   * @param {Object} dbOptions - The database options
+   *  (i.e. readConcern, writeConcern. etc).
+   *
+   * @return {Promise}
+   */
+  async listCollections(
+    database: string,
+    dbOptions: Document = {}): Promise<Result> {
+    return await this.db(database, dbOptions).listCollections().toArray();
+  }
 }
 
 export default CliServiceProvider;

--- a/packages/shell-api/src/database.spec.ts
+++ b/packages/shell-api/src/database.spec.ts
@@ -1,0 +1,56 @@
+import sinon from 'sinon';
+import Mapper from '../../mapper/lib';
+import { Database } from './shell-api';
+import * as types from './shell-types';
+import { expect } from 'chai';
+
+/**
+ * Test that a database method proxies the respective Mapper method correctly,
+ * with the right arguments and returning the right result.
+ *
+ * It ensures:
+ * - that the method is defined in the shell api and that is meant to be a function
+ * - that the mapper method to be proxied to exists
+ * - that the mapper method is called with a database as first argument and with
+ *   the rest of invokation arguments.
+ * - that the result of mapper invokation is returned.
+ *
+ * @param {String} name - the name of the method to invoke
+ */
+function testWrappedMethod(name: string): void {
+  const attribute = types.Database.attributes[name];
+  expect(attribute).to.exist;
+  expect(attribute.type).to.equal('function');
+
+  const mock = sinon.mock();
+  const mapper: Mapper = sinon.createStubInstance(Mapper, {
+    [name]: mock
+  });
+
+  const args = [1, 2, 3];
+  const retVal = {};
+
+  const database = new Database(
+    mapper, 'db1');
+
+  mock.withArgs(database, ...args).returns(retVal);
+
+  const result = database[name](...args);
+  mock.verify();
+
+  expect(result).to.equal(retVal);
+}
+
+describe('Database', () => {
+  describe('#getCollectionInfos', () => {
+    it('wraps mapper.getCollectionInfos', () => {
+      testWrappedMethod('getCollectionInfos');
+    });
+  });
+
+  describe('#getCollectionNames', () => {
+    it('wraps mapper.getCollectionNames', () => {
+      testWrappedMethod('getCollectionNames');
+    });
+  });
+});

--- a/packages/shell-api/src/shell-api.js
+++ b/packages/shell-api/src/shell-api.js
@@ -983,13 +983,21 @@ class Database {
     this.shellApiType = () => {
       return 'Database';
     };
-    this.help = () => new Help({ 'help': 'shell-api.database.description', 'docs': 'https://docs.mongodb.com/manual/reference/method/js-database/', 'attr': [{ 'name': 'runCommand', 'description': 'shell-api.database.help.run-command' }] });
+    this.help = () => new Help({ 'help': 'shell-api.database.description', 'docs': 'https://docs.mongodb.com/manual/reference/method/js-database/', 'attr': [{ 'name': 'runCommand', 'description': 'shell-api.database.help.run-command' }, { 'name': 'getCollectionNames', 'description': 'shell-api.collection.help.get-collection-names.description' }, { 'name': 'getCollectionInfos', 'description': 'shell-api.collection.help.get-collection-infos.description' }] });
 
     return new Proxy(this, handler);
   }
 
   runCommand(...args) {
     return this._mapper.runCommand(this, ...args);
+  }
+
+  getCollectionNames(...args) {
+    return this._mapper.getCollectionNames(this, ...args);
+  }
+
+  getCollectionInfos(...args) {
+    return this._mapper.getCollectionInfos(this, ...args);
   }
 }
 
@@ -999,6 +1007,18 @@ Database.prototype.runCommand.serverVersions = ['0.0.0', '4.4.0'];
 Database.prototype.runCommand.topologies = [0, 1, 2];
 Database.prototype.runCommand.returnsPromise = false;
 Database.prototype.runCommand.returnType = 'unknown';
+
+Database.prototype.getCollectionNames.help = () => new Help({ 'help': 'shell-api.collection.help.get-collection-names' });
+Database.prototype.getCollectionNames.serverVersions = ['0.0.0', '4.4.0'];
+Database.prototype.getCollectionNames.topologies = [0, 1, 2];
+Database.prototype.getCollectionNames.returnsPromise = true;
+Database.prototype.getCollectionNames.returnType = 'unknown';
+
+Database.prototype.getCollectionInfos.help = () => new Help({ 'help': 'shell-api.collection.help.get-collection-infos' });
+Database.prototype.getCollectionInfos.serverVersions = ['3.0.0', '4.4.0'];
+Database.prototype.getCollectionInfos.topologies = [0, 1, 2];
+Database.prototype.getCollectionInfos.returnsPromise = true;
+Database.prototype.getCollectionInfos.returnType = 'unknown';
 
 
 class DeleteResult {

--- a/packages/shell-api/src/shell-types.js
+++ b/packages/shell-api/src/shell-types.js
@@ -114,7 +114,9 @@ const Cursor = {
 const Database = {
   type: 'Database',
   attributes: {
-    runCommand: { type: 'function', returnsPromise: false, returnType: 'unknown', serverVersions: ['0.0.0', '4.4.0'] }
+    runCommand: { type: 'function', returnsPromise: false, returnType: 'unknown', serverVersions: ['0.0.0', '4.4.0'] },
+    getCollectionNames: { type: 'function', returnsPromise: true, returnType: 'unknown', serverVersions: ['0.0.0', '4.4.0'] },
+    getCollectionInfos: { type: 'function', returnsPromise: true, returnType: 'unknown', serverVersions: ['3.0.0', '4.4.0'] }
   }
 };
 const DeleteResult = {

--- a/packages/shell-api/yaml/Database.yaml
+++ b/packages/shell-api/yaml/Database.yaml
@@ -11,7 +11,27 @@ class:
         attr:
             - name: runCommand
               description: 'shell-api.database.help.run-command'
+            - name: getCollectionNames
+              description: 'shell-api.collection.help.get-collection-names.description'
+            - name: getCollectionInfos
+              description: 'shell-api.collection.help.get-collection-infos.description'
     runCommand:
         <<: *__defaultMethod
         help:
             help: 'shell-api.database.help.run-command'
+    getCollectionNames:
+        <<: *__defaultMethod
+        returnsPromise: true
+        serverVersions:
+            - *ServerVersions.earliest
+            - *ServerVersions.latest
+        help:
+            help: 'shell-api.collection.help.get-collection-names'
+    getCollectionInfos:
+        <<: *__defaultMethod
+        returnsPromise: true
+        serverVersions:
+            - '3.0.0'
+            - *ServerVersions.latest
+        help:
+            help: 'shell-api.collection.help.get-collection-infos'


### PR DESCRIPTION
Implements `show collections`.

- Implements `show collections` in mapper
- Implements `getCollectionInfos` and `getCollectionNames` in mapper
- Add `db.getCollectionInfos` and `db.getCollectionNames` in shell-api
- Add `serviceProvider.listCollections`

```
$ mongosh > db.getCollectionInfos()
[
  {
    name: 'fitbit_max',
    type: 'collection',
    options: {},
    info: { readOnly: false, uuid: [Binary] },
    idIndex: { v: 2, key: [Object], name: '_id_', ns: 'test.fitbit_max' }
  },
  {
    name: 'coll2',
    type: 'collection',
    options: { capped: true, size: 1024 },
    info: { readOnly: false, uuid: [Binary] },
    idIndex: { v: 2, key: [Object], name: '_id_', ns: 'test.coll2' }
  },
  {
    name: 'coll1',
    type: 'collection',
    options: { capped: true, size: 10240 },
    info: { readOnly: false, uuid: [Binary] },
    idIndex: { v: 2, key: [Object], name: '_id_', ns: 'test.coll1' }
  }
]
$ mongosh > db.getCollectionNames()
[ 'fitbit_max', 'coll2', 'coll1' ]
$ mongosh > show collections
fitbit_max
coll2
coll1
$ mongosh >
```

NOTE: @lrlna This adds a couple of lines to `mapper.show` we may want to convert the same way after we merge https://github.com/mongodb-js/mongosh/pull/85