### PR TITLE
fix: align aggregate + explain with old shell

### DIFF
--- a/packages/mapper/src/mapper.integration.spec.ts
+++ b/packages/mapper/src/mapper.integration.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import { CliServiceProvider } from '@mongosh/service-provider-server';
 import Mapper from './mapper';
-import { Collection, Cursor, Database, Explainable } from '@mongosh/shell-api';
+import { Collection, Cursor, Database, Explainable, AggregationCursor } from '@mongosh/shell-api';
 
 const mongodbRunnerBefore = require('mongodb-runner/mocha/before');
 const mongodbRunnerAfter = require('mongodb-runner/mocha/after');
@@ -591,21 +591,21 @@ describe('Mapper (integration)', function() {
       it('runs an aggregate pipeline on the database', async() => {
         await serviceProvider.insertOne(dbName, collectionName, { x: 1 });
 
-        const cursor = mapper.collection_aggregate(collection, [{
+        const cursor = await mapper.collection_aggregate(collection, [{
           $count: 'count'
         }]);
 
-        expect(await cursor.toArray()).to.deep.equal([{ count: 1 }]);
+        expect(await (cursor as AggregationCursor).toArray()).to.deep.equal([{ count: 1 }]);
       });
 
       it('runs an explain with explain: true', async() => {
         await serviceProvider.insertOne(dbName, collectionName, { x: 1 });
 
-        const cursor = mapper.collection_aggregate(collection, [{
+        const cursor = await mapper.collection_aggregate(collection, [{
           $count: 'count'
         }]);
 
-        expect(await cursor.toArray()).to.deep.equal([{ count: 1 }]);
+        expect(await (cursor as AggregationCursor).toArray()).to.deep.equal([{ count: 1 }]);
       });
     });
   });
@@ -644,11 +644,11 @@ describe('Mapper (integration)', function() {
 
     describe('aggregate', () => {
       it('runs an aggregate pipeline on the database', async() => {
-        const cursor = mapper.database_aggregate(database, [{
+        const cursor = await mapper.database_aggregate(database, [{
           $listLocalSessions: {}
         }]);
 
-        expect((await cursor.toArray())[0]).to.have.keys('_id', 'lastUse');
+        expect((await (cursor as AggregationCursor).toArray())[0]).to.have.keys('_id', 'lastUse');
       });
     });
   });

--- a/packages/shell-api/src/shell-api-signatures.js
+++ b/packages/shell-api/src/shell-api-signatures.js
@@ -29,7 +29,7 @@ const Collection = {
   type: 'Collection',
   hasAsyncChild: true,
   attributes: {
-    aggregate: { type: 'function', returnsPromise: false, returnType: 'AggregationCursor', serverVersions: ['0.0.0', '4.4.0'] },
+    aggregate: { type: 'function', returnsPromise: true, returnType: 'AggregationCursor', serverVersions: ['0.0.0', '4.4.0'] },
     bulkWrite: { type: 'function', returnsPromise: true, returnType: 'unknown', serverVersions: ['3.2.0', '4.4.0'] },
     countDocuments: { type: 'function', returnsPromise: true, returnType: 'unknown', serverVersions: ['4.0.3', '4.4.0'] },
     count: { type: 'function', returnsPromise: true, returnType: 'unknown', serverVersions: ['0.0.0', '4.4.0'] },
@@ -132,7 +132,7 @@ const Database = {
     getCollectionInfos: { type: 'function', returnsPromise: true, returnType: 'unknown', serverVersions: ['3.0.0', '4.4.0'] },
     runCommand: { type: 'function', returnsPromise: true, returnType: 'unknown', serverVersions: ['0.0.0', '4.4.0'] },
     adminCommand: { type: 'function', returnsPromise: true, returnType: 'unknown', serverVersions: ['3.4.0', '4.4.0'] },
-    aggregate: { type: 'function', returnsPromise: false, returnType: 'AggregationCursor', serverVersions: ['0.0.0', '4.4.0'] }
+    aggregate: { type: 'function', returnsPromise: true, returnType: 'AggregationCursor', serverVersions: ['0.0.0', '4.4.0'] }
   }
 };
 const DeleteResult = {
@@ -150,7 +150,7 @@ const Explainable = {
     getVerbosity: { type: 'function', returnsPromise: false, returnType: 'unknown', serverVersions: ['0.0.0', '4.4.0'] },
     setVerbosity: { type: 'function', returnsPromise: false, returnType: 'unknown', serverVersions: ['0.0.0', '4.4.0'] },
     find: { type: 'function', returnsPromise: false, returnType: 'Cursor', serverVersions: ['0.0.0', '4.4.0'] },
-    aggregate: { type: 'function', returnsPromise: false, returnType: 'Cursor', serverVersions: ['0.0.0', '4.4.0'] }
+    aggregate: { type: 'function', returnsPromise: true, returnType: 'unknown', serverVersions: ['0.0.0', '4.4.0'] }
   }
 };
 const InsertManyResult = {

--- a/packages/shell-api/src/shell-api.js
+++ b/packages/shell-api/src/shell-api.js
@@ -357,7 +357,7 @@ class Collection {
 Collection.prototype.aggregate.help = () => new Help({ 'help': 'shell-api.classes.Collection.help.attributes.aggregate.example', 'docs': 'shell-api.classes.Collection.help.attributes.aggregate.link', 'attr': [{ 'description': 'shell-api.classes.Collection.help.attributes.aggregate.description' }] });
 Collection.prototype.aggregate.serverVersions = ['0.0.0', '4.4.0'];
 Collection.prototype.aggregate.topologies = [0, 1, 2];
-Collection.prototype.aggregate.returnsPromise = false;
+Collection.prototype.aggregate.returnsPromise = true;
 Collection.prototype.aggregate.returnType = 'AggregationCursor';
 
 Collection.prototype.bulkWrite.help = () => new Help({ 'help': 'shell-api.classes.Collection.help.attributes.bulkWrite.example', 'docs': 'shell-api.classes.Collection.help.attributes.bulkWrite.link', 'attr': [{ 'description': 'shell-api.classes.Collection.help.attributes.bulkWrite.description' }] });
@@ -1094,7 +1094,7 @@ Database.prototype.adminCommand.returnType = 'unknown';
 Database.prototype.aggregate.help = () => new Help({ 'help': 'shell-api.classes.Database.help.attributes.aggregate.example', 'docs': 'shell-api.classes.Database.help.attributes.aggregate.link', 'attr': [{ 'description': 'shell-api.classes.Database.help.attributes.aggregate.description' }] });
 Database.prototype.aggregate.serverVersions = ['0.0.0', '4.4.0'];
 Database.prototype.aggregate.topologies = [0, 1, 2];
-Database.prototype.aggregate.returnsPromise = false;
+Database.prototype.aggregate.returnsPromise = true;
 Database.prototype.aggregate.returnType = 'AggregationCursor';
 
 
@@ -1180,8 +1180,8 @@ Explainable.prototype.find.returnType = 'Cursor';
 Explainable.prototype.aggregate.help = () => new Help({ 'help': 'shell-api.classes.Explainable.help.attributes.aggregate.example', 'docs': 'shell-api.classes.Explainable.help.attributes.aggregate.link', 'attr': [{ 'description': 'shell-api.classes.Explainable.help.attributes.aggregate.description' }] });
 Explainable.prototype.aggregate.serverVersions = ['0.0.0', '4.4.0'];
 Explainable.prototype.aggregate.topologies = [0, 1, 2];
-Explainable.prototype.aggregate.returnsPromise = false;
-Explainable.prototype.aggregate.returnType = 'Cursor';
+Explainable.prototype.aggregate.returnsPromise = true;
+Explainable.prototype.aggregate.returnType = 'unknown';
 
 
 class InsertManyResult {

--- a/packages/shell-api/yaml/Collection.yaml
+++ b/packages/shell-api/yaml/Collection.yaml
@@ -13,6 +13,7 @@ class:
     __hasAsyncChild: true
     aggregate:
         <<: *__defaultMethod
+        returnsPromise: true
         returnType: 'AggregationCursor'
     bulkWrite:
         <<: *__defaultMethod

--- a/packages/shell-api/yaml/Database.yaml
+++ b/packages/shell-api/yaml/Database.yaml
@@ -30,6 +30,7 @@ class:
         returnsPromise: true
     aggregate:
         <<: *__defaultMethod
+        returnsPromise: true
         returnType: 'AggregationCursor'
     # getSiblingDB:
     #     <<: *__defaultMethod

--- a/packages/shell-api/yaml/Explainable.yaml
+++ b/packages/shell-api/yaml/Explainable.yaml
@@ -22,7 +22,7 @@ class:
     returnType: 'Cursor'
   aggregate:
     <<: *__defaultMethod
-    returnType: 'Cursor'
+    returnsPromise: true
 
 #   # bsonsize:
 #   # count:


### PR DESCRIPTION
Replicate the behaviour of the old shell in regards to aggregate with explain.

This is a bit odd, but when calling `db.coll.aggregate(pipeline, {explain: undefined or false})`, an `AggregationCursor` is returned. With `db.coll.aggregate(pipeline, {explain: true})` instead a plain object gets returned and the same can be assigned to a variable.

So this PR basically allows for this:

```
explainResult = db.coll.aggregate(pipeline, {explain: true});
explainResult.stages
```

that was not possible before.

Note that `db.coll.explain().aggregate()` behaves in the same way (does not return a cursor), whereas `db.coll.explain().find()` does return a cursor.

