### PR TITLE
Mapper methods prefix

### DIFF
--- a/packages/mapper/src/mapper.integration.spec.ts
+++ b/packages/mapper/src/mapper.integration.spec.ts
@@ -86,7 +86,7 @@ describe('Mapper (integration)', function() {
 
       describe('when calling it after find', () => {
         it('returns next batch of docs', async() => {
-          mapper.find(collection, {}, { _id: 0 });
+          mapper.collection_find(collection, {}, { _id: 0 });
           await mapper.it();
           expect(await mapper.it()).to.deep.equal([{
             doc: 21
@@ -99,7 +99,7 @@ describe('Mapper (integration)', function() {
 
         beforeEach(() => {
           cursor = mapper
-            .find(collection, {}, { _id: 0 })
+            .collection_find(collection, {}, { _id: 0 })
             .skip(1)
             .limit(1);
         });
@@ -136,7 +136,7 @@ describe('Mapper (integration)', function() {
             }
           ];
 
-          result = await mapper.bulkWrite(
+          result = await mapper.collection_bulkWrite(
             collection,
             requests
           );
@@ -180,7 +180,7 @@ describe('Mapper (integration)', function() {
           collectionName
         )).to.be.false;
 
-        result = await mapper.convertToCapped(
+        result = await mapper.collection_convertToCapped(
           collection,
           1000
         );
@@ -205,7 +205,7 @@ describe('Mapper (integration)', function() {
         await createCollection(dbName, collectionName);
         expect(await getIndexNames(dbName, collectionName)).not.to.contain('index-1');
 
-        result = await mapper.createIndexes(collection, [{ x: 1 }], {
+        result = await mapper.collection_createIndexes(collection, [{ x: 1 }], {
           name: 'index-1'
         });
       });
@@ -233,7 +233,7 @@ describe('Mapper (integration)', function() {
           { key: { x: 1 } }
         ]);
 
-        result = await mapper.getIndexes(collection);
+        result = await mapper.collection_getIndexes(collection);
       });
 
       it('returns indexes for the collection', () => {
@@ -269,7 +269,7 @@ describe('Mapper (integration)', function() {
       it('removes indexes', async() => {
         expect(await getIndexNames(dbName, collectionName)).to.contain('index-1');
 
-        await mapper.dropIndexes(collection, '*');
+        await mapper.collection_dropIndexes(collection, '*');
 
         expect(await getIndexNames(dbName, collectionName)).not.to.contain('index-1');
       });
@@ -281,7 +281,7 @@ describe('Mapper (integration)', function() {
       });
 
       it('runs against the db', async() => {
-        const result = await mapper.reIndex(collection);
+        const result = await mapper.collection_reIndex(collection);
 
         expect(
           result
@@ -309,7 +309,7 @@ describe('Mapper (integration)', function() {
       });
 
       it('returns total index size', async() => {
-        expect(typeof await mapper.totalIndexSize(collection)).to.equal('number');
+        expect(typeof await mapper.collection_totalIndexSize(collection)).to.equal('number');
       });
     });
 
@@ -319,7 +319,7 @@ describe('Mapper (integration)', function() {
       });
 
       it('returns total index size', async() => {
-        expect(typeof await mapper.dataSize(collection)).to.equal('number');
+        expect(typeof await mapper.collection_dataSize(collection)).to.equal('number');
       });
     });
 
@@ -329,7 +329,7 @@ describe('Mapper (integration)', function() {
       });
 
       it('returns total index size', async() => {
-        expect(typeof await mapper.storageSize(collection)).to.equal('number');
+        expect(typeof await mapper.collection_storageSize(collection)).to.equal('number');
       });
     });
 
@@ -339,7 +339,7 @@ describe('Mapper (integration)', function() {
       });
 
       it('returns total index size', async() => {
-        expect(typeof await mapper.totalSize(collection)).to.equal('number');
+        expect(typeof await mapper.collection_totalSize(collection)).to.equal('number');
       });
     });
 
@@ -349,7 +349,7 @@ describe('Mapper (integration)', function() {
       });
 
       it('returns stats', async() => {
-        const stats = await mapper.stats(collection);
+        const stats = await mapper.collection_stats(collection);
         expect(stats).to.contain.keys(
           'avgObjSize',
           'capped',
@@ -374,7 +374,7 @@ describe('Mapper (integration)', function() {
         let result;
         beforeEach(async() => {
           await createCollection(dbName, collectionName);
-          result = await mapper.drop(collection);
+          result = await mapper.collection_drop(collection);
         });
 
         it('returns true', async() => {
@@ -392,7 +392,7 @@ describe('Mapper (integration)', function() {
 
       context('when a collection does not exist', () => {
         it('returns false', async() => {
-          expect(await mapper.drop(collection)).to.be.false;
+          expect(await mapper.collection_drop(collection)).to.be.false;
         });
       });
     });
@@ -404,13 +404,13 @@ describe('Mapper (integration)', function() {
         });
 
         it('returns the collection object', async() => {
-          expect((await mapper.exists(collection)).name).to.equal(collectionName);
+          expect((await mapper.collection_exists(collection)).name).to.equal(collectionName);
         });
       });
 
       context('when a collection does not exist', () => {
         it('returns false', async() => {
-          expect(await mapper.drop(collection)).to.be.false;
+          expect(await mapper.collection_drop(collection)).to.be.false;
         });
       });
     });
@@ -421,7 +421,7 @@ describe('Mapper (integration)', function() {
       it('returns an array with collection infos', async() => {
         await createCollection(dbName, collectionName);
 
-        expect(await mapper.getCollectionInfos(database, {}, { nameOnly: true })).to.deep.equal([{
+        expect(await mapper.database_getCollectionInfos(database, {}, { nameOnly: true })).to.deep.equal([{
           name: collectionName,
           type: 'collection'
         }]);
@@ -432,7 +432,7 @@ describe('Mapper (integration)', function() {
       it('returns an array with collection names', async() => {
         await createCollection(dbName, collectionName);
 
-        expect(await mapper.getCollectionNames(database)).to.deep.equal([collectionName]);
+        expect(await mapper.database_getCollectionNames(database)).to.deep.equal([collectionName]);
       });
     });
   });

--- a/packages/mapper/src/mapper.spec.ts
+++ b/packages/mapper/src/mapper.spec.ts
@@ -252,7 +252,7 @@ coll2`;
 
       context('when options is not passed', () => {
         it('calls serviceProvider.createIndexes using keys', async() => {
-          await mapper[method](collection, { x: 1 });
+          await mapper[`collection_${method}`](collection, { x: 1 });
 
           expect(serviceProvider.createIndexes).to.have.been.calledWith(
             'db1',
@@ -264,7 +264,7 @@ coll2`;
 
       context('when options is an object', () => {
         it('calls serviceProvider.createIndexes merging options', async() => {
-          await mapper[method](collection, { x: 1 }, { name: 'index-1' });
+          await mapper[`collection_${method}`](collection, { x: 1 }, { name: 'index-1' });
 
           expect(serviceProvider.createIndexes).to.have.been.calledWith(
             'db1',
@@ -276,7 +276,7 @@ coll2`;
 
       context('when options is not an object', () => {
         it('throws an error', async() => {
-          const error = await mapper[method](
+          const error = await mapper[`collection_${method}`](
             collection, { x: 1 }, 'unsupported' as any
           ).catch(e => e);
 
@@ -303,7 +303,7 @@ coll2`;
       });
 
       it('returns serviceProvider.getIndexes using keys', async() => {
-        expect(await mapper[method](collection)).to.deep.equal(result);
+        expect(await mapper[`collection_${method}`](collection)).to.deep.equal(result);
       });
     });
   });

--- a/packages/mapper/src/mapper.spec.ts
+++ b/packages/mapper/src/mapper.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/camelcase */
 import chai from 'chai';
 import sinonChai from 'sinon-chai';
 import { stubInterface, StubbedInstance } from 'ts-sinon';
@@ -94,7 +95,7 @@ coll2`;
           };
 
           serviceProvider.find.returns(cursor);
-          await mapper.find(collection, {}, {});
+          await mapper.collection_find(collection, {}, {});
         });
 
         it('returns CursorIterationResult', async() => {
@@ -148,7 +149,7 @@ coll2`;
             result: { ok: 1 }
           })) as any;
 
-          await mapper.bulkWrite(collection, requests);
+          await mapper.collection_bulkWrite(collection, requests);
 
           expect(serviceProvider.bulkWrite).to.have.been.calledWith(
             'db1',
@@ -169,7 +170,7 @@ coll2`;
             upsertedIds: [ 7 ]
           });
 
-          const result = await mapper.bulkWrite(collection, requests);
+          const result = await mapper.collection_bulkWrite(collection, requests);
 
           expect(await result.toReplString()).to.be.deep.equal({
             ackowledged: true,
@@ -189,7 +190,7 @@ coll2`;
       it('calls service provider convertToCapped', async() => {
         serviceProvider.convertToCapped.resolves({ ok: 1 });
 
-        const result = await mapper.convertToCapped(collection, 1000);
+        const result = await mapper.collection_convertToCapped(collection, 1000);
 
         expect(serviceProvider.convertToCapped).to.have.been.calledWith(
           'db1',
@@ -208,7 +209,7 @@ coll2`;
 
       context('when options is not passed', () => {
         it('calls serviceProvider.createIndexes using keyPatterns as keys', async() => {
-          await mapper.createIndexes(collection, [{ x: 1 }]);
+          await mapper.collection_createIndexes(collection, [{ x: 1 }]);
 
           expect(serviceProvider.createIndexes).to.have.been.calledWith(
             'db1',
@@ -220,7 +221,7 @@ coll2`;
 
       context('when options is an object', () => {
         it('calls serviceProvider.createIndexes merging options', async() => {
-          await mapper.createIndexes(collection, [{ x: 1 }], { name: 'index-1' });
+          await mapper.collection_createIndexes(collection, [{ x: 1 }], { name: 'index-1' });
 
           expect(serviceProvider.createIndexes).to.have.been.calledWith(
             'db1',
@@ -232,7 +233,7 @@ coll2`;
 
       context('when options is not an object', () => {
         it('throws an error', async() => {
-          const error = await mapper.createIndexes(
+          const error = await mapper.collection_createIndexes(
             collection, [{ x: 1 }], 'unsupported' as any
           ).catch(e => e);
 
@@ -330,7 +331,7 @@ coll2`;
     });
 
     it('returns only indexes keys', async() => {
-      expect(await mapper.getIndexKeys(collection)).to.deep.equal([
+      expect(await mapper.collection_getIndexKeys(collection)).to.deep.equal([
         { _id: 1 },
         { name: 1 }
       ]);
@@ -346,7 +347,7 @@ coll2`;
       });
 
       it('returns the result of serviceProvider.dropIndexes', async() => {
-        expect(await mapper.dropIndexes(collection, 'index_1')).to.deep.equal(result);
+        expect(await mapper.collection_dropIndexes(collection, 'index_1')).to.deep.equal(result);
       });
     });
 
@@ -365,7 +366,7 @@ coll2`;
       });
 
       it('returns the error as object', async() => {
-        expect(await mapper.dropIndexes(collection, 'index_1')).to.deep.equal({
+        expect(await mapper.collection_dropIndexes(collection, 'index_1')).to.deep.equal({
           ok: 0,
           errmsg: 'index not found with name [index_1]',
           code: 27,
@@ -383,27 +384,27 @@ coll2`;
 
       it('rejects with error', async() => {
         let catched;
-        await mapper.dropIndexes(collection, 'index_1').catch(err => { catched = err; });
+        await mapper.collection_dropIndexes(collection, 'index_1').catch(err => { catched = err; });
         expect(catched.message).to.equal(error.message);
       });
     });
   });
 
   describe('dropIndex', () => {
-    context('when mapper.dropIndexes resolves', () => {
+    context('when mapper.collection_dropIndexes resolves', () => {
       let result;
       beforeEach(async() => {
         result = { nIndexesWas: 3, ok: 1 };
-        mapper.dropIndexes = sinon.mock().resolves(result);
+        mapper.collection_dropIndexes = sinon.mock().resolves(result);
       });
 
       it('returns the result of serviceProvider.dropIndexes', async() => {
-        expect(await mapper.dropIndex(collection, 'index_1')).to.deep.equal(result);
+        expect(await mapper.collection_dropIndex(collection, 'index_1')).to.deep.equal(result);
       });
 
       it('throws if index is "*"', async() => {
         let catched;
-        await mapper.dropIndex(collection, '*').catch(err => { catched = err; });
+        await mapper.collection_dropIndex(collection, '*').catch(err => { catched = err; });
 
         expect(catched.message).to.equal(
           'To drop indexes in the collection using \'*\', use db.collection.dropIndexes()'
@@ -412,7 +413,7 @@ coll2`;
 
       it('throws if index is an array', async() => {
         let catched;
-        await mapper.dropIndex(collection, ['index-1']).catch(err => { catched = err; });
+        await mapper.collection_dropIndex(collection, ['index-1']).catch(err => { catched = err; });
 
         expect(catched.message).to.equal(
           'The index to drop must be either the index name or the index specification document'
@@ -429,7 +430,7 @@ coll2`;
 
       serviceProvider.listCollections.resolves(result);
 
-      expect(await mapper.getCollectionInfos(
+      expect(await mapper.database_getCollectionInfos(
         database,
         filter,
         options)).to.deep.equal(result);
@@ -444,7 +445,7 @@ coll2`;
 
       serviceProvider.listCollections.resolves(result);
 
-      expect(await mapper.getCollectionNames(
+      expect(await mapper.database_getCollectionNames(
         database)).to.deep.equal(['coll1']);
 
       expect(serviceProvider.listCollections).to.have.been.calledOnceWith(
@@ -460,13 +461,13 @@ coll2`;
     });
 
     it('returns totalIndexSize', async() => {
-      expect(await mapper.totalIndexSize(collection)).to.equal(1000);
+      expect(await mapper.collection_totalIndexSize(collection)).to.equal(1000);
       expect(serviceProvider.stats).to.have.been.calledOnceWith('db1', 'coll1');
     });
 
     it('throws an error if called with verbose', async() => {
       let catched;
-      await mapper.totalIndexSize(collection, true)
+      await mapper.collection_totalIndexSize(collection, true)
         .catch(err => { catched = err; });
 
       expect(catched.message).to.equal(
@@ -484,7 +485,7 @@ coll2`;
     });
 
     it('returns the result of serviceProvider.dropIndexes', async() => {
-      expect(await mapper.reIndex(collection)).to.deep.equal(result);
+      expect(await mapper.collection_reIndex(collection)).to.deep.equal(result);
       expect(serviceProvider.reIndex).to.have.been.calledWith('db1', 'coll1');
     });
   });
@@ -498,7 +499,7 @@ coll2`;
     });
 
     it('returns stats', async() => {
-      expect(await mapper.stats(collection, { scale: 1 })).to.equal(result);
+      expect(await mapper.collection_stats(collection, { scale: 1 })).to.equal(result);
       expect(serviceProvider.stats).to.have.been.calledOnceWith('db1', 'coll1', { scale: 1 });
     });
   });
@@ -512,7 +513,7 @@ coll2`;
     });
 
     it('returns stats.size', async() => {
-      expect(await mapper.dataSize(collection)).to.equal(1000);
+      expect(await mapper.collection_dataSize(collection)).to.equal(1000);
       expect(serviceProvider.stats).to.have.been.calledOnceWith('db1', 'coll1');
     });
   });
@@ -526,7 +527,7 @@ coll2`;
     });
 
     it('returns stats.storageSize', async() => {
-      expect(await mapper.storageSize(collection)).to.equal(1000);
+      expect(await mapper.collection_storageSize(collection)).to.equal(1000);
       expect(serviceProvider.stats).to.have.been.calledOnceWith('db1', 'coll1');
     });
   });
@@ -540,7 +541,7 @@ coll2`;
     });
 
     it('returns sum of storageSize and totalIndexSize', async() => {
-      expect(await mapper.totalSize(collection)).to.equal(2000);
+      expect(await mapper.collection_totalSize(collection)).to.equal(2000);
       expect(serviceProvider.stats).to.have.been.calledOnceWith('db1', 'coll1');
     });
   });
@@ -549,19 +550,19 @@ coll2`;
     it('re-throws an error that is not NamespaceNotFound', async() => {
       const error = new Error();
       serviceProvider.dropCollection.rejects(error);
-      expect(await (mapper.drop(collection).catch((e) => e))).to.equal(error);
+      expect(await (mapper.collection_drop(collection).catch((e) => e))).to.equal(error);
     });
   });
 
   describe('getFullName', () => { // collection.getFullName
     it('returns the namespaced collection name', async() => {
-      expect(mapper.getFullName(collection)).to.equal('db1.coll1');
+      expect(mapper.collection_getFullName(collection)).to.equal('db1.coll1');
     });
   });
 
   describe('getName', () => { // collection.getFullName
     it('returns the namespaced collection name', async() => {
-      expect(mapper.getName(collection)).to.equal('coll1');
+      expect(mapper.collection_getName(collection)).to.equal('coll1');
     });
   });
 });

--- a/packages/mapper/src/mapper.ts
+++ b/packages/mapper/src/mapper.ts
@@ -72,6 +72,7 @@ export default class Mapper {
 
   private async showCollections(): Promise<CommandResult> {
     const collectionNames = await this.getCollectionNames(this.context.db);
+
     return new CommandResult('ShowCollectionsResult', collectionNames.join('\n'));
   }
 

--- a/packages/mapper/src/mapper.ts
+++ b/packages/mapper/src/mapper.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/camelcase */
 import {
   AggregationCursor,
   BulkWriteResult,
@@ -71,7 +72,7 @@ export default class Mapper {
   }
 
   private async showCollections(): Promise<CommandResult> {
-    const collectionNames = await this.getCollectionNames(this.context.db);
+    const collectionNames = await this.database_getCollectionNames(this.context.db);
 
     return new CommandResult('ShowCollectionsResult', collectionNames.join('\n'));
   }
@@ -135,7 +136,7 @@ export default class Mapper {
    *
    * @returns {AggregationCursor} The promise of the aggregation cursor.
    */
-  aggregate(collection, pipeline, options: any = {}): any {
+  collection_aggregate(collection, pipeline, options: any = {}): any {
     const db = collection._database._name;
     const coll = collection._name;
 
@@ -195,7 +196,7 @@ export default class Mapper {
    *
    * @returns {BulkWriteResult} The promise of the result.
    */
-  async bulkWrite(
+  async collection_bulkWrite(
     collection: Collection,
     operations: Document,
     options: Document = {}
@@ -248,7 +249,7 @@ export default class Mapper {
    *  <limit, skip, hint, maxTimeMS, readConcern, collation>
    * @returns {Integer} The promise of the count.
    */
-  count(collection, query = {}, options: any = {}): any {
+  collection_count(collection, query = {}, options: any = {}): any {
     const dbOpts: any = {};
     const db = collection._database._name;
     const coll = collection._name;
@@ -278,7 +279,7 @@ export default class Mapper {
    *
    * @returns {Integer} The promise of the count.
    */
-  countDocuments(collection, query, options: any = {}): any {
+  collection_countDocuments(collection, query, options: any = {}): any {
     const db = collection._database._name;
     const coll = collection._name;
     this.messageBus.emit(
@@ -306,7 +307,7 @@ export default class Mapper {
    *
    * @returns {DeleteResult} The promise of the result.
    */
-  async deleteMany(collection, filter, options: any = {}): Promise<any> {
+  async collection_deleteMany(collection, filter, options: any = {}): Promise<any> {
     const dbOptions: any = {};
     const db = collection._database._name;
     const coll = collection._name;
@@ -350,7 +351,7 @@ export default class Mapper {
    *
    * @returns {DeleteResult} The promise of the result.
    */
-  async deleteOne(collection, filter, options: any = {}): Promise<any> {
+  async collection_deleteOne(collection, filter, options: any = {}): Promise<any> {
     const dbOptions: any = {};
     const db = collection._database._name;
     const coll = collection._name;
@@ -393,7 +394,7 @@ export default class Mapper {
    *
    * @returns {Array} The promise of the result. TODO: make sure returned type is the same
    */
-  distinct(collection, field, query, options: any = {}): any {
+  collection_distinct(collection, field, query, options: any = {}): any {
     const db = collection._database._name;
     const coll = collection._name;
     this.messageBus.emit(
@@ -417,7 +418,7 @@ export default class Mapper {
    *
    * @returns {Integer} The promise of the count.
    */
-  estimatedDocumentCount(collection, options = {}): Promise<any> {
+  collection_estimatedDocumentCount(collection, options = {}): Promise<any> {
     const db = collection._database._name;
     const coll = collection._name;
     this.messageBus.emit(
@@ -444,7 +445,7 @@ export default class Mapper {
    *
    * @returns {Cursor} The promise of the cursor.
    */
-  find(collection, query, projection): any {
+  collection_find(collection, query, projection): any {
     const options: any = {};
     const db = collection._database._name;
     const coll = collection._name;
@@ -481,7 +482,7 @@ export default class Mapper {
    *
    * @returns {Cursor} The promise of the cursor.
    */
-  findOne(collection, query, projection): Promise<any> {
+  collection_findOne(collection, query, projection): Promise<any> {
     const options: any = {};
     const db = collection._database._name;
     const coll = collection._name;
@@ -505,7 +506,7 @@ export default class Mapper {
     ).limit(1).next();
   }
 
-  // findAndModify(collection, document) {
+  // collection_findAndModify(collection, document) {
   //   return this._serviceProvider.findAndModify(
   //     collection._database._name,
   //     collection._name,
@@ -523,7 +524,7 @@ export default class Mapper {
    *
    * @returns {Document} The promise of the result.
    */
-  async findOneAndDelete(collection, filter, options = {}): Promise<any> {
+  async collection_findOneAndDelete(collection, filter, options = {}): Promise<any> {
     const db = collection._database._name;
     const coll = collection._name;
     this.messageBus.emit(
@@ -560,7 +561,7 @@ export default class Mapper {
    *
    * @returns {Document} The promise of the result.
    */
-  async findOneAndReplace(collection, filter, replacement, options = {}): Promise<any> {
+  async collection_findOneAndReplace(collection, filter, replacement, options = {}): Promise<any> {
     const findOneAndReplaceOptions: any = { ...options };
     const db = collection._database._name;
     const coll = collection._name;
@@ -605,7 +606,7 @@ export default class Mapper {
    *
    * @returns {Document} The promise of the result.
    */
-  async findOneAndUpdate(collection, filter, update, options = {}): Promise<any> {
+  async collection_findOneAndUpdate(collection, filter, update, options = {}): Promise<any> {
     const findOneAndUpdateOptions: any = { ...options };
     const db = collection._database._name;
     const coll = collection._name;
@@ -648,7 +649,7 @@ export default class Mapper {
    *    <writeConcern, ordered>
    * @return {InsertManyResult}
    */
-  async insert(collection, docs, options: any = {}): Promise<any> {
+  async collection_insert(collection, docs, options: any = {}): Promise<any> {
     const d = Object.prototype.toString.call(docs) === '[object Array]' ? docs : [docs];
     const dbOptions: any = {};
     const db = collection._database._name;
@@ -695,7 +696,7 @@ export default class Mapper {
    *    <writeConcern, ordered>
    * @return {InsertManyResult}
    */
-  async insertMany(collection, docs, options: any = {}): Promise<any> {
+  async collection_insertMany(collection, docs, options: any = {}): Promise<any> {
     const dbOptions: any = {};
     const db = collection._database._name;
     const coll = collection._name;
@@ -741,7 +742,7 @@ export default class Mapper {
    *    <writeConcern>
    * @return {InsertOneResult}
    */
-  async insertOne(collection, doc, options: any = {}): Promise<any> {
+  async collection_insertOne(collection, doc, options: any = {}): Promise<any> {
     const dbOptions: any = {};
     const db = collection._database._name;
     const coll = collection._name;
@@ -779,7 +780,7 @@ export default class Mapper {
    * @param {Collection} collection
    * @return {Boolean}
    */
-  isCapped(collection): Promise<any> {
+  collection_isCapped(collection): Promise<any> {
     const db = collection._database._name;
     const coll = collection._name;
     this.messageBus.emit(
@@ -803,7 +804,7 @@ export default class Mapper {
    *    <justOne, writeConcern, collation>
    * @return {Promise}
    */
-  remove(collection, query, options: any = {}): Promise<any> {
+  collection_remove(collection, query, options: any = {}): Promise<any> {
     const dbOptions: any = {};
     const db = collection._database._name;
     const coll = collection._name;
@@ -838,7 +839,7 @@ export default class Mapper {
   }
 
   // TODO
-  save(collection, doc, options: any = {}): Promise<any> {
+  collection_save(collection, doc, options: any = {}): Promise<any> {
     const dbOptions: any = {};
     const db = collection._database._name;
     const coll = collection._name;
@@ -874,7 +875,7 @@ export default class Mapper {
    *
    * @returns {UpdateResult} The promise of the result.
    */
-  async replaceOne(collection, filter, replacement, options: any = {}): Promise<any> {
+  async collection_replaceOne(collection, filter, replacement, options: any = {}): Promise<any> {
     const dbOptions: any = {};
     const db = collection._database._name;
     const coll = collection._name;
@@ -916,7 +917,7 @@ export default class Mapper {
    *
    * @returns {Promise} The promise of command results. TODO: command result object
    */
-  runCommand(database, cmd): Promise<any> {
+  database_runCommand(database, cmd): Promise<any> {
     const db = database._name;
     this.messageBus.emit(
       'mongosh:api-call',
@@ -926,7 +927,7 @@ export default class Mapper {
     return this.serviceProvider.runCommand(db, cmd);
   }
 
-  async update(collection, filter, update, options: any = {}): Promise<any> {
+  async collection_update(collection, filter, update, options: any = {}): Promise<any> {
     const db = collection._database._name;
     const coll = collection._name;
     this.messageBus.emit(
@@ -980,7 +981,7 @@ export default class Mapper {
    *
    * @returns {UpdateResult} The promise of the result.
    */
-  async updateMany(collection, filter, update, options: any = {}): Promise<any> {
+  async collection_updateMany(collection, filter, update, options: any = {}): Promise<any> {
     const dbOptions: any = {};
     const db = collection._database._name;
     const coll = collection._name;
@@ -1028,7 +1029,7 @@ export default class Mapper {
    *
    * @returns {UpdateResult} The promise of the result.
    */
-  async updateOne(collection, filter, update, options: any = {}): Promise<any> {
+  async collection_updateOne(collection, filter, update, options: any = {}): Promise<any> {
     const dbOptions: any = {};
     const db = collection._database._name;
     const coll = collection._name;
@@ -1070,7 +1071,7 @@ export default class Mapper {
    *
    * @return {Promise}
    */
-  async convertToCapped(collection: Collection, size: number): Promise<any> {
+  async collection_convertToCapped(collection: Collection, size: number): Promise<any> {
     const db = collection._database._name;
     const coll = collection._name;
     this.messageBus.emit(
@@ -1100,7 +1101,7 @@ export default class Mapper {
    *  name, background, sparse ...)
    * @return {Promise}
    */
-  async createIndexes(
+  async collection_createIndexes(
     collection: Collection,
     keyPatterns: Document[],
     options: Document = {}
@@ -1140,7 +1141,7 @@ export default class Mapper {
    *
    * @return {Promise}
    */
-  async createIndex(
+  async collection_createIndex(
     collection: Collection,
     keys: Document,
     options: Document = {}
@@ -1156,7 +1157,7 @@ export default class Mapper {
       }
     );
 
-    return await this.createIndexes(
+    return await this.collection_createIndexes(
       collection,
       [keys],
       options
@@ -1175,7 +1176,7 @@ export default class Mapper {
    *
    * @return {Promise}
    */
-  async ensureIndex(
+  async collection_ensureIndex(
     collection: Collection,
     keys: Document,
     options: Document
@@ -1191,7 +1192,7 @@ export default class Mapper {
       }
     );
 
-    return await this.createIndex(
+    return await this.collection_createIndex(
       collection,
       keys,
       options
@@ -1206,7 +1207,7 @@ export default class Mapper {
    *
    * @return {Promise}
    */
-  async getIndexes(
+  async collection_getIndexes(
     collection: Collection,
   ): Promise<any> {
     const db = collection._database._name;
@@ -1228,7 +1229,7 @@ export default class Mapper {
    *
    * @return {Promise}
    */
-  async getIndexSpecs(
+  async collection_getIndexSpecs(
     collection: Collection,
   ): Promise<any> {
     this.messageBus.emit(
@@ -1241,7 +1242,7 @@ export default class Mapper {
       }
     );
 
-    return await this.getIndexes(collection);
+    return await this.collection_getIndexes(collection);
   }
 
   /**
@@ -1252,7 +1253,7 @@ export default class Mapper {
    *
    * @return {Promise}
    */
-  async getIndices(
+  async collection_getIndices(
     collection: Collection,
   ): Promise<any> {
     this.messageBus.emit(
@@ -1265,7 +1266,7 @@ export default class Mapper {
       }
     );
 
-    return await this.getIndexes(collection);
+    return await this.collection_getIndexes(collection);
   }
 
   /**
@@ -1275,7 +1276,7 @@ export default class Mapper {
    *
    * @return {Promise}
    */
-  async getIndexKeys(
+  async collection_getIndexKeys(
     collection: Collection,
   ): Promise<any> {
     this.messageBus.emit(
@@ -1288,7 +1289,7 @@ export default class Mapper {
       }
     );
 
-    return (await this.getIndexes(collection)).map(i => i.key);
+    return (await this.collection_getIndexes(collection)).map(i => i.key);
   }
 
   /**
@@ -1299,7 +1300,7 @@ export default class Mapper {
    * @param {string|string[]|Object|Object[]} indexes the indexes to be removed.
    * @return {Promise}
    */
-  async dropIndexes(
+  async collection_dropIndexes(
     collection: Collection,
     indexes: string|string[]|Document|Document[]
   ): Promise<any> {
@@ -1337,7 +1338,7 @@ export default class Mapper {
    * @param {string|Object} index the index to be removed.
    * @return {Promise}
    */
-  async dropIndex(
+  async collection_dropIndex(
     collection: Collection,
     index: string|Document
   ): Promise<any> {
@@ -1360,7 +1361,7 @@ export default class Mapper {
       throw new Error('The index to drop must be either the index name or the index specification document');
     }
 
-    return await this.dropIndexes(collection, index);
+    return await this.collection_dropIndexes(collection, index);
   }
 
   /**
@@ -1372,7 +1373,7 @@ export default class Mapper {
    *
    * @return {Promise}
    */
-  async getCollectionInfos(
+  async database_getCollectionInfos(
     database: Database,
     filter: Document = {},
     options: Document = {}): Promise<any> {
@@ -1402,7 +1403,7 @@ export default class Mapper {
    *
    * @return {Promise}
    */
-  async getCollectionNames(
+  async database_getCollectionNames(
     database: Database
   ): Promise<any> {
     this.messageBus.emit(
@@ -1410,13 +1411,13 @@ export default class Mapper {
       { method: 'getCollectionNames', class: 'Database', db: database._name }
     );
 
-    const infos = await this.getCollectionInfos(
+    const infos = await this.database_getCollectionInfos(
       database,
       {},
       { nameOnly: true }
     );
 
-    return infos.map(collection => collection.name);
+    return infos.collection_map(collection => collection.name);
   }
 
   /**
@@ -1425,7 +1426,7 @@ export default class Mapper {
    * @param {Collection} collection
    * @return {Promise}
    */
-  async totalIndexSize(
+  async collection_totalIndexSize(
     collection: Collection,
     ...args: any[]
   ): Promise<any> {
@@ -1445,7 +1446,7 @@ export default class Mapper {
       );
     }
 
-    const stats = await this.stats(collection);
+    const stats = await this.collection_stats(collection);
 
     return stats.totalIndexSize;
   }
@@ -1456,7 +1457,7 @@ export default class Mapper {
    * @param {Collection} collection
    * @return {Promise}
    */
-  async reIndex(
+  async collection_reIndex(
     collection: Collection
   ): Promise<any> {
     const db = collection._database._name;
@@ -1475,7 +1476,7 @@ export default class Mapper {
    * @param {Collection} collection
    * @return {Database}
    */
-  getDB(
+  collection_getDB(
     collection: Collection
   ): Database {
     this.messageBus.emit(
@@ -1498,7 +1499,7 @@ export default class Mapper {
    * @param {Object} options - The stats options.
    * @return {Promise} returns Promise
    */
-  async stats(
+  async collection_stats(
     collection: Collection,
     options: Document = {}
   ): Promise<any> {
@@ -1522,7 +1523,7 @@ export default class Mapper {
    * @param {Collection} collection - The collection name.
    * @return {Promise} returns Promise
    */
-  async dataSize(
+  async collection_dataSize(
     collection: Collection,
   ): Promise<any> {
     this.messageBus.emit(
@@ -1535,7 +1536,7 @@ export default class Mapper {
       }
     );
 
-    return (await this.stats(collection)).size;
+    return (await this.collection_stats(collection)).size;
   }
 
   /**
@@ -1544,7 +1545,7 @@ export default class Mapper {
    * @param {Collection} collection - The collection name.
    * @return {Promise} returns Promise
    */
-  async storageSize(
+  async collection_storageSize(
     collection: Collection,
   ): Promise<any> {
     this.messageBus.emit(
@@ -1557,7 +1558,7 @@ export default class Mapper {
       }
     );
 
-    return (await this.stats(collection)).storageSize;
+    return (await this.collection_stats(collection)).storageSize;
   }
 
   /**
@@ -1566,7 +1567,7 @@ export default class Mapper {
    * @param {Collection} collection - The collection.
    * @return {Promise} returns Promise
    */
-  async totalSize(
+  async collection_totalSize(
     collection: Collection,
   ): Promise<any> {
     this.messageBus.emit(
@@ -1579,7 +1580,7 @@ export default class Mapper {
       }
     );
 
-    const stats = await this.stats(collection);
+    const stats = await this.collection_stats(collection);
     return (stats.storageSize || 0) + (stats.totalIndexSize || 0);
   }
 
@@ -1589,7 +1590,7 @@ export default class Mapper {
    * @param {Collection} collection - The collection.
    * @return {Promise} returns Promise
    */
-  async drop(
+  async collection_drop(
     collection: Collection,
   ): Promise<boolean> {
     this.messageBus.emit(
@@ -1631,7 +1632,7 @@ export default class Mapper {
    * @param {Collection} collection - The collection name.
    * @return {Promise} returns Promise
    */
-  async exists(collection: Collection): Promise<any> {
+  async collection_exists(collection: Collection): Promise<any> {
     this.messageBus.emit(
       'mongosh:api-call',
       {
@@ -1652,11 +1653,11 @@ export default class Mapper {
     return collectionInfos[0] || null;
   }
 
-  getFullName(collection: Collection): string {
+  collection_getFullName(collection: Collection): string {
     return `${collection._database._name}.${collection._name}`;
   }
 
-  getName(collection: Collection): string {
+  collection_getName(collection: Collection): string {
     return `${collection._name}`;
   }
 }

--- a/packages/mapper/src/mapper.ts
+++ b/packages/mapper/src/mapper.ts
@@ -1417,7 +1417,7 @@ export default class Mapper {
       { nameOnly: true }
     );
 
-    return infos.collection_map(collection => collection.name);
+    return infos.map(collection => collection.name);
   }
 
   /**

--- a/packages/shell-api/bin/compile-shell-api.js
+++ b/packages/shell-api/bin/compile-shell-api.js
@@ -47,7 +47,7 @@ const attrTemplate = (attrName, lib, base = '') => {
 const methodTemplate = (methodName, lib) => {
   const method = lib[methodName];
   const firstArg = lib.__methods.firstArg !== '' ? `${lib.__methods.firstArg}, ` : '';
-  const wrappeeCall = `this.${lib.__methods.wrappee}.${methodName}(${firstArg}...args)`;
+  const wrappeeCall = `this.${lib.__methods.wrappee}.${lib.__methods.wrappeePrefix || ''}${methodName}(${firstArg}...args)`;
 
   return method.__fluent ?
     `${methodName}(...args) {

--- a/packages/shell-api/src/collection.spec.ts
+++ b/packages/shell-api/src/collection.spec.ts
@@ -24,7 +24,7 @@ function testWrappedMethod(name: string): void {
 
   const mock = sinon.mock();
   const mapper: Mapper = sinon.createStubInstance(Mapper, {
-    [name]: mock
+    [`collection_${name}`]: mock
   });
 
   const args = [1, 2, 3];
@@ -75,7 +75,7 @@ describe('Collection', () => {
     'getName'
   ].forEach((methodName) => {
     describe(`#${methodName}`, () => {
-      it(`wraps mapper.${methodName}`, () => {
+      it(`wraps mapper.collection_${methodName}`, () => {
         testWrappedMethod(methodName);
       });
     });

--- a/packages/shell-api/src/database.spec.ts
+++ b/packages/shell-api/src/database.spec.ts
@@ -24,7 +24,7 @@ function testWrappedMethod(name: string): void {
 
   const mock = sinon.mock();
   const mapper: Mapper = sinon.createStubInstance(Mapper, {
-    [name]: mock
+    [`database_${name}`]: mock
   });
 
   const args = [1, 2, 3];
@@ -42,15 +42,15 @@ function testWrappedMethod(name: string): void {
 }
 
 describe('Database', () => {
-  describe('#getCollectionInfos', () => {
-    it('wraps mapper.getCollectionInfos', () => {
-      testWrappedMethod('getCollectionInfos');
-    });
-  });
-
-  describe('#getCollectionNames', () => {
-    it('wraps mapper.getCollectionNames', () => {
-      testWrappedMethod('getCollectionNames');
+  [
+    'getCollectionInfos',
+    'getCollectionNames',
+    'runCommand'
+  ].forEach((methodName) => {
+    describe(`#${methodName}`, () => {
+      it(`wraps mapper.database_${methodName}`, () => {
+        testWrappedMethod(methodName);
+      });
     });
   });
 });

--- a/packages/shell-api/src/shell-api.js
+++ b/packages/shell-api/src/shell-api.js
@@ -151,183 +151,183 @@ class Collection {
   }
 
   aggregate(...args) {
-    return this._mapper.aggregate(this, ...args);
+    return this._mapper.collection_aggregate(this, ...args);
   }
 
   bulkWrite(...args) {
-    return this._mapper.bulkWrite(this, ...args);
+    return this._mapper.collection_bulkWrite(this, ...args);
   }
 
   countDocuments(...args) {
-    return this._mapper.countDocuments(this, ...args);
+    return this._mapper.collection_countDocuments(this, ...args);
   }
 
   count(...args) {
-    return this._mapper.count(this, ...args);
+    return this._mapper.collection_count(this, ...args);
   }
 
   deleteMany(...args) {
-    return this._mapper.deleteMany(this, ...args);
+    return this._mapper.collection_deleteMany(this, ...args);
   }
 
   deleteOne(...args) {
-    return this._mapper.deleteOne(this, ...args);
+    return this._mapper.collection_deleteOne(this, ...args);
   }
 
   distinct(...args) {
-    return this._mapper.distinct(this, ...args);
+    return this._mapper.collection_distinct(this, ...args);
   }
 
   estimatedDocumentCount(...args) {
-    return this._mapper.estimatedDocumentCount(this, ...args);
+    return this._mapper.collection_estimatedDocumentCount(this, ...args);
   }
 
   find(...args) {
-    return this._mapper.find(this, ...args);
+    return this._mapper.collection_find(this, ...args);
   }
 
   findAndModify(...args) {
-    return this._mapper.findAndModify(this, ...args);
+    return this._mapper.collection_findAndModify(this, ...args);
   }
 
   findOne(...args) {
-    return this._mapper.findOne(this, ...args);
+    return this._mapper.collection_findOne(this, ...args);
   }
 
   findOneAndDelete(...args) {
-    return this._mapper.findOneAndDelete(this, ...args);
+    return this._mapper.collection_findOneAndDelete(this, ...args);
   }
 
   findOneAndReplace(...args) {
-    return this._mapper.findOneAndReplace(this, ...args);
+    return this._mapper.collection_findOneAndReplace(this, ...args);
   }
 
   findOneAndUpdate(...args) {
-    return this._mapper.findOneAndUpdate(this, ...args);
+    return this._mapper.collection_findOneAndUpdate(this, ...args);
   }
 
   insert(...args) {
-    return this._mapper.insert(this, ...args);
+    return this._mapper.collection_insert(this, ...args);
   }
 
   insertMany(...args) {
-    return this._mapper.insertMany(this, ...args);
+    return this._mapper.collection_insertMany(this, ...args);
   }
 
   insertOne(...args) {
-    return this._mapper.insertOne(this, ...args);
+    return this._mapper.collection_insertOne(this, ...args);
   }
 
   isCapped(...args) {
-    return this._mapper.isCapped(this, ...args);
+    return this._mapper.collection_isCapped(this, ...args);
   }
 
   remove(...args) {
-    return this._mapper.remove(this, ...args);
+    return this._mapper.collection_remove(this, ...args);
   }
 
   save(...args) {
-    return this._mapper.save(this, ...args);
+    return this._mapper.collection_save(this, ...args);
   }
 
   replaceOne(...args) {
-    return this._mapper.replaceOne(this, ...args);
+    return this._mapper.collection_replaceOne(this, ...args);
   }
 
   update(...args) {
-    return this._mapper.update(this, ...args);
+    return this._mapper.collection_update(this, ...args);
   }
 
   updateMany(...args) {
-    return this._mapper.updateMany(this, ...args);
+    return this._mapper.collection_updateMany(this, ...args);
   }
 
   updateOne(...args) {
-    return this._mapper.updateOne(this, ...args);
+    return this._mapper.collection_updateOne(this, ...args);
   }
 
   convertToCapped(...args) {
-    return this._mapper.convertToCapped(this, ...args);
+    return this._mapper.collection_convertToCapped(this, ...args);
   }
 
   createIndexes(...args) {
-    return this._mapper.createIndexes(this, ...args);
+    return this._mapper.collection_createIndexes(this, ...args);
   }
 
   createIndex(...args) {
-    return this._mapper.createIndex(this, ...args);
+    return this._mapper.collection_createIndex(this, ...args);
   }
 
   ensureIndex(...args) {
-    return this._mapper.ensureIndex(this, ...args);
+    return this._mapper.collection_ensureIndex(this, ...args);
   }
 
   getIndexes(...args) {
-    return this._mapper.getIndexes(this, ...args);
+    return this._mapper.collection_getIndexes(this, ...args);
   }
 
   getIndexSpecs(...args) {
-    return this._mapper.getIndexSpecs(this, ...args);
+    return this._mapper.collection_getIndexSpecs(this, ...args);
   }
 
   getIndexKeys(...args) {
-    return this._mapper.getIndexKeys(this, ...args);
+    return this._mapper.collection_getIndexKeys(this, ...args);
   }
 
   getIndices(...args) {
-    return this._mapper.getIndices(this, ...args);
+    return this._mapper.collection_getIndices(this, ...args);
   }
 
   dropIndexes(...args) {
-    return this._mapper.dropIndexes(this, ...args);
+    return this._mapper.collection_dropIndexes(this, ...args);
   }
 
   dropIndex(...args) {
-    return this._mapper.dropIndex(this, ...args);
+    return this._mapper.collection_dropIndex(this, ...args);
   }
 
   reIndex(...args) {
-    return this._mapper.reIndex(this, ...args);
+    return this._mapper.collection_reIndex(this, ...args);
   }
 
   totalIndexSize(...args) {
-    return this._mapper.totalIndexSize(this, ...args);
+    return this._mapper.collection_totalIndexSize(this, ...args);
   }
 
   getDB(...args) {
-    return this._mapper.getDB(this, ...args);
+    return this._mapper.collection_getDB(this, ...args);
   }
 
   stats(...args) {
-    return this._mapper.stats(this, ...args);
+    return this._mapper.collection_stats(this, ...args);
   }
 
   dataSize(...args) {
-    return this._mapper.dataSize(this, ...args);
+    return this._mapper.collection_dataSize(this, ...args);
   }
 
   storageSize(...args) {
-    return this._mapper.storageSize(this, ...args);
+    return this._mapper.collection_storageSize(this, ...args);
   }
 
   totalSize(...args) {
-    return this._mapper.totalSize(this, ...args);
+    return this._mapper.collection_totalSize(this, ...args);
   }
 
   drop(...args) {
-    return this._mapper.drop(this, ...args);
+    return this._mapper.collection_drop(this, ...args);
   }
 
   getFullName(...args) {
-    return this._mapper.getFullName(this, ...args);
+    return this._mapper.collection_getFullName(this, ...args);
   }
 
   getName(...args) {
-    return this._mapper.getName(this, ...args);
+    return this._mapper.collection_getName(this, ...args);
   }
 
   exists(...args) {
-    return this._mapper.exists(this, ...args);
+    return this._mapper.collection_exists(this, ...args);
   }
 }
 
@@ -1006,15 +1006,15 @@ class Database {
   }
 
   runCommand(...args) {
-    return this._mapper.runCommand(this, ...args);
+    return this._mapper.db_runCommand(this, ...args);
   }
 
   getCollectionNames(...args) {
-    return this._mapper.getCollectionNames(this, ...args);
+    return this._mapper.db_getCollectionNames(this, ...args);
   }
 
   getCollectionInfos(...args) {
-    return this._mapper.getCollectionInfos(this, ...args);
+    return this._mapper.db_getCollectionInfos(this, ...args);
   }
 }
 

--- a/packages/shell-api/src/shell-api.js
+++ b/packages/shell-api/src/shell-api.js
@@ -1006,15 +1006,15 @@ class Database {
   }
 
   runCommand(...args) {
-    return this._mapper.db_runCommand(this, ...args);
+    return this._mapper.database_runCommand(this, ...args);
   }
 
   getCollectionNames(...args) {
-    return this._mapper.db_getCollectionNames(this, ...args);
+    return this._mapper.database_getCollectionNames(this, ...args);
   }
 
   getCollectionInfos(...args) {
-    return this._mapper.db_getCollectionInfos(this, ...args);
+    return this._mapper.database_getCollectionInfos(this, ...args);
   }
 }
 

--- a/packages/shell-api/yaml/Collection.yaml
+++ b/packages/shell-api/yaml/Collection.yaml
@@ -1,5 +1,9 @@
 class:
     <<: *__defaultClass
+    __methods:
+        wrappee: '_mapper'
+        firstArg: 'this'
+        wrappeePrefix: 'collection_'
     __constructorArgs:
         - _mapper
         - _database

--- a/packages/shell-api/yaml/Database.yaml
+++ b/packages/shell-api/yaml/Database.yaml
@@ -3,7 +3,7 @@ class:
     __methods:
         wrappee: '_mapper'
         firstArg: 'this'
-        wrappeePrefix: 'db_'
+        wrappeePrefix: 'database_'
     __constructorArgs:
         - _mapper
         - _name

--- a/packages/shell-api/yaml/Database.yaml
+++ b/packages/shell-api/yaml/Database.yaml
@@ -1,5 +1,9 @@
 class:
     <<: *__defaultClass
+    __methods:
+        wrappee: '_mapper'
+        firstArg: 'this'
+        wrappeePrefix: 'db_'
     __constructorArgs:
         - _mapper
         - _name


### PR DESCRIPTION
This is another way to avoid clashes between db and collection methods in mapper, even less invasive than splitting it into classes.

Prefix database methods with `database_` and collection methods with `collection_`. The prefix is configurable in the shell api yaml.