### PR TITLE
MONGOSH-104: log connection information

### DIFF
--- a/packages/browser-repl/src/index.stories.tsx
+++ b/packages/browser-repl/src/index.stories.tsx
@@ -11,7 +11,7 @@ export default {
 };
 
 class DemoServiceProvider {
-  async buildInfo(): Promise<string> {
+  async buildInfo(): Promise<object> {
     return { version: '4.0.0' };
   }
 

--- a/packages/browser-repl/src/index.stories.tsx
+++ b/packages/browser-repl/src/index.stories.tsx
@@ -11,8 +11,8 @@ export default {
 };
 
 class DemoServiceProvider {
-  async getServerVersion(): Promise<string> {
-    return '4.0.0';
+  async buildInfo(): Promise<string> {
+    return { version: '4.0.0' };
   }
 
   async listDatabases(): Promise<any> {

--- a/packages/browser-runtime-core/src/open-context-runtime.ts
+++ b/packages/browser-runtime-core/src/open-context-runtime.ts
@@ -35,7 +35,8 @@ export class OpenContextRuntime implements Runtime {
 
   async getCompletions(code: string): Promise<Completion[]> {
     if (!this.autocompleter) {
-      const serverVersion = await this.serviceProvider.buildInfo().version;
+      const buildInfo = await this.serviceProvider.buildInfo();
+      const serverVersion = buildInfo.version;
       this.autocompleter = new ShellApiAutocompleter(serverVersion);
     }
 

--- a/packages/browser-runtime-core/src/open-context-runtime.ts
+++ b/packages/browser-runtime-core/src/open-context-runtime.ts
@@ -35,7 +35,7 @@ export class OpenContextRuntime implements Runtime {
 
   async getCompletions(code: string): Promise<Completion[]> {
     if (!this.autocompleter) {
-      const serverVersion = await this.serviceProvider.getServerVersion();
+      const serverVersion = await this.serviceProvider.buildInfo().version;
       this.autocompleter = new ShellApiAutocompleter(serverVersion);
     }
 

--- a/packages/cli-repl/package-lock.json
+++ b/packages/cli-repl/package-lock.json
@@ -4,287 +4,12 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
-		"@babel/code-frame": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
-			"integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
-			"requires": {
-				"@babel/highlight": "^7.8.3"
-			}
-		},
-		"@babel/core": {
-			"version": "7.9.0",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.9.0.tgz",
-			"integrity": "sha512-kWc7L0fw1xwvI0zi8OKVBuxRVefwGOrKSQMvrQ3dW+bIIavBY3/NpXmpjMy7bQnLgwgzWQZ8TlM57YHpHNHz4w==",
-			"requires": {
-				"@babel/code-frame": "^7.8.3",
-				"@babel/generator": "^7.9.0",
-				"@babel/helper-module-transforms": "^7.9.0",
-				"@babel/helpers": "^7.9.0",
-				"@babel/parser": "^7.9.0",
-				"@babel/template": "^7.8.6",
-				"@babel/traverse": "^7.9.0",
-				"@babel/types": "^7.9.0",
-				"convert-source-map": "^1.7.0",
-				"debug": "^4.1.0",
-				"gensync": "^1.0.0-beta.1",
-				"json5": "^2.1.2",
-				"lodash": "^4.17.13",
-				"resolve": "^1.3.2",
-				"semver": "^5.4.1",
-				"source-map": "^0.5.0"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-				}
-			}
-		},
-		"@babel/generator": {
-			"version": "7.9.5",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.5.tgz",
-			"integrity": "sha512-GbNIxVB3ZJe3tLeDm1HSn2AhuD/mVcyLDpgtLXa5tplmWrJdF/elxB56XNqCuD6szyNkDi6wuoKXln3QeBmCHQ==",
-			"requires": {
-				"@babel/types": "^7.9.5",
-				"jsesc": "^2.5.1",
-				"lodash": "^4.17.13",
-				"source-map": "^0.5.0"
-			}
-		},
-		"@babel/helper-function-name": {
-			"version": "7.9.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.9.5.tgz",
-			"integrity": "sha512-JVcQZeXM59Cd1qanDUxv9fgJpt3NeKUaqBqUEvfmQ+BCOKq2xUgaWZW2hr0dkbyJgezYuplEoh5knmrnS68efw==",
-			"requires": {
-				"@babel/helper-get-function-arity": "^7.8.3",
-				"@babel/template": "^7.8.3",
-				"@babel/types": "^7.9.5"
-			}
-		},
-		"@babel/helper-get-function-arity": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
-			"integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
-			"requires": {
-				"@babel/types": "^7.8.3"
-			}
-		},
-		"@babel/helper-member-expression-to-functions": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.8.3.tgz",
-			"integrity": "sha512-fO4Egq88utkQFjbPrSHGmGLFqmrshs11d46WI+WZDESt7Wu7wN2G2Iu+NMMZJFDOVRHAMIkB5SNh30NtwCA7RA==",
-			"requires": {
-				"@babel/types": "^7.8.3"
-			}
-		},
-		"@babel/helper-module-imports": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.8.3.tgz",
-			"integrity": "sha512-R0Bx3jippsbAEtzkpZ/6FIiuzOURPcMjHp+Z6xPe6DtApDJx+w7UYyOLanZqO8+wKR9G10s/FmHXvxaMd9s6Kg==",
-			"requires": {
-				"@babel/types": "^7.8.3"
-			}
-		},
-		"@babel/helper-module-transforms": {
-			"version": "7.9.0",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.9.0.tgz",
-			"integrity": "sha512-0FvKyu0gpPfIQ8EkxlrAydOWROdHpBmiCiRwLkUiBGhCUPRRbVD2/tm3sFr/c/GWFrQ/ffutGUAnx7V0FzT2wA==",
-			"requires": {
-				"@babel/helper-module-imports": "^7.8.3",
-				"@babel/helper-replace-supers": "^7.8.6",
-				"@babel/helper-simple-access": "^7.8.3",
-				"@babel/helper-split-export-declaration": "^7.8.3",
-				"@babel/template": "^7.8.6",
-				"@babel/types": "^7.9.0",
-				"lodash": "^4.17.13"
-			}
-		},
-		"@babel/helper-optimise-call-expression": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.8.3.tgz",
-			"integrity": "sha512-Kag20n86cbO2AvHca6EJsvqAd82gc6VMGule4HwebwMlwkpXuVqrNRj6CkCV2sKxgi9MyAUnZVnZ6lJ1/vKhHQ==",
-			"requires": {
-				"@babel/types": "^7.8.3"
-			}
-		},
-		"@babel/helper-replace-supers": {
-			"version": "7.8.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.8.6.tgz",
-			"integrity": "sha512-PeMArdA4Sv/Wf4zXwBKPqVj7n9UF/xg6slNRtZW84FM7JpE1CbG8B612FyM4cxrf4fMAMGO0kR7voy1ForHHFA==",
-			"requires": {
-				"@babel/helper-member-expression-to-functions": "^7.8.3",
-				"@babel/helper-optimise-call-expression": "^7.8.3",
-				"@babel/traverse": "^7.8.6",
-				"@babel/types": "^7.8.6"
-			}
-		},
-		"@babel/helper-simple-access": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.8.3.tgz",
-			"integrity": "sha512-VNGUDjx5cCWg4vvCTR8qQ7YJYZ+HBjxOgXEl7ounz+4Sn7+LMD3CFrCTEU6/qXKbA2nKg21CwhhBzO0RpRbdCw==",
-			"requires": {
-				"@babel/template": "^7.8.3",
-				"@babel/types": "^7.8.3"
-			}
-		},
-		"@babel/helper-split-export-declaration": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
-			"integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
-			"requires": {
-				"@babel/types": "^7.8.3"
-			}
-		},
-		"@babel/helper-validator-identifier": {
-			"version": "7.9.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz",
-			"integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g=="
-		},
-		"@babel/helpers": {
-			"version": "7.9.2",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.9.2.tgz",
-			"integrity": "sha512-JwLvzlXVPjO8eU9c/wF9/zOIN7X6h8DYf7mG4CiFRZRvZNKEF5dQ3H3V+ASkHoIB3mWhatgl5ONhyqHRI6MppA==",
-			"requires": {
-				"@babel/template": "^7.8.3",
-				"@babel/traverse": "^7.9.0",
-				"@babel/types": "^7.9.0"
-			}
-		},
-		"@babel/highlight": {
-			"version": "7.9.0",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.9.0.tgz",
-			"integrity": "sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==",
-			"requires": {
-				"@babel/helper-validator-identifier": "^7.9.0",
-				"chalk": "^2.0.0",
-				"js-tokens": "^4.0.0"
-			}
-		},
-		"@babel/parser": {
-			"version": "7.9.4",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.4.tgz",
-			"integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA=="
-		},
-		"@babel/template": {
-			"version": "7.8.6",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
-			"integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
-			"requires": {
-				"@babel/code-frame": "^7.8.3",
-				"@babel/parser": "^7.8.6",
-				"@babel/types": "^7.8.6"
-			}
-		},
-		"@babel/traverse": {
-			"version": "7.9.5",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.9.5.tgz",
-			"integrity": "sha512-c4gH3jsvSuGUezlP6rzSJ6jf8fYjLj3hsMZRx/nX0h+fmHN0w+ekubRrHPqnMec0meycA2nwCsJ7dC8IPem2FQ==",
-			"requires": {
-				"@babel/code-frame": "^7.8.3",
-				"@babel/generator": "^7.9.5",
-				"@babel/helper-function-name": "^7.9.5",
-				"@babel/helper-split-export-declaration": "^7.8.3",
-				"@babel/parser": "^7.9.0",
-				"@babel/types": "^7.9.5",
-				"debug": "^4.1.0",
-				"globals": "^11.1.0",
-				"lodash": "^4.17.13"
-			}
-		},
-		"@babel/types": {
-			"version": "7.9.5",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
-			"integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
-			"requires": {
-				"@babel/helper-validator-identifier": "^7.9.5",
-				"lodash": "^4.17.13",
-				"to-fast-properties": "^2.0.0"
-			}
-		},
-		"@mongosh/async-rewriter": {
-			"version": "0.0.1-alpha.12",
-			"resolved": "https://registry.npmjs.org/@mongosh/async-rewriter/-/async-rewriter-0.0.1-alpha.12.tgz",
-			"integrity": "sha512-LlTp2bCNVy60SX2WKGKRNPFDSEcChqAz3f54it9SFcGQndjRw03wOEPx7hxt/3sMWxxASaGPC45LPjOJpBELOg==",
-			"requires": {
-				"@babel/core": "^7.8.7"
-			}
-		},
-		"@mongosh/history": {
-			"version": "0.0.1-alpha.12",
-			"resolved": "https://registry.npmjs.org/@mongosh/history/-/history-0.0.1-alpha.12.tgz",
-			"integrity": "sha512-vaYC47YmpOAYnzNLlmO1WRDV9DKvDnqTJQUoyglVa1djQ68Zvc5N7ry4LA4DFvYC6kHH75Ffiqcaqh9TuY1CiQ==",
-			"requires": {
-				"mongodb-redact": "^0.2.0"
-			}
-		},
-		"@mongosh/i18n": {
-			"version": "0.0.1-alpha.12",
-			"resolved": "https://registry.npmjs.org/@mongosh/i18n/-/i18n-0.0.1-alpha.12.tgz",
-			"integrity": "sha512-CPJqi4FB1LuK1SJ+H4K+Tbmq2y6/ni7Lh+iYABoncnB09y9FlXoE0l7HZkJ0clWMsVtccceLpKGUu/tZotsO9g==",
-			"requires": {
-				"mustache": "^4.0.0"
-			}
-		},
-		"@mongosh/mapper": {
-			"version": "0.0.1-alpha.12",
-			"resolved": "https://registry.npmjs.org/@mongosh/mapper/-/mapper-0.0.1-alpha.12.tgz",
-			"integrity": "sha512-WB6zeUnbl9jedH1wA8vENdqkBq/Jf+yyPdqlm6gvg9keamhhJEW6pfdFj7XGhSMeTL+NpnSOJ9OyheG0ZF2ljw==",
-			"requires": {
-				"@mongosh/service-provider-core": "^0.0.1-alpha.12",
-				"@mongosh/shell-api": "^0.0.1-alpha.12",
-				"pretty-bytes": "^5.3.0",
-				"text-table": "^0.2.0"
-			}
-		},
-		"@mongosh/service-provider-core": {
-			"version": "0.0.1-alpha.12",
-			"resolved": "https://registry.npmjs.org/@mongosh/service-provider-core/-/service-provider-core-0.0.1-alpha.12.tgz",
-			"integrity": "sha512-lkHGjgvR2GBjFYCYnYE3XcUVoEr3GuzC2+HMB3LTXWDWWNea2HmxiB67KM+9FdyBXb349zSfaCOLy76142lawQ=="
-		},
-		"@mongosh/service-provider-server": {
-			"version": "0.0.1-alpha.12",
-			"resolved": "https://registry.npmjs.org/@mongosh/service-provider-server/-/service-provider-server-0.0.1-alpha.12.tgz",
-			"integrity": "sha512-OpJ/NKGAEa3zKI2+G/87vk+YOsLLvj/p1P+aCOiEHjRKy4PWXmEKc0wf1j0rq5LZ1/RNj2zeJatA2OtX6LY/Jw==",
-			"requires": {
-				"@mongosh/service-provider-core": "^0.0.1-alpha.12",
-				"mongodb": "3.5.3 || ^3.5.5"
-			}
-		},
-		"@mongosh/shell-api": {
-			"version": "0.0.1-alpha.12",
-			"resolved": "https://registry.npmjs.org/@mongosh/shell-api/-/shell-api-0.0.1-alpha.12.tgz",
-			"integrity": "sha512-Mu9OZFc9YvF0+Un8cNyBjBozBoc1lAWHLkRMwhBnD/hf4SbGl5VHn8AGBAEKmId+YLADTyb2HhnBeuzLFKBp2g==",
-			"requires": {
-				"@mongosh/i18n": "^0.0.1-alpha.12"
-			}
-		},
-		"@mongosh/shell-evaluator": {
-			"version": "0.0.1-alpha.12",
-			"resolved": "https://registry.npmjs.org/@mongosh/shell-evaluator/-/shell-evaluator-0.0.1-alpha.12.tgz",
-			"integrity": "sha512-Ovy/Vrh3d+0IZnVmY1KIMR5oY3coREDBztFCemZeaBHJ0dFbJCodaW7VUyU6Qm365H840aMgDyUELec3rDC07Q==",
-			"requires": {
-				"@mongosh/async-rewriter": "^0.0.1-alpha.12",
-				"@mongosh/mapper": "^0.0.1-alpha.12",
-				"@mongosh/service-provider-core": "^0.0.1-alpha.12",
-				"@mongosh/shell-api": "^0.0.1-alpha.12"
-			}
-		},
 		"ansi-escape-sequences": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-5.1.2.tgz",
 			"integrity": "sha512-JcpoVp1W1bl1Qn4cVuiXEhD6+dyXKSOgCn2zlzE8inYgCJCBy1aPnUhlz6I4DFum8D4ovb9Qi/iAjUcGvG2lqw==",
 			"requires": {
 				"array-back": "^4.0.0"
-			}
-		},
-		"ansi-styles": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-			"requires": {
-				"color-convert": "^1.9.0"
 			}
 		},
 		"array-back": {
@@ -301,15 +26,6 @@
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
 			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
-		},
-		"bl": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/bl/-/bl-2.2.0.tgz",
-			"integrity": "sha512-wbgvOpqopSr7uq6fJrLH8EsvYMJf9gzfo2jCsL2eTy75qXPukA4pCgHamOQkZtY5vmfVtjB+P3LNlMHW5CEZXA==",
-			"requires": {
-				"readable-stream": "^2.3.5",
-				"safe-buffer": "^5.1.1"
-			}
 		},
 		"bson": {
 			"version": "4.0.4",
@@ -329,67 +45,6 @@
 				"ieee754": "^1.1.4"
 			}
 		},
-		"chalk": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-			"requires": {
-				"ansi-styles": "^3.2.1",
-				"escape-string-regexp": "^1.0.5",
-				"supports-color": "^5.3.0"
-			}
-		},
-		"color-convert": {
-			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-			"requires": {
-				"color-name": "1.1.3"
-			}
-		},
-		"color-name": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
-		},
-		"convert-source-map": {
-			"version": "1.7.0",
-			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
-			"integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
-			"requires": {
-				"safe-buffer": "~5.1.1"
-			},
-			"dependencies": {
-				"safe-buffer": {
-					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-				}
-			}
-		},
-		"core-util-is": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
-		},
-		"debug": {
-			"version": "4.1.1",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-			"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-			"requires": {
-				"ms": "^2.1.1"
-			}
-		},
-		"denque": {
-			"version": "1.4.1",
-			"resolved": "https://registry.npmjs.org/denque/-/denque-1.4.1.tgz",
-			"integrity": "sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ=="
-		},
-		"escape-string-regexp": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
-		},
 		"fast-redact": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-2.0.0.tgz",
@@ -405,53 +60,10 @@
 			"resolved": "https://registry.npmjs.org/flatstr/-/flatstr-1.0.12.tgz",
 			"integrity": "sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw=="
 		},
-		"gensync": {
-			"version": "1.0.0-beta.1",
-			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
-			"integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg=="
-		},
-		"globals": {
-			"version": "11.12.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
-		},
-		"has-flag": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
-		},
 		"ieee754": {
 			"version": "1.1.13",
 			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
 			"integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
-		},
-		"inherits": {
-			"version": "2.0.4",
-			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
-		},
-		"isarray": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
-		},
-		"js-tokens": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
-		},
-		"jsesc": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
-		},
-		"json5": {
-			"version": "2.1.3",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
-			"integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
-			"requires": {
-				"minimist": "^1.2.5"
-			}
 		},
 		"lodash": {
 			"version": "4.17.15",
@@ -468,12 +80,6 @@
 			"resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
 			"integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
 		},
-		"memory-pager": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
-			"integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
-			"optional": true
-		},
 		"minimist": {
 			"version": "1.2.5",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
@@ -483,26 +89,6 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
 			"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
-		},
-		"mongodb": {
-			"version": "3.5.6",
-			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.5.6.tgz",
-			"integrity": "sha512-sh3q3GLDLT4QmoDLamxtAECwC3RGjq+oNuK1ENV8+tnipIavss6sMYt77hpygqlMOCt0Sla5cl7H4SKCVBCGEg==",
-			"requires": {
-				"bl": "^2.2.0",
-				"bson": "^1.1.4",
-				"denque": "^1.4.1",
-				"require_optional": "^1.0.1",
-				"safe-buffer": "^5.1.2",
-				"saslprep": "^1.0.0"
-			},
-			"dependencies": {
-				"bson": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/bson/-/bson-1.1.4.tgz",
-					"integrity": "sha512-S/yKGU1syOMzO86+dGpg2qGoDL0zvzcb262G+gqEy6TgP6rt6z6qxSFX/8X6vLC91P7G7C3nLs0+bvDzmvBA3Q=="
-				}
-			}
 		},
 		"mongodb-ace-autocompleter": {
 			"version": "0.4.8",
@@ -519,16 +105,6 @@
 			"requires": {
 				"lodash": "^4.17.15"
 			}
-		},
-		"ms": {
-			"version": "2.1.2",
-			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-		},
-		"mustache": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/mustache/-/mustache-4.0.1.tgz",
-			"integrity": "sha512-yL5VE97+OXn4+Er3THSmTdCFCtx5hHWzrolvH+JObZnUYwuaG7XV+Ch4fR2cIrcYI0tFHxS7iyFYl14bW8y2sA=="
 		},
 		"mute-stream": {
 			"version": "0.0.8",
@@ -567,11 +143,6 @@
 				"nanoscheduler": "^1.0.2"
 			}
 		},
-		"path-parse": {
-			"version": "1.0.6",
-			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
-		},
 		"pino": {
 			"version": "5.17.0",
 			"resolved": "https://registry.npmjs.org/pino/-/pino-5.17.0.tgz",
@@ -595,11 +166,6 @@
 			"resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.3.0.tgz",
 			"integrity": "sha512-hjGrh+P926p4R4WbaB6OckyRtO0F0/lQBiT+0gnxjV+5kjPBrfVBFCsCLbMqVQeydvIoouYTCmmEURiH3R1Bdg=="
 		},
-		"process-nextick-args": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
-		},
 		"quick-format-unescaped": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-3.0.3.tgz",
@@ -613,74 +179,10 @@
 				"mute-stream": "~0.0.4"
 			}
 		},
-		"readable-stream": {
-			"version": "2.3.7",
-			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
-			"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-			"requires": {
-				"core-util-is": "~1.0.0",
-				"inherits": "~2.0.3",
-				"isarray": "~1.0.0",
-				"process-nextick-args": "~2.0.0",
-				"safe-buffer": "~5.1.1",
-				"string_decoder": "~1.1.1",
-				"util-deprecate": "~1.0.1"
-			},
-			"dependencies": {
-				"safe-buffer": {
-					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-				}
-			}
-		},
 		"remove-array-items": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/remove-array-items/-/remove-array-items-1.1.1.tgz",
 			"integrity": "sha512-MXW/jtHyl5F1PZI7NbpS8SOtympdLuF20aoWJT5lELR1p/HJDd5nqW8Eu9uLh/hCRY3FgvrIT5AwDCgBODklcA=="
-		},
-		"require_optional": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
-			"integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
-			"requires": {
-				"resolve-from": "^2.0.0",
-				"semver": "^5.1.0"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "5.7.1",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
-				}
-			}
-		},
-		"resolve": {
-			"version": "1.17.0",
-			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
-			"integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
-			"requires": {
-				"path-parse": "^1.0.6"
-			}
-		},
-		"resolve-from": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-			"integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
-		},
-		"safe-buffer": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-			"integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
-		},
-		"saslprep": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
-			"integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
-			"optional": true,
-			"requires": {
-				"sparse-bitfield": "^3.0.3"
-			}
 		},
 		"semver": {
 			"version": "7.3.2",
@@ -696,57 +198,10 @@
 				"flatstr": "^1.0.12"
 			}
 		},
-		"source-map": {
-			"version": "0.5.7",
-			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
-		},
-		"sparse-bitfield": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
-			"integrity": "sha1-/0rm5oZWBWuks+eSqzM004JzyhE=",
-			"optional": true,
-			"requires": {
-				"memory-pager": "^1.0.2"
-			}
-		},
-		"string_decoder": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
-			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-			"requires": {
-				"safe-buffer": "~5.1.0"
-			},
-			"dependencies": {
-				"safe-buffer": {
-					"version": "5.1.2",
-					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
-				}
-			}
-		},
-		"supports-color": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-			"requires": {
-				"has-flag": "^3.0.0"
-			}
-		},
 		"text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
 			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
-		},
-		"to-fast-properties": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
-		},
-		"util-deprecate": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
 		},
 		"uuid": {
 			"version": "7.0.2",

--- a/packages/cli-repl/package-lock.json
+++ b/packages/cli-repl/package-lock.json
@@ -4,12 +4,287 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@babel/code-frame": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+			"integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+			"requires": {
+				"@babel/highlight": "^7.8.3"
+			}
+		},
+		"@babel/core": {
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.9.0.tgz",
+			"integrity": "sha512-kWc7L0fw1xwvI0zi8OKVBuxRVefwGOrKSQMvrQ3dW+bIIavBY3/NpXmpjMy7bQnLgwgzWQZ8TlM57YHpHNHz4w==",
+			"requires": {
+				"@babel/code-frame": "^7.8.3",
+				"@babel/generator": "^7.9.0",
+				"@babel/helper-module-transforms": "^7.9.0",
+				"@babel/helpers": "^7.9.0",
+				"@babel/parser": "^7.9.0",
+				"@babel/template": "^7.8.6",
+				"@babel/traverse": "^7.9.0",
+				"@babel/types": "^7.9.0",
+				"convert-source-map": "^1.7.0",
+				"debug": "^4.1.0",
+				"gensync": "^1.0.0-beta.1",
+				"json5": "^2.1.2",
+				"lodash": "^4.17.13",
+				"resolve": "^1.3.2",
+				"semver": "^5.4.1",
+				"source-map": "^0.5.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+				}
+			}
+		},
+		"@babel/generator": {
+			"version": "7.9.5",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.5.tgz",
+			"integrity": "sha512-GbNIxVB3ZJe3tLeDm1HSn2AhuD/mVcyLDpgtLXa5tplmWrJdF/elxB56XNqCuD6szyNkDi6wuoKXln3QeBmCHQ==",
+			"requires": {
+				"@babel/types": "^7.9.5",
+				"jsesc": "^2.5.1",
+				"lodash": "^4.17.13",
+				"source-map": "^0.5.0"
+			}
+		},
+		"@babel/helper-function-name": {
+			"version": "7.9.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.9.5.tgz",
+			"integrity": "sha512-JVcQZeXM59Cd1qanDUxv9fgJpt3NeKUaqBqUEvfmQ+BCOKq2xUgaWZW2hr0dkbyJgezYuplEoh5knmrnS68efw==",
+			"requires": {
+				"@babel/helper-get-function-arity": "^7.8.3",
+				"@babel/template": "^7.8.3",
+				"@babel/types": "^7.9.5"
+			}
+		},
+		"@babel/helper-get-function-arity": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
+			"integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
+			"requires": {
+				"@babel/types": "^7.8.3"
+			}
+		},
+		"@babel/helper-member-expression-to-functions": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.8.3.tgz",
+			"integrity": "sha512-fO4Egq88utkQFjbPrSHGmGLFqmrshs11d46WI+WZDESt7Wu7wN2G2Iu+NMMZJFDOVRHAMIkB5SNh30NtwCA7RA==",
+			"requires": {
+				"@babel/types": "^7.8.3"
+			}
+		},
+		"@babel/helper-module-imports": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.8.3.tgz",
+			"integrity": "sha512-R0Bx3jippsbAEtzkpZ/6FIiuzOURPcMjHp+Z6xPe6DtApDJx+w7UYyOLanZqO8+wKR9G10s/FmHXvxaMd9s6Kg==",
+			"requires": {
+				"@babel/types": "^7.8.3"
+			}
+		},
+		"@babel/helper-module-transforms": {
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.9.0.tgz",
+			"integrity": "sha512-0FvKyu0gpPfIQ8EkxlrAydOWROdHpBmiCiRwLkUiBGhCUPRRbVD2/tm3sFr/c/GWFrQ/ffutGUAnx7V0FzT2wA==",
+			"requires": {
+				"@babel/helper-module-imports": "^7.8.3",
+				"@babel/helper-replace-supers": "^7.8.6",
+				"@babel/helper-simple-access": "^7.8.3",
+				"@babel/helper-split-export-declaration": "^7.8.3",
+				"@babel/template": "^7.8.6",
+				"@babel/types": "^7.9.0",
+				"lodash": "^4.17.13"
+			}
+		},
+		"@babel/helper-optimise-call-expression": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.8.3.tgz",
+			"integrity": "sha512-Kag20n86cbO2AvHca6EJsvqAd82gc6VMGule4HwebwMlwkpXuVqrNRj6CkCV2sKxgi9MyAUnZVnZ6lJ1/vKhHQ==",
+			"requires": {
+				"@babel/types": "^7.8.3"
+			}
+		},
+		"@babel/helper-replace-supers": {
+			"version": "7.8.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.8.6.tgz",
+			"integrity": "sha512-PeMArdA4Sv/Wf4zXwBKPqVj7n9UF/xg6slNRtZW84FM7JpE1CbG8B612FyM4cxrf4fMAMGO0kR7voy1ForHHFA==",
+			"requires": {
+				"@babel/helper-member-expression-to-functions": "^7.8.3",
+				"@babel/helper-optimise-call-expression": "^7.8.3",
+				"@babel/traverse": "^7.8.6",
+				"@babel/types": "^7.8.6"
+			}
+		},
+		"@babel/helper-simple-access": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.8.3.tgz",
+			"integrity": "sha512-VNGUDjx5cCWg4vvCTR8qQ7YJYZ+HBjxOgXEl7ounz+4Sn7+LMD3CFrCTEU6/qXKbA2nKg21CwhhBzO0RpRbdCw==",
+			"requires": {
+				"@babel/template": "^7.8.3",
+				"@babel/types": "^7.8.3"
+			}
+		},
+		"@babel/helper-split-export-declaration": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
+			"integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
+			"requires": {
+				"@babel/types": "^7.8.3"
+			}
+		},
+		"@babel/helper-validator-identifier": {
+			"version": "7.9.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz",
+			"integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g=="
+		},
+		"@babel/helpers": {
+			"version": "7.9.2",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.9.2.tgz",
+			"integrity": "sha512-JwLvzlXVPjO8eU9c/wF9/zOIN7X6h8DYf7mG4CiFRZRvZNKEF5dQ3H3V+ASkHoIB3mWhatgl5ONhyqHRI6MppA==",
+			"requires": {
+				"@babel/template": "^7.8.3",
+				"@babel/traverse": "^7.9.0",
+				"@babel/types": "^7.9.0"
+			}
+		},
+		"@babel/highlight": {
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.9.0.tgz",
+			"integrity": "sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==",
+			"requires": {
+				"@babel/helper-validator-identifier": "^7.9.0",
+				"chalk": "^2.0.0",
+				"js-tokens": "^4.0.0"
+			}
+		},
+		"@babel/parser": {
+			"version": "7.9.4",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.4.tgz",
+			"integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA=="
+		},
+		"@babel/template": {
+			"version": "7.8.6",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
+			"integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
+			"requires": {
+				"@babel/code-frame": "^7.8.3",
+				"@babel/parser": "^7.8.6",
+				"@babel/types": "^7.8.6"
+			}
+		},
+		"@babel/traverse": {
+			"version": "7.9.5",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.9.5.tgz",
+			"integrity": "sha512-c4gH3jsvSuGUezlP6rzSJ6jf8fYjLj3hsMZRx/nX0h+fmHN0w+ekubRrHPqnMec0meycA2nwCsJ7dC8IPem2FQ==",
+			"requires": {
+				"@babel/code-frame": "^7.8.3",
+				"@babel/generator": "^7.9.5",
+				"@babel/helper-function-name": "^7.9.5",
+				"@babel/helper-split-export-declaration": "^7.8.3",
+				"@babel/parser": "^7.9.0",
+				"@babel/types": "^7.9.5",
+				"debug": "^4.1.0",
+				"globals": "^11.1.0",
+				"lodash": "^4.17.13"
+			}
+		},
+		"@babel/types": {
+			"version": "7.9.5",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
+			"integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
+			"requires": {
+				"@babel/helper-validator-identifier": "^7.9.5",
+				"lodash": "^4.17.13",
+				"to-fast-properties": "^2.0.0"
+			}
+		},
+		"@mongosh/async-rewriter": {
+			"version": "0.0.1-alpha.12",
+			"resolved": "https://registry.npmjs.org/@mongosh/async-rewriter/-/async-rewriter-0.0.1-alpha.12.tgz",
+			"integrity": "sha512-LlTp2bCNVy60SX2WKGKRNPFDSEcChqAz3f54it9SFcGQndjRw03wOEPx7hxt/3sMWxxASaGPC45LPjOJpBELOg==",
+			"requires": {
+				"@babel/core": "^7.8.7"
+			}
+		},
+		"@mongosh/history": {
+			"version": "0.0.1-alpha.12",
+			"resolved": "https://registry.npmjs.org/@mongosh/history/-/history-0.0.1-alpha.12.tgz",
+			"integrity": "sha512-vaYC47YmpOAYnzNLlmO1WRDV9DKvDnqTJQUoyglVa1djQ68Zvc5N7ry4LA4DFvYC6kHH75Ffiqcaqh9TuY1CiQ==",
+			"requires": {
+				"mongodb-redact": "^0.2.0"
+			}
+		},
+		"@mongosh/i18n": {
+			"version": "0.0.1-alpha.12",
+			"resolved": "https://registry.npmjs.org/@mongosh/i18n/-/i18n-0.0.1-alpha.12.tgz",
+			"integrity": "sha512-CPJqi4FB1LuK1SJ+H4K+Tbmq2y6/ni7Lh+iYABoncnB09y9FlXoE0l7HZkJ0clWMsVtccceLpKGUu/tZotsO9g==",
+			"requires": {
+				"mustache": "^4.0.0"
+			}
+		},
+		"@mongosh/mapper": {
+			"version": "0.0.1-alpha.12",
+			"resolved": "https://registry.npmjs.org/@mongosh/mapper/-/mapper-0.0.1-alpha.12.tgz",
+			"integrity": "sha512-WB6zeUnbl9jedH1wA8vENdqkBq/Jf+yyPdqlm6gvg9keamhhJEW6pfdFj7XGhSMeTL+NpnSOJ9OyheG0ZF2ljw==",
+			"requires": {
+				"@mongosh/service-provider-core": "^0.0.1-alpha.12",
+				"@mongosh/shell-api": "^0.0.1-alpha.12",
+				"pretty-bytes": "^5.3.0",
+				"text-table": "^0.2.0"
+			}
+		},
+		"@mongosh/service-provider-core": {
+			"version": "0.0.1-alpha.12",
+			"resolved": "https://registry.npmjs.org/@mongosh/service-provider-core/-/service-provider-core-0.0.1-alpha.12.tgz",
+			"integrity": "sha512-lkHGjgvR2GBjFYCYnYE3XcUVoEr3GuzC2+HMB3LTXWDWWNea2HmxiB67KM+9FdyBXb349zSfaCOLy76142lawQ=="
+		},
+		"@mongosh/service-provider-server": {
+			"version": "0.0.1-alpha.12",
+			"resolved": "https://registry.npmjs.org/@mongosh/service-provider-server/-/service-provider-server-0.0.1-alpha.12.tgz",
+			"integrity": "sha512-OpJ/NKGAEa3zKI2+G/87vk+YOsLLvj/p1P+aCOiEHjRKy4PWXmEKc0wf1j0rq5LZ1/RNj2zeJatA2OtX6LY/Jw==",
+			"requires": {
+				"@mongosh/service-provider-core": "^0.0.1-alpha.12",
+				"mongodb": "3.5.3 || ^3.5.5"
+			}
+		},
+		"@mongosh/shell-api": {
+			"version": "0.0.1-alpha.12",
+			"resolved": "https://registry.npmjs.org/@mongosh/shell-api/-/shell-api-0.0.1-alpha.12.tgz",
+			"integrity": "sha512-Mu9OZFc9YvF0+Un8cNyBjBozBoc1lAWHLkRMwhBnD/hf4SbGl5VHn8AGBAEKmId+YLADTyb2HhnBeuzLFKBp2g==",
+			"requires": {
+				"@mongosh/i18n": "^0.0.1-alpha.12"
+			}
+		},
+		"@mongosh/shell-evaluator": {
+			"version": "0.0.1-alpha.12",
+			"resolved": "https://registry.npmjs.org/@mongosh/shell-evaluator/-/shell-evaluator-0.0.1-alpha.12.tgz",
+			"integrity": "sha512-Ovy/Vrh3d+0IZnVmY1KIMR5oY3coREDBztFCemZeaBHJ0dFbJCodaW7VUyU6Qm365H840aMgDyUELec3rDC07Q==",
+			"requires": {
+				"@mongosh/async-rewriter": "^0.0.1-alpha.12",
+				"@mongosh/mapper": "^0.0.1-alpha.12",
+				"@mongosh/service-provider-core": "^0.0.1-alpha.12",
+				"@mongosh/shell-api": "^0.0.1-alpha.12"
+			}
+		},
 		"ansi-escape-sequences": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-5.1.2.tgz",
 			"integrity": "sha512-JcpoVp1W1bl1Qn4cVuiXEhD6+dyXKSOgCn2zlzE8inYgCJCBy1aPnUhlz6I4DFum8D4ovb9Qi/iAjUcGvG2lqw==",
 			"requires": {
 				"array-back": "^4.0.0"
+			}
+		},
+		"ansi-styles": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"requires": {
+				"color-convert": "^1.9.0"
 			}
 		},
 		"array-back": {
@@ -26,6 +301,15 @@
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
 			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+		},
+		"bl": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/bl/-/bl-2.2.0.tgz",
+			"integrity": "sha512-wbgvOpqopSr7uq6fJrLH8EsvYMJf9gzfo2jCsL2eTy75qXPukA4pCgHamOQkZtY5vmfVtjB+P3LNlMHW5CEZXA==",
+			"requires": {
+				"readable-stream": "^2.3.5",
+				"safe-buffer": "^5.1.1"
+			}
 		},
 		"bson": {
 			"version": "4.0.4",
@@ -45,6 +329,67 @@
 				"ieee754": "^1.1.4"
 			}
 		},
+		"chalk": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"requires": {
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
+			}
+		},
+		"color-convert": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"requires": {
+				"color-name": "1.1.3"
+			}
+		},
+		"color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+		},
+		"convert-source-map": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+			"integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+			"requires": {
+				"safe-buffer": "~5.1.1"
+			},
+			"dependencies": {
+				"safe-buffer": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+				}
+			}
+		},
+		"core-util-is": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
+		},
+		"debug": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+			"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+			"requires": {
+				"ms": "^2.1.1"
+			}
+		},
+		"denque": {
+			"version": "1.4.1",
+			"resolved": "https://registry.npmjs.org/denque/-/denque-1.4.1.tgz",
+			"integrity": "sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ=="
+		},
+		"escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+		},
 		"fast-redact": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-2.0.0.tgz",
@@ -60,10 +405,53 @@
 			"resolved": "https://registry.npmjs.org/flatstr/-/flatstr-1.0.12.tgz",
 			"integrity": "sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw=="
 		},
+		"gensync": {
+			"version": "1.0.0-beta.1",
+			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
+			"integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg=="
+		},
+		"globals": {
+			"version": "11.12.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
+		},
+		"has-flag": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+		},
 		"ieee754": {
 			"version": "1.1.13",
 			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
 			"integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+		},
+		"inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
+		},
+		"isarray": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
+		},
+		"js-tokens": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+		},
+		"jsesc": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
+		},
+		"json5": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+			"integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+			"requires": {
+				"minimist": "^1.2.5"
+			}
 		},
 		"lodash": {
 			"version": "4.17.15",
@@ -80,6 +468,12 @@
 			"resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
 			"integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
 		},
+		"memory-pager": {
+			"version": "1.5.0",
+			"resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+			"integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+			"optional": true
+		},
 		"minimist": {
 			"version": "1.2.5",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
@@ -89,6 +483,26 @@
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
 			"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+		},
+		"mongodb": {
+			"version": "3.5.6",
+			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.5.6.tgz",
+			"integrity": "sha512-sh3q3GLDLT4QmoDLamxtAECwC3RGjq+oNuK1ENV8+tnipIavss6sMYt77hpygqlMOCt0Sla5cl7H4SKCVBCGEg==",
+			"requires": {
+				"bl": "^2.2.0",
+				"bson": "^1.1.4",
+				"denque": "^1.4.1",
+				"require_optional": "^1.0.1",
+				"safe-buffer": "^5.1.2",
+				"saslprep": "^1.0.0"
+			},
+			"dependencies": {
+				"bson": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/bson/-/bson-1.1.4.tgz",
+					"integrity": "sha512-S/yKGU1syOMzO86+dGpg2qGoDL0zvzcb262G+gqEy6TgP6rt6z6qxSFX/8X6vLC91P7G7C3nLs0+bvDzmvBA3Q=="
+				}
+			}
 		},
 		"mongodb-ace-autocompleter": {
 			"version": "0.4.8",
@@ -105,6 +519,16 @@
 			"requires": {
 				"lodash": "^4.17.15"
 			}
+		},
+		"ms": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+		},
+		"mustache": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/mustache/-/mustache-4.0.1.tgz",
+			"integrity": "sha512-yL5VE97+OXn4+Er3THSmTdCFCtx5hHWzrolvH+JObZnUYwuaG7XV+Ch4fR2cIrcYI0tFHxS7iyFYl14bW8y2sA=="
 		},
 		"mute-stream": {
 			"version": "0.0.8",
@@ -143,6 +567,11 @@
 				"nanoscheduler": "^1.0.2"
 			}
 		},
+		"path-parse": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+		},
 		"pino": {
 			"version": "5.17.0",
 			"resolved": "https://registry.npmjs.org/pino/-/pino-5.17.0.tgz",
@@ -166,6 +595,11 @@
 			"resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.3.0.tgz",
 			"integrity": "sha512-hjGrh+P926p4R4WbaB6OckyRtO0F0/lQBiT+0gnxjV+5kjPBrfVBFCsCLbMqVQeydvIoouYTCmmEURiH3R1Bdg=="
 		},
+		"process-nextick-args": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
+		},
 		"quick-format-unescaped": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-3.0.3.tgz",
@@ -179,10 +613,74 @@
 				"mute-stream": "~0.0.4"
 			}
 		},
+		"readable-stream": {
+			"version": "2.3.7",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+			"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+			"requires": {
+				"core-util-is": "~1.0.0",
+				"inherits": "~2.0.3",
+				"isarray": "~1.0.0",
+				"process-nextick-args": "~2.0.0",
+				"safe-buffer": "~5.1.1",
+				"string_decoder": "~1.1.1",
+				"util-deprecate": "~1.0.1"
+			},
+			"dependencies": {
+				"safe-buffer": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+				}
+			}
+		},
 		"remove-array-items": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/remove-array-items/-/remove-array-items-1.1.1.tgz",
 			"integrity": "sha512-MXW/jtHyl5F1PZI7NbpS8SOtympdLuF20aoWJT5lELR1p/HJDd5nqW8Eu9uLh/hCRY3FgvrIT5AwDCgBODklcA=="
+		},
+		"require_optional": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
+			"integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
+			"requires": {
+				"resolve-from": "^2.0.0",
+				"semver": "^5.1.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+				}
+			}
+		},
+		"resolve": {
+			"version": "1.17.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+			"integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+			"requires": {
+				"path-parse": "^1.0.6"
+			}
+		},
+		"resolve-from": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
+			"integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
+		},
+		"safe-buffer": {
+			"version": "5.2.0",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
+			"integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg=="
+		},
+		"saslprep": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
+			"integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
+			"optional": true,
+			"requires": {
+				"sparse-bitfield": "^3.0.3"
+			}
 		},
 		"semver": {
 			"version": "7.3.2",
@@ -198,10 +696,70 @@
 				"flatstr": "^1.0.12"
 			}
 		},
+		"source-map": {
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+		},
+		"sparse-bitfield": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+			"integrity": "sha1-/0rm5oZWBWuks+eSqzM004JzyhE=",
+			"optional": true,
+			"requires": {
+				"memory-pager": "^1.0.2"
+			}
+		},
+		"string_decoder": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+			"requires": {
+				"safe-buffer": "~5.1.0"
+			},
+			"dependencies": {
+				"safe-buffer": {
+					"version": "5.1.2",
+					"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+					"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+				}
+			}
+		},
+		"supports-color": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+			"requires": {
+				"has-flag": "^3.0.0"
+			}
+		},
 		"text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
 			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+		},
+		"to-fast-properties": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+		},
+		"util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
+		},
+		"uuid": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-7.0.2.tgz",
+			"integrity": "sha512-vy9V/+pKG+5ZTYKf+VcphF5Oc6EFiu3W8Nv3P3zIh0EqVI80ZxOzuPfe9EHjkFNvf8+xuTHVeei4Drydlx4zjw=="
+		},
+		"uuidv4": {
+			"version": "6.0.6",
+			"resolved": "https://registry.npmjs.org/uuidv4/-/uuidv4-6.0.6.tgz",
+			"integrity": "sha512-10YcruyGJtsG5SJnPG+8atr8toJa7xAOrcO7B7plYYiwpH1mQ8UZHjNSa2MrwGi6KWuyVrXGHr+Rce22F9UAiw==",
+			"requires": {
+				"uuid": "7.0.2"
+			}
 		}
 	}
 }

--- a/packages/cli-repl/package-lock.json
+++ b/packages/cli-repl/package-lock.json
@@ -98,6 +98,11 @@
 				"semver": "^7.1.1"
 			}
 		},
+		"mongodb-build-info": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/mongodb-build-info/-/mongodb-build-info-1.0.0.tgz",
+			"integrity": "sha512-ZFcBteBQMoGyMV3+FmjPRRI4X2ZR8TNPGlylNuGU1yg/TTC7eXFcd2VhL7SslRM0/tGsx7pIjLEqwjd9CtWSlA=="
+		},
 		"mongodb-redact": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/mongodb-redact/-/mongodb-redact-0.2.0.tgz",

--- a/packages/cli-repl/package.json
+++ b/packages/cli-repl/package.json
@@ -41,6 +41,7 @@
     "minimist": "^1.2.5",
     "mkdirp": "^1.0.3",
     "mongodb-ace-autocompleter": "^0.4.1",
+    "mongodb-build-info": "^1.0.0",
     "mongodb-redact": "^0.2.0",
     "nanobus": "^4.4.0",
     "pino": "^5.16.0",

--- a/packages/cli-repl/src/cli-repl.ts
+++ b/packages/cli-repl/src/cli-repl.ts
@@ -52,6 +52,8 @@ class CliRepl {
     this.serviceProvider = await CliServiceProvider.connect(driverUri, driverOptions);
     this.ShellEvaluator = new ShellEvaluator(this.serviceProvider, this.bus, this);
     this.mdbVersion = await this.serviceProvider.getServerVersion();
+    const connectionInfo = this.getConnectionInfo(driverUri, driverOptions);
+    this.bus.emit('connect', connectionInfo);
     this.start();
   }
 
@@ -73,6 +75,21 @@ class CliRepl {
     } else {
       this.connect(driverUri, driverOptions);
     }
+  }
+
+  // if it's an Atlas connection
+  // if it's a localhost connection
+  // if it's a Data Lake connection
+  // if it's a connection to a server running in one of the public clouds
+  // if it's a connection to a non-genuine MDB
+  // server version
+  // if it's an enterprise service
+  // auth type (SCRAM, Kerberos, LDAP, X.509)
+  getConnectionInfo(uri: string, options: NodeOptions) {
+    const topology = this.serviceProvider.getTopology();
+    console.log(topology)
+    const ATLAS_REGEX = /mongodb.net[:/]/i;
+    const LOCALHOST_REGEX = /localhost/i; 
   }
 
   /**

--- a/packages/cli-repl/src/cli-repl.ts
+++ b/packages/cli-repl/src/cli-repl.ts
@@ -54,7 +54,26 @@ class CliRepl {
     this.serviceProvider = await CliServiceProvider.connect(driverUri, driverOptions);
     this.ShellEvaluator = new ShellEvaluator(this.serviceProvider, this.bus, this);
     this.buildInfo = await this.serviceProvider.buildInfo();
-    const connectInfo = await getConnectInfo(driverUri, this.serviceProvider, this.bus);
+
+    let cmdLineOpts = null;
+    try {
+      cmdLineOpts = await this.serviceProvider.getCmdLineOpts();
+    } catch (e) {
+      // error is thrown here for atlas and DataLake connections.
+      // don't actually throw, as this is only used to log out non-genuine
+      // mongodb connections
+      this.bus.emit('mongodb:error', e)
+    }
+
+    const topology = this.serviceProvider.getTopology();
+
+    const connectInfo = getConnectInfo(
+      driverUri,
+      this.buildInfo,
+      this.cmdLineOpts,
+      topology
+    );
+
     this.bus.emit('connect', connectInfo);
     this.start();
   }

--- a/packages/cli-repl/src/cli-repl.ts
+++ b/packages/cli-repl/src/cli-repl.ts
@@ -1,10 +1,11 @@
 import { CliServiceProvider, NodeOptions } from '@mongosh/service-provider-server';
+import ShellEvaluator from '@mongosh/shell-evaluator';
 import { changeHistory } from '@mongosh/history';
+import getConnectInfo from './connect-info';
 import formatOutput from './format-output';
 import { TELEMETRY } from './constants';
 import repl, { REPLServer } from 'repl';
 import CliOptions from './cli-options';
-import ShellEvaluator from '@mongosh/shell-evaluator';
 import completer from './completer';
 import i18n from '@mongosh/i18n';
 import { ObjectId } from 'bson';
@@ -24,10 +25,6 @@ import { redactPwd } from '.';
  */
 const CONNECTING = 'cli-repl.cli-repl.connecting';
 
-function x () {
-  console.log('cats')
-}
-
 /**
  * The REPL used from the terminal.
  */
@@ -35,6 +32,7 @@ class CliRepl {
   private serviceProvider: CliServiceProvider;
   private ShellEvaluator: ShellEvaluator;
   private buildInfo: any;
+  private cmdLineOpts: any;
   private repl: REPLServer;
   private bus: Nanobus;
   private enableTelemetry: boolean;
@@ -55,9 +53,9 @@ class CliRepl {
 
     this.serviceProvider = await CliServiceProvider.connect(driverUri, driverOptions);
     this.ShellEvaluator = new ShellEvaluator(this.serviceProvider, this.bus, this);
-    // this.buildInfo = await this.serviceProvider.buildInfo();
-    const connectionInfo = this.getConnectionInfo(driverUri, driverOptions);
-    this.bus.emit('connect', connectionInfo);
+    this.buildInfo = await this.serviceProvider.buildInfo();
+    const connectInfo = await getConnectInfo(driverUri, this.serviceProvider, this.bus);
+    this.bus.emit('connect', connectInfo);
     this.start();
   }
 
@@ -78,24 +76,6 @@ class CliRepl {
       this.requirePassword(driverUri, driverOptions);
     } else {
       this.connect(driverUri, driverOptions);
-    }
-  }
-
-  // if it's an Atlas connection
-  // if it's a localhost connection
-  // if it's a Data Lake connection
-  // if it's a connection to a server running in one of the public clouds
-  // if it's a connection to a non-genuine MDB
-  // server version
-  // if it's an enterprise service
-  // auth type (SCRAM, Kerberos, LDAP, X.509)
-  getConnectionInfo(uri: string, options: NodeOptions) {
-    console.log(this.buildInfo)
-    const ATLAS_REGEX = /mongodb.net[:/]/i;
-    const LOCALHOST_REGEX = /(localhost|127\.0\.0\.1)/i;
-    return {
-      isAtlas: !!uri.match(ATLAS_REGEX),
-      isLocalhost: !!uri.match(LOCALHOST_REGEX) 
     }
   }
 

--- a/packages/cli-repl/src/cli-repl.ts
+++ b/packages/cli-repl/src/cli-repl.ts
@@ -205,7 +205,7 @@ class CliRepl {
    */
   greet(): void {
     console.log(`Using MongoDB: ${this.buildInfo.version} \n`);
-    console.log(TELEMETRY);
+    if (!this.disableGreetingMessage) console.log(TELEMETRY);
   }
 
   /**

--- a/packages/cli-repl/src/connect-info.spec.ts
+++ b/packages/cli-repl/src/connect-info.spec.ts
@@ -1,0 +1,112 @@
+import { expect } from 'chai';
+import getConnectInfo from './connect-info';
+
+describe('getConnectInfo', function() {
+  const BUILD_INFO = {
+    'version' : '3.2.0-rc2',
+    'gitVersion' : '8a3acb42742182c5e314636041c2df368232bbc5',
+    'modules' : [
+        'enterprise'
+      ],
+    'allocator' : 'system',
+    'javascriptEngine' : 'mozjs',
+    'sysInfo' : 'deprecated',
+    'versionArray' : [
+        3,
+        2,
+        0,
+        -48
+      ],
+    'openssl' : {
+        'running' : 'OpenSSL 0.9.8zg 14 July 2015',
+        'compiled' : 'OpenSSL 0.9.8y 5 Feb 2013'
+      },
+    'buildEnvironment' : {
+        'distmod' : '',
+        'distarch' : 'x86_64',
+        'cc' : 'gcc: Apple LLVM version 5.1 (clang-503.0.40) (based on LLVM 3.4svn)',
+        'ccflags' : '-fno-omit-frame-pointer -fPIC -fno-strict-aliasing -ggdb -pthread -Wall -Wsign-compare -Wno-unknown-pragmas -Winvalid-pch -Werror -O2 -Wno-unused-function -Wno-unused-private-field -Wno-deprecated-declarations -Wno-tautological-constant-out-of-range-compare -Wno-unused-const-variable -Wno-missing-braces -mmacosx-version-min=10.7 -fno-builtin-memcmp',
+        'cxx' : 'g++: Apple LLVM version 5.1 (clang-503.0.40) (based on LLVM 3.4svn)',
+        'cxxflags' : '-Wnon-virtual-dtor -Woverloaded-virtual -stdlib=libc++ -std=c++11',
+        'linkflags' : '-fPIC -pthread -Wl,-bind_at_load -mmacosx-version-min=10.7 -stdlib=libc++ -fuse-ld=gold',
+        'target_arch' : 'x86_64',
+        'target_os' : 'osx'
+      },
+    'bits' : 64,
+    'debug' : false,
+    'maxBsonObjectSize' : 16777216,
+    'storageEngines' : [
+        'devnull',
+        'ephemeralForTest',
+        'inMemory',
+        'mmapv1',
+        'wiredTiger'
+      ],
+    'ok' : 1
+  };
+
+  const CMD_LINE_OPTS = {
+    'argv' : [
+      '/opt/mongodb-osx-x86_64-enterprise-3.6.3/bin/mongod',
+      '--dbpath=/Users/user/testdata'
+    ],
+    'parsed' : {
+      'storage' : {
+        'dbPath' : '/Users/user/testdata'
+      }
+    },
+    'ok' : 1
+  };
+
+  const TOPOLOGY_WITH_CREDENTIALS = {
+    's': {
+      'credentials': {
+        'mechanism': 'LDAP'
+      }
+    }
+  };
+
+  const TOPOLOGY_NO_CREDENTIALS = {
+    's': {}
+  };
+
+  const ATLAS_URI = 'mongodb+srv://admin:catscatscats@cat-data-sets.cats.mongodb.net/admin';
+
+  it('reports on an enterprise version >=3.2 of mongodb with credentials', function() {
+    const output = {
+      isAtlas: true,
+      isLocalhost: false,
+      serverVersion: '3.2.0-rc2',
+      isEnterprise: true,
+      authType: 'LDAP',
+      isDataLake: false,
+      dlVersion: null,
+      isGenuine: true,
+      serverName: 'mongodb'
+    }
+    expect(getConnectInfo(
+      ATLAS_URI,
+      BUILD_INFO,
+      CMD_LINE_OPTS,
+      TOPOLOGY_WITH_CREDENTIALS)).to.deep.equal(output);
+  });
+
+  it('reports on an enterprise version >=3.2 of mongodb with no credentials', function() {
+    const output = {
+      isAtlas: true,
+      isLocalhost: false,
+      serverVersion: '3.2.0-rc2',
+      isEnterprise: true,
+      authType: null,
+      isDataLake: false,
+      dlVersion: null,
+      isGenuine: true,
+      serverName: 'mongodb'
+    }
+    expect(getConnectInfo(
+      ATLAS_URI,
+      BUILD_INFO,
+      CMD_LINE_OPTS,
+      TOPOLOGY_NO_CREDENTIALS)).to.deep.equal(output);
+  });
+});

--- a/packages/cli-repl/src/connect-info.ts
+++ b/packages/cli-repl/src/connect-info.ts
@@ -1,24 +1,12 @@
-import { CliServiceProvider } from '@mongosh/service-provider-server';
-import getBuildInfo from '../../../../mongodb-build-info';
-import Nanobus from 'nanobus';
+import getBuildInfo from 'mongodb-build-info';
 
-export default async function getConnectInfo(uri: string, serviceProvider: CliServiceProvider, bus: Nanobus) {
-  const buildInfo = await serviceProvider.buildInfo();
-  // wrap in a try/catch since for some connections with no authentication,
-  // cmdLineOpts cannot be run.
-  let cmdLineOpts = undefined;
-  try {
-    cmdLineOpts = await serviceProvider.getCmdLineOpts();
-  } catch (e) {
-    // don't throw this one, as this command is just used for logging
-    // non-genuine mongodb connections.
-    bus.emit('mongodb:error', e)
-  }
-  const topology = serviceProvider.getTopology();
+export default function getConnectInfo(uri: string, buildInfo: any, cmdLineOpts: any, topology: any) {
   const { isGenuine, serverName } =
-    getBuildInfo.isGenuineMongoDB(buildInfo, cmdLineOpts);
-  const { isDataLake, dlVersion } = getBuildInfo.isDataLake(buildInfo);
+    getBuildInfo.getGenuineMongoDB(buildInfo, cmdLineOpts);
+  const { isDataLake, dlVersion } = getBuildInfo.getDataLake(buildInfo);
 
+  // get this information from topology rather than cmdLineOpts, since not all
+  // connections are able to run getCmdLineOpts command
   const authType = topology.s.credentials
     ? topology.s.credentials.mechanism : null;
 

--- a/packages/cli-repl/src/connect-info.ts
+++ b/packages/cli-repl/src/connect-info.ts
@@ -1,0 +1,36 @@
+import { CliServiceProvider } from '@mongosh/service-provider-server';
+import getBuildInfo from '../../../../mongodb-build-info';
+import Nanobus from 'nanobus';
+
+export default async function getConnectInfo(uri: string, serviceProvider: CliServiceProvider, bus: Nanobus) {
+  const buildInfo = await serviceProvider.buildInfo();
+  // wrap in a try/catch since for some connections with no authentication,
+  // cmdLineOpts cannot be run.
+  let cmdLineOpts = undefined;
+  try {
+    cmdLineOpts = await serviceProvider.getCmdLineOpts();
+  } catch (e) {
+    // don't throw this one, as this command is just used for logging
+    // non-genuine mongodb connections.
+    bus.emit('mongodb:error', e)
+  }
+  const topology = serviceProvider.getTopology();
+  const { isGenuine, serverName } =
+    getBuildInfo.isGenuineMongoDB(buildInfo, cmdLineOpts);
+  const { isDataLake, dlVersion } = getBuildInfo.isDataLake(buildInfo);
+
+  const authType = topology.s.credentials
+    ? topology.s.credentials.mechanism : null;
+
+  return {
+    isAtlas: getBuildInfo.isAtlas(uri),
+    isLocalhost: getBuildInfo.isLocalhost(uri),
+    serverVersion: buildInfo.version,
+    isEnterprise: getBuildInfo.isEnterprise(buildInfo),
+    authType,
+    isDataLake,
+    dlVersion,
+    isGenuine,
+    serverName 
+  }
+}

--- a/packages/service-provider-browser/src/stitch-service-provider-browser.ts
+++ b/packages/service-provider-browser/src/stitch-service-provider-browser.ts
@@ -189,8 +189,8 @@ class StitchServiceProviderBrowser implements ServiceProvider {
     throw new Error("Method not implemented.");
   }
 
-  getServerVersion(): Promise<string> {
-    throw new Error("Method not implemented.");
+  buildInfo(): Promise<string> {
+    throw new Error('Method not implemented.');
   }
 
   listDatabases(database: string): Promise<any> {

--- a/packages/service-provider-browser/src/stitch-service-provider-browser.ts
+++ b/packages/service-provider-browser/src/stitch-service-provider-browser.ts
@@ -189,7 +189,11 @@ class StitchServiceProviderBrowser implements ServiceProvider {
     throw new Error("Method not implemented.");
   }
 
-  buildInfo(): Promise<string> {
+  getCmdLineOpts(): Promise<Result> {
+    throw new Error('Method not implemented.');
+  }
+
+  buildInfo(): Promise<Result> {
     throw new Error('Method not implemented.');
   }
 

--- a/packages/service-provider-browser/src/stitch-service-provider-browser.ts
+++ b/packages/service-provider-browser/src/stitch-service-provider-browser.ts
@@ -193,6 +193,10 @@ class StitchServiceProviderBrowser implements ServiceProvider {
     throw new Error('Method not implemented.');
   }
 
+  getTopology(): any {
+    throw new Error('Method not implemented.');
+  }
+
   buildInfo(): Promise<Result> {
     throw new Error('Method not implemented.');
   }

--- a/packages/service-provider-core/src/admin.ts
+++ b/packages/service-provider-core/src/admin.ts
@@ -2,11 +2,18 @@ import Result from "./result";
 
 export default interface Admin {
    /**
-   * Returns the server version.
+   * Returns buildInfo.
+   *
+   * @returns {Promise} buildInfo object.
+   */
+  buildInfo(): Promise<Result>;
+
+  /**
+   * Returns the cmdLineOpts.
    *
    * @returns {Promise} The server version.
    */
-  getServerVersion(): Promise<string>;
+  getCmdLineOpts(): Promise<Result>;
 
   /**
    * list databases.

--- a/packages/service-provider-core/src/readable.ts
+++ b/packages/service-provider-core/src/readable.ts
@@ -139,6 +139,13 @@ interface Readable {
    *
    * @returns {Promise} The server version.
    */
+  getTopology(): any;
+
+  /**
+   * Returns the server version.
+   *
+   * @returns {Promise} The server version.
+   */
   buildInfo(): Promise<Result>;
 
   /**

--- a/packages/service-provider-core/src/readable.ts
+++ b/packages/service-provider-core/src/readable.ts
@@ -135,6 +135,22 @@ interface Readable {
     dbOptions?: DatabaseOptions) : Cursor;
 
   /**
+   * Returns the server version.
+   *
+   * @returns {Promise} The server version.
+   */
+  buildInfo(): Promise<string>;
+
+  /**
+   * list databases.
+   *
+   * @param {String} database - The database name.
+   *
+   * @returns {Promise} The promise of command results.
+   */
+  listDatabases(database: string): Promise<Result>;
+
+  /**
    * Is the collection capped?
    *
    * @param {String} database - The database name.

--- a/packages/service-provider-core/src/readable.ts
+++ b/packages/service-provider-core/src/readable.ts
@@ -139,7 +139,14 @@ interface Readable {
    *
    * @returns {Promise} The server version.
    */
-  buildInfo(): Promise<string>;
+  buildInfo(): Promise<Result>;
+
+  /**
+   * Returns the cmdLineOpts.
+   *
+   * @returns {Promise} The server version.
+   */
+  getCmdLineOpts(): Promise<Result>;
 
   /**
    * list databases.

--- a/packages/service-provider-core/src/readable.ts
+++ b/packages/service-provider-core/src/readable.ts
@@ -142,20 +142,6 @@ interface Readable {
   getTopology(): any;
 
   /**
-   * Returns the server version.
-   *
-   * @returns {Promise} The server version.
-   */
-  buildInfo(): Promise<Result>;
-
-  /**
-   * Returns the cmdLineOpts.
-   *
-   * @returns {Promise} The server version.
-   */
-  getCmdLineOpts(): Promise<Result>;
-
-  /**
    * list databases.
    *
    * @param {String} database - The database name.

--- a/packages/service-provider-server/src/cli-service-provider.integration.spec.ts
+++ b/packages/service-provider-server/src/cli-service-provider.integration.spec.ts
@@ -336,16 +336,16 @@ describe('CliServiceProvider [integration]', function() {
     });
   });
 
-  describe('#getServerVersion', () => {
+  describe('#buildInfo', () => {
     context('when the filter is empty', () => {
       let result;
 
       beforeEach(async() => {
-        result = await serviceProvider.getServerVersion();
+        result = await serviceProvider.buildInfo();
       });
 
       it('returns a semver', () => {
-        expect(result).to.match(/^\d+.\d+/);
+        expect(result.version).to.match(/^\d+.\d+/);
       });
     });
   });

--- a/packages/service-provider-server/src/cli-service-provider.spec.ts
+++ b/packages/service-provider-server/src/cli-service-provider.spec.ts
@@ -468,7 +468,7 @@ describe('CliServiceProvider', () => {
     });
   });
 
-  describe('#getServerVersion', () => {
+  describe('#buildInfo', () => {
     let commandMock;
     let dbMock;
     let clientStub: MongoClient;
@@ -494,8 +494,8 @@ describe('CliServiceProvider', () => {
     });
 
     it('executes the command against the admin database', async() => {
-      const result = await serviceProvider.getServerVersion();
-      expect(result).to.deep.equal('4.0.0');
+      const result = await serviceProvider.buildInfo();
+      expect(result.version).to.deep.equal('4.0.0');
       dbMock.verify();
       commandMock.verify();
     });

--- a/packages/service-provider-server/src/cli-service-provider.spec.ts
+++ b/packages/service-provider-server/src/cli-service-provider.spec.ts
@@ -473,10 +473,17 @@ describe('CliServiceProvider', () => {
     let dbMock;
     let clientStub: MongoClient;
 
+    const buildInfoResult = {
+      version: '4.0.0',
+      gitVersion: 'a4b751dcf51dd249c5865812b390cfd1c0129c30',
+      javascriptEngine: 'mozjs',
+      versionArray: [4, 0, 0, 0],
+    };
+
     beforeEach(() => {
       commandMock = sinon.mock()
         .withArgs({ buildInfo: 1 }, {})
-        .resolves({ version: '4.0.0' });
+        .resolves(buildInfoResult);
 
       const dbStub = sinon.createStubInstance(Db, {
         command: commandMock
@@ -495,7 +502,53 @@ describe('CliServiceProvider', () => {
 
     it('executes the command against the admin database', async() => {
       const result = await serviceProvider.buildInfo();
-      expect(result.version).to.deep.equal('4.0.0');
+      expect(result).to.deep.equal(buildInfoResult);
+      dbMock.verify();
+      commandMock.verify();
+    });
+  });
+
+  describe('#getCmdLineOpts', () => {
+    let commandMock;
+    let dbMock;
+    let clientStub: MongoClient;
+
+    const cmdLineOptsResult = {
+      argv: [
+        '/opt/mongodb-osx-x86_64-enterprise-3.6.3/bin/mongod',
+        '--dbpath=/Users/user/testdata'
+      ],
+      parsed: {
+        storage: {
+          dbPath: '/Users/user/testdata'
+        }
+      },
+      ok: 1
+    };
+
+    beforeEach(() => {
+      commandMock = sinon.mock()
+        .withArgs({ getCmdLineOpts: 1 }, {})
+        .resolves(cmdLineOptsResult);
+
+      const dbStub = sinon.createStubInstance(Db, {
+        command: commandMock
+      });
+
+      dbMock = sinon.mock()
+        .withArgs('admin')
+        .returns(dbStub);
+
+      clientStub = sinon.createStubInstance(MongoClient, {
+        db: dbMock
+      });
+
+      serviceProvider = new CliServiceProvider(clientStub);
+    });
+
+    it('executes getCmdLineOpts against an admin db', async() => {
+      const result = await serviceProvider.getCmdLineOpts();
+      expect(result).to.deep.equal(cmdLineOptsResult);
       dbMock.verify();
       commandMock.verify();
     });

--- a/packages/service-provider-server/src/cli-service-provider.ts
+++ b/packages/service-provider-server/src/cli-service-provider.ts
@@ -710,6 +710,10 @@ class CliServiceProvider implements ServiceProvider {
       .updateOne(filter, update, options);
   }
 
+  getTopology(): any {
+    return this.mongoClient.topology;
+  }
+
   /**
    * Returns the server version.
    *

--- a/packages/service-provider-server/src/cli-service-provider.ts
+++ b/packages/service-provider-server/src/cli-service-provider.ts
@@ -710,18 +710,37 @@ class CliServiceProvider implements ServiceProvider {
       .updateOne(filter, update, options);
   }
 
+  getTopology(): any {
+    return this.mongoClient.topology;
+  }
+
   /**
    * Return buildInfo.
    *
    * @returns {Promise} buildInfo.
    */
-  async buildInfo(): Promise<string> {
+  async buildInfo(): Promise<Result> {
     const result: any = await this.runCommand(
       'admin',
       {
         buildInfo: 1
       },
       {}
+    );
+
+    if (!result) return;
+
+    return result;
+  }
+
+  /**
+   * Return cmdLineOpts.
+   *
+   * @returns {Promise} buildInfo.
+   */
+  async getCmdLineOpts(): Promise<Result> {
+    const result: any = await this.runCommand(
+      'admin', { getCmdLineOpts: 1 }, {}
     );
 
     if (!result) return;

--- a/packages/service-provider-server/src/cli-service-provider.ts
+++ b/packages/service-provider-server/src/cli-service-provider.ts
@@ -710,16 +710,12 @@ class CliServiceProvider implements ServiceProvider {
       .updateOne(filter, update, options);
   }
 
-  getTopology(): any {
-    return this.mongoClient.topology;
-  }
-
   /**
-   * Returns the server version.
+   * Return buildInfo.
    *
-   * @returns {Promise} The server version.
+   * @returns {Promise} buildInfo.
    */
-  async getServerVersion(): Promise<string> {
+  async buildInfo(): Promise<string> {
     const result: any = await this.runCommand(
       'admin',
       {
@@ -728,11 +724,9 @@ class CliServiceProvider implements ServiceProvider {
       {}
     );
 
-    if (!result) {
-      return;
-    }
+    if (!result) return;
 
-    return result.version;
+    return result;
   }
 
   /**

--- a/packages/service-provider-server/src/cli-service-provider.ts
+++ b/packages/service-provider-server/src/cli-service-provider.ts
@@ -710,6 +710,11 @@ class CliServiceProvider implements ServiceProvider {
       .updateOne(filter, update, options);
   }
 
+  /**
+   * Return current topology.
+   *
+   * @returns {Promise} topology.
+   */
   getTopology(): any {
     return this.mongoClient.topology;
   }


### PR DESCRIPTION
## Description
Adds more detailed information about the current connection:
```
{
  isAtlas: true,
  isLocalhost: false,
  serverVersion: '4.2.6',
  isEnterprise: true,
  authType: 'scram-sha-1',
  isDataLake: false,
  dlVersion: null,
  isGenuine: true,
  serverName: 'mongodb'
}
```
Uses [mongodb-build-info](https://github.com/mongodb-js/mongodb-build-info) to determine whether a connection is `DataLake` or a `GenuineMongoDB`. (there is also [a ticket](https://jira.mongodb.org/browse/COMPASS-4260) to use this module in compass)

Adds three more methods to service-provider-server:
- __buildInfo:__ replacement for `getServerVersion`. Returns the whole of `buildInfo` that we then use to extract connection information from.
- __getTopology:__ returns current topology property on CliServiceProvider's `mongoClient`.
- __getCmdLineOpts:__ returns `cmdLineOpts`.