### PR TITLE
MONGOSH-183: add segment api key on evergreen build

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -11,13 +11,6 @@ variables:
       bucket: mciuploads
       permissions: public-read
       content_type: application/octet-stream
-  - &save_segment_key
-      command: shell.exec
-      params:
-        working_dir: src
-        shell: bash
-        script: |
-          export SEGMENT_API_KEY=${segment_key}
   - &compile_exec
     command: shell.exec
     params:
@@ -86,6 +79,12 @@ functions:
           export MONGOSH_STITCH_TEST_SERVICE_NAME=${stitch_test_service_name}
           npm run test-ci
   release_macos:
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          export SEGMENT_API_KEY=${segment_key}
     - <<: *compile_exec
     - command: shell.exec
       params:
@@ -93,13 +92,18 @@ functions:
         shell: bash
         script: |
           echo "################# Sign, notarise, and release MacOS artifacts ################"
-    - <<: *save_segment_key
     - <<: *upload_file
       params:
         local_files_include_filter:
           - src/dist/*.tgz
         remote_file: ${project}/${revision}/
   release_linux:
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          export SEGMENT_API_KEY=${segment_key}
     - <<: *compile_exec
     - command: shell.exec
       params:
@@ -107,13 +111,18 @@ functions:
         shell: bash
         script: |
           echo "################# Sign and release Linux artifacts ################"
-    - <<: *save_segment_key
     - <<: *upload_file
       params:
         local_files_include_filter:
           - src/dist/*.tgz
         remote_file: ${project}/${revision}/
   release_win:
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          export SEGMENT_API_KEY=${segment_key}
     - <<: *compile_exec
     - command: shell.exec
       params:
@@ -121,7 +130,6 @@ functions:
         shell: bash
         script: |
           echo "################# Sign and release Windows artifacts ################"
-    - <<: *save_segment_key
     - <<: *upload_file
       params:
         local_files_include_filter:

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -11,6 +11,12 @@ variables:
       bucket: mciuploads
       permissions: public-read
       content_type: application/octet-stream
+  - &save_segment_key
+      command: expansions.update
+      params:
+        file: src/segment.yml
+        updates:
+          segment: ${segment_key}
   - &compile_exec
     command: shell.exec
     params:
@@ -86,6 +92,7 @@ functions:
         shell: bash
         script: |
           echo "################# Sign, notarise, and release MacOS artifacts ################"
+    - <<: *save_segment_key
     - <<: *upload_file
       params:
         local_files_include_filter:
@@ -99,6 +106,7 @@ functions:
         shell: bash
         script: |
           echo "################# Sign and release Linux artifacts ################"
+    - <<: *save_segment_key
     - <<: *upload_file
       params:
         local_files_include_filter:
@@ -112,6 +120,7 @@ functions:
         shell: bash
         script: |
           echo "################# Sign and release Windows artifacts ################"
+    - <<: *save_segment_key
     - <<: *upload_file
       params:
         local_files_include_filter:

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -12,11 +12,12 @@ variables:
       permissions: public-read
       content_type: application/octet-stream
   - &save_segment_key
-      command: expansions.update
+      command: shell.exec
       params:
-        file: src/segment.yml
-        updates:
-          segment: ${segment_key}
+        working_dir: src
+        shell: bash
+        script: |
+          export SEGMENT_API_KEY=${segment_key}
   - &compile_exec
     command: shell.exec
     params:

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -18,6 +18,7 @@ variables:
       shell: bash
       script: |
         source .evergreen/.setup_env
+        export SEGMENT_API_KEY=${segment_key}
         export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
         npm run compile-exec
 # Functions are any command that can be run.
@@ -79,12 +80,6 @@ functions:
           export MONGOSH_STITCH_TEST_SERVICE_NAME=${stitch_test_service_name}
           npm run test-ci
   release_macos:
-    - command: shell.exec
-      params:
-        working_dir: src
-        shell: bash
-        script: |
-          export SEGMENT_API_KEY=${segment_key}
     - <<: *compile_exec
     - command: shell.exec
       params:
@@ -98,12 +93,6 @@ functions:
           - src/dist/*.tgz
         remote_file: ${project}/${revision}/
   release_linux:
-    - command: shell.exec
-      params:
-        working_dir: src
-        shell: bash
-        script: |
-          export SEGMENT_API_KEY=${segment_key}
     - <<: *compile_exec
     - command: shell.exec
       params:
@@ -117,12 +106,6 @@ functions:
           - src/dist/*.tgz
         remote_file: ${project}/${revision}/
   release_win:
-    - command: shell.exec
-      params:
-        working_dir: src
-        shell: bash
-        script: |
-          export SEGMENT_API_KEY=${segment_key}
     - <<: *compile_exec
     - command: shell.exec
       params:

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -55,6 +55,17 @@ const archive = async() => {
   );
 };
 
+const writeSegmentFile = async() => {
+  const key = `export SEGMENT_API_KEY = ${process.env.SEGMENT_API_KEY}`;
+  try {
+    // create directly in cli-repl/lib so it can be part of artifacts in dist
+    return await fs.writeFile(path.join(__dirname, '..', 'packages', 'cli-repl', 'lib', 'config.js'));
+  } catch (e) {
+    console.log('mongosh: unable to write segment config file');
+    return;
+  }
+}
+
 /**
  * Creates dist/mongosh or dist/mongosh.exe and then creates a
  * tarball or zip of the executable as dist/mongosh-${version}-${os}.tgz or
@@ -62,6 +73,7 @@ const archive = async() => {
  */
 const release = async() => {
   const artifact = getArtifact();
+  const segmentFile = await writeSegmentFile();
   console.log('mongosh: creating binary:', artifact);
   await exec([
     path.join(__dirname, '..', 'packages', 'cli-repl', 'bin', 'mongosh.js'),


### PR DESCRIPTION
## Description

Adds a script to write segment's API key to `process.env` when releasing.