### PR TITLE
MONGOSH-103: redact information from logs and connection dialogue

### DIFF
--- a/packages/cli-repl/package-lock.json
+++ b/packages/cli-repl/package-lock.json
@@ -65,6 +65,11 @@
 			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
 			"integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
 		},
+		"lodash": {
+			"version": "4.17.15",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+		},
 		"lodash.set": {
 			"version": "4.3.2",
 			"resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
@@ -91,6 +96,14 @@
 			"integrity": "sha512-OMDiHtrMt5z7RxQKZKl4kLJqUDbe0xTUSBQT0r+DNHKzsQoyk5RlUK6jsMWmFYn1ADFGGAejVJWbcnlG4WGH8w==",
 			"requires": {
 				"semver": "^7.1.1"
+			}
+		},
+		"mongodb-redact": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/mongodb-redact/-/mongodb-redact-0.2.0.tgz",
+			"integrity": "sha512-kGoR02HsTzNYHFXLklvbEg7mSJZu5+L1JdaYUuSlmVUAXxzhxUBvoFoYulfqqvokE+ilAXGYywdMJStB0lPhCw==",
+			"requires": {
+				"lodash": "^4.17.15"
 			}
 		},
 		"mute-stream": {

--- a/packages/cli-repl/package.json
+++ b/packages/cli-repl/package.json
@@ -41,13 +41,14 @@
     "minimist": "^1.2.5",
     "mkdirp": "^1.0.3",
     "mongodb-ace-autocompleter": "^0.4.1",
+    "mongodb-redact": "^0.2.0",
     "nanobus": "^4.4.0",
     "pino": "^5.16.0",
     "pretty-bytes": "^5.3.0",
     "read": "^1.0.7",
     "semver": "^7.1.2",
-    "uuidv4": "^6.0.6",
-    "text-table": "^0.2.0"
+    "text-table": "^0.2.0",
+    "uuidv4": "^6.0.6"
   },
   "devDependencies": {}
 }

--- a/packages/cli-repl/src/cli-repl.ts
+++ b/packages/cli-repl/src/cli-repl.ts
@@ -5,7 +5,9 @@ import { TELEMETRY } from './constants';
 import repl, { REPLServer } from 'repl';
 import CliOptions from './cli-options';
 import Mapper from '@mongosh/mapper';
+import redactPwd from './redact-pwd';
 import completer from './completer';
+import redact from 'mongodb-redact';
 import i18n from '@mongosh/i18n';
 import { ObjectId } from 'bson';
 import Nanobus from 'nanobus';
@@ -45,7 +47,7 @@ class CliRepl {
    * @param {NodeOptions} driverOptions - The driver options.
    */
   async connect(driverUri: string, driverOptions: NodeOptions): Promise<void> {
-    console.log(i18n.__(CONNECTING), clr(driverUri, 'bold'));
+    console.log(i18n.__(CONNECTING), clr(redactPwd(driverUri), 'bold'));
     this.bus.emit('connect', driverUri);
 
     this.serviceProvider = await CliServiceProvider.connect(driverUri, driverOptions);

--- a/packages/cli-repl/src/index.ts
+++ b/packages/cli-repl/src/index.ts
@@ -1,4 +1,5 @@
 import CliRepl from './cli-repl';
+import redactPwd from './redact-pwd';
 import parseCliArgs from './arg-parser';
 import mapCliToDriver from './arg-mapper';
 import generateUri from './uri-generator';
@@ -13,6 +14,7 @@ export {
   USAGE,
   TELEMETRY,
   CliRepl,
+  redactPwd,
   completer,
   generateUri,
   parseCliArgs,

--- a/packages/cli-repl/src/logger.ts
+++ b/packages/cli-repl/src/logger.ts
@@ -1,3 +1,5 @@
+import redactInfo from 'mongodb-redact';
+import redactPwd from './redact-pwd';
 import { uuid } from 'uuidv4';
 import pino from 'pino';
 import path from 'path';
@@ -12,7 +14,7 @@ function logger(bus: any, logDir: string) {
   bus.on('*', function() {});
 
   bus.on('connect', function(info) {
-    const params = { sessionID, info };
+    const params = { sessionID, info: redactPwd(info) };
     log.info('connect', params);
   });
 
@@ -38,217 +40,217 @@ function logger(bus: any, logDir: string) {
 
   bus.on('method:aggregate', function(collection, pipeline) {
     const params = { collection, pipeline };
-    log.info('method:aggregate', params);
+    log.info('method:aggregate', redactInfo(params));
   });
 
   bus.on('method:bulkWrite', function(collection, operations) {
     const params = { collection, operations };
-    log.info('method:bulkWrite', params);
+    log.info('method:bulkWrite', redactInfo(params));
   });
 
   bus.on('method:count', function(collection, query = {}) {
     const params = { collection, query };
-    log.info('method:count', params);
+    log.info('method:count', redactInfo(params));
   });
 
   bus.on('method:countDocuments', function(collection, query = {}, options) {
     const params = { collection, query, options };
-    log.info('method:countDocument', params);
+    log.info('method:countDocument', redactInfo(params));
   });
 
   bus.on('method:deleteMany', function(collection, filter) {
     const params = { collection, filter };
-    log.info('method:deleteMany', params);
+    log.info('method:deleteMany', redactInfo(params));
   });
 
   bus.on('method:deleteOne', function(collection, filter) {
     const params = { collection, filter };
-    log.info('method:deleteOne', params);
+    log.info('method:deleteOne', redactInfo(params));
   });
 
   bus.on('method:distinct', function(collection, field, query = {}) {
     const params = { collection, field, query };
-    log.info('method:distinct', params);
+    log.info('method:distinct', redactInfo(params));
   });
 
   bus.on('method:estimatedDocumentCount', function(collection) {
     const params = { collection };
-    log.info('method:estimatedDocumentCount', params);
+    log.info('method:estimatedDocumentCount', redactInfo(params));
   });
 
   bus.on('method:find', function(collection, query = {}, projection = {}) {
     const params = { collection, query, projection };
-    log.info('method:find', params);
+    log.info('method:find', redactInfo(params));
   });
 
   bus.on('method:findOne', function(collection, query = {}, projection = {}) {
     const params = { collection, query, projection };
-    log.info('method:findOne', params);
+    log.info('method:findOne', redactInfo(params));
   });
 
   bus.on('method:findOneAndDelete', function(collection, filter = {}) {
     const params = { collection, filter };
-    log.info('method:findOneAndDelete', params);
+    log.info('method:findOneAndDelete', redactInfo(params));
   });
 
   bus.on('method:findOneAndReplace', function(collection, filter) {
     const params = { collection, filter };
-    log.info('method:findOneAndReplace', params);
+    log.info('method:findOneAndReplace', redactInfo(params));
   });
 
   bus.on('method:findOneAndUpdate', function(collection, filter) {
     const params = { collection, filter };
-    log.info('method:findOneAndUpdate', params);
+    log.info('method:findOneAndUpdate', redactInfo(params));
   });
 
   bus.on('method:insert', function(collection, docs) {
     const params = { collection, docs };
-    log.info('method:insert', params);
+    log.info('method:insert', redactInfo(params));
   });
 
   bus.on('method:insertMany', function(collection, docs) {
     const params = { collection, docs };
-    log.info('method:insertMany', params);
+    log.info('method:insertMany', redactInfo(params));
   });
 
   bus.on('method:insertOne', function(collection, doc) {
     const params = { collection, doc };
-    log.info('method:insertOne', params);
+    log.info('method:insertOne', redactInfo(params));
   });
 
   bus.on('method:isCapped', function(collection) {
     const params = { collection };
-    log.info('method:isCapped', params);
+    log.info('method:isCapped', redactInfo(params));
   });
 
   bus.on('method:remove', function(collection, query = {}) {
     const params = { collection, query };
-    log.info('method:remove', params);
+    log.info('method:remove', redactInfo(params));
   });
 
   bus.on('method:save', function(collection, doc) {
     const params = { collection, doc };
-    log.info('method:save', params);
+    log.info('method:save', redactInfo(params));
   });
 
   bus.on('method:replaceOne', function(collection, filter) {
     const params = { collection, filter };
-    log.info('method:replaceOne', params);
+    log.info('method:replaceOne', redactInfo(params));
   });
 
   bus.on('method:runCommand', function(database, cmd) {
     const params = { database, cmd };
-    log.info('method:runCommand', params);
+    log.info('method:runCommand', redactInfo(params));
   });
 
   bus.on('method:update', function(collection, filter) {
     const params = { collection, filter };
-    log.info('method:update', params);
+    log.info('method:update', redactInfo(params));
   });
 
   bus.on('method:updateMany', function(collection, filter) {
     const params = { collection, filter };
-    log.info('method:updateMany', params);
+    log.info('method:updateMany', redactInfo(params));
   });
 
   bus.on('method:updateOne', function(collection, filter) {
     const params = { collection, filter };
-    log.info('method:updateOne', params);
+    log.info('method:updateOne', redactInfo(params));
   });
 
   bus.on('method:convertToCapped', function(collection, size) {
     const params = { collection, size };
-    log.info('method:convertToCapped', params);
+    log.info('method:convertToCapped', redactInfo(params));
   });
 
   bus.on('method:createIndexes', function(collection, keyPatterns, options) {
     const params = { collection, keyPatterns, options };
-    log.info('method:createIndexes', params);
+    log.info('method:createIndexes', redactInfo(params));
   });
 
   bus.on('method:createIndex', function(collection, keys, options) {
     const params = { collection, keys, options };
-    log.info('method:createIndex', params);
+    log.info('method:createIndex', redactInfo(params));
   });
 
   bus.on('method:ensureIndex', function(collection, keys, options) {
     const params = { collection, keys, options };
-    log.info('method:ensureIndex', params);
+    log.info('method:ensureIndex', redactInfo(params));
   });
 
   bus.on('method:getIndexes', function(collection) {
     const params = { collection };
-    log.info('method:getIndexes', params);
+    log.info('method:getIndexes', redactInfo(params));
   });
 
   bus.on('method:getIndexSpecs', function(collection) {
     const params = { collection };
-    log.info('method:getIndexSpecs', params);
+    log.info('method:getIndexSpecs', redactInfo(params));
   });
 
   bus.on('method:getIndices', function(collection) {
     const params = { collection };
-    log.info('method:getIndices', params);
+    log.info('method:getIndices', redactInfo(params));
   });
 
   bus.on('method:getIndexKeys', function(collection) {
     const params = { collection };
-    log.info('method:getIndexKeys', params);
+    log.info('method:getIndexKeys', redactInfo(params));
   });
 
   bus.on('method:dropIndexes', function(collection, indexes) {
     const params = { collection, indexes };
-    log.info('method:dropIndexes', params);
+    log.info('method:dropIndexes', redactInfo(params));
   });
 
   bus.on('method:dropIndex', function(collection, index) {
     const params = { collection, index };
-    log.info('method:dropIndex', params);
+    log.info('method:dropIndex', redactInfo(params));
   });
 
   bus.on('method:getCollectionInfos', function(database, filter, options) {
     const params = { database, filter, options };
-    log.info('method:getCollectionInfos', params);
+    log.info('method:getCollectionInfos', redactInfo(params));
   });
 
   bus.on('method:getCollectionNames', function(database) {
     const params = { database };
-    log.info('method:getCollectionNames', params);
+    log.info('method:getCollectionNames', redactInfo(params));
   });
 
   bus.on('method:totalIndexSize', function(collection) {
     const params = { collection };
-    log.info('method:totalIndexSize', params);
+    log.info('method:totalIndexSize', redactInfo(params));
   });
 
   bus.on('method:reIndex', function(collection) {
     const params = { collection };
-    log.info('method:reIndex', params);
+    log.info('method:reIndex', redactInfo(params));
   });
 
   bus.on('method:getDB', function(collection) {
     const params = { collection };
-    log.info('method:getDB', params);
+    log.info('method:getDB', redactInfo(params));
   });
 
   bus.on('method:stats', function(collection, options) {
     const params = { collection, options };
-    log.info('method:stats', params);
+    log.info('method:stats', redactInfo(params));
   });
 
   bus.on('method:dataSize', function(collection) {
     const params = { collection };
-    log.info('method:dataSize', params);
+    log.info('method:dataSize', redactInfo(params));
   });
 
   bus.on('method:storageSize', function(collection) {
     const params = { collection };
-    log.info('method:storageSize', params);
+    log.info('method:storageSize', redactInfo(params));
   });
 
   bus.on('method:totalSize', function(collection) {
     const params = { collection };
-    log.info('method:totalSize', params);
+    log.info('method:totalSize', redactInfo(params));
   });
 }
 

--- a/packages/cli-repl/src/redact-pwd.spec.ts
+++ b/packages/cli-repl/src/redact-pwd.spec.ts
@@ -1,0 +1,16 @@
+import redactPwd from './redact-pwd';
+import { expect } from 'chai';
+
+describe('redact password', () => {
+  context('when url contains credentials', () => {
+    it('returns the <credentials> in output', () => {
+      expect(redactPwd('mongodb+srv://admin:catsc@tscat3ca1s@cats-data-sets-e08dy.mongodb.net/admin')).to.equal('mongodb+srv://<credentials>@cats-data-sets-e08dy.mongodb.net/admin');
+    });
+  });
+
+  context('when url contains no credentials', () => {
+    it('does not alter input', () => {
+      expect(redactPwd('mongodb://127.0.0.1:27017')).to.include('mongodb://127.0.0.1:27017');
+    });
+  });
+});

--- a/packages/cli-repl/src/redact-pwd.ts
+++ b/packages/cli-repl/src/redact-pwd.ts
@@ -1,0 +1,4 @@
+export default function retractPassword(uri: string): string {
+  const regex = /(?<=\/\/)(.*)(?=\@)/g;
+  return uri.replace(regex, '<credentials>');
+}


### PR DESCRIPTION
## Description
Removes sensitive information from logs if exists. Uses `mongodb-redact` module just like in `@mongosh/history`. To remove credentials in `driverURI` currently a separate regex to replace information with `<credentials>`.

Examples:
<img width="850" alt="Capture d’écran, le 2020-04-15 à 15 07 06" src="https://user-images.githubusercontent.com/8107784/79340998-5edbb600-7f2b-11ea-81db-d0b1aba38cb4.png">

And in logs:
<img width="849" alt="Capture d’écran, le 2020-04-15 à 15 06 41" src="https://user-images.githubusercontent.com/8107784/79341021-69964b00-7f2b-11ea-9608-ec143eee795b.png">
