### PR TITLE
Cli repl tests

### DIFF
--- a/packages/cli-repl/package.json
+++ b/packages/cli-repl/package.json
@@ -18,8 +18,8 @@
     "compile-ts": "tsc -p tsconfig.json",
     "start": "node --experimental-repl-await bin/mongosh.js start",
     "start-async": "node --experimental-repl-await bin/mongosh.js start --async",
-    "test": "mocha --timeout 15000 --colors -r ts-node/register \"./src/**/*.spec.ts\"",
-    "test-ci": "mocha --timeout 15000 -r ts-node/register \"./src/**/*.spec.ts\"",
+    "test": "mocha --timeout 15000 --colors -r ts-node/register \"./{src,test}/**/*.spec.ts\"",
+    "test-ci": "mocha --timeout 15000 -r ts-node/register \"./{src,test}/**/*.spec.ts\"",
     "prepublish": "npm run compile-ts"
   },
   "license": "Apache-2.0",

--- a/packages/cli-repl/test/e2e.spec.ts
+++ b/packages/cli-repl/test/e2e.spec.ts
@@ -1,0 +1,99 @@
+
+import { expect } from 'chai';
+import { MongoClient } from 'mongodb';
+import { eventually, startShell } from './helpers';
+
+describe.only('e2e', function() {
+  this.timeout(10000);
+
+  before(require('mongodb-runner/mocha/before')({ port: 27018, timeout: 60000 }));
+  after(require('mongodb-runner/mocha/after')({ port: 27018 }));
+
+  const openShells = [];
+
+  afterEach(async () => {
+    while(openShells.length) {
+      openShells.pop().kill();
+    }
+  });
+
+  describe('--version', () => {
+    it('shows version', async() => {
+      const shell = startShell('--version');
+      openShells.push(shell);
+
+      await eventually(() => {
+        expect(shell.stdio.stdout).to.contain(
+          require('../package.json').version
+        );
+      });
+    });
+  });
+
+  describe('with connection string', () => {
+    let db;
+    let client;
+    let shell;
+    let dbName;
+
+    beforeEach(async () => {
+      dbName = `test-${Date.now()}`;
+      const connectionString = `mongodb://localhost:27018/${dbName}`;
+
+      shell = startShell(connectionString);
+      openShells.push(shell);
+
+      client = await (MongoClient as any).connect(
+        connectionString,
+        { useNewUrlParser: true }
+      );
+
+      db = client.db(dbName);
+    });
+
+    afterEach(async () => {
+      await db.dropDatabase();
+
+      client.close();
+
+      while(openShells.length) {
+        openShells.pop().kill();
+      }
+    });
+
+    it.skip('connects to the right database', async () => {
+      shell.stdio.stdin.write('db\n');
+
+      await eventually(() => {
+        expect(shell.stdio.stdout).to.contain(`> ${dbName}\n`);
+      });
+    });
+
+    it('runs help command', async () => {
+      shell.stdio.stdin.write('help\n');
+
+      await eventually(() => {
+        expect(shell.stdio.stdout).to.contain('Shell Help');
+      });
+    });
+
+    it('allows to find documents', async () => {
+      shell.stdio.stdin.write(`use ${dbName}\n`);
+
+      await db.collection('test').insertMany([
+        {doc: 1},
+        {doc: 2},
+        {doc: 3}
+      ]);
+
+      shell.stdio.stdin.write('db.test.find()\n');
+
+      await eventually(() => {
+        expect(shell.stdio.stderr).to.be.empty;
+        expect(shell.stdio.stdout).to.contain('doc: 1');
+        expect(shell.stdio.stdout).to.contain('doc: 2');
+        expect(shell.stdio.stdout).to.contain('doc: 3');
+      });
+    });
+  });
+});

--- a/packages/cli-repl/test/e2e.spec.ts
+++ b/packages/cli-repl/test/e2e.spec.ts
@@ -4,8 +4,6 @@ import { MongoClient } from 'mongodb';
 import { eventually, startShell, killOpenShells } from './helpers';
 
 describe.only('e2e', function() {
-  this.timeout(10000);
-
   before(require('mongodb-runner/mocha/before')({ port: 27018, timeout: 60000 }));
   after(require('mongodb-runner/mocha/after')({ port: 27018 }));
 

--- a/packages/cli-repl/test/e2e.spec.ts
+++ b/packages/cli-repl/test/e2e.spec.ts
@@ -15,7 +15,7 @@ describe.only('e2e', function() {
     it('shows version', async() => {
       const shell = startShell('--version');
       await eventually(() => {
-        expect(shell.stdio.stdout).to.contain(
+        expect(shell.stdio.output).to.contain(
           require('../package.json').version
         );
       });
@@ -51,7 +51,7 @@ describe.only('e2e', function() {
       shell.stdio.stdin.write('db\n');
 
       await eventually(() => {
-        expect(shell.stdio.stdout).to.contain(`> ${dbName}\n`);
+        expect(shell.stdio.output).to.contain(`> ${dbName}\n`);
       });
     });
 
@@ -59,7 +59,7 @@ describe.only('e2e', function() {
       shell.stdio.stdin.write('help\n');
 
       await eventually(() => {
-        expect(shell.stdio.stdout).to.contain('Shell Help');
+        expect(shell.stdio.output).to.contain('Shell Help');
       });
     });
 
@@ -76,9 +76,9 @@ describe.only('e2e', function() {
 
       await eventually(() => {
         expect(shell.stdio.stderr).to.be.empty;
-        expect(shell.stdio.stdout).to.contain('doc: 1');
-        expect(shell.stdio.stdout).to.contain('doc: 2');
-        expect(shell.stdio.stdout).to.contain('doc: 3');
+        expect(shell.stdio.output).to.contain('doc: 1');
+        expect(shell.stdio.output).to.contain('doc: 2');
+        expect(shell.stdio.output).to.contain('doc: 3');
       });
     });
   });

--- a/packages/cli-repl/test/e2e.spec.ts
+++ b/packages/cli-repl/test/e2e.spec.ts
@@ -16,7 +16,7 @@ describe.only('e2e', function() {
       const shell = startShell('--version');
       await eventually(() => {
         expect(shell.stdio.stderr).to.be.empty;
-        expect(shell.stdio.output).to.contain(
+        expect(shell.stdio.stdout).to.contain(
           require('../package.json').version
         );
       });

--- a/packages/cli-repl/test/e2e.spec.ts
+++ b/packages/cli-repl/test/e2e.spec.ts
@@ -15,6 +15,7 @@ describe.only('e2e', function() {
     it('shows version', async() => {
       const shell = startShell('--version');
       await eventually(() => {
+        expect(shell.stdio.stderr).to.be.empty;
         expect(shell.stdio.output).to.contain(
           require('../package.json').version
         );
@@ -51,7 +52,8 @@ describe.only('e2e', function() {
       shell.stdio.stdin.write('db\n');
 
       await eventually(() => {
-        expect(shell.stdio.output).to.contain(`> ${dbName}\n`);
+        expect(shell.stdio.stderr).to.be.empty;
+        expect(shell.stdio.stdout).to.contain(`> ${dbName}\n`);
       });
     });
 
@@ -59,7 +61,8 @@ describe.only('e2e', function() {
       shell.stdio.stdin.write('help\n');
 
       await eventually(() => {
-        expect(shell.stdio.output).to.contain('Shell Help');
+        expect(shell.stdio.stderr).to.be.empty;
+        expect(shell.stdio.stdout).to.contain('Shell Help');
       });
     });
 
@@ -76,9 +79,9 @@ describe.only('e2e', function() {
 
       await eventually(() => {
         expect(shell.stdio.stderr).to.be.empty;
-        expect(shell.stdio.output).to.contain('doc: 1');
-        expect(shell.stdio.output).to.contain('doc: 2');
-        expect(shell.stdio.output).to.contain('doc: 3');
+        expect(shell.stdio.stdout).to.contain('doc: 1');
+        expect(shell.stdio.stdout).to.contain('doc: 2');
+        expect(shell.stdio.stdout).to.contain('doc: 3');
       });
     });
   });

--- a/packages/cli-repl/test/e2e.spec.ts
+++ b/packages/cli-repl/test/e2e.spec.ts
@@ -4,8 +4,6 @@ import { MongoClient } from 'mongodb';
 import { eventually, startShell, killOpenShells } from './helpers';
 
 describe.only('e2e', function() {
-  this.timeout(30000);
-
   before(require('mongodb-runner/mocha/before')({ port: 27018, timeout: 60000 }));
   after(require('mongodb-runner/mocha/after')({ port: 27018 }));
 

--- a/packages/cli-repl/test/e2e.spec.ts
+++ b/packages/cli-repl/test/e2e.spec.ts
@@ -4,6 +4,8 @@ import { MongoClient } from 'mongodb';
 import { eventually, startShell, killOpenShells } from './helpers';
 
 describe.only('e2e', function() {
+  this.timeout(30000);
+
   before(require('mongodb-runner/mocha/before')({ port: 27018, timeout: 60000 }));
   after(require('mongodb-runner/mocha/after')({ port: 27018 }));
 

--- a/packages/cli-repl/test/helpers.ts
+++ b/packages/cli-repl/test/helpers.ts
@@ -1,0 +1,45 @@
+import { spawn } from 'child_process';
+import path from 'path';
+import stripAnsi from 'strip-ansi';
+
+export async function eventually(fn) {
+  let i = 50;
+  let err;
+
+  while(i) {
+    i--;
+
+    try {
+      await fn();
+      return;
+    } catch (e) {
+      err = e;
+    }
+
+    await new Promise(resolve => setTimeout(resolve, 100));
+  }
+
+  throw err;
+}
+
+export function startShell(...args) {
+  const execPath = path.resolve(__dirname, '..', 'bin', 'mongosh.js');
+
+  const shell = spawn('node', [execPath, ...args], {
+    stdio: [ 'pipe', 'pipe', 'pipe' ]
+  });
+
+  const stdio = {
+    stdin: shell.stdin,
+    stdout: '',
+    stderr: ''
+  }
+
+  shell.stdout.on('data', (chunk) => { stdio.stdout += stripAnsi(chunk.toString()); })
+  shell.stderr.on('data', (chunk) => { stdio.stderr += stripAnsi(chunk.toString()); })
+
+  return {
+    process: shell,
+    stdio,
+  };
+}

--- a/packages/cli-repl/test/helpers.ts
+++ b/packages/cli-repl/test/helpers.ts
@@ -22,6 +22,8 @@ export async function eventually(fn) {
   throw err;
 }
 
+const openShells = [];
+
 export function startShell(...args) {
   const execPath = path.resolve(__dirname, '..', 'bin', 'mongosh.js');
 
@@ -38,8 +40,16 @@ export function startShell(...args) {
   shell.stdout.on('data', (chunk) => { stdio.stdout += stripAnsi(chunk.toString()); })
   shell.stderr.on('data', (chunk) => { stdio.stderr += stripAnsi(chunk.toString()); })
 
+  openShells.push(shell);
+
   return {
     process: shell,
     stdio,
   };
+}
+
+export function killOpenShells() {
+  while(openShells.length) {
+    openShells.pop().kill();
+  }
 }

--- a/packages/cli-repl/test/helpers.ts
+++ b/packages/cli-repl/test/helpers.ts
@@ -39,7 +39,6 @@ export function startShell(...args) {
 
   const stdio = {
     stdin: shell.stdin,
-    output: '',
     stdout: '',
     stderr: ''
   }

--- a/packages/cli-repl/test/helpers.ts
+++ b/packages/cli-repl/test/helpers.ts
@@ -5,7 +5,7 @@ import stripAnsi from 'strip-ansi';
 export async function eventually(fn, options: { frequency?: number, timeout?: number } = {}) {
   options = {
     frequency: 100,
-    timeout: 15000,
+    timeout: 10000,
     ...options
   };
 

--- a/packages/cli-repl/test/helpers.ts
+++ b/packages/cli-repl/test/helpers.ts
@@ -2,12 +2,18 @@ import { spawn } from 'child_process';
 import path from 'path';
 import stripAnsi from 'strip-ansi';
 
-export async function eventually(fn) {
-  let i = 50;
+export async function eventually(fn, options: { frequency?: number, timeout?: number } = {}) {
+  options = {
+    frequency: 100,
+    timeout: 15000,
+    ...options
+  };
+
+  let attempts = Math.round(options.timeout / options.frequency);
   let err;
 
-  while(i) {
-    i--;
+  while(attempts) {
+    attempts--;
 
     try {
       await fn();
@@ -16,7 +22,7 @@ export async function eventually(fn) {
       err = e;
     }
 
-    await new Promise(resolve => setTimeout(resolve, 100));
+    await new Promise(resolve => setTimeout(resolve, options.frequency));
   }
 
   throw err;

--- a/packages/cli-repl/test/helpers.ts
+++ b/packages/cli-repl/test/helpers.ts
@@ -46,13 +46,11 @@ export function startShell(...args) {
 
   shell.stdout.on('data', (chunk) => {
     const plainChunk = stripAnsi(chunk.toString());
-    stdio.output += plainChunk;
     stdio.stdout += plainChunk;
   });
 
   shell.stderr.on('data', (chunk) => {
     const plainChunk = stripAnsi(chunk.toString());
-    stdio.output += plainChunk;
     stdio.stderr += plainChunk;
   });
 

--- a/packages/cli-repl/test/helpers.ts
+++ b/packages/cli-repl/test/helpers.ts
@@ -39,12 +39,22 @@ export function startShell(...args) {
 
   const stdio = {
     stdin: shell.stdin,
+    output: '',
     stdout: '',
     stderr: ''
   }
 
-  shell.stdout.on('data', (chunk) => { stdio.stdout += stripAnsi(chunk.toString()); })
-  shell.stderr.on('data', (chunk) => { stdio.stderr += stripAnsi(chunk.toString()); })
+  shell.stdout.on('data', (chunk) => {
+    const plainChunk = stripAnsi(chunk.toString());
+    stdio.output += plainChunk;
+    stdio.stdout += plainChunk;
+  });
+
+  shell.stderr.on('data', (chunk) => {
+    const plainChunk = stripAnsi(chunk.toString());
+    stdio.output += plainChunk;
+    stdio.stderr += plainChunk;
+  });
 
   openShells.push(shell);
 


### PR DESCRIPTION
Integration / e2e tests for cli-repl.

Adds sanity check to `cli-repl` to test that the shell starts, connects and can run commands.

The test suite spawns the shell in a new process and interacts with it by writing and reading stdio.

Example:

```
[2020/03/31 16:45:56.637]        with connection string
[2020/03/31 16:45:56.637]          runs help command:
[2020/03/31 16:45:56.637]      expected 'events.js:177\n      throw er; // Unhandled \'error\' event\n      ^\n\nError: ENOENT: no such file or directory, open \'/Users/mci/.mongodb/mongosh/1585673146226_log\'\nEmitted \'error\' event at:\n    at SonicBoom.filterBrokenPipe (/data/mci/d5a663fc272f77a73ee587c57e9050be/src/packages/cli-repl/node_modules/pino/lib/tools.js:271:12)\n    at SonicBoom.emit (events.js:200:13)\n    at SonicBoom.EventEmitter.emit (domain.js:471:20)\n    at /data/mci/d5a663fc272f77a73ee587c57e9050be/src/packages/cli-repl/node_modules/sonic-boom/index.js:25:13\n    at FSReqCallback.oncomplete (fs.js:153:23) {\n  errno: -2,\n  code: \'ENOENT\',\n  syscall: \'open\',\n  path: \'/Users/mci/.mongodb/mongosh/1585673146226_log\'\n}\n' to be empty
```
