### PR TITLE
touch up mongosh greeting

### DIFF
--- a/packages/cli-repl/src/cli-repl.ts
+++ b/packages/cli-repl/src/cli-repl.ts
@@ -260,8 +260,7 @@ class CliRepl {
     const version = this.buildInfo.version;
 
     this.repl = repl.start({
-      prompt: `$ mongosh > `,
-      ignoreUndefined: true,
+      prompt: `msh > `,
       writer: this.writer,
       completer: completer.bind(null, version),
     });

--- a/packages/cli-repl/src/cli-repl.ts
+++ b/packages/cli-repl/src/cli-repl.ts
@@ -5,7 +5,7 @@ import { MongoshWarning } from '@mongosh/errors';
 import { changeHistory } from '@mongosh/history';
 import getConnectInfo from './connect-info';
 import formatOutput from './format-output';
-import { TELEMETRY } from './constants';
+import { TELEMETRY, MONGOSH_WIKI } from './constants';
 import CliOptions from './cli-options';
 import completer from './completer';
 import { REPLServer, Recoverable } from 'repl';
@@ -50,7 +50,7 @@ class CliRepl {
    * @param {NodeOptions} driverOptions - The driver options.
    */
   async connect(driverUri: string, driverOptions: NodeOptions): Promise<void> {
-    console.log(i18n.__(CONNECTING), clr(redactPwd(driverUri), 'bold'));
+    console.log(i18n.__(CONNECTING), clr(redactPwd(driverUri), ['bold', 'green']));
 
     this.serviceProvider = await CliServiceProvider.connect(driverUri, driverOptions);
     this.ShellEvaluator = new ShellEvaluator(this.serviceProvider, this.bus, this);
@@ -215,7 +215,8 @@ class CliRepl {
    * The greeting for the shell.
    */
   greet(): void {
-    console.log(`Using MongoDB: ${this.buildInfo.version} \n`);
+    console.log(`Using MongoDB: ${this.buildInfo.version}`);
+    console.log(`${MONGOSH_WIKI}`);
     if (!this.disableGreetingMessage) console.log(TELEMETRY);
   }
 

--- a/packages/cli-repl/src/constants.ts
+++ b/packages/cli-repl/src/constants.ts
@@ -6,6 +6,10 @@ ${i18n.__('cli-repl.cli-repl.telemetry')}
 ${i18n.__('cli-repl.cli-repl.disableTelemetry')}${clr('disableTelemetry()', 'bold')} ${i18n.__('cli-repl.cli-repl.command')}
 `
 
+export const MONGOSH_WIKI = `
+${i18n.__('cli-repl.cli-repl.wiki.info')} ${clr(i18n.__('cli-repl.cli-repl.wiki.link'), 'bold')}
+`
+
 export const USAGE = `
 
   ${clr(i18n.__('cli-repl.args.usage'), 'bold')}

--- a/packages/cli-repl/src/format-output.spec.ts
+++ b/packages/cli-repl/src/format-output.spec.ts
@@ -12,6 +12,12 @@ describe('formatOutput', () => {
     });
   });
 
+  context('when the result is undefined', () => {
+    it('returns the output', () => {
+      expect(format({value: undefined})).to.equal('');
+    });
+  });
+
   context('when the result is an object', () => {
     it('returns the inspection', () => {
       expect(format({value: 2})).to.include('2');

--- a/packages/cli-repl/src/format-output.ts
+++ b/packages/cli-repl/src/format-output.ts
@@ -47,9 +47,8 @@ export default function formatOutput(evaluationResult: EvaluationResult): string
 }
 
 function formatSimpleType(output) {
-  if (typeof output === 'string') {
-    return output;
-  }
+  if (typeof output === 'string') return output;
+  if (typeof output === 'undefined') return '';
 
   return inspect(output);
 }

--- a/packages/cli-repl/src/index.ts
+++ b/packages/cli-repl/src/index.ts
@@ -5,7 +5,7 @@ import mapCliToDriver from './arg-mapper';
 import generateUri from './uri-generator';
 import completer from './completer'
 import clr from './clr'
-import { USAGE, TELEMETRY } from './constants';
+import { USAGE, TELEMETRY, MONGOSH_WIKI } from './constants';
 
 export default CliRepl;
 
@@ -13,6 +13,7 @@ export {
   clr,
   USAGE,
   TELEMETRY,
+  MONGOSH_WIKI,
   CliRepl,
   redactPwd,
   completer,

--- a/packages/i18n/src/locales/en_US.js
+++ b/packages/i18n/src/locales/en_US.js
@@ -62,7 +62,11 @@ const translations = {
       disableTelemetry: 'You can opt-out by running the ',
       command: 'command.',
       enabledTelemetry: 'Telemetry is now enabled.',
-      disabledTelemetry: 'Telemetry is now disabled.'
+      disabledTelemetry: 'Telemetry is now disabled.',
+      wiki: {
+        info: 'For more information about mongosh, please see the wiki:',
+        link: 'github.com/mongodb-js/mongosh/wiki'
+      }
     },
     'uri-generator': {
       'no-host-port': 'If a full URI is provided, you cannot also specify --host or --port'


### PR DESCRIPTION
## Description

This PR adds a few touch ups to the CLI UI:
- an extra message about the wiki on startup
- extra highlighting to the currently connected url
- changes prompt to `msh >` since `$` is not usually assigned to REPLs and `mongosh` takes up a lot of valuable space.

There is also a fix for `undefined` result. If `result.value` is of type undefined, we will return a new line. 

<img width="724" alt="Capture d’écran, le 2020-05-07 à 16 43 44" src="https://user-images.githubusercontent.com/8107784/81308346-f3948800-9081-11ea-9395-f1304f5662fa.png">
