### PR TITLE
Always pass dbOptions

### DIFF
--- a/packages/mapper/src/mapper.ts
+++ b/packages/mapper/src/mapper.ts
@@ -15,7 +15,8 @@ import {
 
 import {
   ServiceProvider,
-  Document
+  Document,
+  DatabaseOptions
 } from '@mongosh/service-provider-core';
 
 import { EventEmitter } from 'events';
@@ -140,32 +141,22 @@ export default class Mapper {
     const db = collection._database._name;
     const coll = collection._name;
 
-    const dbOptions: any = {};
+    const dbOptions: DatabaseOptions = {};
 
     if ('readConcern' in options) {
       dbOptions.readConcern = options.readConcern;
     }
     if ('writeConcern' in options) {
-      dbOptions.writeConcern = options.writeConcern;
+      Object.assign(dbOptions, options.writeConcern);
     }
 
-    let cmd;
-    if (coll === null) {
-      cmd = this.serviceProvider.aggregateDb(
-        db,
-        pipeline,
-        options,
-        dbOptions
-      );
-    } else {
-      cmd = this.serviceProvider.aggregate(
-        db,
-        coll,
-        pipeline,
-        options,
-        dbOptions
-      );
-    }
+    const cmd = this.serviceProvider.aggregate(
+      db,
+      coll,
+      pipeline,
+      options,
+      dbOptions
+    );
 
     this.messageBus.emit(
       'mongosh:api-call',
@@ -201,7 +192,7 @@ export default class Mapper {
     operations: Document,
     options: Document = {}
   ): Promise<BulkWriteResult> {
-    const dbOptions: any = {};
+    const dbOptions: DatabaseOptions = {};
     const db = collection._database._name;
     const coll = collection._name;
     this.messageBus.emit(
@@ -214,7 +205,7 @@ export default class Mapper {
     );
 
     if ('writeConcern' in options) {
-      dbOptions.writeConcern = options.writeConcern;
+      Object.assign(dbOptions, options.writeConcern);
     }
 
     const result = await this.serviceProvider.bulkWrite(
@@ -308,7 +299,7 @@ export default class Mapper {
    * @returns {DeleteResult} The promise of the result.
    */
   async collection_deleteMany(collection, filter, options: any = {}): Promise<any> {
-    const dbOptions: any = {};
+    const dbOptions: DatabaseOptions = {};
     const db = collection._database._name;
     const coll = collection._name;
     this.messageBus.emit(
@@ -321,7 +312,7 @@ export default class Mapper {
     );
 
     if ('writeConcern' in options) {
-      dbOptions.writeConcern = options.writeConcern;
+      Object.assign(dbOptions, options.writeConcern);
     }
 
     const result = await this.serviceProvider.deleteMany(
@@ -352,7 +343,7 @@ export default class Mapper {
    * @returns {DeleteResult} The promise of the result.
    */
   async collection_deleteOne(collection, filter, options: any = {}): Promise<any> {
-    const dbOptions: any = {};
+    const dbOptions: DatabaseOptions = {};
     const db = collection._database._name;
     const coll = collection._name;
     this.messageBus.emit(
@@ -365,7 +356,7 @@ export default class Mapper {
     );
 
     if ('writeConcern' in options) {
-      dbOptions.writeConcern = options.writeConcern;
+      Object.assign(dbOptions, options.writeConcern);
     }
     const result = await this.serviceProvider.deleteOne(
       db,
@@ -724,12 +715,12 @@ export default class Mapper {
    */
   async collection_insert(collection, docs, options: any = {}): Promise<any> {
     const d = Object.prototype.toString.call(docs) === '[object Array]' ? docs : [docs];
-    const dbOptions: any = {};
+    const dbOptions: DatabaseOptions = {};
     const db = collection._database._name;
     const coll = collection._name;
 
     if ('writeConcern' in options) {
-      dbOptions.writeConcern = options.writeConcern;
+      Object.assign(dbOptions, options.writeConcern);
     }
 
     this.messageBus.emit(
@@ -770,12 +761,12 @@ export default class Mapper {
    * @return {InsertManyResult}
    */
   async collection_insertMany(collection, docs, options: any = {}): Promise<any> {
-    const dbOptions: any = {};
+    const dbOptions: DatabaseOptions = {};
     const db = collection._database._name;
     const coll = collection._name;
 
     if ('writeConcern' in options) {
-      dbOptions.writeConcern = options.writeConcern;
+      Object.assign(dbOptions, options.writeConcern);
     }
 
     this.messageBus.emit(
@@ -816,12 +807,12 @@ export default class Mapper {
    * @return {InsertOneResult}
    */
   async collection_insertOne(collection, doc, options: any = {}): Promise<any> {
-    const dbOptions: any = {};
+    const dbOptions: DatabaseOptions = {};
     const db = collection._database._name;
     const coll = collection._name;
 
     if ('writeConcern' in options) {
-      dbOptions.writeConcern = options.writeConcern;
+      Object.assign(dbOptions, options.writeConcern);
     }
 
     this.messageBus.emit(
@@ -878,12 +869,12 @@ export default class Mapper {
    * @return {Promise}
    */
   collection_remove(collection, query, options: any = {}): Promise<any> {
-    const dbOptions: any = {};
+    const dbOptions: DatabaseOptions = {};
     const db = collection._database._name;
     const coll = collection._name;
 
     if ('writeConcern' in options) {
-      dbOptions.writeConcern = options.writeConcern;
+      Object.assign(dbOptions, options.writeConcern);
     }
 
     let removeOptions: any = {};
@@ -913,7 +904,7 @@ export default class Mapper {
 
   // TODO
   collection_save(collection, doc, options: any = {}): Promise<any> {
-    const dbOptions: any = {};
+    const dbOptions: DatabaseOptions = {};
     const db = collection._database._name;
     const coll = collection._name;
     this.messageBus.emit(
@@ -926,7 +917,7 @@ export default class Mapper {
     );
 
     if ('writeConcern' in options) {
-      dbOptions.writeConcern = options.writeConcern;
+      Object.assign(dbOptions, options.writeConcern);
     }
 
     return this.serviceProvider.save(db, coll, doc, options, dbOptions);
@@ -949,7 +940,7 @@ export default class Mapper {
    * @returns {UpdateResult} The promise of the result.
    */
   async collection_replaceOne(collection, filter, replacement, options: any = {}): Promise<any> {
-    const dbOptions: any = {};
+    const dbOptions: DatabaseOptions = {};
     const db = collection._database._name;
     const coll = collection._name;
     this.messageBus.emit(
@@ -963,7 +954,7 @@ export default class Mapper {
 
 
     if ('writeConcern' in options) {
-      dbOptions.writeConcern = options.writeConcern;
+      Object.assign(dbOptions, options.writeConcern);
     }
     const result = await this.serviceProvider.replaceOne(
       db,
@@ -1055,7 +1046,7 @@ export default class Mapper {
    * @returns {UpdateResult} The promise of the result.
    */
   async collection_updateMany(collection, filter, update, options: any = {}): Promise<any> {
-    const dbOptions: any = {};
+    const dbOptions: DatabaseOptions = {};
     const db = collection._database._name;
     const coll = collection._name;
     this.messageBus.emit(
@@ -1068,7 +1059,7 @@ export default class Mapper {
     );
 
     if ('writeConcern' in options) {
-      dbOptions.writeConcern = options.writeConcern;
+      Object.assign(dbOptions, options.writeConcern);
     }
     const result = await this.serviceProvider.updateMany(
       db,
@@ -1103,7 +1094,7 @@ export default class Mapper {
    * @returns {UpdateResult} The promise of the result.
    */
   async collection_updateOne(collection, filter, update, options: any = {}): Promise<any> {
-    const dbOptions: any = {};
+    const dbOptions: DatabaseOptions = {};
     const db = collection._database._name;
     const coll = collection._name;
     this.messageBus.emit(
@@ -1116,7 +1107,7 @@ export default class Mapper {
     );
 
     if ('writeConcern' in options) {
-      dbOptions.writeConcern = options.writeConcern;
+      Object.assign(dbOptions, options.writeConcern);
     }
     const result = await this.serviceProvider.updateMany(
       db,

--- a/packages/service-provider-browser/src/stitch-service-provider-browser.ts
+++ b/packages/service-provider-browser/src/stitch-service-provider-browser.ts
@@ -1,4 +1,14 @@
-import { ServiceProvider, Result, BulkWriteResult, Document, Cursor } from '@mongosh/service-provider-core';
+import {
+  ServiceProvider,
+  Result,
+  BulkWriteResult,
+  Document,
+  Cursor,
+  DatabaseOptions,
+  CommandOptions,
+  WriteConcern
+} from '@mongosh/service-provider-core';
+
 import StitchTransport from './stitch-transport';
 
 import i18n from '@mongosh/i18n';
@@ -111,80 +121,80 @@ class StitchServiceProviderBrowser implements ServiceProvider {
       new StitchTransport<StitchAppClient, RemoteMongoClient>(stitchClient, mongoClient);
   }
 
-  renameCollection(database: string, collection: string, newName: string, options?: Document, dbOptions?: Document): Promise<any> {
+  aggregateDb(database: string, pipeline: Document[], options?: Document, databaseOptions?: DatabaseOptions): Cursor {
     throw new Error("Method not implemented.");
   }
 
-  findAndModify(database: string, collection: string, query: Document, sort: any[] | Document, update: Document, options?: Document, dbOptions?: Document) {
+  count(db: string, coll: string, query?: Document, options?: Document, databaseOptions?: DatabaseOptions): Promise<any> {
     throw new Error("Method not implemented.");
   }
 
-  dropCollection(database: string, collection: string, dbOptions?: Document): Promise<boolean> {
+  isCapped(database: string, collection: string, databaseOptions?: DatabaseOptions): Promise<any> {
     throw new Error("Method not implemented.");
   }
 
-  listCollections(database: string, filter?: Document, options?: Document, dbOptions?: Document): Promise<any> {
+  getIndexes(database: string, collection: string, databaseOptions?: DatabaseOptions): Promise<any> {
     throw new Error("Method not implemented.");
   }
 
-  stats(database: string, collection: string, options?: Document, dbOptions?: Document): Promise<any> {
+  listCollections(database: string, filter?: Document, options?: Document, databaseOptions?: DatabaseOptions): Promise<any> {
     throw new Error("Method not implemented.");
   }
 
-  reIndex(database: string, collection: string, options?: Document, dbOptions?: Document): Promise<any> {
+  stats(database: string, collection: string, options?: Document, databaseOptions?: DatabaseOptions): Promise<any> {
     throw new Error("Method not implemented.");
   }
 
-  dropIndexes(database: string, collection: string, indexes: string|string[]|Document|Document[], options?: Document, dbOptions?: Document): Promise<any> {
+  dropDatabase(database: string, writeConcern?: WriteConcern, databaseOptions?: DatabaseOptions): Promise<any> {
     throw new Error("Method not implemented.");
   }
 
-  getIndexes(database: string, collection: string, dbOptions?: Document): Promise<any> {
+  findAndModify(database: string, collection: string, query: Document, sort: any[] | Document, update: Document, options?: Document, databaseOptions?: DatabaseOptions) {
     throw new Error("Method not implemented.");
   }
 
-  createIndexes(database: string, collection: string, indexSpecs: Document[], options?: Document, dbOptions?: Document): Promise<any> {
+  save(database: string, collection: string, doc: Document, options?: Document, databaseOptions?: DatabaseOptions): Promise<any> {
     throw new Error("Method not implemented.");
   }
 
-  convertToCapped(database: string, collection: string, size: number): Promise<any> {
+  remove(database: string, collection: string, query: Document, options?: Document, databaseOptions?: DatabaseOptions): Promise<any> {
+    throw new Error("Method not implemented.");
+  }
+
+  convertToCapped(database: string, collection: string, size: number, options?: CommandOptions): Promise<any> {
+    throw new Error("Method not implemented.");
+  }
+
+  createIndexes(database: string, collection: string, indexSpecs: Document[], options?: Document, databaseOptions?: DatabaseOptions): Promise<any> {
+    throw new Error("Method not implemented.");
+  }
+
+  dropIndexes(database: string, collection: string, indexes: string | Document | Document[] | string[], commandOptions?: CommandOptions, databaseOptions?: DatabaseOptions): Promise<any> {
+    throw new Error("Method not implemented.");
+  }
+
+  reIndex(database: string, collection: string, options?: CommandOptions, databaseOptions?: DatabaseOptions): Promise<any> {
+    throw new Error("Method not implemented.");
+  }
+
+  dropCollection(database: string, collection: string, databaseOptions?: DatabaseOptions): Promise<boolean> {
+    throw new Error("Method not implemented.");
+  }
+
+  renameCollection(database: string, oldName: string, newName: string, options?: Document, databaseOptions?: DatabaseOptions): Promise<any> {
+    throw new Error("Method not implemented.");
+  }
+
+  close(boolean: any): Promise<void> {
+    throw new Error("Method not implemented.");
+  }
+
+  getServerVersion(): Promise<string> {
     throw new Error("Method not implemented.");
   }
 
   listDatabases(database: string): Promise<any> {
     throw new Error("Method not implemented.");
-  }
-
-  isCapped(database: string, collection: string): Promise<any> {
-    throw new Error("Method not implemented.");
-  }
-
-  remove(database: string, collection: string, query: Document, options?: Document, dbOptions?: Document): Promise<any> {
-    throw new Error("Method not implemented.");
-  }
-
-  save(database: string, collection: string, doc: Document, options?: Document, dbOptions?: Document): Promise<any> {
-    throw new Error('Method not implemented.');
-  }
-
-  close(boolean: any): Promise<void> {
-    throw new Error('Method not implemented.');
-  }
-
-  aggregateDb(database: string, pipeline: Document[], options?: any, dbOptions?: any): Cursor {
-    throw new Error('Method not implemented.');
-  }
-
-  count(db: string, coll: string, query?: any, options?: any, dbOptions?: any): Promise<any> {
-    throw new Error('Method not implemented.');
-  }
-
-  getServerVersion(): Promise<string> {
-    throw new Error('Method not implemented.');
-  }
-
-  dropDatabase(database: string, writeConcern?: any): Promise<any> {
-    throw new Error('Method not implemented.');
   }
 
   /**

--- a/packages/service-provider-browser/src/stitch-service-provider-browser.ts
+++ b/packages/service-provider-browser/src/stitch-service-provider-browser.ts
@@ -121,43 +121,43 @@ class StitchServiceProviderBrowser implements ServiceProvider {
       new StitchTransport<StitchAppClient, RemoteMongoClient>(stitchClient, mongoClient);
   }
 
-  aggregateDb(database: string, pipeline: Document[], options?: Document, databaseOptions?: DatabaseOptions): Cursor {
+  aggregateDb(database: string, pipeline: Document[], options?: Document, dbOptions?: DatabaseOptions): Cursor {
     throw new Error("Method not implemented.");
   }
 
-  count(db: string, coll: string, query?: Document, options?: Document, databaseOptions?: DatabaseOptions): Promise<any> {
+  count(db: string, coll: string, query?: Document, options?: Document, dbOptions?: DatabaseOptions): Promise<any> {
     throw new Error("Method not implemented.");
   }
 
-  isCapped(database: string, collection: string, databaseOptions?: DatabaseOptions): Promise<any> {
+  isCapped(database: string, collection: string, dbOptions?: DatabaseOptions): Promise<any> {
     throw new Error("Method not implemented.");
   }
 
-  getIndexes(database: string, collection: string, databaseOptions?: DatabaseOptions): Promise<any> {
+  getIndexes(database: string, collection: string, dbOptions?: DatabaseOptions): Promise<any> {
     throw new Error("Method not implemented.");
   }
 
-  listCollections(database: string, filter?: Document, options?: Document, databaseOptions?: DatabaseOptions): Promise<any> {
+  listCollections(database: string, filter?: Document, options?: Document, dbOptions?: DatabaseOptions): Promise<any> {
     throw new Error("Method not implemented.");
   }
 
-  stats(database: string, collection: string, options?: Document, databaseOptions?: DatabaseOptions): Promise<any> {
+  stats(database: string, collection: string, options?: Document, dbOptions?: DatabaseOptions): Promise<any> {
     throw new Error("Method not implemented.");
   }
 
-  dropDatabase(database: string, writeConcern?: WriteConcern, databaseOptions?: DatabaseOptions): Promise<any> {
+  dropDatabase(database: string, writeConcern?: WriteConcern, dbOptions?: DatabaseOptions): Promise<any> {
     throw new Error("Method not implemented.");
   }
 
-  findAndModify(database: string, collection: string, query: Document, sort: any[] | Document, update: Document, options?: Document, databaseOptions?: DatabaseOptions) {
+  findAndModify(database: string, collection: string, query: Document, sort: any[] | Document, update: Document, options?: Document, dbOptions?: DatabaseOptions) {
     throw new Error("Method not implemented.");
   }
 
-  save(database: string, collection: string, doc: Document, options?: Document, databaseOptions?: DatabaseOptions): Promise<any> {
+  save(database: string, collection: string, doc: Document, options?: Document, dbOptions?: DatabaseOptions): Promise<any> {
     throw new Error("Method not implemented.");
   }
 
-  remove(database: string, collection: string, query: Document, options?: Document, databaseOptions?: DatabaseOptions): Promise<any> {
+  remove(database: string, collection: string, query: Document, options?: Document, dbOptions?: DatabaseOptions): Promise<any> {
     throw new Error("Method not implemented.");
   }
 
@@ -165,23 +165,23 @@ class StitchServiceProviderBrowser implements ServiceProvider {
     throw new Error("Method not implemented.");
   }
 
-  createIndexes(database: string, collection: string, indexSpecs: Document[], options?: Document, databaseOptions?: DatabaseOptions): Promise<any> {
+  createIndexes(database: string, collection: string, indexSpecs: Document[], options?: Document, dbOptions?: DatabaseOptions): Promise<any> {
     throw new Error("Method not implemented.");
   }
 
-  dropIndexes(database: string, collection: string, indexes: string | Document | Document[] | string[], commandOptions?: CommandOptions, databaseOptions?: DatabaseOptions): Promise<any> {
+  dropIndexes(database: string, collection: string, indexes: string | Document | Document[] | string[], commandOptions?: CommandOptions, dbOptions?: DatabaseOptions): Promise<any> {
     throw new Error("Method not implemented.");
   }
 
-  reIndex(database: string, collection: string, options?: CommandOptions, databaseOptions?: DatabaseOptions): Promise<any> {
+  reIndex(database: string, collection: string, options?: CommandOptions, dbOptions?: DatabaseOptions): Promise<any> {
     throw new Error("Method not implemented.");
   }
 
-  dropCollection(database: string, collection: string, databaseOptions?: DatabaseOptions): Promise<boolean> {
+  dropCollection(database: string, collection: string, dbOptions?: DatabaseOptions): Promise<boolean> {
     throw new Error("Method not implemented.");
   }
 
-  renameCollection(database: string, oldName: string, newName: string, options?: Document, databaseOptions?: DatabaseOptions): Promise<any> {
+  renameCollection(database: string, oldName: string, newName: string, options?: Document, dbOptions?: DatabaseOptions): Promise<any> {
     throw new Error("Method not implemented.");
   }
 

--- a/packages/service-provider-core/src/admin.ts
+++ b/packages/service-provider-core/src/admin.ts
@@ -1,0 +1,19 @@
+import Result from "./result";
+
+export default interface Admin {
+   /**
+   * Returns the server version.
+   *
+   * @returns {Promise} The server version.
+   */
+  getServerVersion(): Promise<string>;
+
+  /**
+   * list databases.
+   *
+   * @param {String} database - The database name.
+   *
+   * @returns {Promise} The promise of command results.
+   */
+  listDatabases(database: string): Promise<Result>;
+}

--- a/packages/service-provider-core/src/closable.ts
+++ b/packages/service-provider-core/src/closable.ts
@@ -1,0 +1,8 @@
+export default interface Closable {
+  /**
+   * Close the connection.
+   *
+   * @param {boolean} force - Whether to force close.
+   */
+  close(boolean): Promise<void>;
+}

--- a/packages/service-provider-core/src/command-options.ts
+++ b/packages/service-provider-core/src/command-options.ts
@@ -1,0 +1,5 @@
+import WriteConcern from "./write-concern";
+
+export default interface CommandOptions {
+  writeConcern?: WriteConcern
+}

--- a/packages/service-provider-core/src/database-options.ts
+++ b/packages/service-provider-core/src/database-options.ts
@@ -1,0 +1,9 @@
+import WriteConcern from "./write-concern";
+import ReadConcern from "./read-concern";
+import ReadPreference from "./read-preference";
+
+export default interface DatabaseOptions extends WriteConcern {
+  returnNonCachedInstance?: boolean;
+  readConcern?: ReadConcern;
+  readPreference?: ReadPreference
+}

--- a/packages/service-provider-core/src/index.ts
+++ b/packages/service-provider-core/src/index.ts
@@ -3,11 +3,19 @@ import Document from './document';
 import Cursor from './cursor';
 import Result from './result';
 import BulkWriteResult from './bulk-write-result';
+import WriteConcern from './write-concern';
+import ReadConcern from './read-concern';
+import CommandOptions from './command-options';
+import DatabaseOptions from './database-options';
 
 export {
   ServiceProvider,
   BulkWriteResult,
   Document,
   Cursor,
-  Result
+  Result,
+  ReadConcern,
+  WriteConcern,
+  CommandOptions,
+  DatabaseOptions
 };

--- a/packages/service-provider-core/src/read-concern.ts
+++ b/packages/service-provider-core/src/read-concern.ts
@@ -1,0 +1,3 @@
+export default interface ReadConcern {
+  level: string;
+}

--- a/packages/service-provider-core/src/read-preference.ts
+++ b/packages/service-provider-core/src/read-preference.ts
@@ -1,0 +1,4 @@
+export default interface ReadPreference {
+  mode: string,
+  tags?: Record<string, string>[]
+}

--- a/packages/service-provider-core/src/readable.ts
+++ b/packages/service-provider-core/src/readable.ts
@@ -1,6 +1,7 @@
 import Document from './document';
 import Cursor from './cursor';
 import Result from './result';
+import DatabaseOptions from './database-options';
 
 /**
  * Interface for read operations in the CRUD specification.
@@ -14,7 +15,7 @@ interface Readable {
    * @param {String} collection - The collection name.
    * @param {Array} pipeline - The aggregation pipeline.
    * @param {Document} options - The pipeline options.
-   *
+   * @param {DatabaseOptions} databaseOptions - The collection options
    * @returns {Cursor} A cursor.
    */
   aggregate(
@@ -22,7 +23,7 @@ interface Readable {
     collection: string,
     pipeline: Document[],
     options?: Document,
-    dbOptions?: Document) : Cursor;
+    databaseOptions?: DatabaseOptions) : Cursor;
 
   /**
    * Run an aggregation pipeline on the DB.
@@ -37,7 +38,8 @@ interface Readable {
     database: string,
     pipeline: Document[],
     options?: Document,
-    dbOptions?: Document) : Cursor;
+    databaseOptions?: DatabaseOptions
+  ) : Cursor;
 
   /**
    * Returns the count of documents that would match a find() query for the
@@ -49,7 +51,7 @@ interface Readable {
    * @param {String} coll - the collection name
    * @param query
    * @param options
-   * @param dbOptions
+   * @param {DatabaseOptions} databaseOptions - The collection options
    *
    * @returns {Promise} A promise of the result.
    */
@@ -58,7 +60,7 @@ interface Readable {
     coll: string,
     query?: Document,
     options?: Document,
-    dbOptions?: Document): Promise<Result>;
+    databaseOptions?: DatabaseOptions): Promise<Result>;
 
   /**
    * Get an exact document count from the collection.
@@ -67,6 +69,7 @@ interface Readable {
    * @param {String} collection - The collection name.
    * @param {Document} filter - The filter.
    * @param {Document} options - The count options.
+   * @param {DatabaseOptions} databaseOptions - The collection options
    *
    * @returns {Promise} A promise of the result.
    */
@@ -74,7 +77,8 @@ interface Readable {
     database: string,
     collection: string,
     filter?: Document,
-    options?: Document) : Promise<Result>;
+    options?: Document,
+    databaseOptions?: DatabaseOptions): Promise<Result>;
 
   /**
    * Get distinct values for the field.
@@ -84,6 +88,7 @@ interface Readable {
    * @param {String} fieldName - The field name.
    * @param {Document} filter - The filter.
    * @param {Document} options - The distinct options.
+   * @param {DatabaseOptions} databaseOptions - The collection options
    *
    * @returns {Cursor} The cursor.
    */
@@ -93,7 +98,7 @@ interface Readable {
     fieldName: string,
     filter?: Document,
     options?: Document,
-    dbOptions?: Document) : Promise<any>;
+    databaseOptions?: DatabaseOptions) : Promise<Result>;
 
   /**
    * Get an estimated document count from the collection.
@@ -101,13 +106,15 @@ interface Readable {
    * @param {String} database - The database name.
    * @param {String} collection - The collection name.
    * @param {Document} options - The count options.
+   * @param {DatabaseOptions} databaseOptions - The collection options
    *
    * @returns {Promise} The promise of the result.
    */
   estimatedDocumentCount(
     database: string,
     collection: string,
-    options?: Document) : Promise<Result>;
+    options?: Document,
+    databaseOptions?: DatabaseOptions) : Promise<Result>;
 
   /**
    * Find documents in the collection.
@@ -116,6 +123,7 @@ interface Readable {
    * @param {String} collection - The collection name.
    * @param {Document} filter - The filter.
    * @param {Document} options - The find options.
+   * @param {DatabaseOptions} databaseOptions - The collection options
    *
    * @returns {Promise} The promise of the cursor.
    */
@@ -123,34 +131,22 @@ interface Readable {
     database: string,
     collection: string,
     filter?: Document,
-    options?: Document) : Cursor;
-
-  /**
-   * Returns the server version.
-   *
-   * @returns {Promise} The server version.
-   */
-  getServerVersion(): Promise<string>;
-
-  /**
-   * list databases.
-   *
-   * @param {String} database - The database name.
-   *
-   * @returns {Promise} The promise of command results.
-   */
-  listDatabases(database: string): Promise<Result>;
+    options?: Document,
+    databaseOptions?: DatabaseOptions) : Cursor;
 
   /**
    * Is the collection capped?
    *
    * @param {String} database - The database name.
    * @param {String} collection - The collection name.
+   * @param {DatabaseOptions} databaseOptions - The collection options
+   *
    * @returns {Promise} The promise of the result.
    */
   isCapped(
     database: string,
-    collection: string): Promise<Result>;
+    collection: string,
+    databaseOptions?: DatabaseOptions): Promise<Result>;
 
   /**
    * Returns an array that holds a list of documents that identify and
@@ -158,15 +154,14 @@ interface Readable {
    *
    * @param {String} database - The db name.
    * @param {String} collection - The collection name.
-   * @param {Object} dbOptions - The database options
-   *  (i.e. readConcern, writeConcern. etc).
+   * @param {DatabaseOptions} databaseOptions - The collection options
    *
    * @return {Promise}
    */
   getIndexes(
     database: string,
     collection: string,
-    dbOptions?: Document): Promise<Result>;
+    databaseOptions?: DatabaseOptions): Promise<Result>;
 
   /**
    * Returns an array of collection infos
@@ -174,8 +169,7 @@ interface Readable {
    * @param {String} database - The db name.
    * @param {Document} filter - The filter.
    * @param {Document} options - The command options.
-   * @param {Object} dbOptions - The database options
-   *  (i.e. readConcern, writeConcern. etc).
+   * @param {DatabaseOptions} databaseOptions - The collection options
    *
    * @return {Promise}
    */
@@ -183,22 +177,23 @@ interface Readable {
     database: string,
     filter?: Document,
     options?: Document,
-    dbOptions?: Document): Promise<Result>;
+    databaseOptions?: DatabaseOptions): Promise<Result>;
 
-  /*
+  /**
    * Get all the collection statistics.
    *
    * @param {String} database - The db name.
    * @param {String} collection - The collection name.
    * @param {Object} options - The count options.
-   * @param {Object} dbOptions - The database options
+   * @param {DatabaseOptions} databaseOptions - The collection options
+   *
    * @return {Promise} returns Promise
    */
   stats(
     database: string,
     collection: string,
     options?: Document,
-    dbOptions?: Document
+    databaseOptions?: DatabaseOptions
   ): Promise<Result>
 }
 

--- a/packages/service-provider-core/src/readable.ts
+++ b/packages/service-provider-core/src/readable.ts
@@ -15,7 +15,7 @@ interface Readable {
    * @param {String} collection - The collection name.
    * @param {Array} pipeline - The aggregation pipeline.
    * @param {Document} options - The pipeline options.
-   * @param {DatabaseOptions} databaseOptions - The collection options
+   * @param {DatabaseOptions} dbOptions - The database options
    * @returns {Cursor} A cursor.
    */
   aggregate(
@@ -23,7 +23,7 @@ interface Readable {
     collection: string,
     pipeline: Document[],
     options?: Document,
-    databaseOptions?: DatabaseOptions) : Cursor;
+    dbOptions?: DatabaseOptions) : Cursor;
 
   /**
    * Run an aggregation pipeline on the DB.
@@ -38,7 +38,7 @@ interface Readable {
     database: string,
     pipeline: Document[],
     options?: Document,
-    databaseOptions?: DatabaseOptions
+    dbOptions?: DatabaseOptions
   ) : Cursor;
 
   /**
@@ -51,7 +51,7 @@ interface Readable {
    * @param {String} coll - the collection name
    * @param query
    * @param options
-   * @param {DatabaseOptions} databaseOptions - The collection options
+   * @param {DatabaseOptions} dbOptions - The database options
    *
    * @returns {Promise} A promise of the result.
    */
@@ -60,7 +60,7 @@ interface Readable {
     coll: string,
     query?: Document,
     options?: Document,
-    databaseOptions?: DatabaseOptions): Promise<Result>;
+    dbOptions?: DatabaseOptions): Promise<Result>;
 
   /**
    * Get an exact document count from the collection.
@@ -69,7 +69,7 @@ interface Readable {
    * @param {String} collection - The collection name.
    * @param {Document} filter - The filter.
    * @param {Document} options - The count options.
-   * @param {DatabaseOptions} databaseOptions - The collection options
+   * @param {DatabaseOptions} dbOptions - The database options
    *
    * @returns {Promise} A promise of the result.
    */
@@ -78,7 +78,7 @@ interface Readable {
     collection: string,
     filter?: Document,
     options?: Document,
-    databaseOptions?: DatabaseOptions): Promise<Result>;
+    dbOptions?: DatabaseOptions): Promise<Result>;
 
   /**
    * Get distinct values for the field.
@@ -88,7 +88,7 @@ interface Readable {
    * @param {String} fieldName - The field name.
    * @param {Document} filter - The filter.
    * @param {Document} options - The distinct options.
-   * @param {DatabaseOptions} databaseOptions - The collection options
+   * @param {DatabaseOptions} dbOptions - The database options
    *
    * @returns {Cursor} The cursor.
    */
@@ -98,7 +98,7 @@ interface Readable {
     fieldName: string,
     filter?: Document,
     options?: Document,
-    databaseOptions?: DatabaseOptions) : Promise<Result>;
+    dbOptions?: DatabaseOptions) : Promise<Result>;
 
   /**
    * Get an estimated document count from the collection.
@@ -106,7 +106,7 @@ interface Readable {
    * @param {String} database - The database name.
    * @param {String} collection - The collection name.
    * @param {Document} options - The count options.
-   * @param {DatabaseOptions} databaseOptions - The collection options
+   * @param {DatabaseOptions} dbOptions - The database options
    *
    * @returns {Promise} The promise of the result.
    */
@@ -114,7 +114,7 @@ interface Readable {
     database: string,
     collection: string,
     options?: Document,
-    databaseOptions?: DatabaseOptions) : Promise<Result>;
+    dbOptions?: DatabaseOptions) : Promise<Result>;
 
   /**
    * Find documents in the collection.
@@ -123,7 +123,7 @@ interface Readable {
    * @param {String} collection - The collection name.
    * @param {Document} filter - The filter.
    * @param {Document} options - The find options.
-   * @param {DatabaseOptions} databaseOptions - The collection options
+   * @param {DatabaseOptions} dbOptions - The database options
    *
    * @returns {Promise} The promise of the cursor.
    */
@@ -132,21 +132,21 @@ interface Readable {
     collection: string,
     filter?: Document,
     options?: Document,
-    databaseOptions?: DatabaseOptions) : Cursor;
+    dbOptions?: DatabaseOptions) : Cursor;
 
   /**
    * Is the collection capped?
    *
    * @param {String} database - The database name.
    * @param {String} collection - The collection name.
-   * @param {DatabaseOptions} databaseOptions - The collection options
+   * @param {DatabaseOptions} dbOptions - The database options
    *
    * @returns {Promise} The promise of the result.
    */
   isCapped(
     database: string,
     collection: string,
-    databaseOptions?: DatabaseOptions): Promise<Result>;
+    dbOptions?: DatabaseOptions): Promise<Result>;
 
   /**
    * Returns an array that holds a list of documents that identify and
@@ -154,14 +154,14 @@ interface Readable {
    *
    * @param {String} database - The db name.
    * @param {String} collection - The collection name.
-   * @param {DatabaseOptions} databaseOptions - The collection options
+   * @param {DatabaseOptions} dbOptions - The database options
    *
    * @return {Promise}
    */
   getIndexes(
     database: string,
     collection: string,
-    databaseOptions?: DatabaseOptions): Promise<Result>;
+    dbOptions?: DatabaseOptions): Promise<Result>;
 
   /**
    * Returns an array of collection infos
@@ -169,7 +169,7 @@ interface Readable {
    * @param {String} database - The db name.
    * @param {Document} filter - The filter.
    * @param {Document} options - The command options.
-   * @param {DatabaseOptions} databaseOptions - The collection options
+   * @param {DatabaseOptions} dbOptions - The database options
    *
    * @return {Promise}
    */
@@ -177,7 +177,7 @@ interface Readable {
     database: string,
     filter?: Document,
     options?: Document,
-    databaseOptions?: DatabaseOptions): Promise<Result>;
+    dbOptions?: DatabaseOptions): Promise<Result>;
 
   /**
    * Get all the collection statistics.
@@ -185,7 +185,7 @@ interface Readable {
    * @param {String} database - The db name.
    * @param {String} collection - The collection name.
    * @param {Object} options - The count options.
-   * @param {DatabaseOptions} databaseOptions - The collection options
+   * @param {DatabaseOptions} dbOptions - The database options
    *
    * @return {Promise} returns Promise
    */
@@ -193,7 +193,7 @@ interface Readable {
     database: string,
     collection: string,
     options?: Document,
-    databaseOptions?: DatabaseOptions
+    dbOptions?: DatabaseOptions
   ): Promise<Result>
 }
 

--- a/packages/service-provider-core/src/service-provider.ts
+++ b/packages/service-provider-core/src/service-provider.ts
@@ -1,16 +1,11 @@
 import Readable from './readable';
 import Writable from './writable';
+import Closable from './closable';
+import Admin from './admin';
 
 /**
  * Interface for all service providers.
  */
-interface ServiceProvider extends Readable, Writable {
-  /**
-   * Close the connection.
-   *
-   * @param {boolean} force - Whether to force close.
-   */
-  close(boolean): Promise<void>;
-};
+interface ServiceProvider extends Readable, Writable, Closable, Admin {};
 
 export default ServiceProvider;

--- a/packages/service-provider-core/src/writable.ts
+++ b/packages/service-provider-core/src/writable.ts
@@ -1,243 +1,14 @@
 import Document from './document';
 import Result from './result';
 import BulkWriteResult from './bulk-write-result';
+import CommandOptions from './command-options';
+import WriteConcern from './write-concern';
+import DatabaseOptions from './database-options';
 
 /**
  * Interface for write operations in the CRUD specification.
  */
 interface Writable {
-  /**
-   * Execute a mix of write operations.
-   *
-   * @param {String} database - The database name.
-   * @param {String} collection - The collection name.
-   * @param {Document} requests - The bulk write requests.
-   * @param {Document} options - The bulk write options.
-   *
-   * @returns {Promise} The promise of the result.
-   */
-  bulkWrite(
-    database: string,
-    collection: string,
-    requests: Document,
-    options?: Document,
-    dbOptions?: Document) : Promise<BulkWriteResult>;
-
-  /**
-   * Delete multiple documents from the collection.
-   *
-   * @param {String} database - The database name.
-   * @param {String} collection - The collection name.
-   * @param {Document} filter - The filter.
-   * @param {Document} options - The delete many options.
-   *
-   * @returns {Promise} The promise of the result.
-   */
-  deleteMany(
-    database: string,
-    collection: string,
-    filter: Document,
-    options?: Document,
-    dbOptions?: Document) : Promise<Result>;
-
-  /**
-   * Delete one document from the collection.
-   *
-   * @param {String} database - The database name.
-   * @param {String} collection - The collection name.
-   * @param {Document} filter - The filter.
-   * @param {Document} options - The delete one options.
-   *
-   * @returns {Promise} The promise of the result.
-   */
-  deleteOne(
-    database: string,
-    collection: string,
-    filter: Document,
-    options?: Document,
-    dbOptions?: Document) : Promise<Result>;
-
-  /**
-   * Find one document and delete it.
-   *
-   * @param {String} database - The database name.
-   * @param {String} collection - The collection name.
-   * @param {Document} filter - The filter.
-   * @param {Document} options - The find options.
-   *
-   * @returns {Promise} The promise of the result.
-   */
-  findOneAndDelete(
-    database: string,
-    collection: string,
-    filter: Document,
-    options?: Document) : Promise<Result>;
-
-  /**
-   * Find one document and replace it.
-   *
-   * @param {String} database - The database name.
-   * @param {String} collection - The collection name.
-   * @param {Document} filter - The filter.
-   * @param {Document} replacement - The replacement.
-   * @param {Document} options - The find options.
-   *
-   * @returns {Promise} The promise of the result.
-   */
-  findOneAndReplace(
-    database: string,
-    collection: string,
-    filter: Document,
-    replacement: Document,
-    options?: Document) : Promise<Result>;
-
-  /**
-   * Find one document and update it.
-   *
-   * @param {String} database - The database name.
-   * @param {String} collection - The collection name.
-   * @param {Document} filter - The filter.
-   * @param {(Document|Array)} update - The update.
-   * @param {Document} options - The find options.
-   *
-   * @returns {Promise} The promise of the result.
-   */
-  findOneAndUpdate(
-    database: string,
-    collection: string,
-    filter: Document,
-    update: Document,
-    options?: Document) : Promise<Result>;
-
-  /**
-   * Insert many documents into the colleciton.
-   *
-   * @param {String} database - The database name.
-   * @param {String} collection - The collection name.
-   * @param {Array} docs - The documents.
-   * @param {Document} options - The insert many options.
-   *
-   * @returns {Promise} The promise of the result.
-   */
-  insertMany(
-    database: string,
-    collection: string,
-    docs: Document[],
-    options?: Document,
-    dbOptions?: Document) : Promise<Result>;
-
-  /**
-   * Insert one document into the collection.
-   *
-   * @param {String} database - The database name.
-   * @param {String} collection - The collection name.
-   * @param {Document} doc - The document.
-   * @param {Document} options - The insert one options.
-   *
-   * @returns {Promise} The promise of the result.
-   */
-  insertOne(
-    database: string,
-    collection: string,
-    doc: Document,
-    options?: Document,
-    dbOptions?: Document) : Promise<Result>;
-
-  /**
-   * Replace a document with another.
-   *
-   * @param {String} database - The database name.
-   * @param {String} collection - The collection name.
-   * @param {Document} filter - The filter.
-   * @param {Document} replacement - The replacement document for matches.
-   * @param {Document} options - The replace options.
-   *
-   * @returns {Promise} The promise of the result.
-   */
-  replaceOne(
-    database: string,
-    collection: string,
-    filter: Document,
-    replacement: Document,
-    options?: Document,
-    dbOptions?: Document) : Promise<Result>;
-
-  /**
-   * Update many document.
-   *
-   * @param {String} database - The database name.
-   * @param {String} collection - The collection name.
-   * @param {Document} filter - The filter.
-   * @param {(Document|Array)} update - The updates.
-   * @param {Document} options - The update options.
-   *
-   * @returns {Promise} The promise of the result.
-   */
-  updateMany(
-    database: string,
-    collection: string,
-    filter: Document,
-    update: Document,
-    options?: Document,
-    dbOptions?: Document) : Promise<Result>;
-
-  /**
-   * find and update or remove a document.
-   *
-   * @param {String} database - The database name.
-   * @param {String} collection - The collection name.
-   * @param {Document} query - The filter.
-   * @param {Document} sort - The sort option.
-   * @param {Document} update - The update document.
-   * @param {Document} options - The update options.
-   *
-   * @returns {Promise} The promise of the result.
-   */
-  findAndModify(
-    database: string,
-    collection: string,
-    query: Document,
-    sort: any[] | Document,
-    update: Document,
-    options?: Document,
-    dbOptions?: Document
-  )
-
-  /**
-   * Update a document.
-   *
-   * @param {String} database - The database name.
-   * @param {String} collection - The collection name.
-   * @param {Document} filter - The filter.
-   * @param {(Document|Array)} update - The updates.
-   * @param {Document} options - The update options.
-   *
-   * @returns {Promise} The promise of the result.
-   */
-  updateOne(
-    database: string,
-    collection: string,
-    filter: Document,
-    update: Document,
-    options?: Document,
-    dbOptions?: Document) : Promise<Result>;
-
-  /**
-   * Deprecated save command.
-   *
-   * @param {String} database - The db name.
-   * @param {String} collection - The collection name.
-   * @param {Object} doc - The doc.
-   * @param {Object} options - The options.
-   * @param {Object} dbOptions - The DB options
-   * @return {Promise}
-   */
-  save(
-    database: string,
-    collection: string,
-    doc: Document,
-    options?: Document,
-    dbOptions?: Document): Promise<Result>
 
   /**
    * @param {String} db - the db name
@@ -248,7 +19,9 @@ interface Writable {
   runCommand(
     db: string,
     spec: Document,
-    options?: Document): Promise<Result>;
+    options?: CommandOptions,
+    databaseOptions?: DatabaseOptions
+  ): Promise<Result>;
 
   /**
    * Drop a database
@@ -260,8 +33,257 @@ interface Writable {
    */
   dropDatabase(
     database: string,
-    writeConcern?: Document
+    writeConcern?: WriteConcern,
+    databaseOptions?: DatabaseOptions
   ) : Promise<Result>;
+
+  /**
+   * Execute a mix of write operations.
+   *
+   * @param {String} database - The database name.
+   * @param {String} collection - The collection name.
+   * @param {Document} requests - The bulk write requests.
+   * @param {Document} options - The bulk write options.
+   * @param {DatabaseOptions} databaseOptions - The database options
+   *
+   * @returns {Promise} The promise of the result.
+   */
+  bulkWrite(
+    database: string,
+    collection: string,
+    requests: Document,
+    options?: Document,
+    databaseOptions?: DatabaseOptions) : Promise<BulkWriteResult>;
+
+  /**
+   * Delete multiple documents from the collection.
+   *
+   * @param {String} database - The database name.
+   * @param {String} collection - The collection name.
+   * @param {Document} filter - The filter.
+   * @param {Document} options - The delete many options.
+   * @param {DatabaseOptions} databaseOptions - The database options
+   *
+   * @returns {Promise} The promise of the result.
+   */
+  deleteMany(
+    database: string,
+    collection: string,
+    filter: Document,
+    options?: Document,
+    databaseOptions?: DatabaseOptions) : Promise<Result>;
+
+  /**
+   * Delete one document from the collection.
+   *
+   * @param {String} database - The database name.
+   * @param {String} collection - The collection name.
+   * @param {Document} filter - The filter.
+   * @param {Document} options - The delete one options.
+   * @param {DatabaseOptions} databaseOptions - The database options
+   *
+   * @returns {Promise} The promise of the result.
+   */
+  deleteOne(
+    database: string,
+    collection: string,
+    filter: Document,
+    options?: Document,
+    databaseOptions?: DatabaseOptions) : Promise<Result>;
+
+  /**
+   * Find one document and delete it.
+   *
+   * @param {String} database - The database name.
+   * @param {String} collection - The collection name.
+   * @param {Document} filter - The filter.
+   * @param {Document} options - The find options.
+   * @param {DatabaseOptions} databaseOptions - The database options
+   *
+   * @returns {Promise} The promise of the result.
+   */
+  findOneAndDelete(
+    database: string,
+    collection: string,
+    filter: Document,
+    options?: Document,
+    databaseOptions?: DatabaseOptions) : Promise<Result>;
+
+  /**
+   * Find one document and replace it.
+   *
+   * @param {String} database - The database name.
+   * @param {String} collection - The collection name.
+   * @param {Document} filter - The filter.
+   * @param {Document} replacement - The replacement.
+   * @param {Document} options - The find options.
+   * @param {DatabaseOptions} databaseOptions - The database options
+   *
+   * @returns {Promise} The promise of the result.
+   */
+  findOneAndReplace(
+    database: string,
+    collection: string,
+    filter: Document,
+    replacement: Document,
+    options?: Document,
+    databaseOptions?: DatabaseOptions) : Promise<Result>;
+
+  /**
+   * Find one document and update it.
+   *
+   * @param {String} database - The database name.
+   * @param {String} collection - The collection name.
+   * @param {Document} filter - The filter.
+   * @param {(Document|Array)} update - The update.
+   * @param {Document} options - The find options.
+   * @param {DatabaseOptions} databaseOptions - The DB options
+   *
+   * @returns {Promise} The promise of the result.
+   */
+  findOneAndUpdate(
+    database: string,
+    collection: string,
+    filter: Document,
+    update: Document,
+    options?: Document,
+    databaseOptions?: DatabaseOptions) : Promise<Result>;
+
+  /**
+   * Insert many documents into the colleciton.
+   *
+   * @param {String} database - The database name.
+   * @param {String} collection - The collection name.
+   * @param {Array} docs - The documents.
+   * @param {Document} options - The insert many options.
+   * @param {DatabaseOptions} databaseOptions - The DB options
+   *
+   * @returns {Promise} The promise of the result.
+   */
+  insertMany(
+    database: string,
+    collection: string,
+    docs: Document[],
+    options?: Document,
+    databaseOptions?: DatabaseOptions) : Promise<Result>;
+
+  /**
+   * Insert one document into the collection.
+   *
+   * @param {String} database - The database name.
+   * @param {String} collection - The collection name.
+   * @param {Document} doc - The document.
+   * @param {Document} options - The insert one options.
+   * @param {DatabaseOptions} databaseOptions - The DB options
+   *
+   * @returns {Promise} The promise of the result.
+   */
+  insertOne(
+    database: string,
+    collection: string,
+    doc: Document,
+    options?: Document,
+    databaseOptions?: DatabaseOptions) : Promise<Result>;
+
+  /**
+   * Replace a document with another.
+   *
+   * @param {String} database - The database name.
+   * @param {String} collection - The collection name.
+   * @param {Document} filter - The filter.
+   * @param {Document} replacement - The replacement document for matches.
+   * @param {Document} options - The replace options.
+   * @param {DatabaseOptions} databaseOptions - The DB options
+   *
+   * @returns {Promise} The promise of the result.
+   */
+  replaceOne(
+    database: string,
+    collection: string,
+    filter: Document,
+    replacement: Document,
+    options?: Document,
+    databaseOptions?: DatabaseOptions) : Promise<Result>;
+
+  /**
+   * Update many document.
+   *
+   * @param {String} database - The database name.
+   * @param {String} collection - The collection name.
+   * @param {Document} filter - The filter.
+   * @param {(Document|Array)} update - The updates.
+   * @param {Document} options - The update options.
+   * @param {DatabaseOptions} databaseOptions - The DB options
+   *
+   * @returns {Promise} The promise of the result.
+   */
+  updateMany(
+    database: string,
+    collection: string,
+    filter: Document,
+    update: Document,
+    options?: Document,
+    databaseOptions?: DatabaseOptions) : Promise<Result>;
+
+  /**
+   * find and update or remove a document.
+   *
+   * @param {String} database - The database name.
+   * @param {String} collection - The collection name.
+   * @param {Document} query - The filter.
+   * @param {Document} sort - The sort option.
+   * @param {Document} update - The update document.
+   * @param {Document} options - The update options.
+   * @param {DatabaseOptions} databaseOptions - The DB options
+   *
+   * @returns {Promise} The promise of the result.
+   */
+  findAndModify(
+    database: string,
+    collection: string,
+    query: Document,
+    sort: any[] | Document,
+    update: Document,
+    options?: Document,
+    databaseOptions?: DatabaseOptions
+  )
+
+  /**
+   * Update a document.
+   *
+   * @param {String} database - The database name.
+   * @param {String} collection - The collection name.
+   * @param {Document} filter - The filter.
+   * @param {(Document|Array)} update - The updates.
+   * @param {Document} options - The update options.
+   * @param {DatabaseOptions} databaseOptions - The DB options
+   *
+   * @returns {Promise} The promise of the result.
+   */
+  updateOne(
+    database: string,
+    collection: string,
+    filter: Document,
+    update: Document,
+    options?: Document,
+    databaseOptions?: DatabaseOptions) : Promise<Result>;
+
+  /**
+   * Deprecated save command.
+   *
+   * @param {String} database - The db name.
+   * @param {String} collection - The collection name.
+   * @param {Object} doc - The doc.
+   * @param {Object} options - The options.
+   * @param {DatabaseOptions} databaseOptions - The DB options
+   * @return {Promise}
+   */
+  save(
+    database: string,
+    collection: string,
+    doc: Document,
+    options?: Document,
+    databaseOptions?: DatabaseOptions): Promise<Result>
 
   /**
    * Deprecated remove command.
@@ -270,6 +292,8 @@ interface Writable {
    * @param {String} collection - The collection name.
    * @param {Object} query - The query.
    * @param {Object} options - The options.
+   * @param {DatabaseOptions} databaseOptions - The database options
+   *
    * @return {Promise}
    */
   remove(
@@ -277,7 +301,7 @@ interface Writable {
     collection: string,
     query: Document,
     options?: Document,
-    dbOptions?: Document): Promise<Result>;
+    databaseOptions?: DatabaseOptions): Promise<Result>;
 
   /**
    * Converts an existing, non-capped collection to
@@ -286,14 +310,15 @@ interface Writable {
    * @param {String} database - The db name.
    * @param {String} collection - The collection name.
    * @param {String} size - The maximum size, in bytes, for the capped collection.
+   * @param {CommandOptions} commandOptions - The command options
    *
    * @return {Promise}
    */
   convertToCapped(
     database: string,
     collection: string,
-    size: number
-  ): Promise<Result>
+    size: number,
+    options?: CommandOptions): Promise<Result>
 
   /**
    * Adds new indexes to a collection.
@@ -302,7 +327,7 @@ interface Writable {
    * @param {String} collection - The collection name.
    * @param {Object[]} indexSpecs the spec of the indexes to be created.
    * @param {Object} options - The command options.
-   * @param {Object} dbOptions - The database options (i.e. readConcern, writeConcern. etc).
+   * @param {DatabaseOptions} databaseOptions - The database options
    * @return {Promise}
    */
   createIndexes(
@@ -310,8 +335,7 @@ interface Writable {
     collection: string,
     indexSpecs: Document[],
     options?: Document,
-    dbOptions?: Document): Promise<Result>;
-
+    databaseOptions?: DatabaseOptions): Promise<Result>;
 
   /**
    * Drop indexes for a collection.
@@ -319,61 +343,58 @@ interface Writable {
    * @param {String} database - The db name.
    * @param {String} collection - The collection name.
    * @param {string|string[]|Object|Object[]} indexes the indexes to be removed.
-   * @param {Object} options - The command options.
-   * @param {Object} dbOptions - The database options (i.e. readConcern, writeConcern. etc).
+   * @param {CommandOptions} commandOptions - The command options.
    * @return {Promise}
    */
   dropIndexes(
     database: string,
     collection: string,
     indexes: string|string[]|Document|Document[],
-    options?: Document,
-    dbOptions?: Document): Promise<Result>;
+    commandOptions?: CommandOptions,
+    databaseOptions?: DatabaseOptions): Promise<Result>;
 
   /**
    * Reindex all indexes on the collection.
    *
    * @param {String} database - The db name.
    * @param {String} collection - The collection name.
-   * @param {Object} options - The command options.
-   * @param {Object} dbOptions - The database options (i.e. readConcern, writeConcern. etc).
+   * @param {CommandOptions} options - The command options.
    * @return {Promise}
    */
   reIndex(
     database: string,
     collection: string,
-    options?: Document,
-    dbOptions?: Document): Promise<Result>;
-
+    options?: CommandOptions,
+    databaseOptions?: DatabaseOptions
+  ): Promise<Result>;
 
   /**
    * Drops a collection.
    *
    * @param {String} database - The db name.
    * @param {String} collection - The collection name.
-   * @param {Object} dbOptions - The database options (i.e. readConcern, writeConcern. etc).
+   * @param {DatabaseOptions} databaseOptions - The database options
    *
    * @return {Promise}
    */
   dropCollection(
     database: string,
     collection: string,
-    dbOptions?: Document
+    databaseOptions?: DatabaseOptions
   ): Promise<boolean>;
 
   /**
    * @param {String} database - The db name.
-   * @param {String} collection - The collection name.
+   * @param {String} oldName - The collection name.
    * @param {String} newName - The new collection name.
    * @param {String} options - The options.
-   * @param {Object} dbOptions - The database options (i.e. readConcern, writeConcern. etc).
    */
   renameCollection(
     database: string,
-    collection: string,
+    oldName: string,
     newName: string,
     options?: Document,
-    dbOptions?: Document): Promise<Result>;
+    databaseOptions?: DatabaseOptions): Promise<Result>;
 }
 
 export default Writable;

--- a/packages/service-provider-core/src/writable.ts
+++ b/packages/service-provider-core/src/writable.ts
@@ -20,7 +20,7 @@ interface Writable {
     db: string,
     spec: Document,
     options?: CommandOptions,
-    databaseOptions?: DatabaseOptions
+    dbOptions?: DatabaseOptions
   ): Promise<Result>;
 
   /**
@@ -34,7 +34,7 @@ interface Writable {
   dropDatabase(
     database: string,
     writeConcern?: WriteConcern,
-    databaseOptions?: DatabaseOptions
+    dbOptions?: DatabaseOptions
   ) : Promise<Result>;
 
   /**
@@ -44,7 +44,7 @@ interface Writable {
    * @param {String} collection - The collection name.
    * @param {Document} requests - The bulk write requests.
    * @param {Document} options - The bulk write options.
-   * @param {DatabaseOptions} databaseOptions - The database options
+   * @param {DatabaseOptions} dbOptions - The database options
    *
    * @returns {Promise} The promise of the result.
    */
@@ -53,7 +53,7 @@ interface Writable {
     collection: string,
     requests: Document,
     options?: Document,
-    databaseOptions?: DatabaseOptions) : Promise<BulkWriteResult>;
+    dbOptions?: DatabaseOptions) : Promise<BulkWriteResult>;
 
   /**
    * Delete multiple documents from the collection.
@@ -62,7 +62,7 @@ interface Writable {
    * @param {String} collection - The collection name.
    * @param {Document} filter - The filter.
    * @param {Document} options - The delete many options.
-   * @param {DatabaseOptions} databaseOptions - The database options
+   * @param {DatabaseOptions} dbOptions - The database options
    *
    * @returns {Promise} The promise of the result.
    */
@@ -71,7 +71,7 @@ interface Writable {
     collection: string,
     filter: Document,
     options?: Document,
-    databaseOptions?: DatabaseOptions) : Promise<Result>;
+    dbOptions?: DatabaseOptions) : Promise<Result>;
 
   /**
    * Delete one document from the collection.
@@ -80,7 +80,7 @@ interface Writable {
    * @param {String} collection - The collection name.
    * @param {Document} filter - The filter.
    * @param {Document} options - The delete one options.
-   * @param {DatabaseOptions} databaseOptions - The database options
+   * @param {DatabaseOptions} dbOptions - The database options
    *
    * @returns {Promise} The promise of the result.
    */
@@ -89,7 +89,7 @@ interface Writable {
     collection: string,
     filter: Document,
     options?: Document,
-    databaseOptions?: DatabaseOptions) : Promise<Result>;
+    dbOptions?: DatabaseOptions) : Promise<Result>;
 
   /**
    * Find one document and delete it.
@@ -98,7 +98,7 @@ interface Writable {
    * @param {String} collection - The collection name.
    * @param {Document} filter - The filter.
    * @param {Document} options - The find options.
-   * @param {DatabaseOptions} databaseOptions - The database options
+   * @param {DatabaseOptions} dbOptions - The database options
    *
    * @returns {Promise} The promise of the result.
    */
@@ -107,7 +107,7 @@ interface Writable {
     collection: string,
     filter: Document,
     options?: Document,
-    databaseOptions?: DatabaseOptions) : Promise<Result>;
+    dbOptions?: DatabaseOptions) : Promise<Result>;
 
   /**
    * Find one document and replace it.
@@ -117,7 +117,7 @@ interface Writable {
    * @param {Document} filter - The filter.
    * @param {Document} replacement - The replacement.
    * @param {Document} options - The find options.
-   * @param {DatabaseOptions} databaseOptions - The database options
+   * @param {DatabaseOptions} dbOptions - The database options
    *
    * @returns {Promise} The promise of the result.
    */
@@ -127,7 +127,7 @@ interface Writable {
     filter: Document,
     replacement: Document,
     options?: Document,
-    databaseOptions?: DatabaseOptions) : Promise<Result>;
+    dbOptions?: DatabaseOptions) : Promise<Result>;
 
   /**
    * Find one document and update it.
@@ -137,7 +137,7 @@ interface Writable {
    * @param {Document} filter - The filter.
    * @param {(Document|Array)} update - The update.
    * @param {Document} options - The find options.
-   * @param {DatabaseOptions} databaseOptions - The DB options
+   * @param {DatabaseOptions} dbOptions - The DB options
    *
    * @returns {Promise} The promise of the result.
    */
@@ -147,7 +147,7 @@ interface Writable {
     filter: Document,
     update: Document,
     options?: Document,
-    databaseOptions?: DatabaseOptions) : Promise<Result>;
+    dbOptions?: DatabaseOptions) : Promise<Result>;
 
   /**
    * Insert many documents into the colleciton.
@@ -156,7 +156,7 @@ interface Writable {
    * @param {String} collection - The collection name.
    * @param {Array} docs - The documents.
    * @param {Document} options - The insert many options.
-   * @param {DatabaseOptions} databaseOptions - The DB options
+   * @param {DatabaseOptions} dbOptions - The DB options
    *
    * @returns {Promise} The promise of the result.
    */
@@ -165,7 +165,7 @@ interface Writable {
     collection: string,
     docs: Document[],
     options?: Document,
-    databaseOptions?: DatabaseOptions) : Promise<Result>;
+    dbOptions?: DatabaseOptions) : Promise<Result>;
 
   /**
    * Insert one document into the collection.
@@ -174,7 +174,7 @@ interface Writable {
    * @param {String} collection - The collection name.
    * @param {Document} doc - The document.
    * @param {Document} options - The insert one options.
-   * @param {DatabaseOptions} databaseOptions - The DB options
+   * @param {DatabaseOptions} dbOptions - The DB options
    *
    * @returns {Promise} The promise of the result.
    */
@@ -183,7 +183,7 @@ interface Writable {
     collection: string,
     doc: Document,
     options?: Document,
-    databaseOptions?: DatabaseOptions) : Promise<Result>;
+    dbOptions?: DatabaseOptions) : Promise<Result>;
 
   /**
    * Replace a document with another.
@@ -193,7 +193,7 @@ interface Writable {
    * @param {Document} filter - The filter.
    * @param {Document} replacement - The replacement document for matches.
    * @param {Document} options - The replace options.
-   * @param {DatabaseOptions} databaseOptions - The DB options
+   * @param {DatabaseOptions} dbOptions - The DB options
    *
    * @returns {Promise} The promise of the result.
    */
@@ -203,7 +203,7 @@ interface Writable {
     filter: Document,
     replacement: Document,
     options?: Document,
-    databaseOptions?: DatabaseOptions) : Promise<Result>;
+    dbOptions?: DatabaseOptions) : Promise<Result>;
 
   /**
    * Update many document.
@@ -213,7 +213,7 @@ interface Writable {
    * @param {Document} filter - The filter.
    * @param {(Document|Array)} update - The updates.
    * @param {Document} options - The update options.
-   * @param {DatabaseOptions} databaseOptions - The DB options
+   * @param {DatabaseOptions} dbOptions - The DB options
    *
    * @returns {Promise} The promise of the result.
    */
@@ -223,7 +223,7 @@ interface Writable {
     filter: Document,
     update: Document,
     options?: Document,
-    databaseOptions?: DatabaseOptions) : Promise<Result>;
+    dbOptions?: DatabaseOptions) : Promise<Result>;
 
   /**
    * find and update or remove a document.
@@ -234,7 +234,7 @@ interface Writable {
    * @param {Document} sort - The sort option.
    * @param {Document} update - The update document.
    * @param {Document} options - The update options.
-   * @param {DatabaseOptions} databaseOptions - The DB options
+   * @param {DatabaseOptions} dbOptions - The DB options
    *
    * @returns {Promise} The promise of the result.
    */
@@ -245,7 +245,7 @@ interface Writable {
     sort: any[] | Document,
     update: Document,
     options?: Document,
-    databaseOptions?: DatabaseOptions
+    dbOptions?: DatabaseOptions
   )
 
   /**
@@ -256,7 +256,7 @@ interface Writable {
    * @param {Document} filter - The filter.
    * @param {(Document|Array)} update - The updates.
    * @param {Document} options - The update options.
-   * @param {DatabaseOptions} databaseOptions - The DB options
+   * @param {DatabaseOptions} dbOptions - The DB options
    *
    * @returns {Promise} The promise of the result.
    */
@@ -266,7 +266,7 @@ interface Writable {
     filter: Document,
     update: Document,
     options?: Document,
-    databaseOptions?: DatabaseOptions) : Promise<Result>;
+    dbOptions?: DatabaseOptions) : Promise<Result>;
 
   /**
    * Deprecated save command.
@@ -275,7 +275,7 @@ interface Writable {
    * @param {String} collection - The collection name.
    * @param {Object} doc - The doc.
    * @param {Object} options - The options.
-   * @param {DatabaseOptions} databaseOptions - The DB options
+   * @param {DatabaseOptions} dbOptions - The DB options
    * @return {Promise}
    */
   save(
@@ -283,7 +283,7 @@ interface Writable {
     collection: string,
     doc: Document,
     options?: Document,
-    databaseOptions?: DatabaseOptions): Promise<Result>
+    dbOptions?: DatabaseOptions): Promise<Result>
 
   /**
    * Deprecated remove command.
@@ -292,7 +292,7 @@ interface Writable {
    * @param {String} collection - The collection name.
    * @param {Object} query - The query.
    * @param {Object} options - The options.
-   * @param {DatabaseOptions} databaseOptions - The database options
+   * @param {DatabaseOptions} dbOptions - The database options
    *
    * @return {Promise}
    */
@@ -301,7 +301,7 @@ interface Writable {
     collection: string,
     query: Document,
     options?: Document,
-    databaseOptions?: DatabaseOptions): Promise<Result>;
+    dbOptions?: DatabaseOptions): Promise<Result>;
 
   /**
    * Converts an existing, non-capped collection to
@@ -327,7 +327,7 @@ interface Writable {
    * @param {String} collection - The collection name.
    * @param {Object[]} indexSpecs the spec of the indexes to be created.
    * @param {Object} options - The command options.
-   * @param {DatabaseOptions} databaseOptions - The database options
+   * @param {DatabaseOptions} dbOptions - The database options
    * @return {Promise}
    */
   createIndexes(
@@ -335,7 +335,7 @@ interface Writable {
     collection: string,
     indexSpecs: Document[],
     options?: Document,
-    databaseOptions?: DatabaseOptions): Promise<Result>;
+    dbOptions?: DatabaseOptions): Promise<Result>;
 
   /**
    * Drop indexes for a collection.
@@ -351,7 +351,7 @@ interface Writable {
     collection: string,
     indexes: string|string[]|Document|Document[],
     commandOptions?: CommandOptions,
-    databaseOptions?: DatabaseOptions): Promise<Result>;
+    dbOptions?: DatabaseOptions): Promise<Result>;
 
   /**
    * Reindex all indexes on the collection.
@@ -365,7 +365,7 @@ interface Writable {
     database: string,
     collection: string,
     options?: CommandOptions,
-    databaseOptions?: DatabaseOptions
+    dbOptions?: DatabaseOptions
   ): Promise<Result>;
 
   /**
@@ -373,14 +373,14 @@ interface Writable {
    *
    * @param {String} database - The db name.
    * @param {String} collection - The collection name.
-   * @param {DatabaseOptions} databaseOptions - The database options
+   * @param {DatabaseOptions} dbOptions - The database options
    *
    * @return {Promise}
    */
   dropCollection(
     database: string,
     collection: string,
-    databaseOptions?: DatabaseOptions
+    dbOptions?: DatabaseOptions
   ): Promise<boolean>;
 
   /**
@@ -394,7 +394,7 @@ interface Writable {
     oldName: string,
     newName: string,
     options?: Document,
-    databaseOptions?: DatabaseOptions): Promise<Result>;
+    dbOptions?: DatabaseOptions): Promise<Result>;
 }
 
 export default Writable;

--- a/packages/service-provider-core/src/write-concern.ts
+++ b/packages/service-provider-core/src/write-concern.ts
@@ -1,0 +1,5 @@
+export default interface WriteConcern {
+  w?: number | string;
+  wtimeout?: number;
+  j?: boolean;
+}

--- a/packages/service-provider-server/src/cli-service-provider.spec.ts
+++ b/packages/service-provider-server/src/cli-service-provider.spec.ts
@@ -508,7 +508,7 @@ describe('CliServiceProvider', () => {
 
     beforeEach(() => {
       commandMock = sinon.mock()
-        .withArgs({ convertToCapped: 'coll1', size: 1000 }, {})
+        .withArgs({ convertToCapped: 'coll1', size: 1000 })
         .resolves({ ok: 1 });
 
       const dbStub = sinon.createStubInstance(Db, {
@@ -613,7 +613,7 @@ describe('CliServiceProvider', () => {
 
     beforeEach(() => {
       commandMock = sinon.mock()
-        .withArgs({ dropIndexes: 'coll1', index: ['index-1'] }, {})
+        .withArgs({ dropIndexes: 'coll1', index: ['index-1'] })
         .resolves({ ok: 1 });
 
       const dbStub = sinon.createStubInstance(Db, {
@@ -716,7 +716,7 @@ describe('CliServiceProvider', () => {
 
     beforeEach(() => {
       commandMock = sinon.mock()
-        .withArgs({ reIndex: 'coll1' }, {})
+        .withArgs({ reIndex: 'coll1' })
         .resolves({ ok: 1 });
 
       const dbStub = sinon.createStubInstance(Db, {


### PR DESCRIPTION
Preparatory work for `getWriteConcern`, `setWriteConcern`:

1. Add `DatabaseOptions`, `CommandOptions` and related types to `service-provider-core`.
2. Make sure all the methods accepts a `dbOptions` parameter and that `dbOptions` is always passed down to `client.db`.
3. Make sure we set `returnNonCachedInstance: true` as dbOption always