### PR TITLE
test: allow to run test on an already running server

### DIFF
--- a/packages/async-rewriter/package.json
+++ b/packages/async-rewriter/package.json
@@ -4,8 +4,8 @@
   "description": "MongoDB Shell Async Rewriter Package",
   "main": "./lib/index.js",
   "scripts": {
-    "test": "mocha --timeout 15000 --colors -r ts-node/register \"./{src,lib}/**/*.spec.ts\"",
-    "test-ci": "mocha --timeout 15000 -r ts-node/register \"./{src,lib}/**/*.spec.ts\"",
+    "test": "mocha --timeout 60000 --colors -r ts-node/register \"./{src,lib}/**/*.spec.ts\"",
+    "test-ci": "mocha --timeout 60000 -r ts-node/register \"./{src,lib}/**/*.spec.ts\"",
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
     "check": "npm run lint",
     "compile-ts": "tsc -p tsconfig.json",

--- a/packages/browser-runtime-core/package.json
+++ b/packages/browser-runtime-core/package.json
@@ -15,8 +15,8 @@
     "url": "git://github.com/mongodb-js/mongosh.git"
   },
   "scripts": {
-    "test": "mocha --timeout 15000 --colors -r ts-node/register \"./{src,lib}/**/*.spec.ts\"",
-    "test-ci": "mocha --timeout 15000 -r ts-node/register \"./{src,lib}/**/*.spec.ts\"",
+    "test": "mocha --timeout 60000 --colors -r ts-node/register \"./{src,lib}/**/*.spec.ts\"",
+    "test-ci": "mocha --timeout 60000 -r ts-node/register \"./{src,lib}/**/*.spec.ts\"",
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
     "check": "npm run lint",
     "preprepublish": "rimraf ./lib",

--- a/packages/browser-runtime-electron/package.json
+++ b/packages/browser-runtime-electron/package.json
@@ -15,8 +15,8 @@
     "url": "git://github.com/mongodb-js/mongosh.git"
   },
   "scripts": {
-    "test": "mocha --timeout 15000 --colors -r ts-node/register \"./{src,lib}/**/*.spec.ts\"",
-    "test-ci": "mocha --timeout 15000 -r ts-node/register \"./{src,lib}/**/*.spec.ts\"",
+    "test": "mocha --timeout 60000 --colors -r ts-node/register \"./{src,lib}/**/*.spec.ts\"",
+    "test-ci": "mocha --timeout 60000 -r ts-node/register \"./{src,lib}/**/*.spec.ts\"",
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
     "check": "npm run lint",
     "preprepublish": "rimraf ./lib",

--- a/packages/cli-repl/package.json
+++ b/packages/cli-repl/package.json
@@ -18,8 +18,8 @@
     "compile-ts": "tsc -p tsconfig.json",
     "start": "node --experimental-repl-await bin/mongosh.js start",
     "start-async": "node --experimental-repl-await bin/mongosh.js start --async",
-    "test": "mocha --timeout 15000 --colors -r ts-node/register \"./{src,test}/**/*.spec.ts\"",
-    "test-ci": "mocha --timeout 15000 -r ts-node/register \"./{src,test}/**/*.spec.ts\"",
+    "test": "mocha --timeout 60000 --colors -r ts-node/register \"./{src,test}/**/*.spec.ts\"",
+    "test-ci": "mocha --timeout 60000 -r ts-node/register \"./{src,test}/**/*.spec.ts\"",
     "prepublish": "npm run compile-ts"
   },
   "license": "Apache-2.0",

--- a/packages/cli-repl/test/e2e.spec.ts
+++ b/packages/cli-repl/test/e2e.spec.ts
@@ -2,10 +2,10 @@
 import { expect } from 'chai';
 import { MongoClient } from 'mongodb';
 import { eventually, startShell, killOpenShells } from './helpers';
+import { startTestServer } from '../../../testing/integration-testing-hooks';
 
 describe('e2e', function() {
-  before(require('mongodb-runner/mocha/before')({ port: 27018, timeout: 60000 }));
-  after(require('mongodb-runner/mocha/after')({ port: 27018 }));
+  const connectionString = startTestServer();
 
   afterEach(() => killOpenShells());
 
@@ -29,8 +29,6 @@ describe('e2e', function() {
 
     beforeEach(async () => {
       dbName = `test-${Date.now()}`;
-      const connectionString = `mongodb://localhost:27018/${dbName}`;
-
       shell = startShell(connectionString);
       client = await (MongoClient as any).connect(
         connectionString,

--- a/packages/history/package.json
+++ b/packages/history/package.json
@@ -11,8 +11,8 @@
     "unsafe-perm": true
   },
   "scripts": {
-    "test": "mocha --timeout 15000 --colors -r ts-node/register \"./{src,lib}/**/*.spec.ts\"",
-    "test-ci": "mocha --timeout 15000 -r ts-node/register \"./{src,lib}/**/*.spec.ts\"",
+    "test": "mocha --timeout 60000 --colors -r ts-node/register \"./{src,lib}/**/*.spec.ts\"",
+    "test-ci": "mocha --timeout 60000 -r ts-node/register \"./{src,lib}/**/*.spec.ts\"",
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
     "check": "npm run lint",
     "compile-ts": "tsc -p tsconfig.json",

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -14,8 +14,8 @@
   "scripts": {
     "compile-ts": "tsc -p tsconfig.json",
     "prepublish": "npm run compile-ts",
-    "test": "mocha --timeout 15000 --colors -r ts-node/register \"./src/**/*.spec.ts\"",
-    "test-ci": "mocha --timeout 15000 -r ts-node/register \"./src/**/*.spec.ts\""
+    "test": "mocha --timeout 60000 --colors -r ts-node/register \"./src/**/*.spec.ts\"",
+    "test-ci": "mocha --timeout 60000 -r ts-node/register \"./src/**/*.spec.ts\""
   },
   "license": "Apache-2.0",
   "publishConfig": {

--- a/packages/mapper/package.json
+++ b/packages/mapper/package.json
@@ -11,8 +11,8 @@
     "url": "git://github.com/mongodb-js/mongosh.git"
   },
   "scripts": {
-    "test": "mocha --timeout 15000 --colors -r ts-node/register \"./{src,lib}/**/*.spec.ts\"",
-    "test-ci": "mocha --timeout 15000 -r ts-node/register \"./{src,lib}/**/*.spec.ts\"",
+    "test": "mocha --timeout 60000 --colors -r ts-node/register \"./{src,lib}/**/*.spec.ts\"",
+    "test-ci": "mocha --timeout 60000 -r ts-node/register \"./{src,lib}/**/*.spec.ts\"",
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
     "check": "npm run lint",
     "compile-ts": "tsc -p tsconfig.json",

--- a/packages/mapper/src/mapper.integration.spec.ts
+++ b/packages/mapper/src/mapper.integration.spec.ts
@@ -2,22 +2,10 @@ import { expect } from 'chai';
 import { CliServiceProvider } from '@mongosh/service-provider-server';
 import Mapper from './mapper';
 import { Collection, Cursor, Database } from '@mongosh/shell-api';
-
-const mongodbRunnerBefore = require('mongodb-runner/mocha/before');
-const mongodbRunnerAfter = require('mongodb-runner/mocha/after');
+import { startTestServer } from '../../../testing/integration-testing-hooks';
 
 describe('Mapper (integration)', function() {
-  this.timeout(60000);
-
-  before(function(done) {
-    try {
-      mongodbRunnerBefore({ port: 27018, timeout: 60000 }).call(this, done);
-    } catch (e) {
-      done(e);
-    }
-  });
-
-  after(mongodbRunnerAfter({ port: 27018 }));
+  const connectionString = startTestServer();
 
   let serviceProvider: CliServiceProvider;
 
@@ -55,7 +43,7 @@ describe('Mapper (integration)', function() {
   };
 
   before(async() => {
-    serviceProvider = await CliServiceProvider.connect('mongodb://localhost:27018');
+    serviceProvider = await CliServiceProvider.connect(connectionString);
   });
 
   after(() => {

--- a/packages/mapper/src/mapper.integration.spec.ts
+++ b/packages/mapper/src/mapper.integration.spec.ts
@@ -291,7 +291,7 @@ describe('Mapper (integration)', function() {
 
         expect(
           result
-        ).to.deep.equal({
+        ).to.deep.include({
           nIndexesWas: 1,
           nIndexes: 1,
           indexes: [

--- a/packages/service-provider-server/package.json
+++ b/packages/service-provider-server/package.json
@@ -13,8 +13,8 @@
   },
   "scripts": {
     "compile-ts": "tsc -p tsconfig.json",
-    "test": "mocha --timeout 15000 --colors -r ts-node/register \"./src/**/*.spec.ts\"",
-    "test-ci": "mocha --timeout 15000 -r ts-node/register \"./src/**/*.spec.ts\"",
+    "test": "mocha --timeout 60000 --colors -r ts-node/register \"./src/**/*.spec.ts\"",
+    "test-ci": "mocha --timeout 60000 -r ts-node/register \"./src/**/*.spec.ts\"",
     "prepublish": "npm run compile-ts",
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
     "check": "npm run lint"

--- a/packages/service-provider-server/src/cli-service-provider.integration.spec.ts
+++ b/packages/service-provider-server/src/cli-service-provider.integration.spec.ts
@@ -566,7 +566,7 @@ describe('CliServiceProvider [integration]', function() {
 
       expect(
         result
-      ).to.deep.equal({
+      ).to.deep.include({
         nIndexesWas: 1,
         nIndexes: 1,
         indexes: [

--- a/packages/service-provider-server/src/cli-service-provider.integration.spec.ts
+++ b/packages/service-provider-server/src/cli-service-provider.integration.spec.ts
@@ -1,15 +1,10 @@
 import CliServiceProvider from './cli-service-provider';
 import { expect } from 'chai';
 import { MongoClient } from 'mongodb';
+import { startTestServer } from '../../../testing/integration-testing-hooks';
 
 describe('CliServiceProvider [integration]', function() {
-  this.timeout(5000);
-
-  const port = 27018;
-  const connectionString = `mongodb://localhost:${port}`;
-
-  before(require('mongodb-runner/mocha/before')({ port, timeout: 60000 }));
-  after(require('mongodb-runner/mocha/after')({ port }));
+  const connectionString = startTestServer();
 
   let serviceProvider: CliServiceProvider;
   let client: MongoClient;

--- a/packages/shell-api/package.json
+++ b/packages/shell-api/package.json
@@ -18,8 +18,8 @@
     "pretest": "npm run compile-api",
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
     "check": "npm run lint",
-    "test": "mocha --timeout 15000 --colors -r ts-node/register \"./src/**/*.spec.ts\"",
-    "test-ci": "mocha --timeout 15000 -r ts-node/register \"./src/**/*.spec.ts\"",
+    "test": "mocha --timeout 60000 --colors -r ts-node/register \"./src/**/*.spec.ts\"",
+    "test-ci": "mocha --timeout 60000 -r ts-node/register \"./src/**/*.spec.ts\"",
     "prepublish": "npm run compile-ts"
   },
   "license": "Apache-2.0",

--- a/packages/shell-evaluator/package.json
+++ b/packages/shell-evaluator/package.json
@@ -4,8 +4,8 @@
   "description": "MongoDB Top Level API Package",
   "main": "./lib/index.js",
   "scripts": {
-    "test": "mocha --timeout 15000 --colors -r ts-node/register \"./{src,lib}/**/*.spec.ts\"",
-    "test-ci": "mocha --timeout 15000 -r ts-node/register \"./{src,lib}/**/*.spec.ts\"",
+    "test": "mocha --timeout 60000 --colors -r ts-node/register \"./{src,lib}/**/*.spec.ts\"",
+    "test-ci": "mocha --timeout 60000 -r ts-node/register \"./{src,lib}/**/*.spec.ts\"",
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
     "check": "npm run lint",
     "compile-ts": "tsc -p tsconfig.json",

--- a/testing/integration-testing-hooks.ts
+++ b/testing/integration-testing-hooks.ts
@@ -1,0 +1,47 @@
+const mongodbRunnerBefore = require('mongodb-runner/mocha/before');
+const mongodbRunnerAfter = require('mongodb-runner/mocha/after');
+
+const LOCAL_INSTANCE_PORT = 27018;
+
+/**
+ * Starts a local server unless the `MONGOSH_TEST_SERVER_URL`
+ * environment variable is set.
+ *
+ * It returns the uri that can be used to connect to the server.
+ *
+ * If env.MONGOSH_TEST_SERVER_URL is set it assumes a server
+ * is already running on that uri and returns the env variable
+ * as connection string.
+ *
+ * @export
+ * @returns {string} - uri that can be used to connect to the server.
+ */
+export function startTestServer(): string {
+  const envConnectionString = process.env.MONGOSH_TEST_SERVER_URL;
+  const connectionString = envConnectionString || `mongodb://localhost:${LOCAL_INSTANCE_PORT}`;
+
+  if (!envConnectionString) {
+    before(function(done: Function) {
+      try {
+        mongodbRunnerBefore({
+          port: LOCAL_INSTANCE_PORT,
+          timeout: this.timeout()
+        }).call(this, done);
+      } catch (e) {
+        done(e);
+      }
+    });
+
+    after(function(done: Function) {
+      try {
+        mongodbRunnerAfter({
+          port: LOCAL_INSTANCE_PORT
+        }).call(this, done);
+      } catch (e) {
+        done(e);
+      }
+    });
+  }
+
+  return connectionString;
+}

--- a/testing/integration-testing-hooks.ts
+++ b/testing/integration-testing-hooks.ts
@@ -18,9 +18,15 @@ const LOCAL_INSTANCE_PORT = 27018;
  */
 export function startTestServer(): string {
   const envConnectionString = process.env.MONGOSH_TEST_SERVER_URL;
-  const connectionString = envConnectionString || `mongodb://localhost:${LOCAL_INSTANCE_PORT}`;
+  const localConnectionString = `mongodb://localhost:${LOCAL_INSTANCE_PORT}`;
+  const connectionString = envConnectionString || localConnectionString;
 
   if (!envConnectionString) {
+    console.info(
+      'MONGOSH_TEST_SERVER_URL not provided. A local server will be started on',
+      localConnectionString
+    );
+
     before(function(done: Function) {
       try {
         mongodbRunnerBefore({


### PR DESCRIPTION
If a `MONGOSH_TEST_SERVER_URL` is set, we don't start a server with `mongodb-runner` but just use it as connection string.

Also:
- Refactor the `before/after` test hooks in a function that returns the connection string.
- Uniform the mocha timeouts, `mongodb-runner` was silently changing them, now that is not always invoked is better to have them defined externally.
