### PR TITLE
feat: initial explainable

### DIFF
--- a/packages/i18n/src/locales/en_US.js
+++ b/packages/i18n/src/locales/en_US.js
@@ -986,6 +986,12 @@ const translations = {
               example: 'db.collection.runCommand("text", { search: "searchKeywords" })',
               parameters: {}
             },
+            explain: {
+              link: 'https://docs.mongodb.com/manual/reference/method/db.collection.explain',
+              description: 'Returns information on the query plan.',
+              example: 'db.collection.explain().<method(...)>',
+              parameters: {}
+            },
             updateOne: {
               link: 'https://docs.mongodb.com/manual/reference/method/db.collection.updateOne',
               description: 'Updates a single document within the collection based on the filter.',
@@ -1099,6 +1105,31 @@ const translations = {
               link: 'https://docs.mongodb.com/manual/reference/method/db.getCollectionNames',
               description: 'Returns an array containing the names of all collections in the current database.',
               example: 'db.getCollectionNames',
+              parameters: {}
+            }
+          }
+        }
+      },
+      Explainable: {
+        help: {
+          description: 'Explainable Class',
+          attributes: {
+            getCollection: {
+              link: '',
+              description: 'Returns the explainable collection.',
+              example: 'db.coll.explain().getCollection()',
+              parameters: {}
+            },
+            getVerbosity: {
+              link: '',
+              description: 'Returns the explainable verbosity.',
+              example: 'db.coll.explain().getVerbosity()',
+              parameters: {}
+            },
+            setVerbosity: {
+              link: '',
+              description: 'Sets the explainable verbosity.',
+              example: 'db.coll.explain().setVerbosity("queryPlanner")',
               parameters: {}
             }
           }

--- a/packages/mapper/package.json
+++ b/packages/mapper/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@mongosh/service-provider-core": "^0.0.1-alpha.12",
     "@mongosh/shell-api": "^0.0.1-alpha.12",
+    "@mongosh/errors": "^0.0.1-alpha.12",
     "pretty-bytes": "^5.3.0",
     "text-table": "^0.2.0"
   },

--- a/packages/mapper/src/mapper.spec.ts
+++ b/packages/mapper/src/mapper.spec.ts
@@ -238,7 +238,7 @@ coll2`;
           ).catch(e => e);
 
           expect(error).to.be.instanceOf(Error);
-          expect(error.message).to.equal('options must be an object');
+          expect(error.message).to.equal('The "options" argument must be an object.');
         });
       });
     });
@@ -281,7 +281,7 @@ coll2`;
             ).catch(e => e);
 
             expect(error).to.be.instanceOf(Error);
-            expect(error.message).to.equal('options must be an object');
+            expect(error.message).to.equal('The "options" argument must be an object.');
           });
         });
       });
@@ -407,7 +407,7 @@ coll2`;
           await mapper.collection_dropIndex(collection, '*').catch(err => { catched = err; });
 
           expect(catched.message).to.equal(
-            'To drop indexes in the collection using \'*\', use db.collection.dropIndexes()'
+            'To drop indexes in the collection using \'*\', use db.collection.dropIndexes().'
           );
         });
 
@@ -416,7 +416,7 @@ coll2`;
           await mapper.collection_dropIndex(collection, ['index-1']).catch(err => { catched = err; });
 
           expect(catched.message).to.equal(
-            'The index to drop must be either the index name or the index specification document'
+            'The index to drop must be either the index name or the index specification document.'
           );
         });
       });
@@ -440,7 +440,7 @@ coll2`;
           .catch(err => { catched = err; });
 
         expect(catched.message).to.equal(
-          'totalIndexSize takes no argument. Use db.collection.stats to get detailed information.'
+          '"totalIndexSize" takes no argument. Use db.collection.stats to get detailed information.'
         );
       });
     });
@@ -663,7 +663,7 @@ coll2`;
           (await mapper.collection_renameCollection(
             collection, {} as any
           ).catch(e => e)).message
-        ).to.equal('newName must be a string');
+        ).to.equal('The "newName" argument must be a string.');
       });
     });
 
@@ -698,7 +698,7 @@ coll2`;
           (await mapper.collection_runCommand(
             collection, {} as any
           ).catch(e => e)).message
-        ).to.equal('commandName must be a string');
+        ).to.equal('The "commandName" argument must be a string.');
       });
 
       it('throws an error if commandName is passed as option', async() => {
@@ -706,7 +706,7 @@ coll2`;
           (await mapper.collection_runCommand(
             collection, 'commandName', { commandName: 1 } as any
           ).catch(e => e)).message
-        ).to.equal('commandName cannot be passed as an option');
+        ).to.equal('The "commandName" argument cannot be passed as an option to "runCommand".');
       });
     });
 
@@ -732,7 +732,7 @@ coll2`;
       it('throws in case of non valid verbosity', () => {
         expect(() => {
           mapper.collection_explain(collection, 'badVerbosityArgument');
-        }).to.throw('verbosity can only be one of queryPlanner, executionStats, allPlansExecution');
+        }).to.throw('verbosity can only be one of queryPlanner, executionStats, allPlansExecution. Received badVerbosityArgument.');
       });
 
       it('sets the right default verbosity', () => {
@@ -808,7 +808,7 @@ coll2`;
       it('validates the verbosity', () => {
         expect(() => {
           mapper.explainable_setVerbosity(explainable, 'badVerbosityArgument');
-        }).to.throw('verbosity can only be one of queryPlanner, executionStats, allPlansExecution');
+        }).to.throw('verbosity can only be one of queryPlanner, executionStats, allPlansExecution. Received badVerbosityArgument.');
       });
     });
   });

--- a/packages/mapper/src/mapper.ts
+++ b/packages/mapper/src/mapper.ts
@@ -76,7 +76,7 @@ export default class Mapper {
         ];
 
         const err = new MongoshInvalidInputError(
-          `'${arg}' is not a valid argument for show. Valid arguments are: ${validArguments.join(', ')}`
+          `'${arg}' is not a valid argument for "show".\nValid arguments are: ${validArguments.join(', ')}`
         );
 
         this.messageBus.emit('mongosh:error', err);
@@ -94,7 +94,7 @@ export default class Mapper {
     const result = await this.serviceProvider.listDatabases('admin');
 
     if (!('databases' in result)) {
-      const err = new MongoshInternalError('invalid result from listDatabases');
+      const err = new MongoshInternalError('Got invalid result from "listDatabases"');
       this.messageBus.emit('mongosh:error', err);
       throw err;
     }
@@ -564,7 +564,7 @@ export default class Mapper {
     dropTarget?: boolean
   ): Promise<any> {
     if (typeof newName !== 'string') {
-      throw new MongoshInvalidInputError('newName must be a string');
+      throw new MongoshInvalidInputError('The "newName" argument must be a string.');
     }
 
     try {
@@ -1188,7 +1188,7 @@ export default class Mapper {
     const coll = collection._name;
 
     if (typeof options !== 'object' || Array.isArray(options)) {
-      throw new MongoshInvalidInputError('options must be an object');
+      throw new MongoshInvalidInputError('The "options" argument must be an object.');
     }
 
     const specs = keyPatterns.map((pattern) => ({
@@ -1432,11 +1432,11 @@ export default class Mapper {
     );
 
     if (index === '*') {
-      throw new MongoshInvalidInputError('To drop indexes in the collection using \'*\', use db.collection.dropIndexes()');
+      throw new MongoshInvalidInputError('To drop indexes in the collection using \'*\', use db.collection.dropIndexes().');
     }
 
     if (Array.isArray(index)) {
-      throw new MongoshInvalidInputError('The index to drop must be either the index name or the index specification document');
+      throw new MongoshInvalidInputError('The index to drop must be either the index name or the index specification document.');
     }
 
     return await this.collection_dropIndexes(collection, index);
@@ -1520,7 +1520,7 @@ export default class Mapper {
 
     if (args.length) {
       throw new MongoshInvalidInputError(
-        'totalIndexSize takes no argument. Use db.collection.stats to get detailed information.'
+        '"totalIndexSize" takes no argument. Use db.collection.stats to get detailed information.'
       );
     }
 
@@ -1765,11 +1765,11 @@ export default class Mapper {
     options?: Record<string, any>
   ): Promise<any> {
     if (typeof commandName !== 'string') {
-      throw new MongoshInvalidInputError('commandName must be a string');
+      throw new MongoshInvalidInputError('The "commandName" argument must be a string.');
     }
 
     if (options && commandName in options) {
-      throw new MongoshInvalidInputError('commandName cannot be passed as an option');
+      throw new MongoshInvalidInputError('The "commandName" argument cannot be passed as an option to "runCommand".');
     }
 
     this.messageBus.emit(
@@ -1801,7 +1801,7 @@ export default class Mapper {
 
     if (!allowedVerbosity.includes(verbosity)) {
       throw new MongoshInvalidInputError(
-        `verbosity can only be one of ${allowedVerbosity.join(', ')}`
+        `verbosity can only be one of ${allowedVerbosity.join(', ')}. Received ${verbosity}.`
       );
     }
   }

--- a/packages/shell-api/src/collection.spec.ts
+++ b/packages/shell-api/src/collection.spec.ts
@@ -72,7 +72,8 @@ describe('Collection', () => {
     'drop',
     'exists',
     'getFullName',
-    'getName'
+    'getName',
+    'explain'
   ].forEach((methodName) => {
     describe(`#${methodName}`, () => {
       it(`wraps mapper.collection_${methodName}`, () => {

--- a/packages/shell-api/src/explainable.spec.ts
+++ b/packages/shell-api/src/explainable.spec.ts
@@ -1,0 +1,57 @@
+import sinon from 'sinon';
+import Mapper from '../../mapper/lib';
+import { Collection, Database, Explainable } from './shell-api';
+import * as signatures from './shell-api-signatures';
+import { expect } from 'chai';
+
+/**
+ * Test that an explainable method proxies the respective Mapper method correctly,
+ * with the right arguments and returning the right result.
+ *
+ * It ensures:
+ * - that the method is defined in the shell api and that is meant to be a function
+ * - that the mapper method to be proxied to exists
+ * - that the mapper method is called with an explainable as first argument and with
+ *   the rest of invokation arguments.
+ * - that the result of mapper invokation is returned.
+ *
+ * @param {String} name - the name of the method to invoke
+ */
+function testWrappedMethod(name: string): void {
+  const attribute = signatures.Explainable.attributes[name];
+  expect(attribute).to.exist;
+  expect(attribute.type).to.equal('function');
+
+  const mock = sinon.mock();
+  const mapper: Mapper = sinon.createStubInstance(Mapper, {
+    [`explainable_${name}`]: mock
+  });
+
+  const args = [1, 2, 3];
+  const retVal = {};
+
+  const database = new Database('db1');
+  const collection = new Collection(mapper, database, 'coll1');
+  const explainable = new Explainable(mapper, collection);
+
+  mock.withArgs(explainable, ...args).returns(retVal);
+
+  const result = explainable[name](...args);
+  mock.verify();
+
+  expect(result).to.equal(retVal);
+}
+
+describe('Explainable', () => {
+  [
+    'getCollection',
+    'getVerbosity',
+    'setVerbosity'
+  ].forEach((methodName) => {
+    describe(`#${methodName}`, () => {
+      it(`wraps mapper.collection_${methodName}`, () => {
+        testWrappedMethod(methodName);
+      });
+    });
+  });
+});

--- a/packages/shell-api/src/shell-api-signatures.js
+++ b/packages/shell-api/src/shell-api-signatures.js
@@ -74,7 +74,8 @@ const Collection = {
     getName: { type: 'function', returnsPromise: false, returnType: 'unknown', serverVersions: ['0.0.0', '4.4.0'] },
     exists: { type: 'function', returnsPromise: true, returnType: 'unknown', serverVersions: ['0.0.0', '4.4.0'] },
     renameCollection: { type: 'function', returnsPromise: true, returnType: 'unknown', serverVersions: ['0.0.0', '4.4.0'] },
-    runCommand: { type: 'function', returnsPromise: true, returnType: 'unknown', serverVersions: ['0.0.0', '4.4.0'] }
+    runCommand: { type: 'function', returnsPromise: true, returnType: 'unknown', serverVersions: ['0.0.0', '4.4.0'] },
+    explain: { type: 'function', returnsPromise: false, returnType: 'Explainable', serverVersions: ['0.0.0', '4.4.0'] }
   }
 };
 const CommandResult = {
@@ -138,6 +139,15 @@ const DeleteResult = {
 
   }
 };
+const Explainable = {
+  type: 'Explainable',
+  hasAsyncChild: false,
+  attributes: {
+    getCollection: { type: 'function', returnsPromise: false, returnType: 'Collection', serverVersions: ['0.0.0', '4.4.0'] },
+    getVerbosity: { type: 'function', returnsPromise: false, returnType: 'unknown', serverVersions: ['0.0.0', '4.4.0'] },
+    setVerbosity: { type: 'function', returnsPromise: false, returnType: 'unknown', serverVersions: ['0.0.0', '4.4.0'] }
+  }
+};
 const InsertManyResult = {
   type: 'InsertManyResult',
   hasAsyncChild: false,
@@ -182,6 +192,7 @@ export {
   Cursor,
   Database,
   DeleteResult,
+  Explainable,
   InsertManyResult,
   InsertOneResult,
   ReplicaSet,

--- a/packages/shell-api/src/shell-api.js
+++ b/packages/shell-api/src/shell-api.js
@@ -147,7 +147,7 @@ class Collection {
     this.shellApiType = () => {
       return 'Collection';
     };
-    this.help = () => new Help({ 'help': 'shell-api.classes.Collection.help.description', 'docs': 'shell-api.classes.Collection.help.link', 'attr': [{ 'name': 'aggregate', 'description': 'shell-api.classes.Collection.help.attributes.aggregate.description' }, { 'name': 'bulkWrite', 'description': 'shell-api.classes.Collection.help.attributes.bulkWrite.description' }, { 'name': 'countDocuments', 'description': 'shell-api.classes.Collection.help.attributes.countDocuments.description' }, { 'name': 'count', 'description': 'shell-api.classes.Collection.help.attributes.count.description' }, { 'name': 'deleteMany', 'description': 'shell-api.classes.Collection.help.attributes.deleteMany.description' }, { 'name': 'deleteOne', 'description': 'shell-api.classes.Collection.help.attributes.deleteOne.description' }, { 'name': 'distinct', 'description': 'shell-api.classes.Collection.help.attributes.distinct.description' }, { 'name': 'estimatedDocumentCount', 'description': 'shell-api.classes.Collection.help.attributes.estimatedDocumentCount.description' }, { 'name': 'find', 'description': 'shell-api.classes.Collection.help.attributes.find.description' }, { 'name': 'findAndModify', 'description': 'shell-api.classes.Collection.help.attributes.findAndModify.description' }, { 'name': 'findOne', 'description': 'shell-api.classes.Collection.help.attributes.findOne.description' }, { 'name': 'findOneAndDelete', 'description': 'shell-api.classes.Collection.help.attributes.findOneAndDelete.description' }, { 'name': 'findOneAndReplace', 'description': 'shell-api.classes.Collection.help.attributes.findOneAndReplace.description' }, { 'name': 'findOneAndUpdate', 'description': 'shell-api.classes.Collection.help.attributes.findOneAndUpdate.description' }, { 'name': 'insert', 'description': 'shell-api.classes.Collection.help.attributes.insert.description' }, { 'name': 'insertMany', 'description': 'shell-api.classes.Collection.help.attributes.insertMany.description' }, { 'name': 'insertOne', 'description': 'shell-api.classes.Collection.help.attributes.insertOne.description' }, { 'name': 'isCapped', 'description': 'shell-api.classes.Collection.help.attributes.isCapped.description' }, { 'name': 'remove', 'description': 'shell-api.classes.Collection.help.attributes.remove.description' }, { 'name': 'save', 'description': 'shell-api.classes.Collection.help.attributes.save.description' }, { 'name': 'replaceOne', 'description': 'shell-api.classes.Collection.help.attributes.replaceOne.description' }, { 'name': 'update', 'description': 'shell-api.classes.Collection.help.attributes.update.description' }, { 'name': 'updateMany', 'description': 'shell-api.classes.Collection.help.attributes.updateMany.description' }, { 'name': 'updateOne', 'description': 'shell-api.classes.Collection.help.attributes.updateOne.description' }, { 'name': 'convertToCapped', 'description': 'shell-api.classes.Collection.help.attributes.convertToCapped.description' }, { 'name': 'createIndexes', 'description': 'shell-api.classes.Collection.help.attributes.createIndexes.description' }, { 'name': 'createIndex', 'description': 'shell-api.classes.Collection.help.attributes.createIndex.description' }, { 'name': 'ensureIndex', 'description': 'shell-api.classes.Collection.help.attributes.ensureIndex.description' }, { 'name': 'getIndexes', 'description': 'shell-api.classes.Collection.help.attributes.getIndexes.description' }, { 'name': 'getIndexSpecs', 'description': 'shell-api.classes.Collection.help.attributes.getIndexSpecs.description' }, { 'name': 'getIndexKeys', 'description': 'shell-api.classes.Collection.help.attributes.getIndexKeys.description' }, { 'name': 'getIndices', 'description': 'shell-api.classes.Collection.help.attributes.getIndices.description' }, { 'name': 'dropIndexes', 'description': 'shell-api.classes.Collection.help.attributes.dropIndexes.description' }, { 'name': 'dropIndex', 'description': 'shell-api.classes.Collection.help.attributes.dropIndex.description' }, { 'name': 'reIndex', 'description': 'shell-api.classes.Collection.help.attributes.reIndex.description' }, { 'name': 'totalIndexSize', 'description': 'shell-api.classes.Collection.help.attributes.totalIndexSize.description' }, { 'name': 'getDB', 'description': 'shell-api.classes.Collection.help.attributes.getDB.description' }, { 'name': 'stats', 'description': 'shell-api.classes.Collection.help.attributes.stats.description' }, { 'name': 'dataSize', 'description': 'shell-api.classes.Collection.help.attributes.dataSize.description' }, { 'name': 'storageSize', 'description': 'shell-api.classes.Collection.help.attributes.storageSize.description' }, { 'name': 'totalSize', 'description': 'shell-api.classes.Collection.help.attributes.totalSize.description' }, { 'name': 'drop', 'description': 'shell-api.classes.Collection.help.attributes.drop.description' }, { 'name': 'getFullName', 'description': 'shell-api.classes.Collection.help.attributes.getFullName.description' }, { 'name': 'getName', 'description': 'shell-api.classes.Collection.help.attributes.getName.description' }, { 'name': 'exists', 'description': 'shell-api.classes.Collection.help.attributes.exists.description' }, { 'name': 'renameCollection', 'description': 'shell-api.classes.Collection.help.attributes.renameCollection.description' }, { 'name': 'runCommand', 'description': 'shell-api.classes.Collection.help.attributes.runCommand.description' }] });
+    this.help = () => new Help({ 'help': 'shell-api.classes.Collection.help.description', 'docs': 'shell-api.classes.Collection.help.link', 'attr': [{ 'name': 'aggregate', 'description': 'shell-api.classes.Collection.help.attributes.aggregate.description' }, { 'name': 'bulkWrite', 'description': 'shell-api.classes.Collection.help.attributes.bulkWrite.description' }, { 'name': 'countDocuments', 'description': 'shell-api.classes.Collection.help.attributes.countDocuments.description' }, { 'name': 'count', 'description': 'shell-api.classes.Collection.help.attributes.count.description' }, { 'name': 'deleteMany', 'description': 'shell-api.classes.Collection.help.attributes.deleteMany.description' }, { 'name': 'deleteOne', 'description': 'shell-api.classes.Collection.help.attributes.deleteOne.description' }, { 'name': 'distinct', 'description': 'shell-api.classes.Collection.help.attributes.distinct.description' }, { 'name': 'estimatedDocumentCount', 'description': 'shell-api.classes.Collection.help.attributes.estimatedDocumentCount.description' }, { 'name': 'find', 'description': 'shell-api.classes.Collection.help.attributes.find.description' }, { 'name': 'findAndModify', 'description': 'shell-api.classes.Collection.help.attributes.findAndModify.description' }, { 'name': 'findOne', 'description': 'shell-api.classes.Collection.help.attributes.findOne.description' }, { 'name': 'findOneAndDelete', 'description': 'shell-api.classes.Collection.help.attributes.findOneAndDelete.description' }, { 'name': 'findOneAndReplace', 'description': 'shell-api.classes.Collection.help.attributes.findOneAndReplace.description' }, { 'name': 'findOneAndUpdate', 'description': 'shell-api.classes.Collection.help.attributes.findOneAndUpdate.description' }, { 'name': 'insert', 'description': 'shell-api.classes.Collection.help.attributes.insert.description' }, { 'name': 'insertMany', 'description': 'shell-api.classes.Collection.help.attributes.insertMany.description' }, { 'name': 'insertOne', 'description': 'shell-api.classes.Collection.help.attributes.insertOne.description' }, { 'name': 'isCapped', 'description': 'shell-api.classes.Collection.help.attributes.isCapped.description' }, { 'name': 'remove', 'description': 'shell-api.classes.Collection.help.attributes.remove.description' }, { 'name': 'save', 'description': 'shell-api.classes.Collection.help.attributes.save.description' }, { 'name': 'replaceOne', 'description': 'shell-api.classes.Collection.help.attributes.replaceOne.description' }, { 'name': 'update', 'description': 'shell-api.classes.Collection.help.attributes.update.description' }, { 'name': 'updateMany', 'description': 'shell-api.classes.Collection.help.attributes.updateMany.description' }, { 'name': 'updateOne', 'description': 'shell-api.classes.Collection.help.attributes.updateOne.description' }, { 'name': 'convertToCapped', 'description': 'shell-api.classes.Collection.help.attributes.convertToCapped.description' }, { 'name': 'createIndexes', 'description': 'shell-api.classes.Collection.help.attributes.createIndexes.description' }, { 'name': 'createIndex', 'description': 'shell-api.classes.Collection.help.attributes.createIndex.description' }, { 'name': 'ensureIndex', 'description': 'shell-api.classes.Collection.help.attributes.ensureIndex.description' }, { 'name': 'getIndexes', 'description': 'shell-api.classes.Collection.help.attributes.getIndexes.description' }, { 'name': 'getIndexSpecs', 'description': 'shell-api.classes.Collection.help.attributes.getIndexSpecs.description' }, { 'name': 'getIndexKeys', 'description': 'shell-api.classes.Collection.help.attributes.getIndexKeys.description' }, { 'name': 'getIndices', 'description': 'shell-api.classes.Collection.help.attributes.getIndices.description' }, { 'name': 'dropIndexes', 'description': 'shell-api.classes.Collection.help.attributes.dropIndexes.description' }, { 'name': 'dropIndex', 'description': 'shell-api.classes.Collection.help.attributes.dropIndex.description' }, { 'name': 'reIndex', 'description': 'shell-api.classes.Collection.help.attributes.reIndex.description' }, { 'name': 'totalIndexSize', 'description': 'shell-api.classes.Collection.help.attributes.totalIndexSize.description' }, { 'name': 'getDB', 'description': 'shell-api.classes.Collection.help.attributes.getDB.description' }, { 'name': 'stats', 'description': 'shell-api.classes.Collection.help.attributes.stats.description' }, { 'name': 'dataSize', 'description': 'shell-api.classes.Collection.help.attributes.dataSize.description' }, { 'name': 'storageSize', 'description': 'shell-api.classes.Collection.help.attributes.storageSize.description' }, { 'name': 'totalSize', 'description': 'shell-api.classes.Collection.help.attributes.totalSize.description' }, { 'name': 'drop', 'description': 'shell-api.classes.Collection.help.attributes.drop.description' }, { 'name': 'getFullName', 'description': 'shell-api.classes.Collection.help.attributes.getFullName.description' }, { 'name': 'getName', 'description': 'shell-api.classes.Collection.help.attributes.getName.description' }, { 'name': 'exists', 'description': 'shell-api.classes.Collection.help.attributes.exists.description' }, { 'name': 'renameCollection', 'description': 'shell-api.classes.Collection.help.attributes.renameCollection.description' }, { 'name': 'runCommand', 'description': 'shell-api.classes.Collection.help.attributes.runCommand.description' }, { 'name': 'explain', 'description': 'shell-api.classes.Collection.help.attributes.explain.description' }] });
   }
 
   aggregate(...args) {
@@ -336,6 +336,10 @@ class Collection {
 
   runCommand(...args) {
     return this._mapper.collection_runCommand(this, ...args);
+  }
+
+  explain(...args) {
+    return this._mapper.collection_explain(this, ...args);
   }
 }
 
@@ -621,6 +625,12 @@ Collection.prototype.runCommand.serverVersions = ['0.0.0', '4.4.0'];
 Collection.prototype.runCommand.topologies = [0, 1, 2];
 Collection.prototype.runCommand.returnsPromise = true;
 Collection.prototype.runCommand.returnType = 'unknown';
+
+Collection.prototype.explain.help = () => new Help({ 'help': 'shell-api.classes.Collection.help.attributes.explain.example', 'docs': 'shell-api.classes.Collection.help.attributes.explain.link', 'attr': [{ 'description': 'shell-api.classes.Collection.help.attributes.explain.description' }] });
+Collection.prototype.explain.serverVersions = ['0.0.0', '4.4.0'];
+Collection.prototype.explain.topologies = [0, 1, 2];
+Collection.prototype.explain.returnsPromise = false;
+Collection.prototype.explain.returnType = 'Explainable';
 
 
 class CommandResult {
@@ -1075,6 +1085,55 @@ class DeleteResult {
 }
 
 
+class Explainable {
+  constructor(_mapper, _collection, _verbosity) {
+    this._mapper = _mapper;
+    this._collection = _collection;
+    this._verbosity = _verbosity;
+
+    this.toReplString = () => {
+      return `Explainable(${this._collection.getFullName()})`;
+    };
+
+    this.shellApiType = () => {
+      return 'Explainable';
+    };
+    this.help = () => new Help({ 'help': 'shell-api.classes.Explainable.help.description', 'docs': 'shell-api.classes.Explainable.help.link', 'attr': [{ 'name': 'getCollection', 'description': 'shell-api.classes.Explainable.help.attributes.getCollection.description' }, { 'name': 'getVerbosity', 'description': 'shell-api.classes.Explainable.help.attributes.getVerbosity.description' }, { 'name': 'setVerbosity', 'description': 'shell-api.classes.Explainable.help.attributes.setVerbosity.description' }] });
+  }
+
+  getCollection(...args) {
+    return this._mapper.explainable_getCollection(this, ...args);
+  }
+
+  getVerbosity(...args) {
+    return this._mapper.explainable_getVerbosity(this, ...args);
+  }
+
+  setVerbosity(...args) {
+    return this._mapper.explainable_setVerbosity(this, ...args);
+  }
+}
+
+
+Explainable.prototype.getCollection.help = () => new Help({ 'help': 'shell-api.classes.Explainable.help.attributes.getCollection.example', 'docs': 'shell-api.classes.Explainable.help.attributes.getCollection.link', 'attr': [{ 'description': 'shell-api.classes.Explainable.help.attributes.getCollection.description' }] });
+Explainable.prototype.getCollection.serverVersions = ['0.0.0', '4.4.0'];
+Explainable.prototype.getCollection.topologies = [0, 1, 2];
+Explainable.prototype.getCollection.returnsPromise = false;
+Explainable.prototype.getCollection.returnType = 'Collection';
+
+Explainable.prototype.getVerbosity.help = () => new Help({ 'help': 'shell-api.classes.Explainable.help.attributes.getVerbosity.example', 'docs': 'shell-api.classes.Explainable.help.attributes.getVerbosity.link', 'attr': [{ 'description': 'shell-api.classes.Explainable.help.attributes.getVerbosity.description' }] });
+Explainable.prototype.getVerbosity.serverVersions = ['0.0.0', '4.4.0'];
+Explainable.prototype.getVerbosity.topologies = [0, 1, 2];
+Explainable.prototype.getVerbosity.returnsPromise = false;
+Explainable.prototype.getVerbosity.returnType = 'unknown';
+
+Explainable.prototype.setVerbosity.help = () => new Help({ 'help': 'shell-api.classes.Explainable.help.attributes.setVerbosity.example', 'docs': 'shell-api.classes.Explainable.help.attributes.setVerbosity.link', 'attr': [{ 'description': 'shell-api.classes.Explainable.help.attributes.setVerbosity.description' }] });
+Explainable.prototype.setVerbosity.serverVersions = ['0.0.0', '4.4.0'];
+Explainable.prototype.setVerbosity.topologies = [0, 1, 2];
+Explainable.prototype.setVerbosity.returnsPromise = false;
+Explainable.prototype.setVerbosity.returnType = 'unknown';
+
+
 class InsertManyResult {
   constructor(acknowleged, insertedIds) {
     this.acknowleged = acknowleged;
@@ -1195,6 +1254,7 @@ export { CommandResult };
 export { Cursor };
 export { Database };
 export { DeleteResult };
+export { Explainable };
 export { InsertManyResult };
 export { InsertOneResult };
 export { ReplicaSet };

--- a/packages/shell-api/yaml/Collection.yaml
+++ b/packages/shell-api/yaml/Collection.yaml
@@ -198,3 +198,6 @@ class:
     runCommand:
         <<: *__defaultMethod
         returnsPromise: true
+    explain:
+        <<: *__defaultMethod
+        returnType: 'Explainable'

--- a/packages/shell-api/yaml/Explainable.yaml
+++ b/packages/shell-api/yaml/Explainable.yaml
@@ -1,0 +1,27 @@
+class:
+  <<: *__defaultClass
+  __methods:
+    wrappee: '_mapper'
+    firstArg: 'this'
+    wrappeePrefix: 'explainable_'
+  __constructorArgs:
+    - _mapper
+    - _collection
+    - _verbosity
+  __stringRep:
+    - '`Explainable(${this._collection.getFullName()})`'
+  getCollection:
+    <<: *__defaultMethod
+    returnType: 'Collection'
+  getVerbosity:
+    <<: *__defaultMethod
+  setVerbosity:
+    <<: *__defaultMethod
+#   # find:
+#   # aggregate:
+#   # bsonsize:
+#   # count:
+#   # distinct:
+#   # findAndModify:
+#   # remove:
+#   # update:


### PR DESCRIPTION
Implements `db.coll.explain()` so that it returns an explainable.

Initial explainable implementation with just 3 methods:
- `getCollection`
- `get/setVerbosity`

Also use custom errors.