### PR TITLE
exports just the key for analytics-config

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -16,7 +16,6 @@ variables:
     params:
       working_dir: "src"
       env:
-        BLA: bla
         SEGMENT_API_KEY: ${segment_api_key}
       binary: "bash"
       args:

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -12,19 +12,29 @@ variables:
       permissions: public-read
       content_type: application/octet-stream
   - &compile_exec
-    command: shell.exec
+    command: subprocess.exec
     params:
-      working_dir: src
-      shell: bash
-      script: |
-        source .evergreen/.setup_env
-        export SEGMENT_API_KEY=${segment_api_key}
-        echo "SEGMENT_API_KEY is set to $SEGMENT_API_KEY"
-        export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
-        echo "Run compile-exec"
-        npm run compile-exec
-        echo "content of cli-repl/lib/analytics-config.js"
-        cat packages/cli-repl/lib/analytics-config.js
+      working_dir: "src"
+      env:
+        BLA: bla
+        SEGMENT_API_KEY: ${segment_api_key}
+      binary: "bash"
+      args:
+        - ".evergreen/.compile_exec"
+    # command: shell.exec
+    # params:
+    #   working_dir: src
+    #   shell: bash
+    #   script: |
+    #     source .evergreen/.setup_env
+    #     export SEGMENT_API_KEY=${segment_api_key}
+    #     echo SEGMENT API KEY EXPANSION: ${segment_api_key}
+    #     echo "SEGMENT_API_KEY is set to $SEGMENT_API_KEY"
+    #     export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+    #     echo "Run compile-exec"
+    #     npm run compile-exec
+    #     echo "content of cli-repl/lib/analytics-config.js"
+    #     cat packages/cli-repl/lib/analytics-config.js
 # Functions are any command that can be run.
 #
 # Current functions:

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -12,20 +12,20 @@ variables:
       permissions: public-read
       content_type: application/octet-stream
   - &compile_exec
-    command: subprocess.exec
-    params:
-      working_dir: "src"
-      env:
-        SEGMENT_API_KEY: ${segment_api_key}
-      binary: "bash"
-      args:
-        - ".evergreen/.compile_exec"
-    # command: shell.exec
+    # command: subprocess.exec
     # params:
-    #   working_dir: src
-    #   shell: bash
-    #   script: |
-    #     source .evergreen/.setup_env
+    #   working_dir: "src"
+    #   env:
+    #     SEGMENT_API_KEY: ${segment_api_key}
+    #   binary: "bash"
+    #   args:
+    #     - ".evergreen/.compile_exec"
+    command: shell.exec
+    params:
+      working_dir: src
+      shell: bash
+      script: |
+        env | grep segment_api_key
     #     export SEGMENT_API_KEY=${segment_api_key}
     #     echo SEGMENT API KEY EXPANSION: ${segment_api_key}
     #     echo "SEGMENT_API_KEY is set to $SEGMENT_API_KEY"

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -18,7 +18,7 @@ variables:
       shell: bash
       script: |
         source .evergreen/.setup_env
-        export SEGMENT_API_KEY=${segment_key}
+        export SEGMENT_API_KEY=${segment_api_key}
         echo "SEGMENT_API_KEY is set to $SEGMENT_API_KEY"
         export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
         echo "Run compile-exec"

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -151,9 +151,9 @@ tasks:
       - func: install
       - func: release_macos
   - name: release_linux
-    depends_on:
-      - name: check
-      - name: test
+    # depends_on:
+      # - name: check
+      # - name: test
     commands:
       - func: checkout
       - func: install
@@ -168,26 +168,26 @@ tasks:
 # Need to run builds for every possible build variant.
 # TODO: Durran: BUILD-10374 - Need OSX Catalina Signing Machine
 buildvariants:
-  - name: macos
-    display_name: "MacOS Mohave"
-    run_on: macos-1014
-    tasks:
-      - name: check
-      - name: test
-      - name: release_macos
+  # - name: macos
+  #   display_name: "MacOS Mohave"
+  #   run_on: macos-1014
+  #   tasks:
+  #     - name: check
+  #     - name: test
+  #     - name: release_macos
   - name: ubuntu
     display_name: "Ubuntu 18.04"
     run_on: ubuntu1804-test
     tasks:
       - name: check
-      - name: test
+      # - name: test
       - name: release_linux
-  - name: windows
-    display_name: "Windows VS 2019"
-    run_on: windows-64-vs2019-test
-    tasks:
-      - name: check
-      - name: release_win
+  # - name: windows
+  #   display_name: "Windows VS 2019"
+  #   run_on: windows-64-vs2019-test
+  #   tasks:
+  #     - name: check
+  #     - name: release_win
 #  - name: ubuntuppc
 #    display_name: "Ubuntu 18.04 PPC"
 #    run_on: ubuntu1804-power8-test

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -179,7 +179,7 @@ buildvariants:
     display_name: "Ubuntu 18.04"
     run_on: ubuntu1804-test
     tasks:
-      - name: check
+      # - name: check
       # - name: test
       - name: release_linux
   # - name: windows

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -12,28 +12,23 @@ variables:
       permissions: public-read
       content_type: application/octet-stream
   - &compile_exec
-    # command: subprocess.exec
+    # command: shell.exec
     # params:
-    #   working_dir: "src"
-    #   env:
-    #     SEGMENT_API_KEY: ${segment_api_key}
-    #   binary: "bash"
-    #   args:
-    #     - ".evergreen/.compile_exec"
-    command: shell.exec
+    #   working_dir: src
+    #   shell: bash
+    #   script: |
+    #     echo SEGMENT_API_KEY=${segment_api_key}
+    #
+    command: subprocess.exec
     params:
-      working_dir: src
-      shell: bash
-      script: |
-        env | grep segment_api_key
-    #     export SEGMENT_API_KEY=${segment_api_key}
-    #     echo SEGMENT API KEY EXPANSION: ${segment_api_key}
-    #     echo "SEGMENT_API_KEY is set to $SEGMENT_API_KEY"
-    #     export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
-    #     echo "Run compile-exec"
-    #     npm run compile-exec
-    #     echo "content of cli-repl/lib/analytics-config.js"
-    #     cat packages/cli-repl/lib/analytics-config.js
+      working_dir: "src"
+      env:
+        SEGMENT_API_KEY: ${segment_api_key}
+        PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
+      binary: "bash"
+      args:
+        - ".evergreen/.compile_exec"
+
 # Functions are any command that can be run.
 #
 # Current functions:

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -23,8 +23,8 @@ variables:
         export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
         echo "Run compile-exec"
         npm run compile-exec
-        echo "content of browser-repl/lib:"
-        ls packages/browser-repl/lib
+        echo "content of cli-repl/lib/analytics-config.js"
+        cat packages/cli-repl/lib/analytics-config.js
 # Functions are any command that can be run.
 #
 # Current functions:

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -19,8 +19,12 @@ variables:
       script: |
         source .evergreen/.setup_env
         export SEGMENT_API_KEY=${segment_key}
+        echo "SEGMENT_API_KEY is set to $SEGMENT_API_KEY"
         export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD=true
+        echo "Run compile-exec"
         npm run compile-exec
+        echo "content of browser-repl/lib:"
+        ls packages/browser-repl/lib
 # Functions are any command that can be run.
 #
 # Current functions:

--- a/.evergreen/.compile_exec
+++ b/.evergreen/.compile_exec
@@ -1,11 +1,3 @@
-if [[ $OSTYPE == "cygwin" ]]; then
-  echo "Setting up Windows environment"
-else
-  export NVM_DIR="$HOME/.nvm"
-  echo "Setting NVM environment home: $NVM_DIR"
-  [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
-  [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"
-fi
+source "$(dirname $0)/.setup-env"
 
-echo BLA=${BLA}
-echo SEGMENT_API_KEY=${SEGMENT_API_KEY}
+npm run compile-exec

--- a/.evergreen/.compile_exec
+++ b/.evergreen/.compile_exec
@@ -1,0 +1,11 @@
+if [[ $OSTYPE == "cygwin" ]]; then
+  echo "Setting up Windows environment"
+else
+  export NVM_DIR="$HOME/.nvm"
+  echo "Setting NVM environment home: $NVM_DIR"
+  [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+  [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"
+fi
+
+echo BLA=${BLA}
+echo SEGMENT_API_KEY=${SEGMENT_API_KEY}

--- a/.evergreen/.compile_exec
+++ b/.evergreen/.compile_exec
@@ -7,7 +7,7 @@ else
   [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"
 fi
 
+npm run compile-exec
+
 echo "content of cli-repl/lib/analytics-config.js"
 cat packages/cli-repl/lib/analytics-config.js
-
-npm run compile-exec

--- a/.evergreen/.compile_exec
+++ b/.evergreen/.compile_exec
@@ -1,3 +1,13 @@
-source "$(dirname $0)/.setup-env"
+if [[ $OSTYPE == "cygwin" ]]; then
+  echo "Setting up Windows environment"
+else
+  export NVM_DIR="$HOME/.nvm"
+  echo "Setting NVM environment home: $NVM_DIR"
+  [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
+  [ -s "$NVM_DIR/bash_completion" ] && \. "$NVM_DIR/bash_completion"
+fi
+
+echo "content of cli-repl/lib/analytics-config.js"
+cat packages/cli-repl/lib/analytics-config.js
 
 npm run compile-exec

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -3,125 +3,126 @@ variables:
 
 trigger:
   - master
-jobs:
-  - job: Ubuntu_18
-    pool:
-      vmImage: 'ubuntu-18.04'
-    steps:
-      - script: |
-          set -e
-        displayName: 'Install Services'
-      - task: NodeTool@0
-        inputs:
-          versionSpec: '12.4.0'
-        displayName: 'Install Node.js'
-      - script: |
-          npm install --global npm@latest
-          npm install --global lerna
-        displayName: 'Install Global Packages'
-      - script: |
-          npm run bootstrap
-        displayName: 'Bootstrap'
-      - script: |
-          npm run check
-        displayName: 'Run Checks'
-      - script: |
-          npm run test-ci
-        displayName: 'Run Tests'
-      - script: |
-          npm run compile-exec
-        displayName: 'Build REPL'
-      - publish: $(System.DefaultWorkingDirectory)/dist
-        artifact: binaries
-        displayName: 'Publish Binaries'
+jobs: []
 
-  - job: Ubuntu_16
-    pool:
-      vmImage: 'ubuntu-16.04'
-    steps:
-      - script: |
-          set -e
-        displayName: 'Install Services'
-      - task: NodeTool@0
-        inputs:
-          versionSpec: '12.4.0'
-        displayName: 'Install Node.js'
-      - script: |
-          npm install --global npm@latest
-          npm install --global lerna
-        displayName: 'Install Global Packages'
-      - script: |
-          npm run bootstrap
-        displayName: 'Bootstrap'
-      - script: |
-          npm run check
-        displayName: 'Run Checks'
-      - script: |
-          npm run test-ci
-        displayName: 'Run Tests'
+  # - job: Ubuntu_18
+  #   pool:
+  #     vmImage: 'ubuntu-18.04'
+  #   steps:
+  #     - script: |
+  #         set -e
+  #       displayName: 'Install Services'
+  #     - task: NodeTool@0
+  #       inputs:
+  #         versionSpec: '12.4.0'
+  #       displayName: 'Install Node.js'
+  #     - script: |
+  #         npm install --global npm@latest
+  #         npm install --global lerna
+  #       displayName: 'Install Global Packages'
+  #     - script: |
+  #         npm run bootstrap
+  #       displayName: 'Bootstrap'
+  #     - script: |
+  #         npm run check
+  #       displayName: 'Run Checks'
+  #     - script: |
+  #         npm run test-ci
+  #       displayName: 'Run Tests'
+  #     - script: |
+  #         npm run compile-exec
+  #       displayName: 'Build REPL'
+  #     - publish: $(System.DefaultWorkingDirectory)/dist
+  #       artifact: binaries
+  #       displayName: 'Publish Binaries'
 
-  - job: MacOS_Mohave
-    pool:
-      vmImage: 'macOS-10.14'
-    steps:
-      - task: NodeTool@0
-        inputs:
-          versionSpec: '12.4.0'
-        displayName: 'Install Node.js'
-      - script: |
-          npm install --global npm@latest
-          npm install --global lerna
-        displayName: 'Install Global Packages'
-      - script: |
-          npm run bootstrap
-        displayName: 'Bootstrap'
-      - script: |
-          npm run check
-        displayName: 'Run Checks'
-      - script: |
-          npm run test-ci
-        displayName: 'Run Tests'
+  # - job: Ubuntu_16
+  #   pool:
+  #     vmImage: 'ubuntu-16.04'
+  #   steps:
+  #     - script: |
+  #         set -e
+  #       displayName: 'Install Services'
+  #     - task: NodeTool@0
+  #       inputs:
+  #         versionSpec: '12.4.0'
+  #       displayName: 'Install Node.js'
+  #     - script: |
+  #         npm install --global npm@latest
+  #         npm install --global lerna
+  #       displayName: 'Install Global Packages'
+  #     - script: |
+  #         npm run bootstrap
+  #       displayName: 'Bootstrap'
+  #     - script: |
+  #         npm run check
+  #       displayName: 'Run Checks'
+  #     - script: |
+  #         npm run test-ci
+  #       displayName: 'Run Tests'
 
-  - job: Windows_Server_2019
-    pool:
-      vmImage: 'windows-2019'
-    steps:
-      - task: NodeTool@0
-        inputs:
-          versionSpec: '12.4.0'
-        displayName: 'Install Node.js'
-      - script: |
-          npm install --global npm@latest
-          npm install --global lerna
-        displayName: 'Install Global Packages'
-      - script: |
-          npm run bootstrap
-        displayName: 'Bootstrap'
-      - script: |
-          npm run check
-        displayName: 'Run Checks'
-      - script: |
-          npm run test-ci
-        displayName: 'Run Tests'
+  # - job: MacOS_Mohave
+  #   pool:
+  #     vmImage: 'macOS-10.14'
+  #   steps:
+  #     - task: NodeTool@0
+  #       inputs:
+  #         versionSpec: '12.4.0'
+  #       displayName: 'Install Node.js'
+  #     - script: |
+  #         npm install --global npm@latest
+  #         npm install --global lerna
+  #       displayName: 'Install Global Packages'
+  #     - script: |
+  #         npm run bootstrap
+  #       displayName: 'Bootstrap'
+  #     - script: |
+  #         npm run check
+  #       displayName: 'Run Checks'
+  #     - script: |
+  #         npm run test-ci
+  #       displayName: 'Run Tests'
 
-  - job: Windows_Server_2016
-    pool:
-      vmImage: 'vs2017-win2016'
-    steps:
-      - task: NodeTool@0
-        inputs:
-          versionSpec: '12.4.0'
-        displayName: 'Install Node.js'
-      - script: |
-          npm install --global npm@latest
-          npm install --global lerna
-        displayName: 'Install Global Packages'
-      - script: |
-          npm run bootstrap
-        displayName: 'Bootstrap'
-      - script: |
-          npm run check
-        displayName: 'Run Checks'
-      - script: |
-          npm run test-ci
-        displayName: 'Run Tests'
+  # - job: Windows_Server_2019
+  #   pool:
+  #     vmImage: 'windows-2019'
+  #   steps:
+  #     - task: NodeTool@0
+  #       inputs:
+  #         versionSpec: '12.4.0'
+  #       displayName: 'Install Node.js'
+  #     - script: |
+  #         npm install --global npm@latest
+  #         npm install --global lerna
+  #       displayName: 'Install Global Packages'
+  #     - script: |
+  #         npm run bootstrap
+  #       displayName: 'Bootstrap'
+  #     - script: |
+  #         npm run check
+  #       displayName: 'Run Checks'
+  #     - script: |
+  #         npm run test-ci
+  #       displayName: 'Run Tests'
+
+  # - job: Windows_Server_2016
+  #   pool:
+  #     vmImage: 'vs2017-win2016'
+  #   steps:
+  #     - task: NodeTool@0
+  #       inputs:
+  #         versionSpec: '12.4.0'
+  #       displayName: 'Install Node.js'
+  #     - script: |
+  #         npm install --global npm@latest
+  #         npm install --global lerna
+  #       displayName: 'Install Global Packages'
+  #     - script: |
+  #         npm run bootstrap
+  #       displayName: 'Bootstrap'
+  #     - script: |
+  #         npm run check
+  #       displayName: 'Run Checks'
+  #     - script: |
+  #         npm run test-ci
+  #       displayName: 'Run Tests'

--- a/packages/cli-repl/src/logger.ts
+++ b/packages/cli-repl/src/logger.ts
@@ -58,8 +58,8 @@ export default function logger(bus: any, logDir: string) {
   let analytics = new NoopAnalytics();
   try {
     // this file gets written as a part of a release
-    log.warn(require('./analytics-config.js').SEGMENT_API_KEY)
-    analytics = new Analytics(require('./analytics-config.js').SEGMENT_API_KEY);
+    log.warn(require('./analytics-config.js'))
+    analytics = new Analytics(require('./analytics-config.js'));
   } catch (e) {
     bus.emit('mongosh:error', e)
   }

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -57,7 +57,7 @@ const archive = async() => {
 };
 
 const writeSegmentFile = () => {
-  const key = `module.exports = SEGMENT_API_KEY = '${process.env.SEGMENT_API_KEY}';`;
+  const key = `module.exports = '${process.env.SEGMENT_API_KEY}';`;
   // create directly in cli-repl/lib so it can be part of artifacts in dist
   const configPath = path.join(__dirname, '..', 'packages', 'cli-repl', 'lib', 'analytics-config.js');
   try {

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -78,15 +78,7 @@ const writeSegmentFile = () => {
 const release = async() => {
   const artifact = getArtifact();
   console.log(' -- Writing configuration for segment in', ANALYTICS_CONFIG_PATH);
-
   writeSegmentFile();
-
-  console.log(' -- DONE: writing configuration for segment.');
-
-  console.log(' -- Content of', path.dirname(ANALYTICS_CONFIG_PATH));
-
-  console.log(fs.readdirSync(path.dirname(ANALYTICS_CONFIG_PATH)));
-
   console.log('mongosh: creating binary:', artifact);
   await exec([
     path.join(__dirname, '..', 'packages', 'cli-repl', 'bin', 'mongosh.js'),

--- a/scripts/release.js
+++ b/scripts/release.js
@@ -56,13 +56,14 @@ const archive = async() => {
   );
 };
 
+const ANALYTICS_CONFIG_PATH = path.join(__dirname, '..', 'packages', 'cli-repl', 'lib', 'analytics-config.js');
+
 const writeSegmentFile = () => {
   const key = `module.exports = '${process.env.SEGMENT_API_KEY}';`;
   // create directly in cli-repl/lib so it can be part of artifacts in dist
-  const configPath = path.join(__dirname, '..', 'packages', 'cli-repl', 'lib', 'analytics-config.js');
   try {
     // can just write this sync, since it's part of the release script
-    fs.writeFileSync(configPath, key)
+    fs.writeFileSync(ANALYTICS_CONFIG_PATH, key)
   } catch (e) {
     console.log('mognosh: unable to write segment api key')
     return;
@@ -76,7 +77,16 @@ const writeSegmentFile = () => {
  */
 const release = async() => {
   const artifact = getArtifact();
+  console.log(' -- Writing configuration for segment in', ANALYTICS_CONFIG_PATH);
+
   writeSegmentFile();
+
+  console.log(' -- DONE: writing configuration for segment.');
+
+  console.log(' -- Content of', path.dirname(ANALYTICS_CONFIG_PATH));
+
+  console.log(fs.readdirSync(path.dirname(ANALYTICS_CONFIG_PATH)));
+
   console.log('mongosh: creating binary:', artifact);
   await exec([
     path.join(__dirname, '..', 'packages', 'cli-repl', 'bin', 'mongosh.js'),


### PR DESCRIPTION
## Description
simplify analytics-config.js exports in an effort to troubleshoot
evergreen.

## Notes

The way I troubleshoot this locally is:
```shell
$ SEGMENT_API_KEY='cats' npm run compile-exec
```
Then run the mongosh created executable in dist:
```shell
$ ./dist/mongosh
Current sessionID: 045cb52f546a5a9208c5e593
Connecting to: mongodb://127.0.0.1:27017
Using MongoDB: 4.2.0

For more information about mongosh, please see the wiki: github.com/mongodb-js/mongosh/wiki

>
```
The first message in the logger should be a warn with the key, for example:
<img width="686" alt="Capture d’écran, le 2020-05-11 à 17 43 26" src="https://user-images.githubusercontent.com/8107784/81581411-00c9b380-93af-11ea-9056-da6a61062a81.png">

For extra sanity check, before running `compile-exec` again, I purge the `./dist` directory.
