### PR TITLE
feat: implement findAndModify

### DIFF
--- a/packages/mapper/src/mapper.ts
+++ b/packages/mapper/src/mapper.ts
@@ -506,13 +506,41 @@ export default class Mapper {
     ).limit(1).next();
   }
 
-  // collection_findAndModify(collection, document) {
-  //   return this._serviceProvider.findAndModify(
-  //     collection._database._name,
-  //     collection._name,
-  //     document,
-  //   );
-  // };
+  async collection_findAndModify(
+    collection: Collection,
+    options: {
+      query?: Document;
+      sort?: Document | Document[];
+      remove?: boolean;
+      update?: Document | Document[];
+      new?: boolean;
+      fields?: Document;
+      upsert?: boolean;
+      bypassDocumentValidation?: boolean;
+      writeConcern?: Document;
+      collation?: Document;
+      arrayFilters?: Document[];
+    } = {}
+  ): Promise<any> {
+    const providerOptions = {
+      ...options
+    };
+
+    delete providerOptions.query;
+    delete providerOptions.sort;
+    delete providerOptions.update;
+
+    const result = await this.serviceProvider.findAndModify(
+      collection._database._name,
+      collection._name,
+      options.query || {},
+      options.sort,
+      options.update,
+      providerOptions
+    );
+
+    return result.value;
+  }
 
   /**
    * Find one document and delete it.

--- a/packages/service-provider-browser/src/stitch-service-provider-browser.ts
+++ b/packages/service-provider-browser/src/stitch-service-provider-browser.ts
@@ -111,6 +111,10 @@ class StitchServiceProviderBrowser implements ServiceProvider {
       new StitchTransport<StitchAppClient, RemoteMongoClient>(stitchClient, mongoClient);
   }
 
+  findAndModify(database: string, collection: string, query: Document, sort: any[] | Document, update: Document, options?: Document, dbOptions?: Document) {
+    throw new Error("Method not implemented.");
+  }
+
   dropCollection(database: string, collection: string, dbOptions?: Document): Promise<boolean> {
     throw new Error("Method not implemented.");
   }

--- a/packages/service-provider-core/src/writable.ts
+++ b/packages/service-provider-core/src/writable.ts
@@ -182,6 +182,28 @@ interface Writable {
     dbOptions?: Document) : Promise<Result>;
 
   /**
+   * find and update or remove a document.
+   *
+   * @param {String} database - The database name.
+   * @param {String} collection - The collection name.
+   * @param {Document} query - The filter.
+   * @param {Document} sort - The sort option.
+   * @param {Document} update - The update document.
+   * @param {Document} options - The update options.
+   *
+   * @returns {Promise} The promise of the result.
+   */
+  findAndModify(
+    database: string,
+    collection: string,
+    query: Document,
+    sort: any[] | Document,
+    update: Document,
+    options?: Document,
+    dbOptions?: Document
+  )
+
+  /**
    * Update a document.
    *
    * @param {String} database - The database name.

--- a/packages/service-provider-server/src/cli-service-provider.spec.ts
+++ b/packages/service-provider-server/src/cli-service-provider.spec.ts
@@ -191,6 +191,35 @@ describe('CliServiceProvider', () => {
     });
   });
 
+  describe('#findAndModify', () => {
+    const commandResult = { result: { n: 1, ok: 1 } };
+    const findMock = sinon.mock().once().withArgs(
+      { query: 1 },
+      { sort: 1 },
+      { update: 1 },
+      { options: 1 }
+    ).resolves(commandResult);
+
+    beforeEach(() => {
+      const collectionStub = sinon.createStubInstance(Collection, {
+        findAndModify: findMock
+      });
+      serviceProvider = new CliServiceProvider(createClientStub(collectionStub));
+    });
+
+    it('executes the command against the database', async() => {
+      const result = await serviceProvider.findAndModify(
+        'music', 'bands',
+        { query: 1 },
+        { sort: 1 },
+        { update: 1 },
+        { options: 1 }
+      );
+      expect(result).to.deep.equal(commandResult);
+      findMock.verify();
+    });
+  });
+
   describe('#findOneAndDelete', () => {
     const commandResult = { result: { n: 1, ok: 1 } };
     const findMock = sinon.mock().once().withArgs({}).resolves(commandResult);

--- a/packages/service-provider-server/src/cli-service-provider.ts
+++ b/packages/service-provider-server/src/cli-service-provider.ts
@@ -65,6 +65,20 @@ class CliServiceProvider implements ServiceProvider {
     this.mongoClient = mongoClient;
   }
 
+  async findAndModify(
+    database: string,
+    collection: string,
+    query: Document,
+    sort: any[] | Document,
+    update: Document,
+    options?: Document,
+    dbOptions?: Document
+  ): Promise<any> {
+    return await this.db(database, dbOptions)
+      .collection(collection)
+      .findAndModify(query, sort, update, options);
+  }
+
   /**
    * Converts an existing, non-capped collection to
    * a capped collection within the same database.


### PR DESCRIPTION
Implements `findAndModify` which was commented out till now.

Sorry for the changes in `mapper.spec.js` i fixed the brackets, there were collection methods tests inside the commands section and other weirdly skewed stuff. The only real change related to this PR in that file is this one: 
https://github.com/mongodb-js/mongosh/pull/134/files#diff-104d5062b24948c6ee6a9d6d0dd5c314R538
