### PR TITLE
report missing help and supported api scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,9 @@
     "start": "npm run start-cli",
     "precompile-exec": "npm run compile-cli",
     "compile-exec": "node scripts/release.js",
-    "publish-npm": "lerna publish --force-publish"
+    "publish-npm": "lerna publish --force-publish",
+    "report-missing-help": "lerna run --scope @mongosh/shell-api report-missing-help",
+    "report-supported-api": "lerna run --scope @mongosh/shell-api report-supported-api"
   },
   "config": {
     "unsafe-perm": true

--- a/packages/shell-api/bin/report-missing-help.ts
+++ b/packages/shell-api/bin/report-missing-help.ts
@@ -1,0 +1,25 @@
+/* eslint-disable no-console */
+import { signatures } from '../';
+import enUs from '../../i18n/src/locales/en_US';
+
+Object.keys(signatures)
+  .sort()
+  .filter((typeName) => typeName !== 'unknown')
+  .filter((typeName) => !typeName.endsWith('Result'))
+  .forEach((typeName) => {
+    const typeHelp = enUs['shell-api'].classes[typeName];
+    if (!typeHelp) {
+      console.info('Missing en_US help for type:', typeName);
+      return;
+    }
+
+    Object.keys(signatures[typeName].attributes)
+      .sort()
+      .forEach((attributeName) => {
+        const attributeHelp = typeHelp.help.attributes[attributeName];
+
+        if (!attributeHelp || typeof attributeHelp !== 'object' || !attributeHelp.description) {
+          console.info('Missing en_US help for attribute:', `${typeName}.${attributeName}`);
+        }
+      });
+  });

--- a/packages/shell-api/bin/report-supported-api.ts
+++ b/packages/shell-api/bin/report-supported-api.ts
@@ -1,0 +1,15 @@
+/* eslint-disable no-console */
+import { signatures } from '../';
+
+Object.keys(signatures)
+  .sort()
+  .filter((typeName) => typeName !== 'unknown')
+  .filter((typeName) => !typeName.endsWith('Result'))
+  .forEach((typeName) => {
+    console.info(`${typeName}:`);
+    Object.keys(signatures[typeName].attributes)
+      .sort()
+      .forEach((attributeName) => {
+        console.info(`  - ${attributeName}`);
+      });
+  });

--- a/packages/shell-api/package.json
+++ b/packages/shell-api/package.json
@@ -18,6 +18,8 @@
     "pretest": "npm run compile-api",
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
     "check": "npm run lint",
+    "report-missing-help": "ts-node bin/report-missing-help.ts",
+    "report-supported-api": "ts-node bin/report-supported-api.ts",
     "test": "mocha --timeout 15000 --colors -r ts-node/register \"./src/**/*.spec.ts\"",
     "test-ci": "mocha --timeout 15000 -r ts-node/register \"./src/**/*.spec.ts\"",
     "prepublish": "npm run compile-ts"


### PR DESCRIPTION
Adds two scripts:

- `npm run report-supported-api`: outputs all the supported api types and methods in a `diff` friendly way.
- `npm run report-missing-help`: outputs all the types and methods for which help is missing.
