### PR TITLE
Allow message bus in runtime

### DIFF
--- a/packages/browser-runtime-core/src/open-context-runtime.ts
+++ b/packages/browser-runtime-core/src/open-context-runtime.ts
@@ -24,11 +24,14 @@ export class OpenContextRuntime implements Runtime {
 
   constructor(
     serviceProvider: ServiceProvider,
-    interpreterEnvironment: InterpreterEnvironment
+    interpreterEnvironment: InterpreterEnvironment,
+    eventEmitter?: {
+      emit: (eventName: string, ...args: any[]) => void;
+    }
   ) {
     this.serviceProvider = serviceProvider;
     this.interpreterEnvironment = interpreterEnvironment;
-    this.shellEvaluator = new ShellEvaluator(serviceProvider, new EventEmitter());
+    this.shellEvaluator = new ShellEvaluator(serviceProvider, eventEmitter || new EventEmitter());
     this.shellEvaluator.setCtx(this.interpreterEnvironment.getContextObject());
     this.interpreter = new Interpreter(this.interpreterEnvironment);
   }

--- a/packages/browser-runtime-core/src/open-context-runtime.ts
+++ b/packages/browser-runtime-core/src/open-context-runtime.ts
@@ -25,13 +25,13 @@ export class OpenContextRuntime implements Runtime {
   constructor(
     serviceProvider: ServiceProvider,
     interpreterEnvironment: InterpreterEnvironment,
-    eventEmitter?: {
+    messageBus?: {
       emit: (eventName: string, ...args: any[]) => void;
     }
   ) {
     this.serviceProvider = serviceProvider;
     this.interpreterEnvironment = interpreterEnvironment;
-    this.shellEvaluator = new ShellEvaluator(serviceProvider, eventEmitter || new EventEmitter());
+    this.shellEvaluator = new ShellEvaluator(serviceProvider, messageBus || new EventEmitter());
     this.shellEvaluator.setCtx(this.interpreterEnvironment.getContextObject());
     this.interpreter = new Interpreter(this.interpreterEnvironment);
   }

--- a/packages/browser-runtime-electron/package-lock.json
+++ b/packages/browser-runtime-electron/package-lock.json
@@ -4,6 +4,28 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@types/chai": {
+			"version": "4.2.11",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.11.tgz",
+			"integrity": "sha512-t7uW6eFafjO+qJ3BIV2gGUyZs27egcNRkUdalkud+Qa3+kg//f129iuOFivHDXQ+vnU3fDXuwgv0cqMCbcE8sw==",
+			"dev": true
+		},
+		"@types/sinon": {
+			"version": "7.5.2",
+			"resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-7.5.2.tgz",
+			"integrity": "sha512-T+m89VdXj/eidZyejvmoP9jivXgBDdkOSBVQjU9kF349NEx10QdPNGxHeZUaj1IlJ32/ewdyXJjnJxyxJroYwg==",
+			"dev": true
+		},
+		"@types/sinon-chai": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@types/sinon-chai/-/sinon-chai-3.2.4.tgz",
+			"integrity": "sha512-xq5KOWNg70PRC7dnR2VOxgYQ6paumW+4pTZP+6uTSdhpYsAUEeeT5bw6rRHHQrZ4KyR+M5ojOR+lje6TGSpUxA==",
+			"dev": true,
+			"requires": {
+				"@types/chai": "*",
+				"@types/sinon": "*"
+			}
+		},
 		"balanced-match": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",

--- a/packages/browser-runtime-electron/package.json
+++ b/packages/browser-runtime-electron/package.json
@@ -34,6 +34,8 @@
   },
   "devDependencies": {
     "@mongosh/service-provider-server": "^0.0.1-alpha.14",
-    "rimraf": "^3.0.2"
+    "rimraf": "^3.0.2",
+    "@types/sinon": "^7.5.1",
+    "@types/sinon-chai": "^3.2.3"
   }
 }

--- a/packages/browser-runtime-electron/src/electron-runtime.spec.ts
+++ b/packages/browser-runtime-electron/src/electron-runtime.spec.ts
@@ -1,16 +1,22 @@
-import { expect } from 'chai';
-import sinon from 'sinon';
+import sinon, { SinonStubbedInstance } from 'sinon';
+import chai from 'chai';
+import sinonChai from 'sinon-chai';
+chai.use(sinonChai);
+const { expect } = chai;
 
 import { CliServiceProvider } from '@mongosh/service-provider-server';
 import { ElectronRuntime } from './electron-runtime';
+import { EventEmitter } from 'events';
 
 describe('Electron runtime', function() {
-  let serviceProvider: CliServiceProvider;
+  let serviceProvider: SinonStubbedInstance<CliServiceProvider>;
+  let messageBus: SinonStubbedInstance<EventEmitter>;
   let electronRuntime: ElectronRuntime;
 
   beforeEach(async() => {
     serviceProvider = sinon.createStubInstance(CliServiceProvider);
-    electronRuntime = new ElectronRuntime(serviceProvider);
+    messageBus = sinon.createStubInstance(EventEmitter);
+    electronRuntime = new ElectronRuntime(serviceProvider, messageBus);
   });
 
   it('can evaluate simple js', async() => {
@@ -24,7 +30,7 @@ describe('Electron runtime', function() {
   });
 
   it('can run show', async() => {
-    (serviceProvider.listDatabases as sinon.Stub).resolves({
+    serviceProvider.listDatabases.resolves({
       databases: []
     });
 
@@ -42,5 +48,10 @@ describe('Electron runtime', function() {
     expect(
       (await electronRuntime.evaluate('db')).value
     ).to.equal('db1');
+  });
+
+  it('allows to receive telemetry event passing a message bus', async() => {
+    await electronRuntime.evaluate('use db1');
+    expect(messageBus.emit).to.have.been.calledWith('mongosh:use');
   });
 });

--- a/packages/browser-runtime-electron/src/electron-runtime.ts
+++ b/packages/browser-runtime-electron/src/electron-runtime.ts
@@ -14,10 +14,13 @@ import { ServiceProvider } from '@mongosh/service-provider-core';
 export class ElectronRuntime implements Runtime {
   private openContextRuntime: OpenContextRuntime;
 
-  constructor(serviceProvider: ServiceProvider) {
+  constructor(serviceProvider: ServiceProvider, eventEmitter?: {
+    emit: (eventName: string, ...args: any[]) => void;
+  }) {
     this.openContextRuntime = new OpenContextRuntime(
       serviceProvider,
-      new ElectronInterpreterEnvironment({})
+      new ElectronInterpreterEnvironment({}),
+      eventEmitter
     );
   }
 

--- a/packages/browser-runtime-electron/src/electron-runtime.ts
+++ b/packages/browser-runtime-electron/src/electron-runtime.ts
@@ -14,13 +14,13 @@ import { ServiceProvider } from '@mongosh/service-provider-core';
 export class ElectronRuntime implements Runtime {
   private openContextRuntime: OpenContextRuntime;
 
-  constructor(serviceProvider: ServiceProvider, eventEmitter?: {
+  constructor(serviceProvider: ServiceProvider, messageBus?: {
     emit: (eventName: string, ...args: any[]) => void;
   }) {
     this.openContextRuntime = new OpenContextRuntime(
       serviceProvider,
       new ElectronInterpreterEnvironment({}),
-      eventEmitter
+      messageBus
     );
   }
 


### PR DESCRIPTION
Allow to pass a message bus to the runtime so we can use it for telemetry and logging in compass:

```
new ElectronRuntime(serviceProvider, messageBus)
```