### PR TITLE
Clean up AsyncRewriter

### DIFF
--- a/packages/async-rewriter/src/async-writer-babel.spec.ts
+++ b/packages/async-rewriter/src/async-writer-babel.spec.ts
@@ -1,3 +1,4 @@
+/* eslint dot-notation: 0*/
 import { expect } from 'chai';
 import sinon from 'sinon';
 import traverse from '@babel/traverse';
@@ -34,7 +35,7 @@ describe('async-writer-babel', () => {
       it('decorates Identifier', (done) => {
         traverse(ast, {
           Identifier(path) {
-            expect(path.node.shellType).to.deep.equal(signatures.Database);
+            expect(path.node['shellType']).to.deep.equal(signatures.Database);
             done();
           }
         });
@@ -51,7 +52,7 @@ describe('async-writer-babel', () => {
       it('decorates Identifier', (done) => {
         traverse(ast, {
           Identifier(path) {
-            expect(path.node.shellType).to.deep.equal(signatures.unknown);
+            expect(path.node['shellType']).to.deep.equal(signatures.unknown);
             done();
           }
         });
@@ -81,7 +82,7 @@ describe('async-writer-babel', () => {
             traverse(ast, {
               Identifier(path) {
                 if (path.node.name === 'db') {
-                  expect(path.node.shellType).to.deep.equal(signatures.Database);
+                  expect(path.node['shellType']).to.deep.equal(signatures.Database);
                   done();
                 }
               }
@@ -91,7 +92,7 @@ describe('async-writer-babel', () => {
             traverse(ast, {
               Identifier(path) {
                 if (path.node.name === 'coll') {
-                  expect(path.node.shellType).to.deep.equal(signatures.unknown);
+                  expect(path.node['shellType']).to.deep.equal(signatures.unknown);
                   done();
                 }
               }
@@ -100,7 +101,7 @@ describe('async-writer-babel', () => {
           it('decorates MemberExpression', (done) => {
             traverse(ast, {
               MemberExpression(path) {
-                expect(path.node.shellType).to.deep.equal(signatures.Collection);
+                expect(path.node['shellType']).to.deep.equal(signatures.Collection);
                 done();
               }
             });
@@ -119,7 +120,7 @@ describe('async-writer-babel', () => {
               traverse(ast, {
                 Identifier(path) {
                   if (path.node.name === 'c') {
-                    expect(path.node.shellType).to.deep.equal(signatures.Collection);
+                    expect(path.node['shellType']).to.deep.equal(signatures.Collection);
                     done();
                   }
                 }
@@ -129,7 +130,7 @@ describe('async-writer-babel', () => {
               traverse(ast, {
                 Identifier(path) {
                   if (path.node.name === 'insertOne') {
-                    expect(path.node.shellType).to.deep.equal(signatures.unknown);
+                    expect(path.node['shellType']).to.deep.equal(signatures.unknown);
                     done();
                   }
                 }
@@ -138,7 +139,7 @@ describe('async-writer-babel', () => {
             it('decorates MemberExpression', (done) => {
               traverse(ast, {
                 MemberExpression(path) {
-                  expect(path.node.shellType).to.deep.equal(signatures.Collection.attributes.insertOne);
+                  expect(path.node['shellType']).to.deep.equal(signatures.Collection.attributes.insertOne);
                   done();
                 }
               });
@@ -156,7 +157,7 @@ describe('async-writer-babel', () => {
               traverse(ast, {
                 Identifier(path) {
                   if (path.node.name === 'c') {
-                    expect(path.node.shellType).to.deep.equal(signatures.Collection);
+                    expect(path.node['shellType']).to.deep.equal(signatures.Collection);
                     done();
                   }
                 }
@@ -166,7 +167,7 @@ describe('async-writer-babel', () => {
               traverse(ast, {
                 Identifier(path) {
                   if (path.node.name === 'x') {
-                    expect(path.node.shellType).to.deep.equal(signatures.unknown);
+                    expect(path.node['shellType']).to.deep.equal(signatures.unknown);
                     done();
                   }
                 }
@@ -175,7 +176,7 @@ describe('async-writer-babel', () => {
             it('decorates MemberExpression', (done) => {
               traverse(ast, {
                 MemberExpression(path) {
-                  expect(path.node.shellType).to.deep.equal(signatures.unknown);
+                  expect(path.node['shellType']).to.deep.equal(signatures.unknown);
                   done();
                 }
               });
@@ -194,7 +195,7 @@ describe('async-writer-babel', () => {
             traverse(ast, {
               Identifier(path) {
                 if (path.node.name === 'x') {
-                  expect(path.node.shellType).to.deep.equal(signatures.unknown);
+                  expect(path.node['shellType']).to.deep.equal(signatures.unknown);
                   done();
                 }
               }
@@ -204,7 +205,7 @@ describe('async-writer-babel', () => {
             traverse(ast, {
               Identifier(path) {
                 if (path.node.name === 'coll') {
-                  expect(path.node.shellType).to.deep.equal(signatures.unknown);
+                  expect(path.node['shellType']).to.deep.equal(signatures.unknown);
                   done();
                 }
               }
@@ -213,7 +214,7 @@ describe('async-writer-babel', () => {
           it('decorates MemberExpression', (done) => {
             traverse(ast, {
               MemberExpression(path) {
-                expect(path.node.shellType).to.deep.equal(signatures.unknown);
+                expect(path.node['shellType']).to.deep.equal(signatures.unknown);
                 done();
               }
             });
@@ -233,7 +234,7 @@ describe('async-writer-babel', () => {
             traverse(ast, {
               Identifier(path) {
                 if (path.node.name === 'c') {
-                  expect(path.node.shellType).to.deep.equal(signatures.Collection);
+                  expect(path.node['shellType']).to.deep.equal(signatures.Collection);
                   done();
                 }
               }
@@ -241,9 +242,9 @@ describe('async-writer-babel', () => {
           });
           it('decorates node.key Literal', (done) => {
             traverse(ast, {
-              Literal(path) {
+              StringLiteral(path) {
                 if (path.node.value === 'insertOne') {
-                  expect(path.node.shellType).to.deep.equal(signatures.unknown);
+                  expect(path.node['shellType']).to.deep.equal(signatures.unknown);
                   done();
                 }
               }
@@ -252,7 +253,7 @@ describe('async-writer-babel', () => {
           it('decorates MemberExpression', (done) => {
             traverse(ast, {
               MemberExpression(path) {
-                expect(path.node.shellType).to.deep.equal(signatures.Collection.attributes.insertOne);
+                expect(path.node['shellType']).to.deep.equal(signatures.Collection.attributes.insertOne);
                 done();
               }
             });
@@ -279,7 +280,7 @@ describe('async-writer-babel', () => {
               traverse(ast, {
                 Identifier(path) {
                   if (path.node.name === 't') {
-                    expect(path.node.shellType).to.deep.equal(signatures.unknown);
+                    expect(path.node['shellType']).to.deep.equal(signatures.unknown);
                     done();
                   }
                 }
@@ -288,7 +289,7 @@ describe('async-writer-babel', () => {
             it('decorates node.key CallExpression', (done) => {
               traverse(ast, {
                 CallExpression(path) {
-                  expect(path.node.shellType).to.deep.equal(signatures.unknown);
+                  expect(path.node['shellType']).to.deep.equal(signatures.unknown);
                   done();
                 }
               });
@@ -296,7 +297,7 @@ describe('async-writer-babel', () => {
             it('decorates MemberExpression', (done) => {
               traverse(ast, {
                 MemberExpression(path) {
-                  expect(path.node.shellType).to.deep.equal(signatures.unknown);
+                  expect(path.node['shellType']).to.deep.equal(signatures.unknown);
                   done();
                 }
               });
@@ -324,7 +325,7 @@ describe('async-writer-babel', () => {
         it('decorates node.object Identifier', (done) => {
           traverse(ast, {
             Identifier(path) {
-              expect(path.node.shellType).to.deep.equal({
+              expect(path.node['shellType']).to.deep.equal({
                 type: 'object',
                 attributes: { d: signatures.Database },
                 hasAsyncChild: true
@@ -337,7 +338,7 @@ describe('async-writer-babel', () => {
           traverse(ast, {
             Identifier(path) {
               if (path.node.name === 'd') {
-                expect(path.node.shellType).to.deep.equal(signatures.unknown);
+                expect(path.node['shellType']).to.deep.equal(signatures.unknown);
                 done();
               }
             }
@@ -346,7 +347,7 @@ describe('async-writer-babel', () => {
         it('decorates MemberExpression', (done) => {
           traverse(ast, {
             MemberExpression(path) {
-              expect(path.node.shellType).to.deep.equal(signatures.Database);
+              expect(path.node['shellType']).to.deep.equal(signatures.Database);
               done();
             }
           });
@@ -364,7 +365,7 @@ describe('async-writer-babel', () => {
           it('decorates node.object Identifier', (done) => {
             traverse(ast, {
               Identifier(path) {
-                expect(path.node.shellType).to.deep.equal({
+                expect(path.node['shellType']).to.deep.equal({
                   type: 'object',
                   attributes: { d: signatures.Database },
                   hasAsyncChild: true
@@ -376,7 +377,7 @@ describe('async-writer-babel', () => {
           it('decorates MemberExpression', (done) => {
             traverse(ast, {
               MemberExpression(path) {
-                expect(path.node.shellType).to.deep.equal(signatures.Database);
+                expect(path.node['shellType']).to.deep.equal(signatures.Database);
                 done();
               }
             });
@@ -408,7 +409,7 @@ describe('async-writer-babel', () => {
         it('decorates node.object Identifier', (done) => {
           traverse(ast, {
             Identifier(path) {
-              expect(path.node.shellType).to.deep.equal({
+              expect(path.node['shellType']).to.deep.equal({
                 type: 'array',
                 attributes: { '0': signatures.Database },
                 hasAsyncChild: true
@@ -420,7 +421,7 @@ describe('async-writer-babel', () => {
         it('decorates MemberExpression', (done) => {
           traverse(ast, {
             MemberExpression(path) {
-              expect(path.node.shellType).to.deep.equal(signatures.Database);
+              expect(path.node['shellType']).to.deep.equal(signatures.Database);
               done();
             }
           });
@@ -451,7 +452,7 @@ describe('async-writer-babel', () => {
       it('decorates object', (done) => {
         traverse(ast, {
           ObjectExpression(path) {
-            expect(path.node.shellType).to.deep.equal({
+            expect(path.node['shellType']).to.deep.equal({
               type: 'object',
               attributes: { x: signatures.Database },
               hasAsyncChild: true
@@ -463,7 +464,7 @@ describe('async-writer-babel', () => {
       it('decorates element', (done) => {
         traverse(ast, {
           Property(path) {
-            expect(path.node.value.shellType).to.deep.equal(signatures.Database);
+            expect(path.node.value['shellType']).to.deep.equal(signatures.Database);
             done();
           }
         });
@@ -480,7 +481,7 @@ describe('async-writer-babel', () => {
       it('decorates object', (done) => {
         traverse(ast, {
           ObjectExpression(path) {
-            expect(path.node.shellType).to.deep.equal({
+            expect(path.node['shellType']).to.deep.equal({
               type: 'object',
               attributes: { x: signatures.unknown },
               hasAsyncChild: false
@@ -492,7 +493,7 @@ describe('async-writer-babel', () => {
       it('decorates element', (done) => {
         traverse(ast, {
           Property(path) {
-            expect(path.node.value.shellType).to.deep.equal(signatures.unknown);
+            expect(path.node.value['shellType']).to.deep.equal(signatures.unknown);
             done();
           }
         });
@@ -517,7 +518,7 @@ describe('async-writer-babel', () => {
       it('decorates array', (done) => {
         traverse(ast, {
           ArrayExpression(path) {
-            expect(path.node.shellType).to.deep.equal({
+            expect(path.node['shellType']).to.deep.equal({
               type: 'array',
               attributes: { '0': signatures.Database },
               hasAsyncChild: true
@@ -529,7 +530,7 @@ describe('async-writer-babel', () => {
       it('decorates element', (done) => {
         traverse(ast, {
           Identifier(path) {
-            expect(path.node.shellType).to.deep.equal(signatures.Database);
+            expect(path.node['shellType']).to.deep.equal(signatures.Database);
             done();
           }
         });
@@ -546,7 +547,7 @@ describe('async-writer-babel', () => {
       it('decorates array', (done) => {
         traverse(ast, {
           ArrayExpression(path) {
-            expect(path.node.shellType).to.deep.equal({
+            expect(path.node['shellType']).to.deep.equal({
               type: 'array',
               attributes: { '0': signatures.unknown },
               hasAsyncChild: false
@@ -558,7 +559,7 @@ describe('async-writer-babel', () => {
       it('decorates element', (done) => {
         traverse(ast, {
           Identifier(path) {
-            expect(path.node.shellType).to.deep.equal(signatures.unknown);
+            expect(path.node['shellType']).to.deep.equal(signatures.unknown);
             done();
           }
         });
@@ -581,7 +582,7 @@ describe('async-writer-babel', () => {
       it('decorates CallExpression', (done) => {
         traverse(ast, {
           CallExpression(path) {
-            expect(path.node.shellType).to.deep.equal(signatures.unknown);
+            expect(path.node['shellType']).to.deep.equal(signatures.unknown);
             done();
           }
         });
@@ -604,7 +605,7 @@ describe('async-writer-babel', () => {
           it('decorates CallExpression', (done) => {
             traverse(ast, {
               CallExpression(path) {
-                expect(path.node.shellType).to.deep.equal(signatures.unknown);
+                expect(path.node['shellType']).to.deep.equal(signatures.unknown);
                 done();
               }
             });
@@ -625,7 +626,7 @@ describe('async-writer-babel', () => {
           it('decorates CallExpression', (done) => {
             traverse(ast, {
               CallExpression(path) {
-                expect(path.node.shellType).to.deep.equal(signatures.Collection);
+                expect(path.node['shellType']).to.deep.equal(signatures.Collection);
                 done();
               }
             });
@@ -646,7 +647,7 @@ describe('async-writer-babel', () => {
           it('decorates CallExpression', (done) => {
             traverse(ast, {
               CallExpression(path) {
-                expect(path.node.shellType).to.deep.equal({ type: 'new' });
+                expect(path.node['shellType']).to.deep.equal({ type: 'new' });
                 done();
               }
             });
@@ -682,7 +683,7 @@ describe('async-writer-babel', () => {
           it('decorates CallExpression', (done) => {
             traverse(ast, {
               CallExpression(path) {
-                expect(path.node.shellType).to.deep.equal(signatures.unknown);
+                expect(path.node['shellType']).to.deep.equal(signatures.unknown);
                 done();
               }
             });
@@ -703,7 +704,7 @@ describe('async-writer-babel', () => {
           it('decorates CallExpression', (done) => {
             traverse(ast, {
               CallExpression(path) {
-                expect(path.node.shellType).to.deep.equal(signatures.Collection);
+                expect(path.node['shellType']).to.deep.equal(signatures.Collection);
                 done();
               }
             });
@@ -724,7 +725,7 @@ describe('async-writer-babel', () => {
           it('decorates CallExpression', (done) => {
             traverse(ast, {
               CallExpression(path) {
-                expect(path.node.shellType).to.deep.equal({ type: 'new' });
+                expect(path.node['shellType']).to.deep.equal({ type: 'new' });
                 done();
               }
             });
@@ -805,7 +806,7 @@ function f() {
           it('decorates VariableDeclarator', (done) => {
             traverse(ast, {
               VariableDeclarator(path) {
-                expect(path.node.shellType).to.deep.equal(signatures.unknown);
+                expect(path.node['shellType']).to.deep.equal(signatures.unknown);
                 done();
               }
             });
@@ -831,7 +832,7 @@ function f() {
             it('decorates VariableDeclarator', (done) => {
               traverse(ast, {
                 VariableDeclarator(path) {
-                  expect(path.node.shellType).to.deep.equal(signatures.unknown);
+                  expect(path.node['shellType']).to.deep.equal(signatures.unknown);
                   done();
                 }
               });
@@ -856,7 +857,7 @@ function f() {
             it('decorates VariableDeclarator', (done) => {
               traverse(ast, {
                 VariableDeclarator(path) {
-                  expect(path.node.shellType).to.deep.equal(signatures.unknown);
+                  expect(path.node['shellType']).to.deep.equal(signatures.unknown);
                   done();
                 }
               });
@@ -1158,7 +1159,7 @@ function f() {
           it('decorates AssignmentExpression', (done) => {
             traverse(ast, {
               AssignmentExpression(path) {
-                expect(path.node.shellType).to.deep.equal(signatures.Database);
+                expect(path.node['shellType']).to.deep.equal(signatures.Database);
                 done();
               }
             });
@@ -1192,7 +1193,7 @@ function f() {
           it('decorates AssignmentExpression', (done) => {
             traverse(ast, {
               AssignmentExpression(path) {
-                expect(path.node.shellType).to.deep.equal(signatures.unknown);
+                expect(path.node['shellType']).to.deep.equal(signatures.unknown);
                 done();
               }
             });
@@ -1228,7 +1229,7 @@ function f() {
           it('decorates AssignmentExpression', (done) => {
             traverse(ast, {
               AssignmentExpression(path) {
-                expect(path.node.shellType).to.deep.equal(signatures.Database);
+                expect(path.node['shellType']).to.deep.equal(signatures.Database);
                 done();
               }
             });
@@ -1452,7 +1453,7 @@ function f() {
         it('decorates Function', (done) => {
           traverse(ast, {
             Function(path) {
-              expect(skipPath(path.node.shellType)).to.deep.equal({ type: 'function', returnsPromise: false, returnType: signatures.Database });
+              expect(skipPath(path.node['shellType'])).to.deep.equal({ type: 'function', returnsPromise: false, returnType: signatures.Database });
               done();
             }
           });
@@ -1481,7 +1482,7 @@ function f() {
         it('decorates Function', (done) => {
           traverse(ast, {
             Function(path) {
-              expect(skipPath(path.node.shellType)).to.deep.equal({ type: 'function', returnsPromise: false, returnType: signatures.Database });
+              expect(skipPath(path.node['shellType'])).to.deep.equal({ type: 'function', returnsPromise: false, returnType: signatures.Database });
               done();
             }
           });
@@ -1509,7 +1510,7 @@ function f() {
         it('decorates Function', (done) => {
           traverse(ast, {
             Function(path) {
-              expect(skipPath(path.node.shellType)).to.deep.equal({ type: 'function', returnsPromise: true, returnType: signatures.unknown });
+              expect(skipPath(path.node['shellType'])).to.deep.equal({ type: 'function', returnsPromise: true, returnType: signatures.unknown });
               done();
             }
           });
@@ -1532,7 +1533,7 @@ function f() {
         it('decorates Function', (done) => {
           traverse(ast, {
             Function(path) {
-              expect(skipPath(path.node.shellType)).to.deep.equal({ type: 'function', returnsPromise: true, returnType: signatures.unknown });
+              expect(skipPath(path.node['shellType'])).to.deep.equal({ type: 'function', returnsPromise: true, returnType: signatures.unknown });
               done();
             }
           });
@@ -1561,7 +1562,7 @@ function f() {
         it('decorates Function', (done) => {
           traverse(ast, {
             Function(path) {
-              expect(skipPath(path.node.shellType)).to.deep.equal({ type: 'function', returnsPromise: true, returnType: signatures.unknown });
+              expect(skipPath(path.node['shellType'])).to.deep.equal({ type: 'function', returnsPromise: true, returnType: signatures.unknown });
               done();
             }
           });
@@ -1592,7 +1593,7 @@ function f() {
         it('decorates Function', (done) => {
           traverse(ast, {
             Function(path) {
-              expect(skipPath(path.node.shellType)).to.deep.equal({ type: 'function', returnsPromise: false, returnType: signatures.unknown });
+              expect(skipPath(path.node['shellType'])).to.deep.equal({ type: 'function', returnsPromise: false, returnType: signatures.unknown });
               done();
             }
           });
@@ -1615,7 +1616,7 @@ function f() {
         it('decorates Function', (done) => {
           traverse(ast, {
             Function(path) {
-              expect(skipPath(path.node.shellType)).to.deep.equal({ type: 'function', returnsPromise: false, returnType: signatures.Database });
+              expect(skipPath(path.node['shellType'])).to.deep.equal({ type: 'function', returnsPromise: false, returnType: signatures.Database });
               done();
             }
           });
@@ -1636,7 +1637,7 @@ function f() {
         it('decorates Function', (done) => {
           traverse(ast, {
             Function(path) {
-              expect(skipPath(path.node.shellType)).to.deep.equal({ type: 'function', returnsPromise: false, returnType: signatures.Database });
+              expect(skipPath(path.node['shellType'])).to.deep.equal({ type: 'function', returnsPromise: false, returnType: signatures.Database });
               done();
             }
           });
@@ -1657,7 +1658,7 @@ function f() {
         it('decorates Function', (done) => {
           traverse(ast, {
             Function(path) {
-              expect(skipPath(path.node.shellType)).to.deep.equal({ type: 'function', returnsPromise: false, returnType: signatures.unknown });
+              expect(skipPath(path.node['shellType'])).to.deep.equal({ type: 'function', returnsPromise: false, returnType: signatures.unknown });
               done();
             }
           });
@@ -1708,7 +1709,7 @@ function f() {
         it('decorates Function', (done) => {
           traverse(ast, {
             Function(path) {
-              expect(skipPath(path.node.shellType)).to.deep.equal({ type: 'function', returnsPromise: false, returnType: signatures.unknown });
+              expect(skipPath(path.node['shellType'])).to.deep.equal({ type: 'function', returnsPromise: false, returnType: signatures.unknown });
               done();
             }
           });
@@ -1754,16 +1755,14 @@ function f() {
         });
         it('decorates Function', (done) => {
           traverse(ast, {
-            Function(path) {
-              if (path.node.id.name === 'f') {
-                expect(Object.keys(path.node.shellType)).to.deep.equal([ 'type', 'returnsPromise', 'returnType', 'path' ]);
-                expect(path.node.shellType.type).to.equal('function');
-                expect(path.node.shellType.returnsPromise).to.be.false;
-                expect(skipPath(path.node.shellType.returnType)).to.deep.equal(
-                  { type: 'function', returnsPromise: false, returnType: signatures.Database }
-                );
-                done();
-              }
+            FunctionDeclaration(path) {
+              expect(Object.keys(path.node['shellType'])).to.deep.equal([ 'type', 'returnsPromise', 'returnType', 'path' ]);
+              expect(path.node['shellType'].type).to.equal('function');
+              expect(path.node['shellType'].returnsPromise).to.be.false;
+              expect(skipPath(path.node['shellType'].returnType)).to.deep.equal(
+                { type: 'function', returnsPromise: false, returnType: signatures.Database }
+              );
+              done();
             }
           });
         });
@@ -1795,9 +1794,9 @@ function f() {
         });
         it('decorates outer Function', (done) => {
           traverse(ast, {
-            Function(path) {
+            FunctionDeclaration(path) {
               if (path.node.id.name === 'f') {
-                expect(skipPath(path.node.shellType)).to.deep.equal({
+                expect(skipPath(path.node['shellType'])).to.deep.equal({
                   type: 'function',
                   returnsPromise: false,
                   returnType: signatures.unknown
@@ -1809,9 +1808,9 @@ function f() {
         });
         it('decorates inner Function', (done) => {
           traverse(ast, {
-            Function(path) {
+            FunctionDeclaration(path) {
               if (path.node.id.name === 'g') {
-                expect(skipPath(path.node.shellType)).to.deep.equal({
+                expect(skipPath(path.node['shellType'])).to.deep.equal({
                   type: 'function',
                   returnsPromise: false,
                   returnType: signatures.Collection.attributes.find
@@ -1938,7 +1937,7 @@ class Test {
       it('decorates ClassDeclaration', (done) => {
         traverse(ast, {
           ClassDeclaration(path) {
-            const rt = path.node.shellType;
+            const rt = path.node['shellType'];
             expect(rt.type).to.equal('classdef');
             expect(rt.returnType.type).to.equal('Test');
             expect(skipPath(rt.returnType.attributes.regularFn)).to.deep.equal(type.returnType.attributes.regularFn);
@@ -1988,9 +1987,9 @@ class Test {
     it('decorates NewExpression', (done) => {
       traverse(ast, {
         NewExpression(path) {
-          expect(path.node.shellType.type).to.equal('Test');
-          expect(skipPath(path.node.shellType.attributes.regularFn)).to.deep.equal(type.returnType.attributes.regularFn);
-          expect(skipPath(path.node.shellType.attributes.awaitFn)).to.deep.equal(type.returnType.attributes.awaitFn);
+          expect(path.node['shellType'].type).to.equal('Test');
+          expect(skipPath(path.node['shellType'].attributes.regularFn)).to.deep.equal(type.returnType.attributes.regularFn);
+          expect(skipPath(path.node['shellType'].attributes.awaitFn)).to.deep.equal(type.returnType.attributes.awaitFn);
           done();
         }
       });

--- a/packages/async-rewriter/src/async-writer-babel.spec.ts
+++ b/packages/async-rewriter/src/async-writer-babel.spec.ts
@@ -1,4 +1,4 @@
-/* eslint dot-notation: 0*/
+/* eslint dot-notation: 0 */
 import { expect } from 'chai';
 import sinon from 'sinon';
 import traverse from '@babel/traverse';

--- a/packages/async-rewriter/src/async-writer-babel.ts
+++ b/packages/async-rewriter/src/async-writer-babel.ts
@@ -29,44 +29,44 @@ const optionallyWrapNode = (t, path, nodeName): void => {
 // var required so visitor can self-reference
 var TypeInferenceVisitor = { /* eslint no-var:0 */
   Identifier: {
-    exit(path): void {
+    exit(path, state): void {
       const id = path.node.name;
-      let sType = this.symbols.lookup(id);
+      let sType = state.symbols.lookup(id);
       if (typeof sType === 'string') {
-        sType = this.symbols.signatures[sType];
+        sType = state.symbols.signatures[sType];
       }
       path.node['shellType'] = sType;
       debug(`Identifier: { name: ${path.node.name} }`, sType.type);
     }
   },
   MemberExpression: {
-    exit(path): void {
+    exit(path, state): void {
       const lhsType = path.node.object['shellType'];
-      const rhs = getNameOrValue(this.t, path.node.property);
-      if (rhs === false || (path.node.computed && !this.t.isLiteral(path.node.property))) {
+      const rhs = getNameOrValue(state.t, path.node.property);
+      if (rhs === false || (path.node.computed && !state.t.isLiteral(path.node.property))) {
         if (lhsType.hasAsyncChild) {
           const help = lhsType.type === 'Database' ?
             ' If you are accessing a collection try Database.get(\'collection\').' :
             '';
           throw new Error(`Cannot access shell API attributes dynamically.${help}`);
         }
-        path.node['shellType'] = this.symbols.signatures.unknown;
+        path.node['shellType'] = state.symbols.signatures.unknown;
         return;
       }
-      let sType = this.symbols.signatures.unknown;
+      let sType = state.symbols.signatures.unknown;
       if (lhsType.attributes === undefined) {
-        sType = this.symbols.signatures.unknown;
+        sType = state.symbols.signatures.unknown;
       } else if (rhs in lhsType.attributes) {
         sType = lhsType.attributes[rhs];
       } else if (lhsType.type === 'Database') {
-        sType = this.symbols.signatures.Collection;
+        sType = state.symbols.signatures.Collection;
       }
       path.node['shellType'] = sType;
       debug(`MemberExpression: { object.sType: ${lhsType.type}, property.name: ${rhs} }`, sType.type);
     }
   },
   CallExpression: {
-    exit(path): void {
+    exit(path, state): void {
       const dbg = `callee.type: ${path.node.callee.type}`;
       const lhsType = path.node.callee['shellType'];
 
@@ -80,17 +80,17 @@ var TypeInferenceVisitor = { /* eslint no-var:0 */
 
       // determine return type
       const returnType = lhsType.returnType;
-      let sType = this.symbols.signatures.unknown;
+      let sType = state.symbols.signatures.unknown;
       if (lhsType.type === 'function') {
         if (typeof returnType === 'string') {
-          sType = this.symbols.signatures[returnType];
+          sType = state.symbols.signatures[returnType];
         } else if (returnType !== undefined) {
           sType = returnType;
         }
         if (lhsType.returnsPromise) {
           path.node['shellType'] = sType;
-          path.replaceWith(this.t.awaitExpression(path.node));
-          const parent = path.findParent(p => this.t.isFunction(p));
+          path.replaceWith(state.t.awaitExpression(path.node));
+          const parent = path.findParent(p => state.t.isFunction(p));
           if (parent !== null) {
             parent.node.async = true;
           } // TODO: if need to convert top-level await into async func can do it here.
@@ -102,44 +102,44 @@ var TypeInferenceVisitor = { /* eslint no-var:0 */
       if ('path' in lhsType && sType.type !== 'classdef') {
         const funcPath = lhsType.path;
         debug(`== visiting function definition for ${lhsType.type}`);
-        this.symbols.pushScope(); // manually push/pop scope because body doesn't get visited
+        state.symbols.pushScope(); // manually push/pop scope because body doesn't get visited
 
         // TODO: this will allow for passing shell signatures to functions in scripts, but turned off for now.
         // path.node.arguments.forEach((a, i) => {
         //   const argName = funcPath.node.params[i].name;
-        //   this.symbols.add(argName, a['shellType']);
+        //   state.symbols.add(argName, a['shellType']);
         // });
         path.skip();
         funcPath.get('body').traverse(
           TypeInferenceVisitor,
           {
-            t: this.t,
-            skip: this.skip,
-            returnValues: this.returnValues,
-            symbols: this.symbols
+            t: state.t,
+            skip: state.skip,
+            returnValues: state.returnValues,
+            symbols: state.symbols
           }
         );
-        this.symbols.popScope();
+        state.symbols.popScope();
         debug('== end visiting function definition');
       }
       debug(`CallExpression: { ${dbg}, callee['shellType']: ${lhsType.type} }`, path.node['shellType'].type);
     }
   },
   VariableDeclarator: {
-    exit(path): void {
-      let sType = this.symbols.signatures.unknown;
+    exit(path, state): void {
+      let sType = state.symbols.signatures.unknown;
       if (path.node.init !== null) {
         sType = path.node.init['shellType'];
       }
-      path.node['shellType'] = this.symbols.signatures.unknown;
-      const kind = path.findParent(p => this.t.isVariableDeclaration(p));
+      path.node['shellType'] = state.symbols.signatures.unknown;
+      const kind = path.findParent(p => state.t.isVariableDeclaration(p));
       if (kind === null) {
         throw new Error('internal error');
       }
       if (kind.node.kind === 'const' || kind.node.kind === 'let') { // block scoped
-        this.symbols.add(path.node.id.name, sType);
+        state.symbols.add(path.node.id.name, sType);
       } else {
-        this.symbols.updateFunctionScoped(path, path.node.id.name, sType, this.t);
+        state.symbols.updateFunctionScoped(path, path.node.id.name, sType, state.t);
       }
       debug(`VariableDeclarator: { id.name: ${path.node.id.name}, init['shellType']: ${
         path.node.init === null ? 'null' : sType.type
@@ -147,26 +147,26 @@ var TypeInferenceVisitor = { /* eslint no-var:0 */
     }
   },
   AssignmentExpression: {
-    exit(path): void {
-      const sType = path.node.right['shellType'] === undefined ? this.symbols.signatures.unknown : path.node.right['shellType'];
-      if (!this.symbols.updateIfDefined(path.node.left.name, sType)) {
-        this.symbols.updateFunctionScoped(path, path.node.left.name, sType, this.t);
+    exit(path, state): void {
+      const sType = path.node.right['shellType'] === undefined ? state.symbols.signatures.unknown : path.node.right['shellType'];
+      if (!state.symbols.updateIfDefined(path.node.left.name, sType)) {
+        state.symbols.updateFunctionScoped(path, path.node.left.name, sType, state.t);
       }
       path.node['shellType'] = sType; // assignment returns value unlike decl
       debug(`AssignmentExpression: { left.name: ${path.node.left.name}, right.type: ${path.node.right.type} }`, sType.type); // id must be a identifier
     }
   },
   ObjectExpression: {
-    exit(path): void {
+    exit(path, state): void {
       const attributes = {};
       let hasAsyncChild = false;
       path.node.properties.forEach((n) => {
-        const k = getNameOrValue(this.t, n.key);
+        const k = getNameOrValue(state.t, n.key);
         if (k === false) {
           throw new Error('Unreachable');
         }
         attributes[k] = n.value['shellType'];
-        if ((attributes[k].type !== 'unknown' && attributes[k].type in this.symbols.signatures) || attributes[k].hasAsyncChild) {
+        if ((attributes[k].type !== 'unknown' && attributes[k].type in state.symbols.signatures) || attributes[k].hasAsyncChild) {
           hasAsyncChild = true;
         }
       });
@@ -175,12 +175,12 @@ var TypeInferenceVisitor = { /* eslint no-var:0 */
     }
   },
   ArrayExpression: {
-    exit(path): void {
+    exit(path, state): void {
       const attributes = {};
       let hasAsyncChild = false;
       path.node.elements.forEach((n, i) => {
         attributes[i] = n['shellType'];
-        if ((attributes[i].type !== 'unknown' && attributes[i].type in this.symbols.signatures) || attributes[i].hasAsyncChild) {
+        if ((attributes[i].type !== 'unknown' && attributes[i].type in state.symbols.signatures) || attributes[i].hasAsyncChild) {
           hasAsyncChild = true;
         }
       });
@@ -189,7 +189,7 @@ var TypeInferenceVisitor = { /* eslint no-var:0 */
     }
   },
   ClassDeclaration: {
-    exit(path): void {
+    exit(path, state): void {
       const className = path.node.id === null ? 'TODO' : path.node.id.name;
       const attributes = {};
       path.node.body.body.forEach((attr) => {
@@ -204,12 +204,12 @@ var TypeInferenceVisitor = { /* eslint no-var:0 */
         }
       };
       // TODO: double check Class names are *not* hoisted
-      this.symbols.addToParent(className, path.node['shellType']);
+      state.symbols.addToParent(className, path.node['shellType']);
       debug(`ClassDeclaration: { name: ${className} }`, path.node['shellType']);
     }
   },
   NewExpression: {
-    exit(path): void {
+    exit(path, state): void {
       const dbg = `callee.type: ${path.node.callee.type}`;
       const className = path.node.callee.name; // TODO: computed classes
       // check that the user is not passing a type that has async children to a self-defined function
@@ -220,9 +220,9 @@ var TypeInferenceVisitor = { /* eslint no-var:0 */
       });
 
       // determine return type
-      const lhsType = this.symbols.lookup(className);
+      const lhsType = state.symbols.lookup(className);
 
-      path.node['shellType'] = lhsType.returnType || this.symbols.signatures.unknown;
+      path.node['shellType'] = lhsType.returnType || state.symbols.signatures.unknown;
       debug(`NewExpression: { ${dbg}, callee['shellType']: ${lhsType.type} }`, path.node['shellType'].type);
     }
   },
@@ -232,30 +232,30 @@ var TypeInferenceVisitor = { /* eslint no-var:0 */
     }
   },
   Function: {
-    enter(path): void {
+    enter(path, state): void {
       debug('Function Enter');
       const returnTypes = [];
-      const symbolCopy1 = this.symbols.deepCopy();
+      const symbolCopy1 = state.symbols.deepCopy();
       // TODO: add arguments to ST in FuncCall
       path.skip();
       path.node.shellScope = symbolCopy1.pushScope();
       path.traverse(TypeInferenceVisitor, {
-        t: this.t,
-        skip: this.skip,
+        t: state.t,
+        skip: state.skip,
         returnValues: returnTypes,
         symbols: symbolCopy1
       });
       symbolCopy1.popScope();
 
-      let rType = this.symbols.signatures.unknown;
+      let rType = state.symbols.signatures.unknown;
       let dbg;
       if (returnTypes.length === 0) { // no return value, take last or unknown
-        if (!this.t.isBlockStatement(path.node.body)) { // => (...);
+        if (!state.t.isBlockStatement(path.node.body)) { // => (...);
           dbg = 'single value';
           rType = path.node.body['shellType'];
         } else { // => { ... }
           dbg = 'no return in block statement, undefined';
-          rType = this.symbols.signatures.unknown;
+          rType = state.symbols.signatures.unknown;
         }
       } else if (returnTypes.length === 1) {
         dbg = 'single return stmt';
@@ -268,12 +268,12 @@ var TypeInferenceVisitor = { /* eslint no-var:0 */
         if (someAsync) {
           throw new Error('Error: function can return different types, must be the same type');
         }
-        rType = this.symbols.signatures.unknown;
+        rType = state.symbols.signatures.unknown;
       }
 
       const sType = { type: 'function', returnsPromise: path.node.async, returnType: rType, path: path };
-      if (path.node.id !== null && !this.t.isAssignmentExpression(path.parent) && !this.t.isVariableDeclarator(path.parent)) {
-        this.symbols.updateFunctionScoped(path, path.node.id.name, sType, this.t);
+      if (path.node.id !== null && !state.t.isAssignmentExpression(path.parent) && !state.t.isVariableDeclarator(path.parent)) {
+        state.symbols.updateFunctionScoped(path, path.node.id.name, sType, state.t);
       }
 
       path.node['shellType'] = sType;
@@ -281,73 +281,73 @@ var TypeInferenceVisitor = { /* eslint no-var:0 */
     }
   },
   ReturnStatement: {
-    exit(path): void {
-      const sType = path.node.argument === null ? this.symbols.signatures.unknown : path.node.argument['shellType'];
+    exit(path, state): void {
+      const sType = path.node.argument === null ? state.symbols.signatures.unknown : path.node.argument['shellType'];
       path.node['shellType'] = sType;
-      this.returnValues.push(sType);
+      state.returnValues.push(sType);
       debug('ReturnStatement', sType.type);
     }
   },
   Scopable: {
-    enter(path): void {
-      debug(`---new scope at i=${this.symbols.scopeStack.length}`, path.node.type, true);
-      path.node.shellScope = this.symbols.pushScope();
+    enter(path, state): void {
+      debug(`---new scope at i=${state.symbols.depth}`, path.node.type, true);
+      path.node.shellScope = state.symbols.pushScope();
     },
-    exit(path): void {
-      this.symbols.popScope();
-      debug(`---pop scope at i=${this.symbols.scopeStack.length}`, path.node.type, true);
+    exit(path, state): void {
+      state.symbols.popScope();
+      debug(`---pop scope at i=${state.symbols.depth}`, path.node.type, true);
     }
   },
   Conditional: {
-    enter(path): void {
+    enter(path, state): void {
       debug('Conditional');
       path.skip();
 
       // NOTE: this is a workaround for path.get(...).traverse skipping the root node. Replace child node with block.
-      path.get('test').replaceWith(this.t.sequenceExpression([path.node.test]));
+      path.get('test').replaceWith(state.t.sequenceExpression([path.node.test]));
       path.get('test').traverse(TypeInferenceVisitor, {
-        t: this.t,
-        skip: this.skip,
-        returnValues: this.returnValues,
-        symbols: this.symbols
+        t: state.t,
+        skip: state.skip,
+        returnValues: state.returnValues,
+        symbols: state.symbols
       });
 
-      const symbolCopyCons = this.symbols.deepCopy();
-      const symbolCopyAlt = path.node.alternate !== null ? this.symbols.deepCopy() : null;
+      const symbolCopyCons = state.symbols.deepCopy();
+      const symbolCopyAlt = path.node.alternate !== null ? state.symbols.deepCopy() : null;
 
-      optionallyWrapNode(this.t, path, 'consequent');
+      optionallyWrapNode(state.t, path, 'consequent');
       path.node.consequent.shellScope = symbolCopyCons.pushScope();
       path.get('consequent').traverse(TypeInferenceVisitor, {
-        t: this.t,
-        skip: this.skip,
-        returnValues: this.returnValues,
+        t: state.t,
+        skip: state.skip,
+        returnValues: state.returnValues,
         symbols: symbolCopyCons
       });
       symbolCopyCons.popScope();
       if (path.node.alternate === null) {
-        return this.symbols.compareSymbolTables( [this.symbols, symbolCopyCons]);
+        return state.symbols.compareSymbolTables( [state.symbols, symbolCopyCons]);
       }
 
-      optionallyWrapNode(this.t, path, 'alternate');
+      optionallyWrapNode(state.t, path, 'alternate');
       path.node.alternate.shellScope = symbolCopyAlt.pushScope();
       path.get('alternate').traverse(TypeInferenceVisitor, {
-        t: this.t,
-        skip: this.skip,
-        returnValues: this.returnValues,
+        t: state.t,
+        skip: state.skip,
+        returnValues: state.returnValues,
         symbols: symbolCopyAlt
       });
       symbolCopyAlt.popScope();
 
-      this.symbols.compareSymbolTables([symbolCopyCons, symbolCopyAlt]);
+      state.symbols.compareSymbolTables([symbolCopyCons, symbolCopyAlt]);
 
       // set type for ternary
-      if (this.t.isConditionalExpression(path.node)) {
-        path.node['shellType'] = this.symbols.signatures.unknown;
-        if (this.t.isSequenceExpression(path.node.consequent) && this.t.isSequenceExpression(path.node.alternate)) {
+      if (state.t.isConditionalExpression(path.node)) {
+        path.node['shellType'] = state.symbols.signatures.unknown;
+        if (state.t.isSequenceExpression(path.node.consequent) && state.t.isSequenceExpression(path.node.alternate)) {
           const consType = path.node.consequent.expressions[path.node.consequent.expressions.length - 1]['shellType'];
           const altType = path.node.alternate.expressions[path.node.alternate.expressions.length - 1]['shellType'];
 
-          if (this.symbols.compareTypes(consType, altType)) {
+          if (state.symbols.compareTypes(consType, altType)) {
             path.node['shellType'] = consType;
           } else {
             const cAsync = consType && (consType.hasAsyncChild || consType.returnsPromise);
@@ -355,7 +355,7 @@ var TypeInferenceVisitor = { /* eslint no-var:0 */
             if (cAsync || aAsync) {
               throw new Error('cannot conditionally assign shell API types');
             }
-            path.node['shellType'] = this.symbols.signatures.unknown;
+            path.node['shellType'] = state.symbols.signatures.unknown;
           }
         }
       }
@@ -363,59 +363,59 @@ var TypeInferenceVisitor = { /* eslint no-var:0 */
     }
   },
   Loop: {
-    enter(path): void {
+    enter(path, state): void {
       debug('Loop', path.node.type);
 
-      if (this.t.isForXStatement(path)) {
+      if (state.t.isForXStatement(path)) {
         // TODO: this can be implemented, but it's tedious. Save for future work?
         throw new Error('for in and for of statements are not supported at this time.');
       }
       path.skip();
 
       // NOTE: this is a workaround for path.get(...).traverse skipping the root node. Replace child node with block.
-      path.get('test').replaceWith(this.t.sequenceExpression([path.node.test]));
+      path.get('test').replaceWith(state.t.sequenceExpression([path.node.test]));
       path.get('test').traverse(TypeInferenceVisitor, {
-        t: this.t,
-        skip: this.skip,
-        returnValues: this.returnValues,
-        symbols: this.symbols
+        t: state.t,
+        skip: state.skip,
+        returnValues: state.returnValues,
+        symbols: state.symbols
       });
-      const symbolCopyBody = this.symbols.deepCopy();
+      const symbolCopyBody = state.symbols.deepCopy();
 
-      optionallyWrapNode(this.t, path, 'body');
+      optionallyWrapNode(state.t, path, 'body');
       path.node.body.shellScope = symbolCopyBody.pushScope();
       path.get('body').traverse(TypeInferenceVisitor, {
-        t: this.t,
-        skip: this.skip,
-        returnValues: this.returnValues,
+        t: state.t,
+        skip: state.skip,
+        returnValues: state.returnValues,
         symbols: symbolCopyBody
       });
       symbolCopyBody.popScope();
-      this.symbols.compareSymbolTables( [this.symbols, symbolCopyBody]);
+      state.symbols.compareSymbolTables( [state.symbols, symbolCopyBody]);
     }
   },
   SwitchStatement: {
-    enter(path): void {
+    enter(path, state): void {
       debug('SwitchStatement');
       path.skip();
 
-      path.get('discriminant').replaceWith(this.t.sequenceExpression([path.node.discriminant]));
+      path.get('discriminant').replaceWith(state.t.sequenceExpression([path.node.discriminant]));
       path.get('discriminant').traverse(TypeInferenceVisitor, {
-        t: this.t,
-        skip: this.skip,
-        returnValues: this.returnValues,
-        symbols: this.symbols
+        t: state.t,
+        skip: state.skip,
+        returnValues: state.returnValues,
+        symbols: state.symbols
       });
 
       let exhaustive = false;
-      const symbolCopies = path.node.cases.map(() => this.symbols.deepCopy());
+      const symbolCopies = path.node.cases.map(() => state.symbols.deepCopy());
       path.node.cases.forEach((consNode, i) => {
         path.node.cases[i].shellScope = symbolCopies[i].pushScope();
         const casePath = path.get(`cases.${i}`);
         casePath.traverse(TypeInferenceVisitor, {
-          t: this.t,
-          skip: this.skip,
-          returnValues: this.returnValues,
+          t: state.t,
+          skip: state.skip,
+          returnValues: state.returnValues,
           symbols: symbolCopies[i]
         });
         symbolCopies[i].popScope();
@@ -426,14 +426,14 @@ var TypeInferenceVisitor = { /* eslint no-var:0 */
       });
       // check if the last case is default, if not then not all branches covered by switch
       if (!exhaustive) {
-        symbolCopies.unshift(this.symbols);
+        symbolCopies.unshift(state.symbols);
       }
-      this.symbols.compareSymbolTables(symbolCopies);
+      state.symbols.compareSymbolTables(symbolCopies);
     }
   },
-  exit(path): void {
-    const type = path.node['shellType'] || this.symbols.signatures.unknown;
-    if (this.skip.some((t) => (this.t[t](path.node)))) { // TODO: nicer?
+  exit(path, state): void {
+    const type = path.node['shellType'] || state.symbols.signatures.unknown;
+    if (state.skip.some((t) => (state.t[t](path.node)))) { // TODO: nicer?
       debug(`${path.node.type}`);
       return;
     }

--- a/packages/async-rewriter/src/async-writer-babel.ts
+++ b/packages/async-rewriter/src/async-writer-babel.ts
@@ -1,4 +1,4 @@
-/* eslint no-console:0, complexity:0, dot-notation: 0*/
+/* eslint no-console:0, complexity:0, dot-notation: 0 */
 import * as babel from '@babel/core';
 import SymbolTable from './symbol-table';
 

--- a/packages/async-rewriter/src/async-writer-babel.ts
+++ b/packages/async-rewriter/src/async-writer-babel.ts
@@ -92,7 +92,7 @@ var TypeInferenceVisitor = { /* eslint no-var:0 */
           path.replaceWith(state.t.awaitExpression(path.node));
           const parent = path.findParent(p => state.t.isFunction(p));
           if (parent !== null) {
-            parent.node.async = true;
+            parent.node['async'] = true;
           } // TODO: if need to convert top-level await into async func can do it here.
           path.skip();
         }
@@ -238,7 +238,7 @@ var TypeInferenceVisitor = { /* eslint no-var:0 */
       const symbolCopy1 = state.symbols.deepCopy();
       // TODO: add arguments to ST in FuncCall
       path.skip();
-      path.node.shellScope = symbolCopy1.pushScope();
+      path.node['shellScope'] = symbolCopy1.pushScope();
       path.traverse(TypeInferenceVisitor, {
         t: state.t,
         skip: state.skip,
@@ -291,7 +291,7 @@ var TypeInferenceVisitor = { /* eslint no-var:0 */
   Scopable: {
     enter(path, state): void {
       debug(`---new scope at i=${state.symbols.depth}`, path.node.type, true);
-      path.node.shellScope = state.symbols.pushScope();
+      path.node['shellScope'] = state.symbols.pushScope();
     },
     exit(path, state): void {
       state.symbols.popScope();
@@ -316,7 +316,7 @@ var TypeInferenceVisitor = { /* eslint no-var:0 */
       const symbolCopyAlt = path.node.alternate !== null ? state.symbols.deepCopy() : null;
 
       optionallyWrapNode(state.t, path, 'consequent');
-      path.node.consequent.shellScope = symbolCopyCons.pushScope();
+      path.node.consequent['shellScope'] = symbolCopyCons.pushScope();
       path.get('consequent').traverse(TypeInferenceVisitor, {
         t: state.t,
         skip: state.skip,
@@ -329,7 +329,7 @@ var TypeInferenceVisitor = { /* eslint no-var:0 */
       }
 
       optionallyWrapNode(state.t, path, 'alternate');
-      path.node.alternate.shellScope = symbolCopyAlt.pushScope();
+      path.node.alternate['shellScope'] = symbolCopyAlt.pushScope();
       path.get('alternate').traverse(TypeInferenceVisitor, {
         t: state.t,
         skip: state.skip,
@@ -383,7 +383,7 @@ var TypeInferenceVisitor = { /* eslint no-var:0 */
       const symbolCopyBody = state.symbols.deepCopy();
 
       optionallyWrapNode(state.t, path, 'body');
-      path.node.body.shellScope = symbolCopyBody.pushScope();
+      path.node.body['shellScope'] = symbolCopyBody.pushScope();
       path.get('body').traverse(TypeInferenceVisitor, {
         t: state.t,
         skip: state.skip,
@@ -410,7 +410,7 @@ var TypeInferenceVisitor = { /* eslint no-var:0 */
       let exhaustive = false;
       const symbolCopies = path.node.cases.map(() => state.symbols.deepCopy());
       path.node.cases.forEach((consNode, i) => {
-        path.node.cases[i].shellScope = symbolCopies[i].pushScope();
+        path.node.cases[i]['shellScope'] = symbolCopies[i].pushScope();
         const casePath = path.get(`cases.${i}`);
         casePath.traverse(TypeInferenceVisitor, {
           t: state.t,
@@ -461,7 +461,7 @@ export default class AsyncWriter {
         visitor: {
           Program: {
             enter(path): void {
-              path.node.shellScope = symbols.pushScope();
+              path.node['shellScope'] = symbols.pushScope();
               path.skip();
               path.traverse(TypeInferenceVisitor, {
                 t: t,


### PR DESCRIPTION
This is in preparation for adding the babel types as annotations in AsyncRewriter. In order for the PR to be easy to follow, I'm making the syntax changes first so that when the real changes come in a sparate PR (preview here: #123) it'll be easy to follow. This PR includes 2 types of changes:

1. Replace dot notation with index notation for decorations on instances of `Node` to avoid TypeScript errors. `Node` is a babel-defined type that I add type decorations to in order to do type inference. I'm not sure this is the best way to satisfy the ts compiler, but also the `Node` type is nested within other babel types so I'm not sure how I can inform the ts compiler that I need two extra attributes on some `Node` instances.
2. Apparently `this` and `state` are interchangable for babel visitor classes, so I've switched from using `this` to `state` in order to satisfy the ts compiler (the type annotations will come in a separate PR)