### PR TITLE
Implement db.adminCommand

### DIFF
--- a/packages/i18n/src/locales/en_US.js
+++ b/packages/i18n/src/locales/en_US.js
@@ -1094,7 +1094,18 @@ const translations = {
         help: {
           description: 'Database Class',
           attributes: {
-            runCommand: 'Runs an arbitrary command on the database.',
+            runCommand: {
+              link: 'https://docs.mongodb.com/manual/reference/method/db.runCommand',
+              description: 'Runs an arbitrary command on the database.',
+              example: 'db.runCommand({ text: "myCollection", search: "searchKeywords" })',
+              parameters: {}
+            },
+            adminCommand: {
+              link: 'https://docs.mongodb.com/manual/reference/method/db.adminCommand',
+              description: 'Runs an arbitrary command against the admin database.',
+              example: 'db.adminCommand({ serverStatus: 1 })',
+              parameters: {}
+            },
             getCollectionInfos: {
               link: 'https://docs.mongodb.com/manual/reference/method/db.getCollectionInfos',
               description: 'Returns an array of documents with collection information, i.e. collection name and options, for the current database.',

--- a/packages/mapper/src/mapper.integration.spec.ts
+++ b/packages/mapper/src/mapper.integration.spec.ts
@@ -609,6 +609,16 @@ describe('Mapper (integration)', function() {
         ).to.deep.equal([collectionName]);
       });
     });
+
+    describe('adminCommand', () => {
+      it('runs an adminCommand', async() => {
+        const result = await mapper.database_adminCommand(
+          database, { serverStatus: 1 }
+        );
+        expect(result.ok).to.equal(1);
+        expect(result.process).to.match(/^mongo/);
+      });
+    });
   });
 
   describe('explainable', () => {

--- a/packages/mapper/src/mapper.spec.ts
+++ b/packages/mapper/src/mapper.spec.ts
@@ -773,7 +773,64 @@ coll2`;
           'db1', {}, { nameOnly: true });
       });
     });
+
+    describe('runCommand', () => {
+      it('calls serviceProvider.runCommand on the database', async() => {
+        await mapper.database_runCommand(database, { someCommand: 'someCollection' });
+
+        expect(serviceProvider.runCommand).to.have.been.calledWith(
+          database._name,
+          {
+            someCommand: 'someCollection'
+          }
+        );
+      });
+
+      it('returns whatever serviceProvider.runCommand returns', async() => {
+        const expectedResult = { ok: 1 };
+        serviceProvider.runCommand.resolves(expectedResult);
+        const result = await mapper.database_runCommand(database, { someCommand: 'someCollection' });
+        expect(result).to.deep.equal(expectedResult);
+      });
+
+      it('throws if serviceProvider.runCommand rejects', async() => {
+        const expectedError = new Error();
+        serviceProvider.runCommand.rejects(expectedError);
+        const catchedError = await mapper.database_runCommand(database, { someCommand: 'someCollection' })
+          .catch(e => e);
+        expect(catchedError).to.equal(expectedError);
+      });
+    });
+
+    describe('adminCommand', () => {
+      it('calls serviceProvider.runCommand with the admin database', async() => {
+        await mapper.database_adminCommand(database, { someCommand: 'someCollection' });
+
+        expect(serviceProvider.runCommand).to.have.been.calledWith(
+          'admin',
+          {
+            someCommand: 'someCollection'
+          }
+        );
+      });
+
+      it('returns whatever serviceProvider.runCommand returns', async() => {
+        const expectedResult = { ok: 1 };
+        serviceProvider.runCommand.resolves(expectedResult);
+        const result = await mapper.database_adminCommand(database, { someCommand: 'someCollection' });
+        expect(result).to.deep.equal(expectedResult);
+      });
+
+      it('throws if serviceProvider.runCommand rejects', async() => {
+        const expectedError = new Error();
+        serviceProvider.runCommand.rejects(expectedError);
+        const catchedError = await mapper.database_adminCommand(database, { someCommand: 'someCollection' })
+          .catch(e => e);
+        expect(catchedError).to.equal(expectedError);
+      });
+    });
   });
+
 
   describe('explainable', () => {
     let explainable: Explainable;

--- a/packages/shell-api/src/database.spec.ts
+++ b/packages/shell-api/src/database.spec.ts
@@ -45,7 +45,8 @@ describe('Database', () => {
   [
     'getCollectionInfos',
     'getCollectionNames',
-    'runCommand'
+    'runCommand',
+    'adminCommand'
   ].forEach((methodName) => {
     describe(`#${methodName}`, () => {
       it(`wraps mapper.database_${methodName}`, () => {

--- a/packages/shell-api/src/shell-api-signatures.js
+++ b/packages/shell-api/src/shell-api-signatures.js
@@ -128,9 +128,10 @@ const Database = {
   type: 'Database',
   hasAsyncChild: true,
   attributes: {
-    runCommand: { type: 'function', returnsPromise: true, returnType: 'unknown', serverVersions: ['0.0.0', '4.4.0'] },
     getCollectionNames: { type: 'function', returnsPromise: true, returnType: 'unknown', serverVersions: ['0.0.0', '4.4.0'] },
-    getCollectionInfos: { type: 'function', returnsPromise: true, returnType: 'unknown', serverVersions: ['3.0.0', '4.4.0'] }
+    getCollectionInfos: { type: 'function', returnsPromise: true, returnType: 'unknown', serverVersions: ['3.0.0', '4.4.0'] },
+    runCommand: { type: 'function', returnsPromise: true, returnType: 'unknown', serverVersions: ['0.0.0', '4.4.0'] },
+    adminCommand: { type: 'function', returnsPromise: true, returnType: 'unknown', serverVersions: ['3.4.0', '4.4.0'] }
   }
 };
 const DeleteResult = {

--- a/packages/shell-api/src/shell-api.js
+++ b/packages/shell-api/src/shell-api.js
@@ -1040,13 +1040,9 @@ class Database {
     this.shellApiType = () => {
       return 'Database';
     };
-    this.help = () => new Help({ 'help': 'shell-api.classes.Database.help.description', 'docs': 'shell-api.classes.Database.help.link', 'attr': [{ 'name': 'runCommand', 'description': 'shell-api.classes.Database.help.attributes.runCommand.description' }, { 'name': 'getCollectionNames', 'description': 'shell-api.classes.Database.help.attributes.getCollectionNames.description' }, { 'name': 'getCollectionInfos', 'description': 'shell-api.classes.Database.help.attributes.getCollectionInfos.description' }] });
+    this.help = () => new Help({ 'help': 'shell-api.classes.Database.help.description', 'docs': 'shell-api.classes.Database.help.link', 'attr': [{ 'name': 'getCollectionNames', 'description': 'shell-api.classes.Database.help.attributes.getCollectionNames.description' }, { 'name': 'getCollectionInfos', 'description': 'shell-api.classes.Database.help.attributes.getCollectionInfos.description' }, { 'name': 'runCommand', 'description': 'shell-api.classes.Database.help.attributes.runCommand.description' }, { 'name': 'adminCommand', 'description': 'shell-api.classes.Database.help.attributes.adminCommand.description' }] });
 
     return proxy;
-  }
-
-  runCommand(...args) {
-    return this._mapper.database_runCommand(this, ...args);
   }
 
   getCollectionNames(...args) {
@@ -1056,14 +1052,16 @@ class Database {
   getCollectionInfos(...args) {
     return this._mapper.database_getCollectionInfos(this, ...args);
   }
+
+  runCommand(...args) {
+    return this._mapper.database_runCommand(this, ...args);
+  }
+
+  adminCommand(...args) {
+    return this._mapper.database_adminCommand(this, ...args);
+  }
 }
 
-
-Database.prototype.runCommand.help = () => new Help({ 'help': 'shell-api.classes.Database.help.attributes.runCommand.example', 'docs': 'shell-api.classes.Database.help.attributes.runCommand.link', 'attr': [{ 'description': 'shell-api.classes.Database.help.attributes.runCommand.description' }] });
-Database.prototype.runCommand.serverVersions = ['0.0.0', '4.4.0'];
-Database.prototype.runCommand.topologies = [0, 1, 2];
-Database.prototype.runCommand.returnsPromise = true;
-Database.prototype.runCommand.returnType = 'unknown';
 
 Database.prototype.getCollectionNames.help = () => new Help({ 'help': 'shell-api.classes.Database.help.attributes.getCollectionNames.example', 'docs': 'shell-api.classes.Database.help.attributes.getCollectionNames.link', 'attr': [{ 'description': 'shell-api.classes.Database.help.attributes.getCollectionNames.description' }] });
 Database.prototype.getCollectionNames.serverVersions = ['0.0.0', '4.4.0'];
@@ -1076,6 +1074,18 @@ Database.prototype.getCollectionInfos.serverVersions = ['3.0.0', '4.4.0'];
 Database.prototype.getCollectionInfos.topologies = [0, 1, 2];
 Database.prototype.getCollectionInfos.returnsPromise = true;
 Database.prototype.getCollectionInfos.returnType = 'unknown';
+
+Database.prototype.runCommand.help = () => new Help({ 'help': 'shell-api.classes.Database.help.attributes.runCommand.example', 'docs': 'shell-api.classes.Database.help.attributes.runCommand.link', 'attr': [{ 'description': 'shell-api.classes.Database.help.attributes.runCommand.description' }] });
+Database.prototype.runCommand.serverVersions = ['0.0.0', '4.4.0'];
+Database.prototype.runCommand.topologies = [0, 1, 2];
+Database.prototype.runCommand.returnsPromise = true;
+Database.prototype.runCommand.returnType = 'unknown';
+
+Database.prototype.adminCommand.help = () => new Help({ 'help': 'shell-api.classes.Database.help.attributes.adminCommand.example', 'docs': 'shell-api.classes.Database.help.attributes.adminCommand.link', 'attr': [{ 'description': 'shell-api.classes.Database.help.attributes.adminCommand.description' }] });
+Database.prototype.adminCommand.serverVersions = ['3.4.0', '4.4.0'];
+Database.prototype.adminCommand.topologies = [0, 1, 2];
+Database.prototype.adminCommand.returnsPromise = true;
+Database.prototype.adminCommand.returnType = 'unknown';
 
 
 class DeleteResult {

--- a/packages/shell-api/yaml/Database.yaml
+++ b/packages/shell-api/yaml/Database.yaml
@@ -10,9 +10,6 @@ class:
     __stringRep:
         - this._name
     __hasAsyncChild: true
-    runCommand:
-        <<: *__defaultMethod
-        returnsPromise: true
     getCollectionNames:
         <<: *__defaultMethod
         returnsPromise: true
@@ -22,3 +19,24 @@ class:
         serverVersions:
             - '3.0.0'
             - *ServerVersions.latest
+    runCommand:
+        <<: *__defaultMethod
+        returnsPromise: true
+    adminCommand:
+        <<: *__defaultMethod
+        serverVersions:
+            - '3.4.0'
+            - *ServerVersions.latest
+        returnsPromise: true
+    # aggregate:
+    #     <<: *__defaultMethod
+    #     returnType: 'Cursor'
+    # getSiblingDB:
+    #     <<: *__defaultMethod
+    #     returnType: 'Database'
+    # dropDatabase:
+    #     <<: *__defaultMethod
+    #     returnsPromise: true
+    # getCollection:
+    #     <<: *__defaultMethod
+    #     returnsPromise: true


### PR DESCRIPTION
Implements `db.adminCommand`.

Also:
- tests `db.runCommand`
- moves all db methods in the same section of the mapper
- refactor messageBus.emit('api-call') for db methods in `_emitDatabaseApiCall`;