### PR TITLE
Implements `db. getSiblingDB()` and `db.getCollection()`

### DIFF
--- a/packages/i18n/src/locales/en_US.js
+++ b/packages/i18n/src/locales/en_US.js
@@ -1131,7 +1131,13 @@ const translations = {
             getSiblingDB: {
               link: 'https://docs.mongodb.com/manual/reference/method/db.getSiblingDB',
               description: 'Returns another database without modifying the db variable in the shell environment.',
-              example: 'db.getSiblingDB("users")',
+              example: 'db.getSiblingDB(name)',
+              parameters: {}
+            },
+            getCollection: {
+              link: 'https://docs.mongodb.com/manual/reference/method/db.getCollection',
+              description: 'Returns a collection or a view object by its name.',
+              example: 'db.getCollection(name)',
               parameters: {}
             }
           }

--- a/packages/i18n/src/locales/en_US.js
+++ b/packages/i18n/src/locales/en_US.js
@@ -1127,6 +1127,12 @@ const translations = {
               description: 'Returns an array containing the names of all collections in the current database.',
               example: 'db.getCollectionNames',
               parameters: {}
+            },
+            getSiblingDB: {
+              link: 'https://docs.mongodb.com/manual/reference/method/db.getSiblingDB',
+              description: 'Returns another database without modifying the db variable in the shell environment.',
+              example: 'db.getSiblingDB("users")',
+              parameters: {}
             }
           }
         }

--- a/packages/java-shell/package-lock.json
+++ b/packages/java-shell/package-lock.json
@@ -15,9 +15,9 @@
 			}
 		},
 		"acorn": {
-			"version": "7.1.1",
-			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.1.1.tgz",
-			"integrity": "sha512-add7dgA5ppRPxCFJoAGfMDi7PIBXq1RtGo7BhbLaxwrXPOmw8gq48Y9ozT01hUKy9byMjlR20EJhu5zlkErEkg==",
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.2.0.tgz",
+			"integrity": "sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ==",
 			"dev": true
 		},
 		"acorn-node": {
@@ -1083,9 +1083,9 @@
 			}
 		},
 		"safe-buffer": {
-			"version": "5.2.0",
-			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.0.tgz",
-			"integrity": "sha512-fZEwUGbVl7kouZs1jCdMLdt95hdIv0ZeHg6L7qPeciMZhZ+/gdesW4wgTARkrFWEpspjEATAzUGPG8N2jJiwbg==",
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
 			"dev": true
 		},
 		"sha.js": {

--- a/packages/mapper/src/mapper.spec.ts
+++ b/packages/mapper/src/mapper.spec.ts
@@ -1025,9 +1025,54 @@ describe('Mapper', () => {
           mapper.database_getSiblingDB(database, '');
         }).to.throw('Database name cannot be empty.');
       });
+
+      it('reuses db instances', () => {
+        const otherDb = mapper.database_getSiblingDB(database, 'otherdb');
+        expect(
+          mapper.database_getSiblingDB(database, 'otherdb')
+        ).to.equal(otherDb);
+      });
+    });
+
+    describe('getCollection', () => {
+      it('returns a collection for the database', async() => {
+        const coll = mapper.database_getCollection(database, 'coll');
+        expect(coll).to.be.instanceOf(Collection);
+        expect(coll._name).to.equal('coll');
+        expect(coll._database).to.equal(database);
+      });
+
+      it('throws if name is not a string', () => {
+        expect(() => {
+          mapper.database_getCollection(database, undefined);
+        }).to.throw('Collection name must be a string. Received undefined.');
+      });
+
+      it('throws if name is empty', () => {
+        expect(() => {
+          mapper.database_getCollection(database, '');
+        }).to.throw('Collection name cannot be empty.');
+      });
+
+      it('allows to use collection names that would collide with methods', () => {
+        const coll = mapper.database_getCollection(database, 'getCollection');
+        expect(coll).to.be.instanceOf(Collection);
+        expect(coll._name).to.equal('getCollection');
+      });
+
+      it('allows to use collection names that starts with _', () => {
+        const coll = mapper.database_getCollection(database, '_coll1');
+        expect(coll).to.be.instanceOf(Collection);
+        expect(coll._name).to.equal('_coll1');
+      });
+
+      it('reuses collections', () => {
+        expect(
+          mapper.database_getCollection(database, 'coll')
+        ).to.equal(mapper.database_getCollection(database, 'coll'));
+      });
     });
   });
-
 
   describe('explainable', () => {
     let explainable: Explainable;

--- a/packages/mapper/src/mapper.ts
+++ b/packages/mapper/src/mapper.ts
@@ -1966,4 +1966,23 @@ export default class Mapper {
   database_getSiblingDB(database: Database, name: string): Database {
     return this._getDatabase(name);
   }
+
+  database_getCollection(database: Database, name: string): Collection {
+    if (typeof name !== 'string') {
+      throw new MongoshInvalidInputError(
+        `Collection name must be a string. Received ${typeof name}.`);
+    }
+
+    if (!name.trim()) {
+      throw new MongoshInvalidInputError('Collection name cannot be empty.');
+    }
+
+    const collections: Record<string, Collection> = (database as any)._collections;
+
+    if (!collections[name]) {
+      collections[name] = new Collection(this, database, name);
+    }
+
+    return collections[name];
+  }
 }

--- a/packages/shell-api/bin/compile-shell-api.js
+++ b/packages/shell-api/bin/compile-shell-api.js
@@ -5,13 +5,28 @@ const yaml = require('js-yaml');
 const YAML_DIR = 'yaml';
 
 const databaseConstructorTemplate = (contents) => (`
+    const collections = {};
+    this._collections = collections;
+
     const proxy = new Proxy(this, {
-      get: (obj, prop) => {
-        if (!(prop in obj)) {
-          obj[prop] = new Collection(_mapper, proxy, prop);
+      get: (target, prop) => {
+        if (prop in target) {
+          return target[prop];
         }
 
-        return obj[prop];
+        if (
+          typeof prop !== 'string' ||
+            prop.startsWith('_') ||
+            !prop.trim()
+        ) {
+          return;
+        }
+
+        if (!collections[prop]) {
+          collections[prop] = new Collection(_mapper, proxy, prop);
+        }
+
+        return collections[prop];
       }
     });
 ${contents}

--- a/packages/shell-api/src/database.spec.ts
+++ b/packages/shell-api/src/database.spec.ts
@@ -47,7 +47,8 @@ describe('Database', () => {
     'getCollectionNames',
     'runCommand',
     'adminCommand',
-    'aggregate'
+    'aggregate',
+    'getSiblingDB'
   ].forEach((methodName) => {
     describe(`#${methodName}`, () => {
       it(`wraps mapper.database_${methodName}`, () => {

--- a/packages/shell-api/src/database.spec.ts
+++ b/packages/shell-api/src/database.spec.ts
@@ -1,6 +1,6 @@
 import sinon from 'sinon';
 import Mapper from '../../mapper/lib';
-import { Database } from './shell-api';
+import { Database, Collection } from './shell-api';
 import * as signatures from './shell-api-signatures';
 import { expect } from 'chai';
 
@@ -48,12 +48,51 @@ describe('Database', () => {
     'runCommand',
     'adminCommand',
     'aggregate',
-    'getSiblingDB'
+    'getSiblingDB',
+    'getCollection'
   ].forEach((methodName) => {
     describe(`#${methodName}`, () => {
       it(`wraps mapper.database_${methodName}`, () => {
         testWrappedMethod(methodName);
       });
     });
+  });
+
+  it('allows to get a collection as property if is not one of the existing methods', () => {
+    const database: any = new Database({}, 'db1');
+    expect(database.someCollection).to.have.instanceOf(Collection);
+    expect(database.someCollection._name).to.equal('someCollection');
+  });
+
+  it('reuses collections', () => {
+    const database: any = new Database({}, 'db1');
+    expect(database.someCollection).to.equal(database.someCollection);
+  });
+
+  it('does not return a collection starting with _', () => {
+    // this is the behaviour in the old shell
+
+    const database: any = new Database({}, 'db1');
+    expect(database._someProperty).to.equal(undefined);
+  });
+
+  it('does not return a collection for symbols', () => {
+    const database: any = new Database({}, 'db1');
+    expect(database[Symbol('someProperty')]).to.equal(undefined);
+  });
+
+  it('does not return a collection with invalid name', () => {
+    const database: any = new Database({}, 'db1');
+    expect(database['   ']).to.equal(undefined);
+  });
+
+  it('allows to access _name', () => {
+    const database: any = new Database({}, 'db1');
+    expect(database._name).to.equal('db1');
+  });
+
+  it('allows to access _collections', () => {
+    const database: any = new Database({}, 'db1');
+    expect(database._collections).to.deep.equal({});
   });
 });

--- a/packages/shell-api/src/shell-api-signatures.js
+++ b/packages/shell-api/src/shell-api-signatures.js
@@ -132,7 +132,8 @@ const Database = {
     getCollectionInfos: { type: 'function', returnsPromise: true, returnType: 'unknown', serverVersions: ['3.0.0', '4.4.0'] },
     runCommand: { type: 'function', returnsPromise: true, returnType: 'unknown', serverVersions: ['0.0.0', '4.4.0'] },
     adminCommand: { type: 'function', returnsPromise: true, returnType: 'unknown', serverVersions: ['3.4.0', '4.4.0'] },
-    aggregate: { type: 'function', returnsPromise: true, returnType: 'AggregationCursor', serverVersions: ['0.0.0', '4.4.0'] }
+    aggregate: { type: 'function', returnsPromise: true, returnType: 'AggregationCursor', serverVersions: ['0.0.0', '4.4.0'] },
+    getSiblingDB: { type: 'function', returnsPromise: false, returnType: 'Database', serverVersions: ['0.0.0', '4.4.0'] }
   }
 };
 const DeleteResult = {

--- a/packages/shell-api/src/shell-api-signatures.js
+++ b/packages/shell-api/src/shell-api-signatures.js
@@ -133,7 +133,8 @@ const Database = {
     runCommand: { type: 'function', returnsPromise: true, returnType: 'unknown', serverVersions: ['0.0.0', '4.4.0'] },
     adminCommand: { type: 'function', returnsPromise: true, returnType: 'unknown', serverVersions: ['3.4.0', '4.4.0'] },
     aggregate: { type: 'function', returnsPromise: true, returnType: 'AggregationCursor', serverVersions: ['0.0.0', '4.4.0'] },
-    getSiblingDB: { type: 'function', returnsPromise: false, returnType: 'Database', serverVersions: ['0.0.0', '4.4.0'] }
+    getSiblingDB: { type: 'function', returnsPromise: false, returnType: 'Database', serverVersions: ['0.0.0', '4.4.0'] },
+    getCollection: { type: 'function', returnsPromise: true, returnType: 'unknown', serverVersions: ['0.0.0', '4.4.0'] }
   }
 };
 const DeleteResult = {

--- a/packages/shell-api/src/shell-api.js
+++ b/packages/shell-api/src/shell-api.js
@@ -1040,7 +1040,7 @@ class Database {
     this.shellApiType = () => {
       return 'Database';
     };
-    this.help = () => new Help({ 'help': 'shell-api.classes.Database.help.description', 'docs': 'shell-api.classes.Database.help.link', 'attr': [{ 'name': 'getCollectionNames', 'description': 'shell-api.classes.Database.help.attributes.getCollectionNames.description' }, { 'name': 'getCollectionInfos', 'description': 'shell-api.classes.Database.help.attributes.getCollectionInfos.description' }, { 'name': 'runCommand', 'description': 'shell-api.classes.Database.help.attributes.runCommand.description' }, { 'name': 'adminCommand', 'description': 'shell-api.classes.Database.help.attributes.adminCommand.description' }, { 'name': 'aggregate', 'description': 'shell-api.classes.Database.help.attributes.aggregate.description' }] });
+    this.help = () => new Help({ 'help': 'shell-api.classes.Database.help.description', 'docs': 'shell-api.classes.Database.help.link', 'attr': [{ 'name': 'getCollectionNames', 'description': 'shell-api.classes.Database.help.attributes.getCollectionNames.description' }, { 'name': 'getCollectionInfos', 'description': 'shell-api.classes.Database.help.attributes.getCollectionInfos.description' }, { 'name': 'runCommand', 'description': 'shell-api.classes.Database.help.attributes.runCommand.description' }, { 'name': 'adminCommand', 'description': 'shell-api.classes.Database.help.attributes.adminCommand.description' }, { 'name': 'aggregate', 'description': 'shell-api.classes.Database.help.attributes.aggregate.description' }, { 'name': 'getSiblingDB', 'description': 'shell-api.classes.Database.help.attributes.getSiblingDB.description' }] });
 
     return proxy;
   }
@@ -1063,6 +1063,10 @@ class Database {
 
   aggregate(...args) {
     return this._mapper.database_aggregate(this, ...args);
+  }
+
+  getSiblingDB(...args) {
+    return this._mapper.database_getSiblingDB(this, ...args);
   }
 }
 
@@ -1096,6 +1100,12 @@ Database.prototype.aggregate.serverVersions = ['0.0.0', '4.4.0'];
 Database.prototype.aggregate.topologies = [0, 1, 2];
 Database.prototype.aggregate.returnsPromise = true;
 Database.prototype.aggregate.returnType = 'AggregationCursor';
+
+Database.prototype.getSiblingDB.help = () => new Help({ 'help': 'shell-api.classes.Database.help.attributes.getSiblingDB.example', 'docs': 'shell-api.classes.Database.help.attributes.getSiblingDB.link', 'attr': [{ 'description': 'shell-api.classes.Database.help.attributes.getSiblingDB.description' }] });
+Database.prototype.getSiblingDB.serverVersions = ['0.0.0', '4.4.0'];
+Database.prototype.getSiblingDB.topologies = [0, 1, 2];
+Database.prototype.getSiblingDB.returnsPromise = false;
+Database.prototype.getSiblingDB.returnType = 'Database';
 
 
 class DeleteResult {

--- a/packages/shell-api/src/shell-api.js
+++ b/packages/shell-api/src/shell-api.js
@@ -1021,13 +1021,28 @@ Cursor.prototype.toArray.returnType = 'unknown';
 
 class Database {
   constructor(_mapper, _name) {
+    const collections = {};
+    this._collections = collections;
+
     const proxy = new Proxy(this, {
-      get: (obj, prop) => {
-        if (!(prop in obj)) {
-          obj[prop] = new Collection(_mapper, proxy, prop);
+      get: (target, prop) => {
+        if (prop in target) {
+          return target[prop];
         }
 
-        return obj[prop];
+        if (
+          typeof prop !== 'string' ||
+            prop.startsWith('_') ||
+            !prop.trim()
+        ) {
+          return;
+        }
+
+        if (!collections[prop]) {
+          collections[prop] = new Collection(_mapper, proxy, prop);
+        }
+
+        return collections[prop];
       }
     });
     this._mapper = _mapper;
@@ -1040,7 +1055,7 @@ class Database {
     this.shellApiType = () => {
       return 'Database';
     };
-    this.help = () => new Help({ 'help': 'shell-api.classes.Database.help.description', 'docs': 'shell-api.classes.Database.help.link', 'attr': [{ 'name': 'getCollectionNames', 'description': 'shell-api.classes.Database.help.attributes.getCollectionNames.description' }, { 'name': 'getCollectionInfos', 'description': 'shell-api.classes.Database.help.attributes.getCollectionInfos.description' }, { 'name': 'runCommand', 'description': 'shell-api.classes.Database.help.attributes.runCommand.description' }, { 'name': 'adminCommand', 'description': 'shell-api.classes.Database.help.attributes.adminCommand.description' }, { 'name': 'aggregate', 'description': 'shell-api.classes.Database.help.attributes.aggregate.description' }, { 'name': 'getSiblingDB', 'description': 'shell-api.classes.Database.help.attributes.getSiblingDB.description' }] });
+    this.help = () => new Help({ 'help': 'shell-api.classes.Database.help.description', 'docs': 'shell-api.classes.Database.help.link', 'attr': [{ 'name': 'getCollectionNames', 'description': 'shell-api.classes.Database.help.attributes.getCollectionNames.description' }, { 'name': 'getCollectionInfos', 'description': 'shell-api.classes.Database.help.attributes.getCollectionInfos.description' }, { 'name': 'runCommand', 'description': 'shell-api.classes.Database.help.attributes.runCommand.description' }, { 'name': 'adminCommand', 'description': 'shell-api.classes.Database.help.attributes.adminCommand.description' }, { 'name': 'aggregate', 'description': 'shell-api.classes.Database.help.attributes.aggregate.description' }, { 'name': 'getSiblingDB', 'description': 'shell-api.classes.Database.help.attributes.getSiblingDB.description' }, { 'name': 'getCollection', 'description': 'shell-api.classes.Database.help.attributes.getCollection.description' }] });
 
     return proxy;
   }
@@ -1067,6 +1082,10 @@ class Database {
 
   getSiblingDB(...args) {
     return this._mapper.database_getSiblingDB(this, ...args);
+  }
+
+  getCollection(...args) {
+    return this._mapper.database_getCollection(this, ...args);
   }
 }
 
@@ -1106,6 +1125,12 @@ Database.prototype.getSiblingDB.serverVersions = ['0.0.0', '4.4.0'];
 Database.prototype.getSiblingDB.topologies = [0, 1, 2];
 Database.prototype.getSiblingDB.returnsPromise = false;
 Database.prototype.getSiblingDB.returnType = 'Database';
+
+Database.prototype.getCollection.help = () => new Help({ 'help': 'shell-api.classes.Database.help.attributes.getCollection.example', 'docs': 'shell-api.classes.Database.help.attributes.getCollection.link', 'attr': [{ 'description': 'shell-api.classes.Database.help.attributes.getCollection.description' }] });
+Database.prototype.getCollection.serverVersions = ['0.0.0', '4.4.0'];
+Database.prototype.getCollection.topologies = [0, 1, 2];
+Database.prototype.getCollection.returnsPromise = true;
+Database.prototype.getCollection.returnType = 'unknown';
 
 
 class DeleteResult {

--- a/packages/shell-api/yaml/Database.yaml
+++ b/packages/shell-api/yaml/Database.yaml
@@ -37,7 +37,7 @@ class:
         returnType: 'Database'
     getCollection:
         <<: *__defaultMethod
-        returnsPromise: true
+        returnType: 'Collection'
     # dropDatabase:
     #     <<: *__defaultMethod
     #     returnsPromise: true

--- a/packages/shell-api/yaml/Database.yaml
+++ b/packages/shell-api/yaml/Database.yaml
@@ -32,9 +32,9 @@ class:
         <<: *__defaultMethod
         returnsPromise: true
         returnType: 'AggregationCursor'
-    # getSiblingDB:
-    #     <<: *__defaultMethod
-    #     returnType: 'Database'
+    getSiblingDB:
+        <<: *__defaultMethod
+        returnType: 'Database'
     # dropDatabase:
     #     <<: *__defaultMethod
     #     returnsPromise: true

--- a/packages/shell-api/yaml/Database.yaml
+++ b/packages/shell-api/yaml/Database.yaml
@@ -35,9 +35,9 @@ class:
     getSiblingDB:
         <<: *__defaultMethod
         returnType: 'Database'
+    getCollection:
+        <<: *__defaultMethod
+        returnsPromise: true
     # dropDatabase:
-    #     <<: *__defaultMethod
-    #     returnsPromise: true
-    # getCollection:
     #     <<: *__defaultMethod
     #     returnsPromise: true


### PR DESCRIPTION
Implements `db.getSiblingDB()` and `db.getCollection()`.

- For `getSiblingDB` also factor the code with `use`
- For `getCollection` also changes the shell-api compilation for `Database` putting the collections in a separate property `_collections`, in such way  using `getCollection` we can have collection names that would normally conflict with property names in the database instance.

 