### PR TITLE
implements `explainable.find` and `.aggregate`

### DIFF
--- a/packages/mapper/src/mapper.integration.spec.ts
+++ b/packages/mapper/src/mapper.integration.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { CliServiceProvider } from '@mongosh/service-provider-server';
 import Mapper from './mapper';
-import { Collection, Cursor, Database } from '@mongosh/shell-api';
+import { Collection, Cursor, Database, Explainable } from '@mongosh/shell-api';
 
 const mongodbRunnerBefore = require('mongodb-runner/mocha/before');
 const mongodbRunnerAfter = require('mongodb-runner/mocha/after');
@@ -604,7 +604,49 @@ describe('Mapper (integration)', function() {
       it('returns an array with collection names', async() => {
         await createCollection(dbName, collectionName);
 
-        expect(await mapper.database_getCollectionNames(database)).to.deep.equal([collectionName]);
+        expect(
+          await mapper.database_getCollectionNames(database)
+        ).to.deep.equal([collectionName]);
+      });
+    });
+  });
+
+  describe('explainable', () => {
+    let explainable;
+
+    beforeEach(() => {
+      explainable = new Explainable(
+        mapper,
+        collection,
+        'queryPlanner'
+      );
+    });
+
+    describe('find', () => {
+      it('returns a cursor that has the explain as result of toReplString', async() => {
+        const cursor = await mapper.explainable_find(explainable)
+          .skip(1)
+          .limit(1);
+        const result = await cursor.toReplString();
+        expect(result).to.have.keys([
+          'ok',
+          'queryPlanner',
+          'serverInfo'
+        ]);
+      });
+    });
+
+    describe('aggregate', () => {
+      it('returns a cursor that has the explain as result of toReplString', async() => {
+        const cursor = await mapper.explainable_find(explainable)
+          .skip(1)
+          .limit(1);
+        const result = await cursor.toReplString();
+        expect(result).to.have.keys([
+          'ok',
+          'queryPlanner',
+          'serverInfo'
+        ]);
       });
     });
   });

--- a/packages/mapper/src/mapper.spec.ts
+++ b/packages/mapper/src/mapper.spec.ts
@@ -811,5 +811,93 @@ coll2`;
         }).to.throw('verbosity can only be one of queryPlanner, executionStats, allPlansExecution. Received badVerbosityArgument.');
       });
     });
+
+    describe('find', () => {
+      let cursorStub;
+      let explainResult;
+      beforeEach(() => {
+        explainResult = { ok: 1 };
+
+        collection.find = sinon.spy(() => ({
+          explain: sinon.spy(() => explainResult)
+        }));
+
+        cursorStub = mapper.explainable_find(
+          explainable,
+          { query: 1 },
+          { projection: 1 }
+        );
+      });
+
+      it('calls collection.find with arguments', () => {
+        expect(collection.find).to.have.been.calledOnceWithExactly(
+          { query: 1 },
+          { projection: 1 }
+        );
+      });
+
+      it('returns an ExplainableCursor', () => {
+        expect(cursorStub.shellApiType()).to.equal('ExplainableCursor');
+      });
+
+      context('when calling toReplString on the result', () => {
+        it('calls explain with verbosity', async() => {
+          await cursorStub.toReplString();
+          expect(
+            cursorStub.explain
+          ).to.have.been.calledOnceWithExactly('queryPlanner');
+        });
+
+        it('returns the explain result', async() => {
+          expect(
+            await cursorStub.toReplString()
+          ).to.equal(explainResult);
+        });
+      });
+    });
+
+    describe('aggregate', () => {
+      let cursorStub;
+      let explainResult;
+      beforeEach(() => {
+        explainResult = { ok: 1 };
+
+        collection.aggregate = sinon.spy(() => ({
+          explain: sinon.spy(() => explainResult)
+        }));
+
+        cursorStub = mapper.explainable_aggregate(
+          explainable,
+          { pipeline: 1 },
+          { aggregate: 1 }
+        );
+      });
+
+      it('calls collection.aggregate with arguments', () => {
+        expect(collection.aggregate).to.have.been.calledOnceWithExactly(
+          { pipeline: 1 },
+          { aggregate: 1 }
+        );
+      });
+
+      it('returns an ExplainableCursor', () => {
+        expect(cursorStub.shellApiType()).to.equal('ExplainableAggregationCursor');
+      });
+
+      context('when calling toReplString on the result', () => {
+        it('calls explain with verbosity', async() => {
+          await cursorStub.toReplString();
+          expect(
+            cursorStub.explain
+          ).to.have.been.calledOnceWithExactly('queryPlanner');
+        });
+
+        it('returns the explain result', async() => {
+          expect(
+            await cursorStub.toReplString()
+          ).to.equal(explainResult);
+        });
+      });
+    });
   });
 });

--- a/packages/mapper/src/mapper.ts
+++ b/packages/mapper/src/mapper.ts
@@ -1861,6 +1861,7 @@ export default class Mapper {
   explainable_find(explainable: Explainable, query?: any, projection?: any): any {
     this._emitExplainableApiCall(explainable, 'find', { query, projection });
 
+    // TODO: turn ExplainableCursor in a proper type.
     const cursor = explainable._collection.find(query, projection);
     cursor.shellApiType = (): string => 'ExplainableCursor';
     cursor.toReplString = (): Promise<any> => {
@@ -1873,6 +1874,7 @@ export default class Mapper {
   explainable_aggregate(explainable: Explainable, pipeline?: any, options?: any): any {
     this._emitExplainableApiCall(explainable, 'aggregate', { pipeline, options });
 
+    // TODO: turn ExplainableAggregationCursor in a proper type.
     const cursor = explainable._collection.aggregate(pipeline, options);
     cursor.shellApiType = (): string => 'ExplainableAggregationCursor';
     cursor.toReplString = (): Promise<any> => {

--- a/packages/service-provider-server/src/node/node-cursor.ts
+++ b/packages/service-provider-server/src/node/node-cursor.ts
@@ -377,6 +377,30 @@ class NodeCursor implements Cursor {
     this.cursor.addCursorFlag(flag, true);
     return this;
   }
+
+  async explain(verbosity: string): Promise<any> {
+    const fullExplain = await this.cursor.explain();
+
+    const explain: any = {
+      ...fullExplain
+    };
+
+    if (
+      verbosity !== 'executionStats' &&
+      verbosity !== 'allPlansExecution' &&
+      explain.executionStats
+    ) {
+      delete explain.executionStats;
+    }
+
+    if (verbosity === 'executionStats' &&
+      explain.executionStats &&
+      explain.executionStats.allPlansExecution) {
+      delete explain.executionStats.allPlansExecution;
+    }
+
+    return explain;
+  }
 }
 
 export default NodeCursor;

--- a/packages/service-provider-server/src/node/node-cursor.ts
+++ b/packages/service-provider-server/src/node/node-cursor.ts
@@ -378,7 +378,12 @@ class NodeCursor implements Cursor {
     return this;
   }
 
+  // TODO: we should probably move this in the mapper
+  // layer
   async explain(verbosity: string): Promise<any> {
+    // NOTE: the node driver always returns the full explain plan
+    // for Cursor and the queryPlanner explain for AggregationCursor.
+
     const fullExplain = await this.cursor.explain();
 
     const explain: any = {

--- a/packages/shell-api/src/shell-api-signatures.js
+++ b/packages/shell-api/src/shell-api-signatures.js
@@ -14,7 +14,8 @@ const AggregationCursor = {
     itcount: { type: 'function', returnsPromise: true, returnType: 'unknown', serverVersions: ['0.0.0', '4.4.0'] },
     map: { type: 'function', returnsPromise: false, returnType: 'AggregationCursor', serverVersions: ['0.0.0', '4.4.0'] },
     next: { type: 'function', returnsPromise: true, returnType: 'unknown', serverVersions: ['0.0.0', '4.4.0'] },
-    toArray: { type: 'function', returnsPromise: true, returnType: 'unknown', serverVersions: ['0.0.0', '4.4.0'] }
+    toArray: { type: 'function', returnsPromise: true, returnType: 'unknown', serverVersions: ['0.0.0', '4.4.0'] },
+    explain: { type: 'function', returnsPromise: true, returnType: 'unknown', serverVersions: ['0.0.0', '4.4.0'] }
   }
 };
 const BulkWriteResult = {
@@ -145,7 +146,9 @@ const Explainable = {
   attributes: {
     getCollection: { type: 'function', returnsPromise: false, returnType: 'Collection', serverVersions: ['0.0.0', '4.4.0'] },
     getVerbosity: { type: 'function', returnsPromise: false, returnType: 'unknown', serverVersions: ['0.0.0', '4.4.0'] },
-    setVerbosity: { type: 'function', returnsPromise: false, returnType: 'unknown', serverVersions: ['0.0.0', '4.4.0'] }
+    setVerbosity: { type: 'function', returnsPromise: false, returnType: 'unknown', serverVersions: ['0.0.0', '4.4.0'] },
+    find: { type: 'function', returnsPromise: false, returnType: 'Cursor', serverVersions: ['0.0.0', '4.4.0'] },
+    aggregate: { type: 'function', returnsPromise: false, returnType: 'Cursor', serverVersions: ['0.0.0', '4.4.0'] }
   }
 };
 const InsertManyResult = {

--- a/packages/shell-api/src/shell-api.js
+++ b/packages/shell-api/src/shell-api.js
@@ -14,7 +14,7 @@ class AggregationCursor {
     this.shellApiType = () => {
       return 'AggregationCursor';
     };
-    this.help = () => new Help({ 'help': 'shell-api.classes.AggregationCursor.help.description', 'docs': 'shell-api.classes.AggregationCursor.help.link', 'attr': [{ 'name': 'close', 'description': 'shell-api.classes.AggregationCursor.help.attributes.close.description' }, { 'name': 'forEach', 'description': 'shell-api.classes.AggregationCursor.help.attributes.forEach.description' }, { 'name': 'hasNext', 'description': 'shell-api.classes.AggregationCursor.help.attributes.hasNext.description' }, { 'name': 'isClosed', 'description': 'shell-api.classes.AggregationCursor.help.attributes.isClosed.description' }, { 'name': 'isExhausted', 'description': 'shell-api.classes.AggregationCursor.help.attributes.isExhausted.description' }, { 'name': 'itcount', 'description': 'shell-api.classes.AggregationCursor.help.attributes.itcount.description' }, { 'name': 'map', 'description': 'shell-api.classes.AggregationCursor.help.attributes.map.description' }, { 'name': 'next', 'description': 'shell-api.classes.AggregationCursor.help.attributes.next.description' }, { 'name': 'toArray', 'description': 'shell-api.classes.AggregationCursor.help.attributes.toArray.description' }] });
+    this.help = () => new Help({ 'help': 'shell-api.classes.AggregationCursor.help.description', 'docs': 'shell-api.classes.AggregationCursor.help.link', 'attr': [{ 'name': 'close', 'description': 'shell-api.classes.AggregationCursor.help.attributes.close.description' }, { 'name': 'forEach', 'description': 'shell-api.classes.AggregationCursor.help.attributes.forEach.description' }, { 'name': 'hasNext', 'description': 'shell-api.classes.AggregationCursor.help.attributes.hasNext.description' }, { 'name': 'isClosed', 'description': 'shell-api.classes.AggregationCursor.help.attributes.isClosed.description' }, { 'name': 'isExhausted', 'description': 'shell-api.classes.AggregationCursor.help.attributes.isExhausted.description' }, { 'name': 'itcount', 'description': 'shell-api.classes.AggregationCursor.help.attributes.itcount.description' }, { 'name': 'map', 'description': 'shell-api.classes.AggregationCursor.help.attributes.map.description' }, { 'name': 'next', 'description': 'shell-api.classes.AggregationCursor.help.attributes.next.description' }, { 'name': 'toArray', 'description': 'shell-api.classes.AggregationCursor.help.attributes.toArray.description' }, { 'name': 'explain', 'description': 'shell-api.classes.AggregationCursor.help.attributes.explain.description' }] });
   }
 
   close(...args) {
@@ -52,6 +52,10 @@ class AggregationCursor {
 
   toArray(...args) {
     return this._cursor.toArray(...args);
+  }
+
+  explain(...args) {
+    return this._cursor.explain(...args);
   }
 }
 
@@ -109,6 +113,12 @@ AggregationCursor.prototype.toArray.serverVersions = ['0.0.0', '4.4.0'];
 AggregationCursor.prototype.toArray.topologies = [0, 1, 2];
 AggregationCursor.prototype.toArray.returnsPromise = true;
 AggregationCursor.prototype.toArray.returnType = 'unknown';
+
+AggregationCursor.prototype.explain.help = () => new Help({ 'help': 'shell-api.classes.AggregationCursor.help.attributes.explain.example', 'docs': 'shell-api.classes.AggregationCursor.help.attributes.explain.link', 'attr': [{ 'description': 'shell-api.classes.AggregationCursor.help.attributes.explain.description' }] });
+AggregationCursor.prototype.explain.serverVersions = ['0.0.0', '4.4.0'];
+AggregationCursor.prototype.explain.topologies = [0, 1, 2];
+AggregationCursor.prototype.explain.returnsPromise = true;
+AggregationCursor.prototype.explain.returnType = 'unknown';
 
 
 class BulkWriteResult {
@@ -1098,7 +1108,7 @@ class Explainable {
     this.shellApiType = () => {
       return 'Explainable';
     };
-    this.help = () => new Help({ 'help': 'shell-api.classes.Explainable.help.description', 'docs': 'shell-api.classes.Explainable.help.link', 'attr': [{ 'name': 'getCollection', 'description': 'shell-api.classes.Explainable.help.attributes.getCollection.description' }, { 'name': 'getVerbosity', 'description': 'shell-api.classes.Explainable.help.attributes.getVerbosity.description' }, { 'name': 'setVerbosity', 'description': 'shell-api.classes.Explainable.help.attributes.setVerbosity.description' }] });
+    this.help = () => new Help({ 'help': 'shell-api.classes.Explainable.help.description', 'docs': 'shell-api.classes.Explainable.help.link', 'attr': [{ 'name': 'getCollection', 'description': 'shell-api.classes.Explainable.help.attributes.getCollection.description' }, { 'name': 'getVerbosity', 'description': 'shell-api.classes.Explainable.help.attributes.getVerbosity.description' }, { 'name': 'setVerbosity', 'description': 'shell-api.classes.Explainable.help.attributes.setVerbosity.description' }, { 'name': 'find', 'description': 'shell-api.classes.Explainable.help.attributes.find.description' }, { 'name': 'aggregate', 'description': 'shell-api.classes.Explainable.help.attributes.aggregate.description' }] });
   }
 
   getCollection(...args) {
@@ -1111,6 +1121,14 @@ class Explainable {
 
   setVerbosity(...args) {
     return this._mapper.explainable_setVerbosity(this, ...args);
+  }
+
+  find(...args) {
+    return this._mapper.explainable_find(this, ...args);
+  }
+
+  aggregate(...args) {
+    return this._mapper.explainable_aggregate(this, ...args);
   }
 }
 
@@ -1132,6 +1150,18 @@ Explainable.prototype.setVerbosity.serverVersions = ['0.0.0', '4.4.0'];
 Explainable.prototype.setVerbosity.topologies = [0, 1, 2];
 Explainable.prototype.setVerbosity.returnsPromise = false;
 Explainable.prototype.setVerbosity.returnType = 'unknown';
+
+Explainable.prototype.find.help = () => new Help({ 'help': 'shell-api.classes.Explainable.help.attributes.find.example', 'docs': 'shell-api.classes.Explainable.help.attributes.find.link', 'attr': [{ 'description': 'shell-api.classes.Explainable.help.attributes.find.description' }] });
+Explainable.prototype.find.serverVersions = ['0.0.0', '4.4.0'];
+Explainable.prototype.find.topologies = [0, 1, 2];
+Explainable.prototype.find.returnsPromise = false;
+Explainable.prototype.find.returnType = 'Cursor';
+
+Explainable.prototype.aggregate.help = () => new Help({ 'help': 'shell-api.classes.Explainable.help.attributes.aggregate.example', 'docs': 'shell-api.classes.Explainable.help.attributes.aggregate.link', 'attr': [{ 'description': 'shell-api.classes.Explainable.help.attributes.aggregate.description' }] });
+Explainable.prototype.aggregate.serverVersions = ['0.0.0', '4.4.0'];
+Explainable.prototype.aggregate.topologies = [0, 1, 2];
+Explainable.prototype.aggregate.returnsPromise = false;
+Explainable.prototype.aggregate.returnType = 'Cursor';
 
 
 class InsertManyResult {

--- a/packages/shell-api/yaml/AggregationCursor.yaml
+++ b/packages/shell-api/yaml/AggregationCursor.yaml
@@ -38,3 +38,6 @@ class:
     toArray:
         <<: *__defaultMethod
         returnsPromise: true
+    explain:
+        <<: *__defaultMethod
+        returnsPromise: true

--- a/packages/shell-api/yaml/Explainable.yaml
+++ b/packages/shell-api/yaml/Explainable.yaml
@@ -17,8 +17,13 @@ class:
     <<: *__defaultMethod
   setVerbosity:
     <<: *__defaultMethod
-#   # find:
-#   # aggregate:
+  find:
+    <<: *__defaultMethod
+    returnType: 'Cursor'
+  aggregate:
+    <<: *__defaultMethod
+    returnType: 'Cursor'
+
 #   # bsonsize:
 #   # count:
 #   # distinct:


### PR DESCRIPTION
Implements `explainable.find()` and `explainable.aggregate()`.

The way the cursor is reused is not super pretty: we just rewrite the `toReplString` and `shellApiType`, perhaps 2 types proxying the cursor methods would be better.

