### PR TITLE
db.aggregate and aggregate with explain

### DIFF
--- a/packages/i18n/src/locales/en_US.js
+++ b/packages/i18n/src/locales/en_US.js
@@ -1094,6 +1094,12 @@ const translations = {
         help: {
           description: 'Database Class',
           attributes: {
+            aggregate: {
+              link: 'https://docs.mongodb.com/manual/reference/method/db.aggregate',
+              description: 'Runs a specified admin/diagnostic pipeline which does not require an underlying collection.',
+              example: 'db.aggregate(pipeline, options)',
+              parameters: {}
+            },
             runCommand: {
               link: 'https://docs.mongodb.com/manual/reference/method/db.runCommand',
               description: 'Runs an arbitrary command on the database.',

--- a/packages/mapper/src/mapper.integration.spec.ts
+++ b/packages/mapper/src/mapper.integration.spec.ts
@@ -586,6 +586,28 @@ describe('Mapper (integration)', function() {
         });
       });
     });
+
+    describe('aggregate', () => {
+      it('runs an aggregate pipeline on the database', async() => {
+        await serviceProvider.insertOne(dbName, collectionName, { x: 1 });
+
+        const cursor = mapper.collection_aggregate(collection, [{
+          $count: 'count'
+        }]);
+
+        expect(await cursor.toArray()).to.deep.equal([{ count: 1 }]);
+      });
+
+      it('runs an explain with explain: true', async() => {
+        await serviceProvider.insertOne(dbName, collectionName, { x: 1 });
+
+        const cursor = mapper.collection_aggregate(collection, [{
+          $count: 'count'
+        }]);
+
+        expect(await cursor.toArray()).to.deep.equal([{ count: 1 }]);
+      });
+    });
   });
 
   describe('db', () => {

--- a/packages/mapper/src/mapper.integration.spec.ts
+++ b/packages/mapper/src/mapper.integration.spec.ts
@@ -619,6 +619,16 @@ describe('Mapper (integration)', function() {
         expect(result.process).to.match(/^mongo/);
       });
     });
+
+    describe('aggregate', () => {
+      it('runs an aggregate pipeline on the database', async() => {
+        const cursor = mapper.database_aggregate(database, [{
+          $listLocalSessions: {}
+        }]);
+
+        expect((await cursor.toArray())[0]).to.have.keys('_id', 'lastUse');
+      });
+    });
   });
 
   describe('explainable', () => {

--- a/packages/service-provider-browser/src/unsupported-cursor.ts
+++ b/packages/service-provider-browser/src/unsupported-cursor.ts
@@ -15,6 +15,122 @@ class UnsupportedCursor implements Cursor {
     this.message = message;
   }
 
+  addOption(option: number): Cursor {
+    throw new Error("Method not implemented.");
+  }
+
+  allowPartialResults(): Cursor {
+    throw new Error("Method not implemented.");
+  }
+
+  batchSize(size: number): Cursor {
+    throw new Error("Method not implemented.");
+  }
+
+  close(options: Document): Promise<void> {
+    throw new Error("Method not implemented.");
+  }
+
+  isClosed(): boolean {
+    throw new Error("Method not implemented.");
+  }
+
+  collation(spec: Document): Cursor {
+    throw new Error("Method not implemented.");
+  }
+
+  comment(cmt: string): Cursor {
+    throw new Error("Method not implemented.");
+  }
+
+  count(): Promise<number> {
+    throw new Error("Method not implemented.");
+  }
+
+  forEach(f: any): Promise<void> {
+    throw new Error("Method not implemented.");
+  }
+
+  hasNext(): Promise<boolean> {
+    throw new Error("Method not implemented.");
+  }
+
+  hint(index: string): Cursor {
+    throw new Error("Method not implemented.");
+  }
+
+  isExhausted(): Promise<boolean> {
+    throw new Error("Method not implemented.");
+  }
+
+  itcount(): Promise<number> {
+    throw new Error("Method not implemented.");
+  }
+
+  limit(value: number): Cursor {
+    throw new Error("Method not implemented.");
+  }
+
+  map(f: any): Cursor {
+    throw new Error("Method not implemented.");
+  }
+
+  max(indexBounds: Document): Cursor {
+    throw new Error("Method not implemented.");
+  }
+
+  maxTimeMS(value: number): Cursor {
+    throw new Error("Method not implemented.");
+  }
+
+  min(indexBounds: Document): Cursor {
+    throw new Error("Method not implemented.");
+  }
+
+  next(): Promise<any> {
+    throw new Error("Method not implemented.");
+  }
+
+  noCursorTimeout(): Cursor {
+    throw new Error("Method not implemented.");
+  }
+
+  oplogReplay(): Cursor {
+    throw new Error("Method not implemented.");
+  }
+
+  projection(spec: Document): Cursor {
+    throw new Error("Method not implemented.");
+  }
+
+  readPref(preference: string): Cursor {
+    throw new Error("Method not implemented.");
+  }
+
+  returnKey(enabled: boolean): Cursor {
+    throw new Error("Method not implemented.");
+  }
+
+  size(): Promise<number> {
+    throw new Error("Method not implemented.");
+  }
+
+  skip(value: number): Cursor {
+    throw new Error("Method not implemented.");
+  }
+
+  sort(spec: Document): Cursor {
+    throw new Error("Method not implemented.");
+  }
+
+  tailable(): Cursor {
+    throw new Error("Method not implemented.");
+  }
+
+  explain(verbosity: string): Promise<any> {
+    throw new Error("Method not implemented.");
+  }
+
   /**
    * When the cursor is for an unsupported operation,
    * this method will reject.

--- a/packages/service-provider-core/src/cursor.ts
+++ b/packages/service-provider-core/src/cursor.ts
@@ -1,14 +1,218 @@
 import Document from './document';
 
-/**
- * Common fluid interface for cursors in the transport module.
- */
 interface Cursor {
+  /**
+   * Add a cursor flag as an option to the cursor.
+   *
+   * @param {number} option - The flag number.
+   *
+   * @returns {Cursor} The cursor.
+   */
+  addOption(option: number): Cursor
+
+  /**
+   * Set cursor to allow partial results.
+   *
+   * @returns {Cursor} The cursor.
+   */
+  allowPartialResults(): Cursor;
+
+  /**
+   * Set the cursor batch size.
+   *
+   * @param {number} size - The batch size.
+   *
+   * @returns {Cursor} The cursor.
+   */
+  batchSize(size: number): Cursor;
+
+  /**
+   * Close the cursor.
+   *
+   * @returns {Cursor} The cursor.
+   */
+  close(options: Document): Promise<void>;
+
+  /**
+   * Determine if the cursor has been closed.
+   *
+   * @returns {boolean} If the cursor is closed.
+   */
+  isClosed(): boolean;
+
+  /**
+   * Set the collation on the cursor.
+   *
+   * @param {Document} spec - The collation.
+   *
+   * @returns {Cursor} The cursor.
+   */
+  collation(spec: Document): Cursor;
+
+  /**
+   * Add a comment to the cursor.
+   *
+   * @param {string} cmt - The comment.
+   *
+   * @returns {Cursor} The cursor.
+   */
+  comment(cmt: string): Cursor;
+
+  /**
+   * Get the count from the cursor.
+   *
+   * @returns {Promise<number>} The count.
+   */
+  count(): Promise<number>;
+
+  forEach(f): Promise<void>;
+
+  /**
+   * Does the cursor have a next document?
+   *
+   * @returns {Promise<boolean>} If there is a next document.
+   */
+  hasNext(): Promise<boolean>;
+
+  /**
+   * Set a hint for indexes on the cursor.
+   *
+   * @param {string} index - The index hint.
+   *
+   * @returns {Cursor} The cursor.
+   */
+  hint(index: string): Cursor;
+
+  /**
+   * cursor.isExhausted() returns true if the cursor is closed and there are no
+   * remaining objects in the batch.
+   *
+   * @returns Promise<boolean> - whether the cursor is exhausted
+   */
+  isExhausted(): Promise<boolean>;
+
+  itcount(): Promise<number>;
+
+  /**
+   * Set the limit of documents to return.
+   *
+   * @param {number} value - The limit value.
+   *
+   * @returns {Cursor} The cursor.
+   */
+  limit(value: number): Cursor;
+
+  map(f): Cursor;
+
+  /**
+   * Set the max index bounds.
+   *
+   * @param {Document} indexBounds - The max bounds.
+   *
+   * @returns {Cursor} The cursor.
+   */
+  max(indexBounds: Document): Cursor;
+
+  /**
+   * Set the maxTimeMS value.
+   *
+   * @param {number} The maxTimeMS value.
+   *
+   * @returns {Cursor} The cursor.
+   */
+  maxTimeMS(value: number): Cursor;
+
+  /**
+   * Set the min index bounds.
+   *
+   * @param {Document} indexBounds - The min bounds.
+   *
+   * @returns {Cursor} The cursor.
+   */
+  min(indexBounds: Document): Cursor;
+
+  next(): Promise<any>;
+
+  /**
+   * Tell the cursor not to timeout.
+   *
+   * @returns {Cursor} The cursor.
+   */
+  noCursorTimeout(): Cursor;
+
+  /**
+   * Flag the cursor as an oplog replay.
+   *
+   * @returns {Cursor} The cursor.
+   */
+  oplogReplay(): Cursor;
+
+  /**
+   * Set the projection on the cursor.
+   *
+   * @param {Document} spec - The projection.
+   *
+   * @returns {Cursor} The cursor.
+   */
+  projection(spec: Document): Cursor;
+
+  /**
+   * Set the read preference.
+   *
+   * @param {string} preference - The read preference.
+   *
+   * @returns {Cursor} The cursor.
+   */
+  readPref(preference: string): Cursor;
+
+  /**
+   * Set the cursor to return the index field.
+   *
+   * @param {boolean} enabled - Whether to enable return key.
+   *
+   * @returns {Cursor} The cursor.
+   */
+  returnKey(enabled: boolean): Cursor;
+
+  size(): Promise<number>;
+
+  /**
+   * Set the skip value.
+   *
+   * @param {number} value - The number of docs to skip.
+   *
+   * @returns {Cursor} The cursor.
+   */
+  skip(value: number): Cursor;
+
+  /**
+   * Set the sort on the cursor.
+   *
+   * @param {Document} spec - The sort.
+   *
+   * @returns {Cursor} The cursor.
+   */
+  sort(spec: Document): Cursor;
+
+  /**
+   * Flag the cursor as tailable.
+   *
+   * @returns {Cursor} The cursor.
+   */
+  tailable(): Cursor;
 
   /**
    * Get the documents from the cursor as an array of objects.
    */
   toArray(): Promise<Document[]>;
+
+  /**
+   * Get the explain of the cursor.
+   *
+   * @param {string} verbosity - the explain verbosity.
+   * @returns {Promise<any>}
+   */
+  explain(verbosity: string): Promise<any>;
 }
 
 export default Cursor;

--- a/packages/shell-api/src/database.spec.ts
+++ b/packages/shell-api/src/database.spec.ts
@@ -46,7 +46,8 @@ describe('Database', () => {
     'getCollectionInfos',
     'getCollectionNames',
     'runCommand',
-    'adminCommand'
+    'adminCommand',
+    'aggregate'
   ].forEach((methodName) => {
     describe(`#${methodName}`, () => {
       it(`wraps mapper.database_${methodName}`, () => {

--- a/packages/shell-api/src/shell-api-signatures.js
+++ b/packages/shell-api/src/shell-api-signatures.js
@@ -131,7 +131,8 @@ const Database = {
     getCollectionNames: { type: 'function', returnsPromise: true, returnType: 'unknown', serverVersions: ['0.0.0', '4.4.0'] },
     getCollectionInfos: { type: 'function', returnsPromise: true, returnType: 'unknown', serverVersions: ['3.0.0', '4.4.0'] },
     runCommand: { type: 'function', returnsPromise: true, returnType: 'unknown', serverVersions: ['0.0.0', '4.4.0'] },
-    adminCommand: { type: 'function', returnsPromise: true, returnType: 'unknown', serverVersions: ['3.4.0', '4.4.0'] }
+    adminCommand: { type: 'function', returnsPromise: true, returnType: 'unknown', serverVersions: ['3.4.0', '4.4.0'] },
+    aggregate: { type: 'function', returnsPromise: false, returnType: 'AggregationCursor', serverVersions: ['0.0.0', '4.4.0'] }
   }
 };
 const DeleteResult = {

--- a/packages/shell-api/src/shell-api.js
+++ b/packages/shell-api/src/shell-api.js
@@ -1040,7 +1040,7 @@ class Database {
     this.shellApiType = () => {
       return 'Database';
     };
-    this.help = () => new Help({ 'help': 'shell-api.classes.Database.help.description', 'docs': 'shell-api.classes.Database.help.link', 'attr': [{ 'name': 'getCollectionNames', 'description': 'shell-api.classes.Database.help.attributes.getCollectionNames.description' }, { 'name': 'getCollectionInfos', 'description': 'shell-api.classes.Database.help.attributes.getCollectionInfos.description' }, { 'name': 'runCommand', 'description': 'shell-api.classes.Database.help.attributes.runCommand.description' }, { 'name': 'adminCommand', 'description': 'shell-api.classes.Database.help.attributes.adminCommand.description' }] });
+    this.help = () => new Help({ 'help': 'shell-api.classes.Database.help.description', 'docs': 'shell-api.classes.Database.help.link', 'attr': [{ 'name': 'getCollectionNames', 'description': 'shell-api.classes.Database.help.attributes.getCollectionNames.description' }, { 'name': 'getCollectionInfos', 'description': 'shell-api.classes.Database.help.attributes.getCollectionInfos.description' }, { 'name': 'runCommand', 'description': 'shell-api.classes.Database.help.attributes.runCommand.description' }, { 'name': 'adminCommand', 'description': 'shell-api.classes.Database.help.attributes.adminCommand.description' }, { 'name': 'aggregate', 'description': 'shell-api.classes.Database.help.attributes.aggregate.description' }] });
 
     return proxy;
   }
@@ -1059,6 +1059,10 @@ class Database {
 
   adminCommand(...args) {
     return this._mapper.database_adminCommand(this, ...args);
+  }
+
+  aggregate(...args) {
+    return this._mapper.database_aggregate(this, ...args);
   }
 }
 
@@ -1086,6 +1090,12 @@ Database.prototype.adminCommand.serverVersions = ['3.4.0', '4.4.0'];
 Database.prototype.adminCommand.topologies = [0, 1, 2];
 Database.prototype.adminCommand.returnsPromise = true;
 Database.prototype.adminCommand.returnType = 'unknown';
+
+Database.prototype.aggregate.help = () => new Help({ 'help': 'shell-api.classes.Database.help.attributes.aggregate.example', 'docs': 'shell-api.classes.Database.help.attributes.aggregate.link', 'attr': [{ 'description': 'shell-api.classes.Database.help.attributes.aggregate.description' }] });
+Database.prototype.aggregate.serverVersions = ['0.0.0', '4.4.0'];
+Database.prototype.aggregate.topologies = [0, 1, 2];
+Database.prototype.aggregate.returnsPromise = false;
+Database.prototype.aggregate.returnType = 'AggregationCursor';
 
 
 class DeleteResult {

--- a/packages/shell-api/yaml/Database.yaml
+++ b/packages/shell-api/yaml/Database.yaml
@@ -28,9 +28,9 @@ class:
             - '3.4.0'
             - *ServerVersions.latest
         returnsPromise: true
-    # aggregate:
-    #     <<: *__defaultMethod
-    #     returnType: 'Cursor'
+    aggregate:
+        <<: *__defaultMethod
+        returnType: 'AggregationCursor'
     # getSiblingDB:
     #     <<: *__defaultMethod
     #     returnType: 'Database'


### PR DESCRIPTION
- Implements `db.aggregate` and add support for `{explain: true}` in `db.coll.aggregate`.

Changes:
- Implements `db.aggregate`
- Add tests for `db.coll.aggregate`
- Refactor the common code of  `mapper.database_aggregate` and `mapper.collection_aggregate` in a private method.
- Refactor the code to make a cursor explainable into a private method.
- Add all the methods to the `Cursor` interface so it can be stubbed properly with `stubInterface`.

**NOTE**:  `Explainable.aggregate`, `Collection.aggregate([...], {explain: true})` and `Database.aggregate([...], {explain: true})` are currently returning an `AggregationCursor` that turns into an explain once evaluated. That is not what happens in the old shell, but i'd keep it for a follow up PR as this one is quite large already.