### PR TITLE
Made the prompt just '>'

### DIFF
--- a/packages/cli-repl/src/cli-repl.ts
+++ b/packages/cli-repl/src/cli-repl.ts
@@ -260,7 +260,7 @@ class CliRepl {
     const version = this.buildInfo.version;
 
     this.repl = repl.start({
-      prompt: `msh > `,
+      prompt: `> `,
       writer: this.writer,
       completer: completer.bind(null, version),
     });


### PR DESCRIPTION
As discussed in #161, let's make the prompt just `>`.