### PR TITLE
MONGOSH-177: handle unhandled rejections

### DIFF
--- a/packages/cli-repl/src/format-output.ts
+++ b/packages/cli-repl/src/format-output.ts
@@ -69,7 +69,7 @@ function formatDatabases(output) {
   return textTable(tableEntries, { align: ['l', 'r'] });
 }
 
-function formatError(error) {
+export function formatError(error) {
   let result = '';
   if (error.name) result += `\r${clr(error.name, ['bold', 'red'])}: `;
   if (error.message) result += error.message;


### PR DESCRIPTION
## Description

There are certain asynchronous functions where we don't properly handle promise rejections. These are mainly done on startup: `connect` and `buildInfo`. This PR wraps them all in a `try`/`catch` to display the error to the user properly, and terminate the process when necessary. 

__Before:__
<img width="715" alt="Capture d’écran, le 2020-04-27 à 17 25 50" src="https://user-images.githubusercontent.com/8107784/81554682-82a5e680-9387-11ea-9e9c-763fbb79436f.png">

__After:__
<img width="1188" alt="Capture d’écran, le 2020-05-09 à 19 29 09" src="https://user-images.githubusercontent.com/8107784/81554824-c0a30a80-9387-11ea-95bd-6f3758520ac6.png">


## Open Questions
I've tried to get errors with a whole bunch of our other service-provider-* methods, and it seems like everything else gets handled well. This is due to the fact that our API methods are part of the mapper, and the result from the mapper gets handled in the writer, which explicitly checks for `result.message && result.stack`. This allows us to always format the incoming error and return it gracefully. 

I might not have seen all the unhandled `await`s. If you spotted something before that also ought to be handled, please let me know. 

## Notes
I've rearranged some methods in cli-repl, which is why the PR is a tad larger.