### PR TITLE
feat: allows commands with trailing semicolon

### DIFF
--- a/packages/shell-evaluator/src/shell-evaluator.spec.ts
+++ b/packages/shell-evaluator/src/shell-evaluator.spec.ts
@@ -45,4 +45,23 @@ describe('ShellEvaluator', () => {
       expect((shellEvaluator as any).mapper.context).to.equal(ctx);
     });
   });
+
+  describe('customEval', () => {
+    it('strips trailing spaces and ; before calling commands', async() => {
+      const use = sinon.spy();
+      (shellEvaluator as any).mapper.use = use;
+      await shellEvaluator.customEval(null, 'use somedb;  ', {}, '');
+      expect(use).to.have.been.calledWith('somedb');
+    });
+
+    it('calls original eval for plain javascript', async() => {
+      const originalEval = sinon.spy();
+      await shellEvaluator.customEval(originalEval, 'doSomething();', {}, '');
+      expect(originalEval).to.have.been.calledWith(
+        'doSomething();',
+        {},
+        ''
+      );
+    });
+  });
 });

--- a/packages/shell-evaluator/src/shell-evaluator.ts
+++ b/packages/shell-evaluator/src/shell-evaluator.ts
@@ -89,7 +89,7 @@ class ShellEvaluator {
    * @param {String} filename
    */
   private async innerEval(originalEval: any, input: string, context: any, filename: string): Promise<any> {
-    const argv = input.trim().split(' ');
+    const argv = input.trim().replace(/;$/, '').split(' ');
     const cmd = argv[0];
     argv.shift();
     switch (cmd) {


### PR DESCRIPTION
Allows commands to be invoked with a trailing semi-colon: `use db1;`, `show dbs;`.