### PR TITLE
feat: increase inspect depth

### DIFF
--- a/packages/cli-repl/src/format-output.ts
+++ b/packages/cli-repl/src/format-output.ts
@@ -76,6 +76,7 @@ function inspect(output) {
   return util.inspect(output, {
     showProxy: false,
     colors: true,
+    depth: 6
   });
 }
 


### PR DESCRIPTION
Set default inspect depth to 6.

So that the following output would be visible:

```
{
  stages: [
    { '$cursor': [Object] },
    { '$group': [Object] },
    { '$project': [Object] }
  ],
  ok: 1
}
```

```
{
  stages: [
    {
      '$cursor': {
        query: {},
        queryPlanner: {
          plannerVersion: 1,
          namespace: 'test.coll7',
          indexFilterSet: false,
          parsedQuery: {},
          queryHash: '8B3D4AB8',
          planCacheKey: '8B3D4AB8',
          winningPlan: { stage: 'COLLSCAN', direction: 'forward' },
          rejectedPlans: []
        }
      }
    },
    {
      '$group': { _id: { '$const': null }, count: { '$sum': { '$const': 1 } } }
    },
    { '$project': { _id: false, count: true } }
  ],
  ok: 1
}
```