### PR TITLE
MONGOSH-110: send telemetry events to segment if opted-in

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -18,6 +18,7 @@ variables:
       shell: bash
       script: |
         source .evergreen/.setup_env
+        export SEGMENT_API_KEY=${segment_key}
         export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
         npm run compile-exec
 # Functions are any command that can be run.

--- a/packages/cli-repl/README.md
+++ b/packages/cli-repl/README.md
@@ -1,0 +1,256 @@
+# @mongosh/cli-repl [![Build Status][azure-build-url]][azure-build]
+
+[Evergreen Build][evergreen-url]
+
+CLI interface for [MongoDB Shell][mongosh], an extension to Node.js REPL with MongoDB API.
+
+## Usage
+```shell
+  $ mongosh [options] [db address]
+
+  Options:
+    -h, --help                                 Show this usage information
+        --ipv6                                 Enable IPv6 support (disabled by default)
+        --host [arg]                           Server to connect to
+        --port [arg]                           Port to connect to
+        --version                              Show version information
+        --shell                                Run the shell after executing files
+        --nodb                                 Don't connect to mongod on startup - no 'db address' [arg] expected
+        --norc                                 Will not run the '.mongorc.js' file on start up
+        --eval [arg]                           Evaluate javascript
+        --retryWrites                          Automatically retry write operations upon transient network errors
+        --disableImplicitSessions              Do not automatically create and use implicit sessions
+
+  Authentication Options:
+
+    -u, --username [arg]                       Username for authentication
+    -p, --password [arg]                       Password for authentication
+        --authenticationDatabase [arg]         User source (defaults to dbname)
+        --authenticationMechanism [arg]        Authentication mechanism
+        --gssapiServiceName [arg] (=mongodb)   undefined
+        --gssapiHostName [arg]                 Automatically retry write operations upon transient network errors
+
+  TLS Options:
+
+        --tls                                  Use TLS for all connections
+        --tlsCertificateKeyFile [arg]          PEM certificate/key file for TLS
+        --tlsCertificateKeyFilePassword [arg]  undefined
+        --tlsCAFile [arg]                      Certificate Authority file for TLS
+        --tlsCRLFile [arg]                     Certificate Revocation List file for TLS
+        --tlsAllowInvalidHostnames             undefined
+        --tlsAllowInvalidCertificates          undefined
+        --tlsCertificateSelector [arg]         TLS Certificate in system store
+        --tlsDisabledProtocols [arg]           Comma separated list of TLS protocols to disable [TLS1_0,TLS1_1,TLS1_2]
+
+  FLE AWS Options
+
+        --awsAccessKeyId [arg]                 AWS Access Key for FLE Amazon KMS
+        --awsSecretAccessKey [arg]             AWS Secret Key for FLE Amazon KMS
+        --awsSessionToken [arg]                Optional AWS Session Token ID
+        --keyVaultNamespace [arg]              database.collection to store encrypted FLE parameters
+        --kmsURL [arg]                         Test parameter to override the URL for
+
+  DB Address Examples
+
+        foo                                    Foo database on local machine
+        192.168.0.5/foo                        Foo database on 192.168.0.5 machine
+        192.168.0.5:9999/foo                   Foo database on 192.168.0.5 machine on port 9999
+        mongodb://192.168.0.5:9999/foo         Connection string URI can also be used
+
+  File Names
+
+        A list of files to run. Files must end in .js and will exit after unless --shell is specified.
+
+  Examples
+
+        Start mongosh using 'ships' database on specified connection string:
+        $ mongosh mongodb://192.168.0.5:9999/ships
+
+  For more information on mongosh usage: https://docs.mongodb.com/manual/mongo/.
+```
+
+### Log Format
+CLI REPL listens to a few events via a message bus  that are then logged to
+user's local log file in `~/.mongodb/mongosh/` in ndjson format using
+[pino][pino-js].
+
+### bus.on('mongosh:connect', connectEvent)
+Where `connectionInfo` is an object with the following interface:
+```ts
+interface ConnectEvent {
+  driverUri: string;
+}
+```
+Used to log and send telemetry about connection information. Sensitive
+information is stripped beforehand.
+
+Example: 
+```js
+bus.emit('mongosh:connect', {
+  driverUri: 'mongodb://192.168.0.5:9999/ships' 
+})
+```
+
+### bus.on('mongosh:new-user', userID, enableTelemetry)
+Where `userID` is a [BSON ObjectID][object-id] and `enableTelemetry` is a boolean flag.
+This is used for telemetry tracking when the user initially uses mongosh.
+
+Example: 
+```js
+bus.emit('mongosh:new-user', '12394dfjvnaw3uw3erdf', true)
+```
+
+### bus.on('mongosh:update-user', id, enableTelemetry)
+Where `userID` is a [BSON ObjectID][object-id] and `enableTelemetry` is a boolean flag.
+This is used internally to update telemetry preferences and userID in the
+logger.
+
+Example: 
+```js
+bus.emit('mongosh:update-user', '12394dfjvnaw3uw3erdf', false)
+```
+
+### bus.on('mongosh:error', error)
+Where `error` is an [Error Object][error-object]. Used to log and send telemetry
+about errors that are _thrown_.
+
+Example: 
+```js
+bus.emit('mongosh:error', new Error('Unable to show collections'))
+```
+
+### bus.on('mongosh:help')
+Used when `help` command was used.
+
+Example: 
+```js
+bus.emit('mongosh:help')
+```
+
+### bus.on('mongosh:rewritten-async-input', inputInfo)
+Used for internal debugging of async-rewriter. `inputInfo` is an object with the
+following interface:
+```ts
+interface AsyncRewriterEvent {
+  original: string;
+  rewritten: string;
+}
+```
+
+Example: 
+```js
+bus.emit('mongosh:rewritten-async-input', {
+  original: 'db.coll.find().forEach()',
+  rewritten: 'await db.coll.find().forEach();'
+})
+
+```
+
+### bus.on('mongosh:use', args)
+Used for recording information about `use`. `args` has the following interface:
+
+```ts
+interface UseEvent {
+  db: string;
+}
+```
+
+Example: 
+```js
+bus.emit('mongosh:use', { db: 'cats' })
+
+```
+
+### bus.on('mongosh:show', args)
+Used for recording information about `show` command. `args` has the following
+interface:
+
+```ts
+interface ShowEvent {
+  method: string;
+}
+```
+
+Example: 
+```js
+bus.emit('mongosh:show', { method: 'dbs' })
+
+```
+
+### bus.on('mongosh:it')
+Used for recording when `it` command was called.
+
+Example: 
+```js
+bus.emit('mongosh:it')
+
+```
+### bus.on('mongosh:api-call', args)
+Used for recording information when API calls are made. `args` has the following
+interface:
+```ts
+interface ApiEvent {
+  method?: string; 
+  class?: string;
+  db?: string;
+  coll?: string;
+  arguments?: ApiEventArguments;
+}
+```
+
+```ts
+interface ApiEventArguments {
+  pipeline?: any[];
+  query?: object;
+  options?: object;
+  filter?: object; 
+}
+```
+
+`arguments` may contain information about the API call. As a rule, we don't emit
+information containing documents coming from API calls such as
+`db.coll.insert()` or `db.coll.bulkWrite()` to keep cleaner logs.
+
+`aggregate` Event Example: 
+```js
+this.messageBus.emit('mongosh:api-call', {
+  method: 'aggregate',
+  class: 'Collection',
+  db, coll, arguments: { options, pipeline }
+});
+
+```
+
+`runCommand` Event Example: 
+```js
+this.messageBus.emit('mongosh:api-call', {
+  method: 'runCommand', class: 'Database', db, arguments: { cmd }
+});
+
+```
+
+`createIndex` Event Example:
+```js
+this.messageBus.emit('mongosh:api-call', {
+  method: 'createIndex',
+  class: 'Collection',
+  db, coll, arguments: { keys, options }
+});
+```
+
+
+## Local Development
+
+
+## Installation
+```shell
+npm install --save @mongosh/cli-repl
+```
+
+[mongosh]: https://github.com/mongodb-js/mongosh
+[azure-build-url]: https://dev.azure.com/team-compass/mongosh/_apis/build/status/mongodb-js.mongosh?branchName=master
+[azure-build]: https://dev.azure.com/team-compass/mongosh/_build/latest?definitionId=5&branchName=master
+[evergreen-url]: https://evergreen.mongodb.com/waterfall/mongosh 
+[pino-js]: https://github.com/pinojs/pino 
+[object-id]: https://docs.mongodb.com/manual/reference/method/ObjectId/
+[error-object]: https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error

--- a/packages/cli-repl/package-lock.json
+++ b/packages/cli-repl/package-lock.json
@@ -253,71 +253,71 @@
 			}
 		},
 		"@mongosh/async-rewriter": {
-			"version": "0.0.1-alpha.11",
-			"resolved": "https://registry.npmjs.org/@mongosh/async-rewriter/-/async-rewriter-0.0.1-alpha.11.tgz",
-			"integrity": "sha512-iBdc7fjgshcpFzwziOerbfNuet5y6WqkIk120lenk+wTch/6T7jSCRrkQGQcSiOISXIfbl7wpXrD7E3T5H7rLw==",
+			"version": "0.0.1-alpha.12",
+			"resolved": "https://registry.npmjs.org/@mongosh/async-rewriter/-/async-rewriter-0.0.1-alpha.12.tgz",
+			"integrity": "sha512-LlTp2bCNVy60SX2WKGKRNPFDSEcChqAz3f54it9SFcGQndjRw03wOEPx7hxt/3sMWxxASaGPC45LPjOJpBELOg==",
 			"requires": {
 				"@babel/core": "^7.8.7"
 			}
 		},
 		"@mongosh/history": {
-			"version": "0.0.1-alpha.11",
-			"resolved": "https://registry.npmjs.org/@mongosh/history/-/history-0.0.1-alpha.11.tgz",
-			"integrity": "sha512-cIWlxkS4rhOAZE1DRwJkeM5UPHZC0z/pU+HEsD/+HMNoBooTrXdv7EQwKNl3PY89hxBzGx/ufhHMJ+F3jAofkA==",
+			"version": "0.0.1-alpha.12",
+			"resolved": "https://registry.npmjs.org/@mongosh/history/-/history-0.0.1-alpha.12.tgz",
+			"integrity": "sha512-vaYC47YmpOAYnzNLlmO1WRDV9DKvDnqTJQUoyglVa1djQ68Zvc5N7ry4LA4DFvYC6kHH75Ffiqcaqh9TuY1CiQ==",
 			"requires": {
 				"mongodb-redact": "^0.2.0"
 			}
 		},
 		"@mongosh/i18n": {
-			"version": "0.0.1-alpha.11",
-			"resolved": "https://registry.npmjs.org/@mongosh/i18n/-/i18n-0.0.1-alpha.11.tgz",
-			"integrity": "sha512-lc1D50UrVvFCAViYAkFSvOlOtY9rOf/WtEvBlYkP5ry7iSPBLk85BAM71dj6+NrwcJZDZD3OGw5nXH/sbSVe2Q==",
+			"version": "0.0.1-alpha.12",
+			"resolved": "https://registry.npmjs.org/@mongosh/i18n/-/i18n-0.0.1-alpha.12.tgz",
+			"integrity": "sha512-CPJqi4FB1LuK1SJ+H4K+Tbmq2y6/ni7Lh+iYABoncnB09y9FlXoE0l7HZkJ0clWMsVtccceLpKGUu/tZotsO9g==",
 			"requires": {
 				"mustache": "^4.0.0"
 			}
 		},
 		"@mongosh/mapper": {
-			"version": "0.0.1-alpha.11",
-			"resolved": "https://registry.npmjs.org/@mongosh/mapper/-/mapper-0.0.1-alpha.11.tgz",
-			"integrity": "sha512-ZohODL7az++yiSU47D4IgCWXE9D/HBkAwzBnQvsRGoOd0t19wPTcpsnhQLJxBMeH2ia2RFpQkYCJX5v5Er0M8g==",
+			"version": "0.0.1-alpha.12",
+			"resolved": "https://registry.npmjs.org/@mongosh/mapper/-/mapper-0.0.1-alpha.12.tgz",
+			"integrity": "sha512-WB6zeUnbl9jedH1wA8vENdqkBq/Jf+yyPdqlm6gvg9keamhhJEW6pfdFj7XGhSMeTL+NpnSOJ9OyheG0ZF2ljw==",
 			"requires": {
-				"@mongosh/service-provider-core": "^0.0.1-alpha.11",
-				"@mongosh/shell-api": "^0.0.1-alpha.11",
+				"@mongosh/service-provider-core": "^0.0.1-alpha.12",
+				"@mongosh/shell-api": "^0.0.1-alpha.12",
 				"pretty-bytes": "^5.3.0",
 				"text-table": "^0.2.0"
 			}
 		},
 		"@mongosh/service-provider-core": {
-			"version": "0.0.1-alpha.11",
-			"resolved": "https://registry.npmjs.org/@mongosh/service-provider-core/-/service-provider-core-0.0.1-alpha.11.tgz",
-			"integrity": "sha512-3MHaqv6/gPjQ8WJnGIecRC9MOkA6d/ja+FDafNM1Q15IpBjILeUxkwiI1CMPpSTuTDNCCItMmIsHIsA1Jd6qag=="
+			"version": "0.0.1-alpha.12",
+			"resolved": "https://registry.npmjs.org/@mongosh/service-provider-core/-/service-provider-core-0.0.1-alpha.12.tgz",
+			"integrity": "sha512-lkHGjgvR2GBjFYCYnYE3XcUVoEr3GuzC2+HMB3LTXWDWWNea2HmxiB67KM+9FdyBXb349zSfaCOLy76142lawQ=="
 		},
 		"@mongosh/service-provider-server": {
-			"version": "0.0.1-alpha.11",
-			"resolved": "https://registry.npmjs.org/@mongosh/service-provider-server/-/service-provider-server-0.0.1-alpha.11.tgz",
-			"integrity": "sha512-+nehdiz7WtqUfKzNYbbHwe6ejL3mdGcWmX1K0Ax4ROgPyhO9pk1H9bUBiw+YolLgC1EQ63zqrDOI+ThpFYiOCA==",
+			"version": "0.0.1-alpha.12",
+			"resolved": "https://registry.npmjs.org/@mongosh/service-provider-server/-/service-provider-server-0.0.1-alpha.12.tgz",
+			"integrity": "sha512-OpJ/NKGAEa3zKI2+G/87vk+YOsLLvj/p1P+aCOiEHjRKy4PWXmEKc0wf1j0rq5LZ1/RNj2zeJatA2OtX6LY/Jw==",
 			"requires": {
-				"@mongosh/service-provider-core": "^0.0.1-alpha.11",
+				"@mongosh/service-provider-core": "^0.0.1-alpha.12",
 				"mongodb": "3.5.3 || ^3.5.5"
 			}
 		},
 		"@mongosh/shell-api": {
-			"version": "0.0.1-alpha.11",
-			"resolved": "https://registry.npmjs.org/@mongosh/shell-api/-/shell-api-0.0.1-alpha.11.tgz",
-			"integrity": "sha512-pYGO2y/p3gbDrwaezs6Qt1HFQv/Bfy5pm9eMHem2B+YWJr0hKPUwcUDkU881n2wZof44yicKduKG18akgTPXNw==",
+			"version": "0.0.1-alpha.12",
+			"resolved": "https://registry.npmjs.org/@mongosh/shell-api/-/shell-api-0.0.1-alpha.12.tgz",
+			"integrity": "sha512-Mu9OZFc9YvF0+Un8cNyBjBozBoc1lAWHLkRMwhBnD/hf4SbGl5VHn8AGBAEKmId+YLADTyb2HhnBeuzLFKBp2g==",
 			"requires": {
-				"@mongosh/i18n": "^0.0.1-alpha.11"
+				"@mongosh/i18n": "^0.0.1-alpha.12"
 			}
 		},
 		"@mongosh/shell-evaluator": {
-			"version": "0.0.1-alpha.11",
-			"resolved": "https://registry.npmjs.org/@mongosh/shell-evaluator/-/shell-evaluator-0.0.1-alpha.11.tgz",
-			"integrity": "sha512-SeF+jxhNPyJtaa3nM6wuvU7Ghqih4r9tNvYoqvR1W3ZfLldZQozILRx8B49yM4sdW/17c3dDvEZtjAtc7nIr4A==",
+			"version": "0.0.1-alpha.12",
+			"resolved": "https://registry.npmjs.org/@mongosh/shell-evaluator/-/shell-evaluator-0.0.1-alpha.12.tgz",
+			"integrity": "sha512-Ovy/Vrh3d+0IZnVmY1KIMR5oY3coREDBztFCemZeaBHJ0dFbJCodaW7VUyU6Qm365H840aMgDyUELec3rDC07Q==",
 			"requires": {
-				"@mongosh/async-rewriter": "^0.0.1-alpha.11",
-				"@mongosh/mapper": "^0.0.1-alpha.11",
-				"@mongosh/service-provider-core": "^0.0.1-alpha.11",
-				"@mongosh/shell-api": "^0.0.1-alpha.11"
+				"@mongosh/async-rewriter": "^0.0.1-alpha.12",
+				"@mongosh/mapper": "^0.0.1-alpha.12",
+				"@mongosh/service-provider-core": "^0.0.1-alpha.12",
+				"@mongosh/shell-api": "^0.0.1-alpha.12"
 			}
 		},
 		"@segment/loosely-validate-event": {
@@ -400,6 +400,15 @@
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
 			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
 		},
+		"bl": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/bl/-/bl-2.2.0.tgz",
+			"integrity": "sha512-wbgvOpqopSr7uq6fJrLH8EsvYMJf9gzfo2jCsL2eTy75qXPukA4pCgHamOQkZtY5vmfVtjB+P3LNlMHW5CEZXA==",
+			"requires": {
+				"readable-stream": "^2.3.5",
+				"safe-buffer": "^5.1.1"
+			}
+		},
 		"bson": {
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/bson/-/bson-4.0.4.tgz",
@@ -466,15 +475,66 @@
 			"resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
 			"integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
 		},
+		"color-convert": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"requires": {
+				"color-name": "1.1.3"
+			}
+		},
+		"color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+		},
 		"component-type": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/component-type/-/component-type-1.2.1.tgz",
 			"integrity": "sha1-ikeQFwAjjk/DIml3EjAibyS0Fak="
 		},
+		"convert-source-map": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+			"integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+			"requires": {
+				"safe-buffer": "~5.1.1"
+			},
+			"dependencies": {
+				"safe-buffer": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+				}
+			}
+		},
+		"core-util-is": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+		},
 		"crypt": {
 			"version": "0.0.2",
 			"resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
 			"integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
+		},
+		"debug": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+			"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+			"requires": {
+				"ms": "^2.1.1"
+			}
+		},
+		"denque": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/denque/-/denque-1.4.1.tgz",
+			"integrity": "sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ=="
+		},
+		"escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 		},
 		"fast-redact": {
 			"version": "2.0.0",
@@ -514,6 +574,21 @@
 			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.12.0.tgz",
 			"integrity": "sha1-5tnb5Xy+/mB1HwKvM2GVhwyQwB4="
 		},
+		"gensync": {
+			"version": "1.0.0-beta.1",
+			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
+			"integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg=="
+		},
+		"globals": {
+			"version": "11.12.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
+		},
+		"has-flag": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+		},
 		"ieee754": {
 			"version": "1.1.13",
 			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
@@ -537,6 +612,11 @@
 					"integrity": "sha512-Rv2gFCK8IXvbXtNjPJz7/KCH7qb7PCBwuwp8H3JBWUehLRd3e3lLZAdOXLIm8MGsmvzHKJvskwRaXndtEQFvRA=="
 				}
 			}
+		"inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+		},
 		"is-buffer": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
@@ -547,10 +627,33 @@
 			"resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
 			"integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg=="
 		},
+		"isarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+		},
 		"join-component": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/join-component/-/join-component-1.1.0.tgz",
 			"integrity": "sha1-uEF7dQZho5K+4sJTfGiyqdSXfNU="
+		},
+		"js-tokens": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+		},
+		"jsesc": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
+		},
+		"json5": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+			"integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+			"requires": {
+				"minimist": "^1.2.5"
+			}
 		},
 		"lodash": {
 			"version": "4.17.15",
@@ -581,6 +684,12 @@
 				"highlight.js": "~9.12.0"
 			}
 		},
+		"memory-pager": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+			"integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+			"optional": true
+		},
 		"minimist": {
 			"version": "1.2.5",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
@@ -590,6 +699,26 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
 			"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+		},
+		"mongodb": {
+			"version": "3.5.6",
+			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.5.6.tgz",
+			"integrity": "sha512-sh3q3GLDLT4QmoDLamxtAECwC3RGjq+oNuK1ENV8+tnipIavss6sMYt77hpygqlMOCt0Sla5cl7H4SKCVBCGEg==",
+			"requires": {
+				"bl": "^2.2.0",
+				"bson": "^1.1.4",
+				"denque": "^1.4.1",
+				"require_optional": "^1.0.1",
+				"safe-buffer": "^5.1.2",
+				"saslprep": "^1.0.0"
+			},
+			"dependencies": {
+				"bson": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/bson/-/bson-1.1.4.tgz",
+					"integrity": "sha512-S/yKGU1syOMzO86+dGpg2qGoDL0zvzcb262G+gqEy6TgP6rt6z6qxSFX/8X6vLC91P7G7C3nLs0+bvDzmvBA3Q=="
+				}
+			}
 		},
 		"mongodb-ace-autocompleter": {
 			"version": "0.4.8",
@@ -616,6 +745,11 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+		},
+		"mustache": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/mustache/-/mustache-4.0.1.tgz",
+			"integrity": "sha512-yL5VE97+OXn4+Er3THSmTdCFCtx5hHWzrolvH+JObZnUYwuaG7XV+Ch4fR2cIrcYI0tFHxS7iyFYl14bW8y2sA=="
 		},
 		"mute-stream": {
 			"version": "0.0.8",
@@ -653,6 +787,11 @@
 				"nanoassert": "^1.1.0",
 				"nanoscheduler": "^1.0.2"
 			}
+		},
+		"path-parse": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
 		},
 		"pino": {
 			"version": "5.17.0",
@@ -701,6 +840,27 @@
 				"mute-stream": "~0.0.4"
 			}
 		},
+		"readable-stream": {
+			"version": "2.3.7",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+			"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+			"requires": {
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
+			},
+			"dependencies": {
+				"safe-buffer": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+				}
+			}
+		},
 		"remove-array-items": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/remove-array-items/-/remove-array-items-1.1.1.tgz",
@@ -710,6 +870,49 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/remove-trailing-slash/-/remove-trailing-slash-0.1.0.tgz",
 			"integrity": "sha1-FJjl3wmEwn5Jt26/Boh8otARUNI="
+		},
+		"require_optional": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
+			"integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
+			"requires": {
+				"resolve-from": "^2.0.0",
+				"semver": "^5.1.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+				}
+			}
+		},
+		"resolve": {
+			"version": "1.16.1",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.16.1.tgz",
+			"integrity": "sha512-rmAglCSqWWMrrBv/XM6sW0NuRFiKViw/W4d9EbC4pt+49H8JwHy+mcGmALTEg504AUDcLTvb1T2q3E9AnmY+ig==",
+			"requires": {
+				"path-parse": "^1.0.6"
+			}
+		},
+		"resolve-from": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+			"integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
+		},
+		"safe-buffer": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+			"integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+		},
+		"saslprep": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
+			"integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
+			"optional": true,
+			"requires": {
+				"sparse-bitfield": "^3.0.3"
+			}
 		},
 		"semver": {
 			"version": "7.3.2",
@@ -737,6 +940,16 @@
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
 			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+		},
+		"to-fast-properties": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+		},
+		"util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
 		}
 	}
 }

--- a/packages/cli-repl/package-lock.json
+++ b/packages/cli-repl/package-lock.json
@@ -329,6 +329,11 @@
 				"join-component": "^1.1.0"
 			}
 		},
+		"@types/color-name": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
+			"integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
+		},
 		"analytics-node": {
 			"version": "3.4.0-beta.1",
 			"resolved": "https://registry.npmjs.org/analytics-node/-/analytics-node-3.4.0-beta.1.tgz",
@@ -350,6 +355,11 @@
 					"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
 				}
 			}
+		},
+		"ansi": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
+			"integrity": "sha1-DELU+xcWDVqa8eSEus4cZpIsGyE="
 		},
 		"ansi-escape-sequences": {
 			"version": "5.1.2",
@@ -427,6 +437,11 @@
 				"supports-color": "^7.1.0"
 			}
 		},
+		"charenc": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+			"integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
+		},
 		"color-convert": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
@@ -439,6 +454,31 @@
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+		},
+		"component-type": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/component-type/-/component-type-1.2.1.tgz",
+			"integrity": "sha1-ikeQFwAjjk/DIml3EjAibyS0Fak="
+		},
+		"crypt": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+			"integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
+		},
+		"debug": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+			"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+			"requires": {
+				"ms": "2.0.0"
+			},
+			"dependencies": {
+				"ms": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+					"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+				}
+			}
 		},
 		"emphasize": {
 			"version": "3.0.0",
@@ -460,21 +500,6 @@
 					}
 				}
 			}
-		},
-		"charenc": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-			"integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
-		},
-		"component-type": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/component-type/-/component-type-1.2.1.tgz",
-			"integrity": "sha1-ikeQFwAjjk/DIml3EjAibyS0Fak="
-		},
-		"crypt": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-			"integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
 		},
 		"fast-redact": {
 			"version": "2.0.0",
@@ -498,6 +523,14 @@
 			"version": "1.0.12",
 			"resolved": "https://registry.npmjs.org/flatstr/-/flatstr-1.0.12.tgz",
 			"integrity": "sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw=="
+		},
+		"follow-redirects": {
+			"version": "1.5.10",
+			"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+			"integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+			"requires": {
+				"debug": "=3.1.0"
+			}
 		},
 		"format": {
 			"version": "0.2.2",
@@ -580,6 +613,23 @@
 			"requires": {
 				"fault": "^1.0.2",
 				"highlight.js": "~9.12.0"
+			}
+		},
+		"md5": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
+			"integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
+			"requires": {
+				"charenc": "~0.0.1",
+				"crypt": "~0.0.1",
+				"is-buffer": "~1.1.1"
+			},
+			"dependencies": {
+				"is-buffer": {
+					"version": "1.1.6",
+					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+					"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+				}
 			}
 		},
 		"minimist": {

--- a/packages/cli-repl/package-lock.json
+++ b/packages/cli-repl/package-lock.json
@@ -400,15 +400,6 @@
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
 			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
 		},
-		"bl": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/bl/-/bl-2.2.0.tgz",
-			"integrity": "sha512-wbgvOpqopSr7uq6fJrLH8EsvYMJf9gzfo2jCsL2eTy75qXPukA4pCgHamOQkZtY5vmfVtjB+P3LNlMHW5CEZXA==",
-			"requires": {
-				"readable-stream": "^2.3.5",
-				"safe-buffer": "^5.1.1"
-			}
-		},
 		"bson": {
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/bson/-/bson-4.0.4.tgz",
@@ -475,66 +466,15 @@
 			"resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
 			"integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
 		},
-		"color-convert": {
-			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-			"requires": {
-				"color-name": "1.1.3"
-			}
-		},
-		"color-name": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-		},
 		"component-type": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/component-type/-/component-type-1.2.1.tgz",
 			"integrity": "sha1-ikeQFwAjjk/DIml3EjAibyS0Fak="
 		},
-		"convert-source-map": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
-			"integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
-			"requires": {
-				"safe-buffer": "~5.1.1"
-			},
-			"dependencies": {
-				"safe-buffer": {
-					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-				}
-			}
-		},
-		"core-util-is": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-		},
 		"crypt": {
 			"version": "0.0.2",
 			"resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
 			"integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
-		},
-		"debug": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-			"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-			"requires": {
-				"ms": "^2.1.1"
-			}
-		},
-		"denque": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/denque/-/denque-1.4.1.tgz",
-			"integrity": "sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ=="
-		},
-		"escape-string-regexp": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 		},
 		"fast-redact": {
 			"version": "2.0.0",
@@ -574,21 +514,6 @@
 			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.12.0.tgz",
 			"integrity": "sha1-5tnb5Xy+/mB1HwKvM2GVhwyQwB4="
 		},
-		"gensync": {
-			"version": "1.0.0-beta.1",
-			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
-			"integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg=="
-		},
-		"globals": {
-			"version": "11.12.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
-		},
-		"has-flag": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
-		},
 		"ieee754": {
 			"version": "1.1.13",
 			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
@@ -611,12 +536,8 @@
 					"resolved": "https://registry.npmjs.org/acorn-numeric-separator/-/acorn-numeric-separator-0.3.1.tgz",
 					"integrity": "sha512-Rv2gFCK8IXvbXtNjPJz7/KCH7qb7PCBwuwp8H3JBWUehLRd3e3lLZAdOXLIm8MGsmvzHKJvskwRaXndtEQFvRA=="
 				}
-			}
-		"inherits": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-		},
+      }
+    },
 		"is-buffer": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
@@ -627,33 +548,10 @@
 			"resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
 			"integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg=="
 		},
-		"isarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-		},
 		"join-component": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/join-component/-/join-component-1.1.0.tgz",
 			"integrity": "sha1-uEF7dQZho5K+4sJTfGiyqdSXfNU="
-		},
-		"js-tokens": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
-		},
-		"jsesc": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
-		},
-		"json5": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
-			"integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
-			"requires": {
-				"minimist": "^1.2.5"
-			}
 		},
 		"lodash": {
 			"version": "4.17.15",
@@ -684,12 +582,6 @@
 				"highlight.js": "~9.12.0"
 			}
 		},
-		"memory-pager": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
-			"integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
-			"optional": true
-		},
 		"minimist": {
 			"version": "1.2.5",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
@@ -699,26 +591,6 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
 			"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
-		},
-		"mongodb": {
-			"version": "3.5.6",
-			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.5.6.tgz",
-			"integrity": "sha512-sh3q3GLDLT4QmoDLamxtAECwC3RGjq+oNuK1ENV8+tnipIavss6sMYt77hpygqlMOCt0Sla5cl7H4SKCVBCGEg==",
-			"requires": {
-				"bl": "^2.2.0",
-				"bson": "^1.1.4",
-				"denque": "^1.4.1",
-				"require_optional": "^1.0.1",
-				"safe-buffer": "^5.1.2",
-				"saslprep": "^1.0.0"
-			},
-			"dependencies": {
-				"bson": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/bson/-/bson-1.1.4.tgz",
-					"integrity": "sha512-S/yKGU1syOMzO86+dGpg2qGoDL0zvzcb262G+gqEy6TgP6rt6z6qxSFX/8X6vLC91P7G7C3nLs0+bvDzmvBA3Q=="
-				}
-			}
 		},
 		"mongodb-ace-autocompleter": {
 			"version": "0.4.8",
@@ -745,11 +617,6 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-		},
-		"mustache": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/mustache/-/mustache-4.0.1.tgz",
-			"integrity": "sha512-yL5VE97+OXn4+Er3THSmTdCFCtx5hHWzrolvH+JObZnUYwuaG7XV+Ch4fR2cIrcYI0tFHxS7iyFYl14bW8y2sA=="
 		},
 		"mute-stream": {
 			"version": "0.0.8",
@@ -787,11 +654,6 @@
 				"nanoassert": "^1.1.0",
 				"nanoscheduler": "^1.0.2"
 			}
-		},
-		"path-parse": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
 		},
 		"pino": {
 			"version": "5.17.0",
@@ -840,27 +702,6 @@
 				"mute-stream": "~0.0.4"
 			}
 		},
-		"readable-stream": {
-			"version": "2.3.7",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-			"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-			"requires": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.3",
-				"isarray": "~1.0.0",
-				"process-nextick-args": "~2.0.0",
-				"safe-buffer": "~5.1.1",
-				"string_decoder": "~1.1.1",
-				"util-deprecate": "~1.0.1"
-			},
-			"dependencies": {
-				"safe-buffer": {
-					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-				}
-			}
-		},
 		"remove-array-items": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/remove-array-items/-/remove-array-items-1.1.1.tgz",
@@ -870,49 +711,6 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/remove-trailing-slash/-/remove-trailing-slash-0.1.0.tgz",
 			"integrity": "sha1-FJjl3wmEwn5Jt26/Boh8otARUNI="
-		},
-		"require_optional": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
-			"integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
-			"requires": {
-				"resolve-from": "^2.0.0",
-				"semver": "^5.1.0"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-				}
-			}
-		},
-		"resolve": {
-			"version": "1.16.1",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.16.1.tgz",
-			"integrity": "sha512-rmAglCSqWWMrrBv/XM6sW0NuRFiKViw/W4d9EbC4pt+49H8JwHy+mcGmALTEg504AUDcLTvb1T2q3E9AnmY+ig==",
-			"requires": {
-				"path-parse": "^1.0.6"
-			}
-		},
-		"resolve-from": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-			"integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
-		},
-		"safe-buffer": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-			"integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
-		},
-		"saslprep": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
-			"integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
-			"optional": true,
-			"requires": {
-				"sparse-bitfield": "^3.0.3"
-			}
 		},
 		"semver": {
 			"version": "7.3.2",
@@ -940,16 +738,6 @@
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
 			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
-		},
-		"to-fast-properties": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
-		},
-		"util-deprecate": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
 		}
 	}
 }

--- a/packages/cli-repl/package-lock.json
+++ b/packages/cli-repl/package-lock.json
@@ -4,6 +4,15 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@segment/loosely-validate-event": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@segment/loosely-validate-event/-/loosely-validate-event-2.0.0.tgz",
+			"integrity": "sha512-ZMCSfztDBqwotkl848ODgVcAmN4OItEWDCkshcKz0/W6gGSQayuuCtWV/MlodFivAZD793d6UgANd6wCXUfrIw==",
+			"requires": {
+				"component-type": "^1.2.1",
+				"join-component": "^1.1.0"
+			}
+		},
 		"@types/color-name": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
@@ -47,292 +56,6 @@
 			"requires": {
 				"acorn-private-class-elements": "^0.2.3"
 			}
-		},
-		"ansi": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
-			"integrity": "sha1-DELU+xcWDVqa8eSEus4cZpIsGyE="
-    },
-		"@babel/code-frame": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
-			"integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
-			"requires": {
-				"@babel/highlight": "^7.8.3"
-			}
-		},
-		"@babel/core": {
-			"version": "7.9.0",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.9.0.tgz",
-			"integrity": "sha512-kWc7L0fw1xwvI0zi8OKVBuxRVefwGOrKSQMvrQ3dW+bIIavBY3/NpXmpjMy7bQnLgwgzWQZ8TlM57YHpHNHz4w==",
-			"requires": {
-				"@babel/code-frame": "^7.8.3",
-				"@babel/generator": "^7.9.0",
-				"@babel/helper-module-transforms": "^7.9.0",
-				"@babel/helpers": "^7.9.0",
-				"@babel/parser": "^7.9.0",
-				"@babel/template": "^7.8.6",
-				"@babel/traverse": "^7.9.0",
-				"@babel/types": "^7.9.0",
-				"convert-source-map": "^1.7.0",
-				"debug": "^4.1.0",
-				"gensync": "^1.0.0-beta.1",
-				"json5": "^2.1.2",
-				"lodash": "^4.17.13",
-				"resolve": "^1.3.2",
-				"semver": "^5.4.1",
-				"source-map": "^0.5.0"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-				}
-			}
-		},
-		"@babel/generator": {
-			"version": "7.9.5",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.5.tgz",
-			"integrity": "sha512-GbNIxVB3ZJe3tLeDm1HSn2AhuD/mVcyLDpgtLXa5tplmWrJdF/elxB56XNqCuD6szyNkDi6wuoKXln3QeBmCHQ==",
-			"requires": {
-				"@babel/types": "^7.9.5",
-				"jsesc": "^2.5.1",
-				"lodash": "^4.17.13",
-				"source-map": "^0.5.0"
-			}
-		},
-		"@babel/helper-function-name": {
-			"version": "7.9.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.9.5.tgz",
-			"integrity": "sha512-JVcQZeXM59Cd1qanDUxv9fgJpt3NeKUaqBqUEvfmQ+BCOKq2xUgaWZW2hr0dkbyJgezYuplEoh5knmrnS68efw==",
-			"requires": {
-				"@babel/helper-get-function-arity": "^7.8.3",
-				"@babel/template": "^7.8.3",
-				"@babel/types": "^7.9.5"
-			}
-		},
-		"@babel/helper-get-function-arity": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
-			"integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
-			"requires": {
-				"@babel/types": "^7.8.3"
-			}
-		},
-		"@babel/helper-member-expression-to-functions": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.8.3.tgz",
-			"integrity": "sha512-fO4Egq88utkQFjbPrSHGmGLFqmrshs11d46WI+WZDESt7Wu7wN2G2Iu+NMMZJFDOVRHAMIkB5SNh30NtwCA7RA==",
-			"requires": {
-				"@babel/types": "^7.8.3"
-			}
-		},
-		"@babel/helper-module-imports": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.8.3.tgz",
-			"integrity": "sha512-R0Bx3jippsbAEtzkpZ/6FIiuzOURPcMjHp+Z6xPe6DtApDJx+w7UYyOLanZqO8+wKR9G10s/FmHXvxaMd9s6Kg==",
-			"requires": {
-				"@babel/types": "^7.8.3"
-			}
-		},
-		"@babel/helper-module-transforms": {
-			"version": "7.9.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.9.0.tgz",
-			"integrity": "sha512-0FvKyu0gpPfIQ8EkxlrAydOWROdHpBmiCiRwLkUiBGhCUPRRbVD2/tm3sFr/c/GWFrQ/ffutGUAnx7V0FzT2wA==",
-			"requires": {
-				"@babel/helper-module-imports": "^7.8.3",
-				"@babel/helper-replace-supers": "^7.8.6",
-				"@babel/helper-simple-access": "^7.8.3",
-				"@babel/helper-split-export-declaration": "^7.8.3",
-				"@babel/template": "^7.8.6",
-				"@babel/types": "^7.9.0",
-				"lodash": "^4.17.13"
-			}
-		},
-		"@babel/helper-optimise-call-expression": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.8.3.tgz",
-			"integrity": "sha512-Kag20n86cbO2AvHca6EJsvqAd82gc6VMGule4HwebwMlwkpXuVqrNRj6CkCV2sKxgi9MyAUnZVnZ6lJ1/vKhHQ==",
-			"requires": {
-				"@babel/types": "^7.8.3"
-			}
-		},
-		"@babel/helper-replace-supers": {
-			"version": "7.8.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.8.6.tgz",
-			"integrity": "sha512-PeMArdA4Sv/Wf4zXwBKPqVj7n9UF/xg6slNRtZW84FM7JpE1CbG8B612FyM4cxrf4fMAMGO0kR7voy1ForHHFA==",
-			"requires": {
-				"@babel/helper-member-expression-to-functions": "^7.8.3",
-				"@babel/helper-optimise-call-expression": "^7.8.3",
-				"@babel/traverse": "^7.8.6",
-				"@babel/types": "^7.8.6"
-			}
-		},
-		"@babel/helper-simple-access": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.8.3.tgz",
-			"integrity": "sha512-VNGUDjx5cCWg4vvCTR8qQ7YJYZ+HBjxOgXEl7ounz+4Sn7+LMD3CFrCTEU6/qXKbA2nKg21CwhhBzO0RpRbdCw==",
-			"requires": {
-				"@babel/template": "^7.8.3",
-				"@babel/types": "^7.8.3"
-			}
-		},
-		"@babel/helper-split-export-declaration": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
-			"integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
-			"requires": {
-				"@babel/types": "^7.8.3"
-			}
-		},
-		"@babel/helper-validator-identifier": {
-			"version": "7.9.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz",
-			"integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g=="
-		},
-		"@babel/helpers": {
-			"version": "7.9.2",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.9.2.tgz",
-			"integrity": "sha512-JwLvzlXVPjO8eU9c/wF9/zOIN7X6h8DYf7mG4CiFRZRvZNKEF5dQ3H3V+ASkHoIB3mWhatgl5ONhyqHRI6MppA==",
-			"requires": {
-				"@babel/template": "^7.8.3",
-				"@babel/traverse": "^7.9.0",
-				"@babel/types": "^7.9.0"
-			}
-		},
-		"@babel/highlight": {
-			"version": "7.9.0",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.9.0.tgz",
-			"integrity": "sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==",
-			"requires": {
-				"@babel/helper-validator-identifier": "^7.9.0",
-				"chalk": "^2.0.0",
-				"js-tokens": "^4.0.0"
-			}
-		},
-		"@babel/parser": {
-			"version": "7.9.4",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.4.tgz",
-			"integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA=="
-		},
-		"@babel/template": {
-			"version": "7.8.6",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
-			"integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
-			"requires": {
-				"@babel/code-frame": "^7.8.3",
-				"@babel/parser": "^7.8.6",
-				"@babel/types": "^7.8.6"
-			}
-		},
-		"@babel/traverse": {
-			"version": "7.9.5",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.9.5.tgz",
-			"integrity": "sha512-c4gH3jsvSuGUezlP6rzSJ6jf8fYjLj3hsMZRx/nX0h+fmHN0w+ekubRrHPqnMec0meycA2nwCsJ7dC8IPem2FQ==",
-			"requires": {
-				"@babel/code-frame": "^7.8.3",
-				"@babel/generator": "^7.9.5",
-				"@babel/helper-function-name": "^7.9.5",
-				"@babel/helper-split-export-declaration": "^7.8.3",
-				"@babel/parser": "^7.9.0",
-				"@babel/types": "^7.9.5",
-				"debug": "^4.1.0",
-				"globals": "^11.1.0",
-				"lodash": "^4.17.13"
-			}
-		},
-		"@babel/types": {
-			"version": "7.9.5",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
-			"integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
-			"requires": {
-				"@babel/helper-validator-identifier": "^7.9.5",
-				"lodash": "^4.17.13",
-				"to-fast-properties": "^2.0.0"
-			}
-		},
-		"@mongosh/async-rewriter": {
-			"version": "0.0.1-alpha.12",
-			"resolved": "https://registry.npmjs.org/@mongosh/async-rewriter/-/async-rewriter-0.0.1-alpha.12.tgz",
-			"integrity": "sha512-LlTp2bCNVy60SX2WKGKRNPFDSEcChqAz3f54it9SFcGQndjRw03wOEPx7hxt/3sMWxxASaGPC45LPjOJpBELOg==",
-			"requires": {
-				"@babel/core": "^7.8.7"
-			}
-		},
-		"@mongosh/history": {
-			"version": "0.0.1-alpha.12",
-			"resolved": "https://registry.npmjs.org/@mongosh/history/-/history-0.0.1-alpha.12.tgz",
-			"integrity": "sha512-vaYC47YmpOAYnzNLlmO1WRDV9DKvDnqTJQUoyglVa1djQ68Zvc5N7ry4LA4DFvYC6kHH75Ffiqcaqh9TuY1CiQ==",
-			"requires": {
-				"mongodb-redact": "^0.2.0"
-			}
-		},
-		"@mongosh/i18n": {
-			"version": "0.0.1-alpha.12",
-			"resolved": "https://registry.npmjs.org/@mongosh/i18n/-/i18n-0.0.1-alpha.12.tgz",
-			"integrity": "sha512-CPJqi4FB1LuK1SJ+H4K+Tbmq2y6/ni7Lh+iYABoncnB09y9FlXoE0l7HZkJ0clWMsVtccceLpKGUu/tZotsO9g==",
-			"requires": {
-				"mustache": "^4.0.0"
-			}
-		},
-		"@mongosh/mapper": {
-			"version": "0.0.1-alpha.12",
-			"resolved": "https://registry.npmjs.org/@mongosh/mapper/-/mapper-0.0.1-alpha.12.tgz",
-			"integrity": "sha512-WB6zeUnbl9jedH1wA8vENdqkBq/Jf+yyPdqlm6gvg9keamhhJEW6pfdFj7XGhSMeTL+NpnSOJ9OyheG0ZF2ljw==",
-			"requires": {
-				"@mongosh/service-provider-core": "^0.0.1-alpha.12",
-				"@mongosh/shell-api": "^0.0.1-alpha.12",
-				"pretty-bytes": "^5.3.0",
-				"text-table": "^0.2.0"
-			}
-		},
-		"@mongosh/service-provider-core": {
-			"version": "0.0.1-alpha.12",
-			"resolved": "https://registry.npmjs.org/@mongosh/service-provider-core/-/service-provider-core-0.0.1-alpha.12.tgz",
-			"integrity": "sha512-lkHGjgvR2GBjFYCYnYE3XcUVoEr3GuzC2+HMB3LTXWDWWNea2HmxiB67KM+9FdyBXb349zSfaCOLy76142lawQ=="
-		},
-		"@mongosh/service-provider-server": {
-			"version": "0.0.1-alpha.12",
-			"resolved": "https://registry.npmjs.org/@mongosh/service-provider-server/-/service-provider-server-0.0.1-alpha.12.tgz",
-			"integrity": "sha512-OpJ/NKGAEa3zKI2+G/87vk+YOsLLvj/p1P+aCOiEHjRKy4PWXmEKc0wf1j0rq5LZ1/RNj2zeJatA2OtX6LY/Jw==",
-			"requires": {
-				"@mongosh/service-provider-core": "^0.0.1-alpha.12",
-				"mongodb": "3.5.3 || ^3.5.5"
-			}
-		},
-		"@mongosh/shell-api": {
-			"version": "0.0.1-alpha.12",
-			"resolved": "https://registry.npmjs.org/@mongosh/shell-api/-/shell-api-0.0.1-alpha.12.tgz",
-			"integrity": "sha512-Mu9OZFc9YvF0+Un8cNyBjBozBoc1lAWHLkRMwhBnD/hf4SbGl5VHn8AGBAEKmId+YLADTyb2HhnBeuzLFKBp2g==",
-			"requires": {
-				"@mongosh/i18n": "^0.0.1-alpha.12"
-			}
-		},
-		"@mongosh/shell-evaluator": {
-			"version": "0.0.1-alpha.12",
-			"resolved": "https://registry.npmjs.org/@mongosh/shell-evaluator/-/shell-evaluator-0.0.1-alpha.12.tgz",
-			"integrity": "sha512-Ovy/Vrh3d+0IZnVmY1KIMR5oY3coREDBztFCemZeaBHJ0dFbJCodaW7VUyU6Qm365H840aMgDyUELec3rDC07Q==",
-			"requires": {
-				"@mongosh/async-rewriter": "^0.0.1-alpha.12",
-				"@mongosh/mapper": "^0.0.1-alpha.12",
-				"@mongosh/service-provider-core": "^0.0.1-alpha.12",
-				"@mongosh/shell-api": "^0.0.1-alpha.12"
-			}
-		},
-		"@segment/loosely-validate-event": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@segment/loosely-validate-event/-/loosely-validate-event-2.0.0.tgz",
-			"integrity": "sha512-ZMCSfztDBqwotkl848ODgVcAmN4OItEWDCkshcKz0/W6gGSQayuuCtWV/MlodFivAZD793d6UgANd6wCXUfrIw==",
-			"requires": {
-				"component-type": "^1.2.1",
-				"join-component": "^1.1.0"
-			}
-		},
-		"@types/color-name": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-			"integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
 		},
 		"analytics-node": {
 			"version": "3.4.0-beta.1",
@@ -552,6 +275,11 @@
 			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
 			"integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
 		},
+		"is-buffer": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+			"integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
+		},
 		"is-recoverable-error": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-recoverable-error/-/is-recoverable-error-1.0.0.tgz",
@@ -569,12 +297,7 @@
 					"resolved": "https://registry.npmjs.org/acorn-numeric-separator/-/acorn-numeric-separator-0.3.1.tgz",
 					"integrity": "sha512-Rv2gFCK8IXvbXtNjPJz7/KCH7qb7PCBwuwp8H3JBWUehLRd3e3lLZAdOXLIm8MGsmvzHKJvskwRaXndtEQFvRA=="
 				}
-      }
-    },
-		"is-buffer": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-			"integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
+			}
 		},
 		"is-retry-allowed": {
 			"version": "1.2.0",

--- a/packages/cli-repl/package-lock.json
+++ b/packages/cli-repl/package-lock.json
@@ -52,6 +52,303 @@
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
 			"integrity": "sha1-DELU+xcWDVqa8eSEus4cZpIsGyE="
+		"@babel/code-frame": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+			"integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+			"requires": {
+				"@babel/highlight": "^7.8.3"
+			}
+		},
+		"@babel/core": {
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.9.0.tgz",
+			"integrity": "sha512-kWc7L0fw1xwvI0zi8OKVBuxRVefwGOrKSQMvrQ3dW+bIIavBY3/NpXmpjMy7bQnLgwgzWQZ8TlM57YHpHNHz4w==",
+			"requires": {
+				"@babel/code-frame": "^7.8.3",
+				"@babel/generator": "^7.9.0",
+				"@babel/helper-module-transforms": "^7.9.0",
+				"@babel/helpers": "^7.9.0",
+				"@babel/parser": "^7.9.0",
+				"@babel/template": "^7.8.6",
+				"@babel/traverse": "^7.9.0",
+				"@babel/types": "^7.9.0",
+				"convert-source-map": "^1.7.0",
+				"debug": "^4.1.0",
+				"gensync": "^1.0.0-beta.1",
+				"json5": "^2.1.2",
+				"lodash": "^4.17.13",
+				"resolve": "^1.3.2",
+				"semver": "^5.4.1",
+				"source-map": "^0.5.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+				}
+			}
+		},
+		"@babel/generator": {
+			"version": "7.9.5",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.5.tgz",
+			"integrity": "sha512-GbNIxVB3ZJe3tLeDm1HSn2AhuD/mVcyLDpgtLXa5tplmWrJdF/elxB56XNqCuD6szyNkDi6wuoKXln3QeBmCHQ==",
+			"requires": {
+				"@babel/types": "^7.9.5",
+				"jsesc": "^2.5.1",
+				"lodash": "^4.17.13",
+				"source-map": "^0.5.0"
+			}
+		},
+		"@babel/helper-function-name": {
+			"version": "7.9.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.9.5.tgz",
+			"integrity": "sha512-JVcQZeXM59Cd1qanDUxv9fgJpt3NeKUaqBqUEvfmQ+BCOKq2xUgaWZW2hr0dkbyJgezYuplEoh5knmrnS68efw==",
+			"requires": {
+				"@babel/helper-get-function-arity": "^7.8.3",
+				"@babel/template": "^7.8.3",
+				"@babel/types": "^7.9.5"
+			}
+		},
+		"@babel/helper-get-function-arity": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
+			"integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
+			"requires": {
+				"@babel/types": "^7.8.3"
+			}
+		},
+		"@babel/helper-member-expression-to-functions": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.8.3.tgz",
+			"integrity": "sha512-fO4Egq88utkQFjbPrSHGmGLFqmrshs11d46WI+WZDESt7Wu7wN2G2Iu+NMMZJFDOVRHAMIkB5SNh30NtwCA7RA==",
+			"requires": {
+				"@babel/types": "^7.8.3"
+			}
+		},
+		"@babel/helper-module-imports": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.8.3.tgz",
+			"integrity": "sha512-R0Bx3jippsbAEtzkpZ/6FIiuzOURPcMjHp+Z6xPe6DtApDJx+w7UYyOLanZqO8+wKR9G10s/FmHXvxaMd9s6Kg==",
+			"requires": {
+				"@babel/types": "^7.8.3"
+			}
+		},
+		"@babel/helper-module-transforms": {
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.9.0.tgz",
+			"integrity": "sha512-0FvKyu0gpPfIQ8EkxlrAydOWROdHpBmiCiRwLkUiBGhCUPRRbVD2/tm3sFr/c/GWFrQ/ffutGUAnx7V0FzT2wA==",
+			"requires": {
+				"@babel/helper-module-imports": "^7.8.3",
+				"@babel/helper-replace-supers": "^7.8.6",
+				"@babel/helper-simple-access": "^7.8.3",
+				"@babel/helper-split-export-declaration": "^7.8.3",
+				"@babel/template": "^7.8.6",
+				"@babel/types": "^7.9.0",
+				"lodash": "^4.17.13"
+			}
+		},
+		"@babel/helper-optimise-call-expression": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.8.3.tgz",
+			"integrity": "sha512-Kag20n86cbO2AvHca6EJsvqAd82gc6VMGule4HwebwMlwkpXuVqrNRj6CkCV2sKxgi9MyAUnZVnZ6lJ1/vKhHQ==",
+			"requires": {
+				"@babel/types": "^7.8.3"
+			}
+		},
+		"@babel/helper-replace-supers": {
+			"version": "7.8.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.8.6.tgz",
+			"integrity": "sha512-PeMArdA4Sv/Wf4zXwBKPqVj7n9UF/xg6slNRtZW84FM7JpE1CbG8B612FyM4cxrf4fMAMGO0kR7voy1ForHHFA==",
+			"requires": {
+				"@babel/helper-member-expression-to-functions": "^7.8.3",
+				"@babel/helper-optimise-call-expression": "^7.8.3",
+				"@babel/traverse": "^7.8.6",
+				"@babel/types": "^7.8.6"
+			}
+		},
+		"@babel/helper-simple-access": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.8.3.tgz",
+			"integrity": "sha512-VNGUDjx5cCWg4vvCTR8qQ7YJYZ+HBjxOgXEl7ounz+4Sn7+LMD3CFrCTEU6/qXKbA2nKg21CwhhBzO0RpRbdCw==",
+			"requires": {
+				"@babel/template": "^7.8.3",
+				"@babel/types": "^7.8.3"
+			}
+		},
+		"@babel/helper-split-export-declaration": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
+			"integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
+			"requires": {
+				"@babel/types": "^7.8.3"
+			}
+		},
+		"@babel/helper-validator-identifier": {
+			"version": "7.9.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz",
+			"integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g=="
+		},
+		"@babel/helpers": {
+			"version": "7.9.2",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.9.2.tgz",
+			"integrity": "sha512-JwLvzlXVPjO8eU9c/wF9/zOIN7X6h8DYf7mG4CiFRZRvZNKEF5dQ3H3V+ASkHoIB3mWhatgl5ONhyqHRI6MppA==",
+			"requires": {
+				"@babel/template": "^7.8.3",
+				"@babel/traverse": "^7.9.0",
+				"@babel/types": "^7.9.0"
+			}
+		},
+		"@babel/highlight": {
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.9.0.tgz",
+			"integrity": "sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==",
+			"requires": {
+				"@babel/helper-validator-identifier": "^7.9.0",
+				"chalk": "^2.0.0",
+				"js-tokens": "^4.0.0"
+			}
+		},
+		"@babel/parser": {
+			"version": "7.9.4",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.4.tgz",
+			"integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA=="
+		},
+		"@babel/template": {
+			"version": "7.8.6",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
+			"integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
+			"requires": {
+				"@babel/code-frame": "^7.8.3",
+				"@babel/parser": "^7.8.6",
+				"@babel/types": "^7.8.6"
+			}
+		},
+		"@babel/traverse": {
+			"version": "7.9.5",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.9.5.tgz",
+			"integrity": "sha512-c4gH3jsvSuGUezlP6rzSJ6jf8fYjLj3hsMZRx/nX0h+fmHN0w+ekubRrHPqnMec0meycA2nwCsJ7dC8IPem2FQ==",
+			"requires": {
+				"@babel/code-frame": "^7.8.3",
+				"@babel/generator": "^7.9.5",
+				"@babel/helper-function-name": "^7.9.5",
+				"@babel/helper-split-export-declaration": "^7.8.3",
+				"@babel/parser": "^7.9.0",
+				"@babel/types": "^7.9.5",
+				"debug": "^4.1.0",
+				"globals": "^11.1.0",
+				"lodash": "^4.17.13"
+			}
+		},
+		"@babel/types": {
+			"version": "7.9.5",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
+			"integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
+			"requires": {
+				"@babel/helper-validator-identifier": "^7.9.5",
+				"lodash": "^4.17.13",
+				"to-fast-properties": "^2.0.0"
+			}
+		},
+		"@mongosh/async-rewriter": {
+			"version": "0.0.1-alpha.11",
+			"resolved": "https://registry.npmjs.org/@mongosh/async-rewriter/-/async-rewriter-0.0.1-alpha.11.tgz",
+			"integrity": "sha512-iBdc7fjgshcpFzwziOerbfNuet5y6WqkIk120lenk+wTch/6T7jSCRrkQGQcSiOISXIfbl7wpXrD7E3T5H7rLw==",
+			"requires": {
+				"@babel/core": "^7.8.7"
+			}
+		},
+		"@mongosh/history": {
+			"version": "0.0.1-alpha.11",
+			"resolved": "https://registry.npmjs.org/@mongosh/history/-/history-0.0.1-alpha.11.tgz",
+			"integrity": "sha512-cIWlxkS4rhOAZE1DRwJkeM5UPHZC0z/pU+HEsD/+HMNoBooTrXdv7EQwKNl3PY89hxBzGx/ufhHMJ+F3jAofkA==",
+			"requires": {
+				"mongodb-redact": "^0.2.0"
+			}
+		},
+		"@mongosh/i18n": {
+			"version": "0.0.1-alpha.11",
+			"resolved": "https://registry.npmjs.org/@mongosh/i18n/-/i18n-0.0.1-alpha.11.tgz",
+			"integrity": "sha512-lc1D50UrVvFCAViYAkFSvOlOtY9rOf/WtEvBlYkP5ry7iSPBLk85BAM71dj6+NrwcJZDZD3OGw5nXH/sbSVe2Q==",
+			"requires": {
+				"mustache": "^4.0.0"
+			}
+		},
+		"@mongosh/mapper": {
+			"version": "0.0.1-alpha.11",
+			"resolved": "https://registry.npmjs.org/@mongosh/mapper/-/mapper-0.0.1-alpha.11.tgz",
+			"integrity": "sha512-ZohODL7az++yiSU47D4IgCWXE9D/HBkAwzBnQvsRGoOd0t19wPTcpsnhQLJxBMeH2ia2RFpQkYCJX5v5Er0M8g==",
+			"requires": {
+				"@mongosh/service-provider-core": "^0.0.1-alpha.11",
+				"@mongosh/shell-api": "^0.0.1-alpha.11",
+				"pretty-bytes": "^5.3.0",
+				"text-table": "^0.2.0"
+			}
+		},
+		"@mongosh/service-provider-core": {
+			"version": "0.0.1-alpha.11",
+			"resolved": "https://registry.npmjs.org/@mongosh/service-provider-core/-/service-provider-core-0.0.1-alpha.11.tgz",
+			"integrity": "sha512-3MHaqv6/gPjQ8WJnGIecRC9MOkA6d/ja+FDafNM1Q15IpBjILeUxkwiI1CMPpSTuTDNCCItMmIsHIsA1Jd6qag=="
+		},
+		"@mongosh/service-provider-server": {
+			"version": "0.0.1-alpha.11",
+			"resolved": "https://registry.npmjs.org/@mongosh/service-provider-server/-/service-provider-server-0.0.1-alpha.11.tgz",
+			"integrity": "sha512-+nehdiz7WtqUfKzNYbbHwe6ejL3mdGcWmX1K0Ax4ROgPyhO9pk1H9bUBiw+YolLgC1EQ63zqrDOI+ThpFYiOCA==",
+			"requires": {
+				"@mongosh/service-provider-core": "^0.0.1-alpha.11",
+				"mongodb": "3.5.3 || ^3.5.5"
+			}
+		},
+		"@mongosh/shell-api": {
+			"version": "0.0.1-alpha.11",
+			"resolved": "https://registry.npmjs.org/@mongosh/shell-api/-/shell-api-0.0.1-alpha.11.tgz",
+			"integrity": "sha512-pYGO2y/p3gbDrwaezs6Qt1HFQv/Bfy5pm9eMHem2B+YWJr0hKPUwcUDkU881n2wZof44yicKduKG18akgTPXNw==",
+			"requires": {
+				"@mongosh/i18n": "^0.0.1-alpha.11"
+			}
+		},
+		"@mongosh/shell-evaluator": {
+			"version": "0.0.1-alpha.11",
+			"resolved": "https://registry.npmjs.org/@mongosh/shell-evaluator/-/shell-evaluator-0.0.1-alpha.11.tgz",
+			"integrity": "sha512-SeF+jxhNPyJtaa3nM6wuvU7Ghqih4r9tNvYoqvR1W3ZfLldZQozILRx8B49yM4sdW/17c3dDvEZtjAtc7nIr4A==",
+			"requires": {
+				"@mongosh/async-rewriter": "^0.0.1-alpha.11",
+				"@mongosh/mapper": "^0.0.1-alpha.11",
+				"@mongosh/service-provider-core": "^0.0.1-alpha.11",
+				"@mongosh/shell-api": "^0.0.1-alpha.11"
+			}
+		},
+		"@segment/loosely-validate-event": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@segment/loosely-validate-event/-/loosely-validate-event-2.0.0.tgz",
+			"integrity": "sha512-ZMCSfztDBqwotkl848ODgVcAmN4OItEWDCkshcKz0/W6gGSQayuuCtWV/MlodFivAZD793d6UgANd6wCXUfrIw==",
+			"requires": {
+				"component-type": "^1.2.1",
+				"join-component": "^1.1.0"
+			}
+		},
+		"analytics-node": {
+			"version": "3.4.0-beta.1",
+			"resolved": "https://registry.npmjs.org/analytics-node/-/analytics-node-3.4.0-beta.1.tgz",
+			"integrity": "sha512-+0F/y4Asc5S2qhWcYss+iCob6TTXQktwbqlIk02gcZaRxpekCbnTbJu/rcaRooVHxqp9WSzUXiWCesJYPJETZQ==",
+			"requires": {
+				"@segment/loosely-validate-event": "^2.0.0",
+				"axios": "^0.18.1",
+				"axios-retry": "^3.0.2",
+				"lodash.isstring": "^4.0.1",
+				"md5": "^2.2.1",
+				"ms": "^2.0.0",
+				"remove-trailing-slash": "^0.1.0",
+				"uuid": "^3.2.1"
+			},
+			"dependencies": {
+				"uuid": {
+					"version": "3.4.0",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+					"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+				}
+			}
 		},
 		"ansi-escape-sequences": {
 			"version": "5.1.2",
@@ -80,6 +377,23 @@
 			"resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
 			"integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="
 		},
+		"axios": {
+			"version": "0.18.1",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-0.18.1.tgz",
+			"integrity": "sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==",
+			"requires": {
+				"follow-redirects": "1.5.10",
+				"is-buffer": "^2.0.2"
+			}
+		},
+		"axios-retry": {
+			"version": "3.1.5",
+			"resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.1.5.tgz",
+			"integrity": "sha512-8OImX5nk7RAAexnSAI3mI1DyHi+ukpQnZhhjcq5odTBPD0/BjHS4pdcst4fNAREThck5psQtMzDvKbRwCZX5Qg==",
+			"requires": {
+				"is-retry-allowed": "^1.1.0"
+			}
+		},
 		"base64-js": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
@@ -104,6 +418,7 @@
 			}
 		},
 		"chalk": {
+<<<<<<< HEAD
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.0.0.tgz",
 			"integrity": "sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==",
@@ -146,6 +461,83 @@
 				}
 			}
 		},
+=======
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"requires": {
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
+			}
+		},
+		"color-convert": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"requires": {
+				"color-name": "1.1.3"
+			}
+		},
+		"color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+		},
+		"convert-source-map": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+			"integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+			"requires": {
+				"safe-buffer": "~5.1.1"
+			},
+			"dependencies": {
+				"safe-buffer": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+				}
+			}
+		},
+		"core-util-is": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+		},
+		"debug": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+			"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+			"requires": {
+				"ms": "^2.1.1"
+			}
+		},
+		"denque": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/denque/-/denque-1.4.1.tgz",
+			"integrity": "sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ=="
+		},
+		"escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+		},
+		"charenc": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+			"integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
+		},
+		"component-type": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/component-type/-/component-type-1.2.1.tgz",
+			"integrity": "sha1-ikeQFwAjjk/DIml3EjAibyS0Fak="
+		},
+		"crypt": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+			"integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
+		},
+>>>>>>> add segment integration for analytics
 		"fast-redact": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-2.0.0.tgz",
@@ -212,6 +604,11 @@
 			"version": "4.17.15",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
 			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+		},
+		"lodash.isstring": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+			"integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
 		},
 		"lodash.set": {
 			"version": "4.3.2",

--- a/packages/cli-repl/package-lock.json
+++ b/packages/cli-repl/package-lock.json
@@ -52,6 +52,7 @@
 			"version": "0.3.1",
 			"resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
 			"integrity": "sha1-DELU+xcWDVqa8eSEus4cZpIsGyE="
+    },
 		"@babel/code-frame": {
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
@@ -418,7 +419,6 @@
 			}
 		},
 		"chalk": {
-<<<<<<< HEAD
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.0.0.tgz",
 			"integrity": "sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==",
@@ -461,67 +461,6 @@
 				}
 			}
 		},
-=======
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-			"requires": {
-				"ansi-styles": "^3.2.1",
-				"escape-string-regexp": "^1.0.5",
-				"supports-color": "^5.3.0"
-			}
-		},
-		"color-convert": {
-			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-			"requires": {
-				"color-name": "1.1.3"
-			}
-		},
-		"color-name": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-		},
-		"convert-source-map": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
-			"integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
-			"requires": {
-				"safe-buffer": "~5.1.1"
-			},
-			"dependencies": {
-				"safe-buffer": {
-					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-				}
-			}
-		},
-		"core-util-is": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-		},
-		"debug": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-			"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-			"requires": {
-				"ms": "^2.1.1"
-			}
-		},
-		"denque": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/denque/-/denque-1.4.1.tgz",
-			"integrity": "sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ=="
-		},
-		"escape-string-regexp": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-		},
 		"charenc": {
 			"version": "0.0.2",
 			"resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
@@ -537,7 +476,6 @@
 			"resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
 			"integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
 		},
->>>>>>> add segment integration for analytics
 		"fast-redact": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-2.0.0.tgz",
@@ -599,6 +537,20 @@
 					"integrity": "sha512-Rv2gFCK8IXvbXtNjPJz7/KCH7qb7PCBwuwp8H3JBWUehLRd3e3lLZAdOXLIm8MGsmvzHKJvskwRaXndtEQFvRA=="
 				}
 			}
+		"is-buffer": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+			"integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
+		},
+		"is-retry-allowed": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
+			"integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg=="
+		},
+		"join-component": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/join-component/-/join-component-1.1.0.tgz",
+			"integrity": "sha1-uEF7dQZho5K+4sJTfGiyqdSXfNU="
 		},
 		"lodash": {
 			"version": "4.17.15",
@@ -659,6 +611,11 @@
 			"requires": {
 				"lodash": "^4.17.15"
 			}
+		},
+		"ms": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 		},
 		"mute-stream": {
 			"version": "0.0.8",
@@ -748,6 +705,11 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/remove-array-items/-/remove-array-items-1.1.1.tgz",
 			"integrity": "sha512-MXW/jtHyl5F1PZI7NbpS8SOtympdLuF20aoWJT5lELR1p/HJDd5nqW8Eu9uLh/hCRY3FgvrIT5AwDCgBODklcA=="
+		},
+		"remove-trailing-slash": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/remove-trailing-slash/-/remove-trailing-slash-0.1.0.tgz",
+			"integrity": "sha1-FJjl3wmEwn5Jt26/Boh8otARUNI="
 		},
 		"semver": {
 			"version": "7.3.2",

--- a/packages/cli-repl/package.json
+++ b/packages/cli-repl/package.json
@@ -41,6 +41,7 @@
     "acorn-numeric-separator": "^0.3.0",
     "acorn-private-methods": "^0.3.1",
     "acorn-static-class-features": "^0.2.1",
+    "analytics-node": "^3.4.0-beta.1",
     "ansi-escape-sequences": "^5.1.2",
     "bson": "^4.0.4",
     "is-recoverable-error": "^1.0.0",

--- a/packages/cli-repl/src/cli-repl.ts
+++ b/packages/cli-repl/src/cli-repl.ts
@@ -51,7 +51,6 @@ class CliRepl {
    */
   async connect(driverUri: string, driverOptions: NodeOptions): Promise<void> {
     console.log(i18n.__(CONNECTING), clr(redactPwd(driverUri), 'bold'));
-    this.bus.emit('mongosh:connect', { driverUri });
 
     this.serviceProvider = await CliServiceProvider.connect(driverUri, driverOptions);
     this.ShellEvaluator = new ShellEvaluator(this.serviceProvider, this.bus, this);
@@ -66,7 +65,7 @@ class CliRepl {
       topology
     );
 
-    this.bus.emit('connect', connectInfo);
+    this.bus.emit('mongosh:connect', connectInfo);
     this.start();
   }
 

--- a/packages/cli-repl/src/cli-repl.ts
+++ b/packages/cli-repl/src/cli-repl.ts
@@ -78,10 +78,11 @@ class CliRepl {
     this.mongoshDir = path.join(os.homedir(), '.mongodb/mongosh/');
 
     this.createMongoshDir();
-    this.generateOrReadTelemetryConfig();
 
     this.bus = new Nanobus('mongosh');
     logger(this.bus, this.mongoshDir);
+
+    this.generateOrReadTelemetryConfig();
 
     if (this.isPasswordMissing(driverOptions)) {
       this.requirePassword(driverUri, driverOptions);
@@ -132,6 +133,7 @@ class CliRepl {
       this.userId = new ObjectId(Date.now());
       this.enableTelemetry = true ;
       this.disableGreetingMessage = false;
+      this.bus.emit('mongosh:new-user', this.userId, this.enableTelemetry);
       this.writeConfigFileSync(configPath);
     } catch (err) {
       if (err.code === 'EEXIST') {
@@ -139,6 +141,7 @@ class CliRepl {
         this.userId = config.userId;
         this.disableGreetingMessage = true;
         this.enableTelemetry = config.enableTelemetry;
+        this.bus.emit('mongosh:update-user', this.userId, this.enableTelemetry);
         return;
       }
       this.bus.emit('mongosh:error', err)
@@ -161,6 +164,7 @@ class CliRepl {
     this.enableTelemetry = enabled;
     this.disableGreetingMessage = true;
 
+    this.bus.emit('mongosh:toggleTelemetry', this.enableTelemetry);
     const configPath = path.join(this.mongoshDir, 'config');
     this.writeConfigFileSync(configPath);
 

--- a/packages/cli-repl/src/cli-repl.ts
+++ b/packages/cli-repl/src/cli-repl.ts
@@ -51,7 +51,7 @@ class CliRepl {
    */
   async connect(driverUri: string, driverOptions: NodeOptions): Promise<void> {
     console.log(i18n.__(CONNECTING), clr(redactPwd(driverUri), 'bold'));
-    this.bus.emit('mongosh:connect', driverUri);
+    this.bus.emit('mongosh:connect', { driverUri });
 
     this.serviceProvider = await CliServiceProvider.connect(driverUri, driverOptions);
     this.ShellEvaluator = new ShellEvaluator(this.serviceProvider, this.bus, this);
@@ -164,7 +164,7 @@ class CliRepl {
     this.enableTelemetry = enabled;
     this.disableGreetingMessage = true;
 
-    this.bus.emit('mongosh:toggleTelemetry', this.enableTelemetry);
+    this.bus.emit('mongosh:update-user', this.userId, this.enableTelemetry);
     const configPath = path.join(this.mongoshDir, 'config');
     this.writeConfigFileSync(configPath);
 

--- a/packages/cli-repl/src/connect-info.spec.ts
+++ b/packages/cli-repl/src/connect-info.spec.ts
@@ -82,7 +82,8 @@ describe('getConnectInfo', function() {
       isDataLake: false,
       dlVersion: null,
       isGenuine: true,
-      serverName: 'mongodb'
+      serverName: 'mongodb',
+      uri: ATLAS_URI
     }
     expect(getConnectInfo(
       ATLAS_URI,
@@ -101,7 +102,8 @@ describe('getConnectInfo', function() {
       isDataLake: false,
       dlVersion: null,
       isGenuine: true,
-      serverName: 'mongodb'
+      serverName: 'mongodb',
+      uri: ATLAS_URI
     }
     expect(getConnectInfo(
       ATLAS_URI,

--- a/packages/cli-repl/src/connect-info.ts
+++ b/packages/cli-repl/src/connect-info.ts
@@ -15,6 +15,7 @@ export default function getConnectInfo(uri: string, buildInfo: any, cmdLineOpts:
     isLocalhost: getBuildInfo.isLocalhost(uri),
     serverVersion: buildInfo.version,
     isEnterprise: getBuildInfo.isEnterprise(buildInfo),
+    uri,
     authType,
     isDataLake,
     dlVersion,

--- a/packages/cli-repl/src/logger.ts
+++ b/packages/cli-repl/src/logger.ts
@@ -61,7 +61,8 @@ export default function logger(bus: any, logDir: string) {
 
   let analytics = new NoopAnalytics();
   try {
-    analytics = new Analytics(process.env.SEGMENT_API_KEY);
+    // this file gets written as a part of a release
+    analytics = new Analytics(require('./config.js'));
   } catch (e) {
     bus.emit('mongosh:error', e)
   }

--- a/packages/cli-repl/src/logger.ts
+++ b/packages/cli-repl/src/logger.ts
@@ -62,9 +62,8 @@ export default function logger(bus: any, logDir: string) {
   let analytics = new NoopAnalytics();
   try {
     // this file gets written as a part of a release
-    console.log(require('./config.js'))
-    log.warn(require('./config.js').SEGMENT_API_KEY)
-    analytics = new Analytics(require('./config.js').SEGMENT_API_KEY);
+    log.warn(require('./analytics-config.js').SEGMENT_API_KEY)
+    analytics = new Analytics(require('./analytics-config.js').SEGMENT_API_KEY);
   } catch (e) {
     bus.emit('mongosh:error', e)
   }
@@ -100,7 +99,7 @@ export default function logger(bus: any, logDir: string) {
   bus.on('mongosh:error', function(error: ErrorEvent) {
     log.error(error);
 
-    if (telemetry) {
+    if (telemetry && error.name.includes('Mongosh')) {
       analytics.track({
         userId,
         event: 'mongosh:error',
@@ -143,17 +142,6 @@ export default function logger(bus: any, logDir: string) {
         userId,
         event: 'mongosh:show',
         properties: { method: args.method }
-      });
-    }
-  });
-
-  bus.on('mongosh:it', function() {
-    log.info('mongosh:it');
-
-    if (telemetry) {
-      analytics.track({
-        userId,
-        event: 'mongosh:it'
       });
     }
   });

--- a/packages/cli-repl/src/logger.ts
+++ b/packages/cli-repl/src/logger.ts
@@ -62,8 +62,9 @@ export default function logger(bus: any, logDir: string) {
   let analytics = new NoopAnalytics();
   try {
     // this file gets written as a part of a release
-    analytics = new Analytics(require('./config.js'));
-    log.warn(require('./config.js'))
+    console.log(require('./config.js'))
+    log.warn(require('./config.js').SEGMENT_API_KEY)
+    analytics = new Analytics(require('./config.js').SEGMENT_API_KEY);
   } catch (e) {
     bus.emit('mongosh:error', e)
   }

--- a/packages/cli-repl/src/logger.ts
+++ b/packages/cli-repl/src/logger.ts
@@ -63,6 +63,7 @@ export default function logger(bus: any, logDir: string) {
   try {
     // this file gets written as a part of a release
     analytics = new Analytics(require('./config.js'));
+    log.warn(require('./config.js'))
   } catch (e) {
     bus.emit('mongosh:error', e)
   }

--- a/packages/cli-repl/src/logger.ts
+++ b/packages/cli-repl/src/logger.ts
@@ -39,7 +39,16 @@ interface ErrorEvent {
 }
 
 interface ConnectEvent {
-  driverUri: string;
+  uri: string;
+  isAtlas: boolean;
+  isLocalhost: boolean;
+  serverVersion: string;
+  isEnterprise: boolean;
+  authType: string;
+  isDataLake: boolean;
+  dlVersion?: string;
+  isGenuine: boolean;
+  serverName: string;
 }
 
 export default function logger(bus: any, logDir: string) {
@@ -58,15 +67,16 @@ export default function logger(bus: any, logDir: string) {
   }
 
   bus.on('mongosh:connect', function(args: ConnectEvent) {
-    const connectionUri = redactPwd(args.driverUri);
-    const params = { sessionID, userId, connectionUri };
-    log.info('connect', params);
+    const connectionUri = redactPwd(args.uri);
+    delete args.uri;
+    const params = { sessionID, userId, connectionUri, ...args };
+    log.info('mongosh:connect', params);
 
     if (telemetry) {
       analytics.track({
         userId,
         event: 'mongosh:connect',
-        properties: { sessionID, connectionUri }
+        properties: { sessionID, connectionUri, ...args }
       });
     }
   });
@@ -112,7 +122,7 @@ export default function logger(bus: any, logDir: string) {
   });
 
   bus.on('mongosh:use', function(args: UseEvent) {
-    log.info(args);
+    log.info('mongosh:use', args);
 
     if (telemetry) {
       analytics.track({
@@ -123,7 +133,7 @@ export default function logger(bus: any, logDir: string) {
   });
 
   bus.on('mongosh:show', function(args: ShowEvent) {
-    log.info(args);
+    log.info('mongosh:show', args);
 
     if (telemetry) {
       analytics.track({
@@ -146,11 +156,11 @@ export default function logger(bus: any, logDir: string) {
   });
 
   bus.on('mongosh:setCtx', function(args) {
-    log.info(args)
+    log.info('mongosh:setCtx')
   })
 
   bus.on('mongosh:api-call', function(args: ApiEvent) {
-    log.info(redactInfo(args));
+    log.info('mongosh:api-call', redactInfo(args));
 
     // analytics properties to include if they are present in an api-call
     let properties: ApiEvent = {};

--- a/packages/cli-repl/src/logger.ts
+++ b/packages/cli-repl/src/logger.ts
@@ -1,4 +1,5 @@
 import redactInfo from 'mongodb-redact';
+import Analytics from 'analytics-node';
 import redactPwd from './redact-pwd';
 import { ObjectId } from 'bson';
 import pino from 'pino';
@@ -6,23 +7,86 @@ import clr from './clr';
 import path from 'path';
 import os from 'os';
 
+interface ApiCallArguments {
+  pipeline?: any[];
+  query?: object;
+  options?: object;
+  filter?: object; 
+}
+
+interface ApiCall {
+  method?: string; 
+  class?: string;
+  db?: any;
+  coll?: any;
+  arguments?: ApiCallArguments;
+}
+
 function logger(bus: any, logDir: string) {
   const sessionID = new ObjectId(Date.now());
   const logDest = path.join(logDir, `${sessionID}_log`);
   const log = pino({ name: 'monogsh' }, pino.destination(logDest));
   console.log(`Current sessionID: ${sessionID}`);
+  let userId;
+  let telemetry;
+
+  let analytics = new NoopAnalytics();
+  try {
+    analytics = new Analytics(process.env.SEGMENT_API_KEY);
+  } catch (e) {
+    bus.emit('mongosh:error', e)
+  }
 
   bus.on('mongosh:connect', function(info) {
-    const params = { sessionID, info: redactPwd(info) };
+    const params = { sessionID, userId, info: redactPwd(info) };
     log.info('connect', params);
+
+    if (telemetry) {
+      analytics.track({
+        userId,
+        event: 'mongosh:connect',
+        properties: { sessionID, info: redactPwd(info) }
+      });
+    }
   });
+
+  bus.on('mongosh:new-user', function(id, enableTelemetry) {
+    userId = id;
+    telemetry = enableTelemetry;
+    if (telemetry) analytics.identify({ userId });
+  })
+
+  bus.on('mongosh:update-user', function(id, enableTelemetry) {
+    userId = id;
+    telemetry = enableTelemetry;
+  })
+
+  bus.on('mongosh:toggleTelemetry', function(enableTelemetry) {
+    telemetry = enableTelemetry;
+    log.info('mongosh:toggleTelemetry', { enableTelemetry })
+  })
 
   bus.on('mongosh:error', function(error) {
     log.error(error);
+
+    if (telemetry) {
+      analytics.track({
+        userId,
+        event: 'mongosh:error',
+        properties: { error }
+      });
+    }
   });
 
   bus.on('mongosh:help', function() {
     log.info('mongosh:help');
+
+    if (telemetry) {
+      analytics.track({
+        userId,
+        event: 'mongosh:help'
+      });
+    }
   });
 
   bus.on('mongosh:rewrittenAsyncInput', function(inputInfo) {
@@ -31,23 +95,68 @@ function logger(bus: any, logDir: string) {
 
   bus.on('mongosh:use', function(args) {
     log.info(args);
+
+    if (telemetry) {
+      analytics.track({
+        userId,
+        event: 'mongosh:use'
+      });
+    }
   });
 
   bus.on('mongosh:show', function(args) {
     log.info(args);
+
+    if (telemetry) {
+      analytics.track({
+        userId,
+        event: 'mongosh:show'
+      });
+    }
   });
 
   bus.on('mongosh:it', function(args) {
     log.info(args);
+
+    if (telemetry) {
+      analytics.track({
+        userId,
+        event: 'mongosh:it'
+      });
+    }
   });
 
   bus.on('mongosh:setCtx', function(args) {
     log.info(args)
   })
 
-  bus.on('mongosh:api-call', function(args) {
+  bus.on('mongosh:api-call', function(args: ApiCall) {
     log.info(redactInfo(args));
+
+    // analytics properties to include if they are present in an api-call
+    let properties: ApiCall = {};
+    properties.arguments = {};
+    if (args.method) properties.method = args.method;
+    if (args.class) properties.class = args.class;
+    if (args.arguments.pipeline) properties.arguments.pipeline = args.arguments.pipeline;
+    if (args.arguments.query) properties.arguments.query = args.arguments.query;
+    if (args.arguments.options) properties.arguments.options = args.arguments.options;
+    if (args.arguments.filter) properties.arguments.filter= args.arguments.filter;
+
+    if (telemetry) {
+      analytics.track({
+        userId,
+        event: 'mongosh:api-call',
+        properties: redactInfo(properties)
+      });
+    }
   });
 }
+
+// set up a noop, in case we are not able to connect to segment.
+function NoopAnalytics() {}
+
+NoopAnalytics.prototype.identify = function() {}
+NoopAnalytics.prototype.track = function() {}
 
 export default logger;

--- a/packages/java-shell/package-lock.json
+++ b/packages/java-shell/package-lock.json
@@ -46,6 +46,14 @@
 				"bn.js": "^4.0.0",
 				"inherits": "^2.0.1",
 				"minimalistic-assert": "^1.0.0"
+			},
+			"dependencies": {
+				"bn.js": {
+					"version": "4.11.8",
+					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+					"integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+					"dev": true
+				}
 			}
 		},
 		"assert": {
@@ -88,9 +96,9 @@
 			"dev": true
 		},
 		"bn.js": {
-			"version": "4.11.8",
-			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
-			"integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-5.1.1.tgz",
+			"integrity": "sha512-IUTD/REb78Z2eodka1QZyyEk66pciRcP6Sroka0aI3tG/iwIdYLrBD62RsubR7vqdt3WyX8p4jxeatzmRSphtA==",
 			"dev": true
 		},
 		"brace-expansion": {
@@ -241,21 +249,43 @@
 			"requires": {
 				"bn.js": "^4.1.0",
 				"randombytes": "^2.0.1"
+			},
+			"dependencies": {
+				"bn.js": {
+					"version": "4.11.8",
+					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+					"integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+					"dev": true
+				}
 			}
 		},
 		"browserify-sign": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
-			"integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
+			"version": "4.1.0",
+			"resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.1.0.tgz",
+			"integrity": "sha512-VYxo7cDCeYUoBZ0ZCy4UyEUCP3smyBd4DRQM5nrFS1jJjPJjX7rP3oLRpPoWfkhQfyJ0I9ZbHbKafrFD/SGlrg==",
 			"dev": true,
 			"requires": {
-				"bn.js": "^4.1.1",
-				"browserify-rsa": "^4.0.0",
-				"create-hash": "^1.1.0",
-				"create-hmac": "^1.1.2",
-				"elliptic": "^6.0.0",
-				"inherits": "^2.0.1",
-				"parse-asn1": "^5.0.0"
+				"bn.js": "^5.1.1",
+				"browserify-rsa": "^4.0.1",
+				"create-hash": "^1.2.0",
+				"create-hmac": "^1.1.7",
+				"elliptic": "^6.5.2",
+				"inherits": "^2.0.4",
+				"parse-asn1": "^5.1.5",
+				"readable-stream": "^3.6.0"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+					"dev": true,
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
 			}
 		},
 		"browserify-zlib": {
@@ -373,6 +403,14 @@
 			"requires": {
 				"bn.js": "^4.1.0",
 				"elliptic": "^6.0.0"
+			},
+			"dependencies": {
+				"bn.js": {
+					"version": "4.11.8",
+					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+					"integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+					"dev": true
+				}
 			}
 		},
 		"create-hash": {
@@ -475,6 +513,14 @@
 				"bn.js": "^4.1.0",
 				"miller-rabin": "^4.0.0",
 				"randombytes": "^2.0.0"
+			},
+			"dependencies": {
+				"bn.js": {
+					"version": "4.11.8",
+					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+					"integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+					"dev": true
+				}
 			}
 		},
 		"domain-browser": {
@@ -505,6 +551,14 @@
 				"inherits": "^2.0.1",
 				"minimalistic-assert": "^1.0.0",
 				"minimalistic-crypto-utils": "^1.0.0"
+			},
+			"dependencies": {
+				"bn.js": {
+					"version": "4.11.8",
+					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+					"integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+					"dev": true
+				}
 			}
 		},
 		"events": {
@@ -571,13 +625,27 @@
 			}
 		},
 		"hash-base": {
-			"version": "3.0.4",
-			"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
-			"integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.1.0.tgz",
+			"integrity": "sha512-1nmYp/rhMDiE7AYkDw+lLwlAzz0AntGIe51F3RfFfEqyQ3feY2eI/NcwC6umIQVOASPMsWJLJScWKSSvzL9IVA==",
 			"dev": true,
 			"requires": {
-				"inherits": "^2.0.1",
-				"safe-buffer": "^5.0.1"
+				"inherits": "^2.0.4",
+				"readable-stream": "^3.6.0",
+				"safe-buffer": "^5.2.0"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+					"dev": true,
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
 			}
 		},
 		"hash.js": {
@@ -730,6 +798,14 @@
 			"requires": {
 				"bn.js": "^4.0.0",
 				"brorand": "^1.0.1"
+			},
+			"dependencies": {
+				"bn.js": {
+					"version": "4.11.8",
+					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+					"integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+					"dev": true
+				}
 			}
 		},
 		"minimalistic-assert": {
@@ -760,9 +836,9 @@
 			"dev": true
 		},
 		"mkdirp-classic": {
-			"version": "0.5.2",
-			"resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.2.tgz",
-			"integrity": "sha512-ejdnDQcR75gwknmMw/tx02AuRs8jCtqFoFqDZMjiNxsu85sRIJVXDKHuLYvUUPRBUtV2FpSZa9bL1BUa3BdR2g==",
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+			"integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
 			"dev": true
 		},
 		"module-deps": {
@@ -899,6 +975,14 @@
 				"parse-asn1": "^5.0.0",
 				"randombytes": "^2.0.1",
 				"safe-buffer": "^5.1.2"
+			},
+			"dependencies": {
+				"bn.js": {
+					"version": "4.11.8",
+					"resolved": "https://registry.npmjs.org/bn.js/-/bn.js-4.11.8.tgz",
+					"integrity": "sha512-ItfYfPLkWHUjckQCk8xC+LwxgK8NYcXywGigJgSwOP8Y2iyWT4f2vsZnoOXTTbo+o5yXmIUJ4gn5538SO5S3gA==",
+					"dev": true
+				}
 			}
 		},
 		"punycode": {
@@ -1072,15 +1156,15 @@
 			}
 		},
 		"stream-http": {
-			"version": "3.1.0",
-			"resolved": "https://registry.npmjs.org/stream-http/-/stream-http-3.1.0.tgz",
-			"integrity": "sha512-cuB6RgO7BqC4FBYzmnvhob5Do3wIdIsXAgGycHJnW+981gHqoYcYz9lqjJrk8WXRddbwPuqPYRl+bag6mYv4lw==",
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/stream-http/-/stream-http-3.1.1.tgz",
+			"integrity": "sha512-S7OqaYu0EkFpgeGFb/NPOoPLxFko7TPqtEeFg5DXPB4v/KETHG0Ln6fRFrNezoelpaDKmycEmmZ81cC9DAwgYg==",
 			"dev": true,
 			"requires": {
 				"builtin-status-codes": "^3.0.0",
-				"inherits": "^2.0.1",
-				"readable-stream": "^3.0.6",
-				"xtend": "^4.0.0"
+				"inherits": "^2.0.4",
+				"readable-stream": "^3.6.0",
+				"xtend": "^4.0.2"
 			},
 			"dependencies": {
 				"readable-stream": {

--- a/packages/mapper/src/mapper.ts
+++ b/packages/mapper/src/mapper.ts
@@ -82,22 +82,14 @@ export default class Mapper {
     if (!(db in this.databases)) {
       this.databases[db] = new Database(this, db);
     }
-    this.messageBus.emit(
-      'mongosh:use',
-      { method: 'use', arguments: { db: db } }
-    );
+    this.messageBus.emit( 'mongosh:use', { db });
     this.context.db = this.databases[db];
 
     return `switched to db ${db}`;
   }
 
   async show(arg): Promise<CommandResult> {
-    this.messageBus.emit(
-      'mongosh:show',
-      {
-        arguments: { arg }
-      }
-    );
+    this.messageBus.emit( 'mongosh:show', { method: `show ${arg}` });
 
     switch (arg) {
       case 'databases':
@@ -153,20 +145,14 @@ export default class Mapper {
 
     for (let i = 0; i < 20; i++) { // TODO: ensure that assigning cursor doesn't iterate
       if (!await this.currentCursor.hasNext()) {
-        this.messageBus.emit(
-          'mongosh:it',
-          { method: 'it', arguments: { result: 'no cursor' } }
-        );
+        this.messageBus.emit('mongosh:it');
         break;
       }
 
       results.push(await this.currentCursor.next());
     }
 
-    this.messageBus.emit(
-      'mongosh:it',
-      { method: 'it', arguments: { result: results.length } }
-    );
+    this.messageBus.emit('mongosh:it');
     return results;
   }
 

--- a/packages/mapper/src/mapper.ts
+++ b/packages/mapper/src/mapper.ts
@@ -145,14 +145,12 @@ export default class Mapper {
 
     for (let i = 0; i < 20; i++) { // TODO: ensure that assigning cursor doesn't iterate
       if (!await this.currentCursor.hasNext()) {
-        this.messageBus.emit('mongosh:it');
         break;
       }
 
       results.push(await this.currentCursor.next());
     }
 
-    this.messageBus.emit('mongosh:it');
     return results;
   }
 

--- a/packages/mapper/src/mapper.ts
+++ b/packages/mapper/src/mapper.ts
@@ -372,7 +372,7 @@ export default class Mapper {
       {
         method: 'bulkWrite',
         class: 'Collection',
-        db, coll, arguments: { operations, options }
+        db, coll, arguments: { options }
       }
     );
 

--- a/packages/shell-api/package-lock.json
+++ b/packages/shell-api/package-lock.json
@@ -4,19 +4,6 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
-		"@mongosh/errors": {
-			"version": "0.0.1-alpha.13",
-			"resolved": "https://registry.npmjs.org/@mongosh/errors/-/errors-0.0.1-alpha.13.tgz",
-			"integrity": "sha512-jJ5s2lpszODjYm8FH7+zhf2tAXTFnsUMchdUYlIxfcodr3QzQJNxySrmj0C9jwddwvFQ5zzxkJDtA4EUcF+YaA=="
-		},
-		"@mongosh/i18n": {
-			"version": "0.0.1-alpha.13",
-			"resolved": "https://registry.npmjs.org/@mongosh/i18n/-/i18n-0.0.1-alpha.13.tgz",
-			"integrity": "sha512-afSXLbzsW+F9zbeN0T1cc6VwmDrOjr5qQzF+r5KYvz6Z3tbkJf6uxct9m6YicNy2qxnGKDQtQ2lMdtmFXV5Ptw==",
-			"requires": {
-				"mustache": "^4.0.0"
-			}
-		},
 		"ansi-colors": {
 			"version": "3.2.3",
 			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.3.tgz",
@@ -607,11 +594,6 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.1.tgz",
 			"integrity": "sha512-tgp+dl5cGk28utYktBsrFqA7HKgrhgPsg6Z/EfhWI4gl1Hwq8B/GmY/0oXZ6nF8hDVesS/FpnYaD/kOWhYQvyg==",
 			"dev": true
-		},
-		"mustache": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/mustache/-/mustache-4.0.1.tgz",
-			"integrity": "sha512-yL5VE97+OXn4+Er3THSmTdCFCtx5hHWzrolvH+JObZnUYwuaG7XV+Ch4fR2cIrcYI0tFHxS7iyFYl14bW8y2sA=="
 		},
 		"node-environment-flags": {
 			"version": "1.0.6",

--- a/packages/shell-evaluator/src/shell-evaluator.ts
+++ b/packages/shell-evaluator/src/shell-evaluator.ts
@@ -123,7 +123,7 @@ class ShellEvaluator {
         this.saveState();
         const rewrittenInput = this.asyncWriter.compile(input);
         this.bus.emit(
-          'mongosh:rewrittenAsyncInput',
+          'mongosh:rewritten-async-input',
           { original: input.trim(), rewritten: rewrittenInput.trim() }
         );
         try {

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -57,7 +57,8 @@ const archive = async() => {
 };
 
 const writeSegmentFile = () => {
-  const key = `module.exports = '${process.env.SEGMENT_API_KEY}';`;
+  console.log(process.env.SEGMENT_API_KEY)
+  const key = `module.exports = SEGMENT_API_KEY = '${process.env.SEGMENT_API_KEY}';`;
   // create directly in cli-repl/lib so it can be part of artifacts in dist
   const configPath = path.join(__dirname, '..', 'packages', 'cli-repl', 'lib', 'config.js');
   try {
@@ -76,7 +77,7 @@ const writeSegmentFile = () => {
  */
 const release = async() => {
   const artifact = getArtifact();
-  const segmentFile = await writeSegmentFile();
+  writeSegmentFile();
   console.log('mongosh: creating binary:', artifact);
   await exec([
     path.join(__dirname, '..', 'packages', 'cli-repl', 'bin', 'mongosh.js'),

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -2,6 +2,7 @@ const os = require('os');
 const path = require('path');
 const { exec } = require('pkg');
 const tar = require('tar');
+const fs = require('fs');
 const config = require(path.join(__dirname, '..', 'packages', 'cli-repl', 'package.json'));
 
 /**
@@ -56,7 +57,7 @@ const archive = async() => {
 };
 
 const writeSegmentFile = () => {
-  const key = `exports SEGMENT_API_KEY = '${process.env.SEGMENT_API_KEY}'`;
+  const key = `module.exports = '${process.env.SEGMENT_API_KEY}';`;
   // create directly in cli-repl/lib so it can be part of artifacts in dist
   const configPath = path.join(__dirname, '..', 'packages', 'cli-repl', 'lib', 'config.js');
   try {

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -55,13 +55,15 @@ const archive = async() => {
   );
 };
 
-const writeSegmentFile = async() => {
-  const key = `export SEGMENT_API_KEY = ${process.env.SEGMENT_API_KEY}`;
+const writeSegmentFile = () => {
+  const key = `exports SEGMENT_API_KEY = '${process.env.SEGMENT_API_KEY}'`;
+  // create directly in cli-repl/lib so it can be part of artifacts in dist
+  const configPath = path.join(__dirname, '..', 'packages', 'cli-repl', 'lib', 'config.js');
   try {
-    // create directly in cli-repl/lib so it can be part of artifacts in dist
-    return await fs.writeFile(path.join(__dirname, '..', 'packages', 'cli-repl', 'lib', 'config.js'));
+    // can just write this sync, since it's part of the release script
+    fs.writeFileSync(configPath, key)
   } catch (e) {
-    console.log('mongosh: unable to write segment config file');
+    console.log('mognosh: unable to write segment api key')
     return;
   }
 }

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -57,10 +57,9 @@ const archive = async() => {
 };
 
 const writeSegmentFile = () => {
-  console.log(process.env.SEGMENT_API_KEY)
   const key = `module.exports = SEGMENT_API_KEY = '${process.env.SEGMENT_API_KEY}';`;
   // create directly in cli-repl/lib so it can be part of artifacts in dist
-  const configPath = path.join(__dirname, '..', 'packages', 'cli-repl', 'lib', 'config.js');
+  const configPath = path.join(__dirname, '..', 'packages', 'cli-repl', 'lib', 'analytics-config.js');
   try {
     // can just write this sync, since it's part of the release script
     fs.writeFileSync(configPath, key)

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -55,6 +55,17 @@ const archive = async() => {
   );
 };
 
+const writeSegmentFile = async() => {
+  const key = `export SEGMENT_API_KEY = ${process.env.SEGMENT_API_KEY}`;
+  try {
+    // create directly in cli-repl/lib so it can be part of artifacts in dist
+    return await fs.writeFile(path.join(__dirname, '..', 'packages', 'cli-repl', 'lib', 'config.js'));
+  } catch (e) {
+    console.log('mongosh: unable to write segment config file');
+    return;
+  }
+}
+
 /**
  * Creates dist/mongosh or dist/mongosh.exe and then creates a
  * tarball or zip of the executable as dist/mongosh-${version}-${os}.tgz or
@@ -62,6 +73,7 @@ const archive = async() => {
  */
 const release = async() => {
   const artifact = getArtifact();
+  const segmentFile = await writeSegmentFile();
   console.log('mongosh: creating binary:', artifact);
   await exec([
     path.join(__dirname, '..', 'packages', 'cli-repl', 'bin', 'mongosh.js'),


### PR DESCRIPTION
## Description

Sends information to segment if user opted-in. 

API_KEY from segment is to be read from `./config.js` file that evergreen writes when releasing the binary. This PR adds a task to `release.js` to populate that file. Evergreen already has the appropriate key to be written.

This PR also adds a few more events: `mongosh:new-user`, `mongosh-update-user`
and `mongosh:toggle-telemetry`.

Information sent to segment is stripped of possible sensitive information that
could come in queries via `mongodb-redact` module.

Adds documentation on events we listen to in `logger.ts`

## Open Questions

~@durran what's the best possible way for me to get this API key into an
Evergreen build?~
