### PR TITLE
Add hasAsyncChild to Cursors

### DIFF
--- a/packages/shell-api/src/shell-api-signatures.js
+++ b/packages/shell-api/src/shell-api-signatures.js
@@ -4,7 +4,7 @@ const unknown = {
 };
 const AggregationCursor = {
   type: 'AggregationCursor',
-  hasAsyncChild: false,
+  hasAsyncChild: true,
   attributes: {
     close: { type: 'function', returnsPromise: false, returnType: 'unknown', serverVersions: ['0.0.0', '4.4.0'] },
     forEach: { type: 'function', returnsPromise: true, returnType: 'unknown', serverVersions: ['0.0.0', '4.4.0'] },
@@ -80,7 +80,7 @@ const CommandResult = {
 };
 const Cursor = {
   type: 'Cursor',
-  hasAsyncChild: false,
+  hasAsyncChild: true,
   attributes: {
     addOption: { type: 'function', returnsPromise: false, returnType: 'Cursor', serverVersions: ['0.0.0', '3.2.0'] },
     allowPartialResults: { type: 'function', returnsPromise: false, returnType: 'Cursor', serverVersions: ['0.0.0', '4.4.0'] },

--- a/packages/shell-api/yaml/AggregationCursor.yaml
+++ b/packages/shell-api/yaml/AggregationCursor.yaml
@@ -8,6 +8,7 @@ class:
     __methods:
         wrappee: _cursor
         firstArg: ''
+    __hasAsyncChild: true
     # bsonsize: *__defaultMethod # TODO
     close:
         <<: *__defaultMethod

--- a/packages/shell-api/yaml/Cursor.yaml
+++ b/packages/shell-api/yaml/Cursor.yaml
@@ -8,6 +8,7 @@ class:
     __methods:
         wrappee: _cursor
         firstArg: ''
+    __hasAsyncChild: true
     addOption:
         <<: *__defaultMethod
         __fluent: true


### PR DESCRIPTION
Checking for un-inferrable code is done via a property of API classes called `__hasAsyncChild` (we could manually check for all children that have a `returnsPromise: true` attribute but that could get very slow).