### PR TITLE
MONGOSH-186: move show collections formatting to implementors

### DIFF
--- a/packages/browser-repl/src/components/shell-output-line.spec.tsx
+++ b/packages/browser-repl/src/components/shell-output-line.spec.tsx
@@ -127,6 +127,18 @@ describe('<ShellOutputLine />', () => {
     expect(wrapper.text()).to.contain('admin     45.1 kB\ndxl       8.19 kB\nsupplies  2.24 MB\ntest      5.66 MB\ntest       600 GB');
   });
 
+  it('renders ShowCollectionsResult', () => {
+    const wrapper = mount(<ShellOutputLine entry={{
+      type: 'output',
+      shellApiType: 'ShowCollectionsResult',
+      value: [
+        'nested_documents', 'decimal128', 'coll', 'people_imported', 'cats'
+      ]
+    }} />);
+
+    expect(wrapper.text()).to.contain('nested_documents\ndecimal128\ncoll\npeople_imported\ncats');
+  });
+
   it('renders an error', () => {
     const err = new Error('x');
     const wrapper = shallow(<ShellOutputLine entry={{ type: 'output', value: err }} />);

--- a/packages/browser-repl/src/components/shell-output-line.tsx
+++ b/packages/browser-repl/src/components/shell-output-line.tsx
@@ -8,6 +8,7 @@ import { LineWithIcon } from './utils/line-with-icon';
 
 import { HelpOutput } from './types/help-output';
 import { ShowDbsOutput } from './types/show-dbs-output';
+import { ShowCollectionsOutput } from './types/show-collections-output';
 import { CursorOutput } from './types/cursor-output';
 import { CursorIterationResultOutput } from './types/cursor-iteration-result-output';
 import { ObjectOutput } from './types/object-output';
@@ -55,6 +56,10 @@ export class ShellOutputLine extends Component<ShellOutputLineProps> {
       return <ShowDbsOutput value={value} />;
     }
 
+    if (shellApiType === 'ShowCollectionsResult') {
+      return <ShowCollectionsOutput value={value} />;
+    }
+
     if (shellApiType === 'Cursor') {
       return <CursorOutput value={value} />;
     }
@@ -77,7 +82,6 @@ export class ShellOutputLine extends Component<ShellOutputLineProps> {
   private isPreformattedResult(value: any, shellApiType: string): boolean {
     return typeof value === 'string' &&
     shellApiType === 'Database' ||
-    shellApiType === 'ShowCollectionsResult' ||
     shellApiType === 'Collection';
   }
 

--- a/packages/browser-repl/src/components/types/show-collections-output.spec.tsx
+++ b/packages/browser-repl/src/components/types/show-collections-output.spec.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+import { expect } from '../../../testing/chai';
+import { shallow } from '../../../testing/enzyme';
+
+import { ShowCollectionsOutput } from './show-collections-output';
+
+describe('ShowCollectionsOutput', () => {
+  it('renders no show dbs output if value is empty', () => {
+    const wrapper = shallow(<ShowCollectionsOutput value={[]} />);
+
+    expect(wrapper.text()).to.equal('');
+  });
+
+  it('renders a ShowCollectionsOutput for each element in value', () => {
+    const wrapper = shallow(<ShowCollectionsOutput value={[
+      'nested_documents', 'decimal128', 'coll', 'people_imported', 'cats'
+    ]} />);
+
+    expect(wrapper.text()).to.contain('nested_documents\ndecimal128\ncoll\npeople_imported\ncats');
+  });
+});

--- a/packages/browser-repl/src/components/types/show-collections-output.tsx
+++ b/packages/browser-repl/src/components/types/show-collections-output.tsx
@@ -1,0 +1,16 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+
+interface ShowCollectionsOutputProps {
+  value: string[];
+}
+
+export class ShowCollectionsOutput extends Component<ShowCollectionsOutputProps> {
+  static propTypes = {
+    value: PropTypes.array
+  };
+
+  render(): JSX.Element {
+    return <pre>{this.props.value.join('\n')}</pre>;
+  }
+}

--- a/packages/cli-repl/src/format-output.spec.ts
+++ b/packages/cli-repl/src/format-output.spec.ts
@@ -94,6 +94,20 @@ describe('formatOutput', () => {
       expect(output).to.contain('admin     45.1 kB\ndxl       8.19 kB\nsupplies  2.24 MB\ntest      5.66 MB\ntest       600 GB');
     });
   });
+
+  context('when the result is ShowCollectionsResult', () => {
+    it('returns the help text', () => {
+      const output = stripAnsiColors(format({
+        value: [
+          'nested_documents', 'decimal128', 'coll', 'people_imported', 'cats'
+        ],
+        type: 'ShowCollectionsResult'
+      }));
+
+      expect(output).to.contain('nested_documents\ndecimal128\ncoll\npeople_imported\ncats');
+    });
+  });
+
   context('when the result is Help', () => {
     it('returns help text', () => {
       const output = stripAnsiColors(format({

--- a/packages/cli-repl/src/format-output.ts
+++ b/packages/cli-repl/src/format-output.ts
@@ -39,6 +39,10 @@ export default function formatOutput(evaluationResult: EvaluationResult): string
     return formatDatabases(value)
   }
 
+  if (type === 'ShowCollectionsResult') {
+    return formatCollections(value)
+  }
+
   if (type === 'Error') {
     return formatError(value)
   }
@@ -52,6 +56,10 @@ function formatSimpleType(output) {
   }
 
   return inspect(output);
+}
+
+function formatCollections(output) {
+  return output.join('\n');
 }
 
 function formatDatabases(output) {

--- a/packages/mapper/src/mapper.spec.ts
+++ b/packages/mapper/src/mapper.spec.ts
@@ -65,11 +65,10 @@ describe('Mapper', () => {
               { name: 'coll2' }
             ]);
 
-            const expectedOutput = `coll1
-coll2`;
+            const expectedOutput = ['coll1', 'coll2'];
             expect(
               (await mapper.show(showArgument)).toReplString()
-            ).to.equal(expectedOutput);
+            ).to.deep.equal(expectedOutput);
           });
         });
       });

--- a/packages/mapper/src/mapper.ts
+++ b/packages/mapper/src/mapper.ts
@@ -118,7 +118,7 @@ export default class Mapper {
   private async _showCollections(): Promise<CommandResult> {
     const collectionNames = await this.database_getCollectionNames(this.context.db);
 
-    return new CommandResult('ShowCollectionsResult', collectionNames.join('\n'));
+    return new CommandResult('ShowCollectionsResult', collectionNames);
   }
 
   private async _showDatabases(): Promise<CommandResult> {


### PR DESCRIPTION
## Description
`show collections` should be formatted in implementors instead of the mapper.
This PR removes `.join('\n')` out of the mapper.