### PR TITLE
add 'db. ' autocompletes

### DIFF
--- a/packages/cli-repl/src/completer.spec.ts
+++ b/packages/cli-repl/src/completer.spec.ts
@@ -25,6 +25,28 @@ describe('completer.completer', () => {
     // this should eventually encompass tests for DATABASE commands and
     // COLLECTION names.
     // for now, this will only return the current input.
+    it('matches a database command', () => {
+      const i = 'db.agg';
+      expect(completer('4.4.0', i)).to.deep.equal([['db.aggregate'], i]);
+    });
+
+    it('returns all suggestions', () => {
+      const i = 'db.';
+      const dbComplete = Object.keys(shellSignatures.Database.attributes)
+      const adjusted = dbComplete.map(c => `${i}${c}`)
+      expect(completer('4.4.0', i)).to.deep.equal([adjusted, i]);
+    });
+
+    it('matches several suggestions', () => {
+      const i = 'db.get';
+      expect(completer('4.4.0', i)[0]).to.include.members(
+        [
+          'db.getCollectionNames',
+          'db.getCollection',
+          'db.getCollectionInfos',
+          'db.getSiblingDB'
+        ]);
+    });
 
     it('returns current input and no suggestions', () => {
       const i = 'db.shipw';

--- a/packages/cli-repl/src/completer.ts
+++ b/packages/cli-repl/src/completer.ts
@@ -17,6 +17,7 @@ const MATCH_COMPLETIONS = QUERY_OPERATORS.concat(BSON_TYPES);
 
 const SHELL_COMPLETIONS = shellApiSignature.attributes;
 const COLL_COMPLETIONS = shellSignatures.Collection.attributes;
+const DB_COMPLETIONS = shellSignatures.Database.attributes;
 const AGG_CURSOR_COMPLETIONS = shellSignatures.AggregationCursor.attributes;
 const COLL_CURSOR_COMPLETIONS = shellSignatures.Cursor.attributes;
 const RS_COMPLETIONS = shellSignatures.ReplicaSet.attributes;
@@ -62,10 +63,9 @@ function completer(mdbVersion: string, line: string): [string[], string] {
     const hits = filterShellAPI(mdbVersion, SHELL_COMPLETIONS, elToComplete);
     return [hits.length ? hits : [], line];
   } else if (firstLineEl.includes('db') && splitLine.length === 2) {
-    // TODO: @lrlna suggest DATABASE commands (currently not available in
-    // shellSignatures)
-    // TODO: @lrlna is there a way to suggest currently available collections?
-    return [[], line];
+    // TODO: @lrlna this also needs to suggest currently available collections
+    const hits = filterShellAPI(mdbVersion, DB_COMPLETIONS, elToComplete, splitLine);
+    return [hits.length ? hits : [], line];
   } else if (firstLineEl.includes('db') && splitLine.length > 2) {
     if (splitLine.length > 3) {
       // aggregation cursor completions


### PR DESCRIPTION
## Description

Reads from `ShellAPI` and autocompletes the `db` objects. This _does not_ include collection completions. Those will be done later on.

<img width="508" alt="Capture d’écran, le 2020-05-11 à 18 47 00" src="https://user-images.githubusercontent.com/8107784/81591020-08dc2000-93bc-11ea-887b-5d7146e75d07.png">
