### PR TITLE
MONGOSH-89: Shell as global compass role

### DIFF
--- a/packages/compass-shell/package-lock.json
+++ b/packages/compass-shell/package-lock.json
@@ -1339,9 +1339,22 @@
 			}
 		},
 		"@leafygreen-ui/icon": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/@leafygreen-ui/icon/-/icon-4.3.0.tgz",
-			"integrity": "sha512-6DOFKxj3U0hp2yQEq/Yq19qIiIIUXwRj2fH1ddOJFYLtAoeFOCSeuF6rE2dqXrXW/puQdjgpXV60w9J8gyXGog=="
+			"version": "5.1.0",
+			"resolved": "https://registry.npmjs.org/@leafygreen-ui/icon/-/icon-5.1.0.tgz",
+			"integrity": "sha512-5iCQSTR5e1M7xaYXjACndeHeCIIrCMc3RxWpQhVwB4zvlhCsu5ckyqdumOeei7eRvtkC5N04jCkIKUIt5gJTJw==",
+			"requires": {
+				"@leafygreen-ui/lib": "^4.4.1"
+			}
+		},
+		"@leafygreen-ui/icon-button": {
+			"version": "5.0.2",
+			"resolved": "https://registry.npmjs.org/@leafygreen-ui/icon-button/-/icon-button-5.0.2.tgz",
+			"integrity": "sha512-vgrYl/OXuA8+eI/MfwrwkWoQj/IPJyAWzXF2IUgu30bdWnMVUD5TgSCTsmoGb1UAAzgvpfoWB3gqkwkPAtKEoA==",
+			"requires": {
+				"@leafygreen-ui/emotion": "2.0.1",
+				"@leafygreen-ui/lib": "^4.4.1",
+				"@leafygreen-ui/palette": "2.0.1"
+			}
 		},
 		"@leafygreen-ui/lib": {
 			"version": "4.4.1",
@@ -1414,6 +1427,11 @@
 				"text-table": "^0.2.0"
 			},
 			"dependencies": {
+				"@leafygreen-ui/icon": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/@leafygreen-ui/icon/-/icon-4.3.0.tgz",
+					"integrity": "sha512-6DOFKxj3U0hp2yQEq/Yq19qIiIIUXwRj2fH1ddOJFYLtAoeFOCSeuF6rE2dqXrXW/puQdjgpXV60w9J8gyXGog=="
+				},
 				"pretty-bytes": {
 					"version": "5.3.0",
 					"resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.3.0.tgz",

--- a/packages/compass-shell/package-lock.json
+++ b/packages/compass-shell/package-lock.json
@@ -3195,7 +3195,8 @@
 		"ansi-regex": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+			"dev": true
 		},
 		"ansi-styles": {
 			"version": "3.2.1",
@@ -3229,12 +3230,14 @@
 		"aproba": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
+			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+			"dev": true
 		},
 		"are-we-there-yet": {
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
 			"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+			"dev": true,
 			"requires": {
 				"delegates": "^1.0.0",
 				"readable-stream": "^2.0.6"
@@ -5394,6 +5397,8 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
 			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+			"dev": true,
+			"optional": true,
 			"requires": {
 				"file-uri-to-path": "1.0.0"
 			}
@@ -6032,7 +6037,8 @@
 		"chownr": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-			"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
+			"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+			"dev": true
 		},
 		"chrome-trace-event": {
 			"version": "1.0.2",
@@ -6208,7 +6214,8 @@
 		"code-point-at": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
+			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+			"dev": true
 		},
 		"collection-visit": {
 			"version": "1.0.0",
@@ -6448,7 +6455,8 @@
 		"console-control-strings": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
+			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+			"dev": true
 		},
 		"constants-browserify": {
 			"version": "1.0.0",
@@ -7102,6 +7110,7 @@
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
 			"integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
+			"dev": true,
 			"requires": {
 				"mimic-response": "^2.0.0"
 			}
@@ -7173,7 +7182,8 @@
 		"deep-extend": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
+			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+			"dev": true
 		},
 		"deep-is": {
 			"version": "0.1.3",
@@ -7350,7 +7360,8 @@
 		"delegates": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
+			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+			"dev": true
 		},
 		"denque": {
 			"version": "1.4.1",
@@ -7575,7 +7586,8 @@
 		"detect-libc": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-			"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
+			"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+			"dev": true
 		},
 		"detect-node": {
 			"version": "2.0.4",
@@ -8511,6 +8523,7 @@
 			"version": "1.4.4",
 			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
 			"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+			"dev": true,
 			"requires": {
 				"once": "^1.4.0"
 			}
@@ -9436,7 +9449,8 @@
 		"expand-template": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-			"integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="
+			"integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+			"dev": true
 		},
 		"expand-tilde": {
 			"version": "2.0.2",
@@ -9859,7 +9873,9 @@
 		"file-uri-to-path": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
+			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+			"dev": true,
+			"optional": true
 		},
 		"filesize": {
 			"version": "3.5.11",
@@ -10100,7 +10116,8 @@
 		"fs-constants": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-			"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
+			"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+			"dev": true
 		},
 		"fs-extra": {
 			"version": "4.0.3",
@@ -10736,6 +10753,7 @@
 			"version": "2.7.4",
 			"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
 			"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+			"dev": true,
 			"requires": {
 				"aproba": "^1.0.3",
 				"console-control-strings": "^1.0.0",
@@ -10826,7 +10844,8 @@
 		"github-from-package": {
 			"version": "0.0.0",
 			"resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-			"integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4="
+			"integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=",
+			"dev": true
 		},
 		"glamor": {
 			"version": "2.20.40",
@@ -11181,7 +11200,8 @@
 		"has-unicode": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
+			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+			"dev": true
 		},
 		"has-value": {
 			"version": "1.0.0",
@@ -11849,7 +11869,8 @@
 		"ini": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
+			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
+			"dev": true
 		},
 		"inline-source-map": {
 			"version": "0.6.2",
@@ -12152,6 +12173,7 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 			"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+			"dev": true,
 			"requires": {
 				"number-is-nan": "^1.0.0"
 			}
@@ -14384,7 +14406,8 @@
 		"mimic-response": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
-			"integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA=="
+			"integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
+			"dev": true
 		},
 		"min-document": {
 			"version": "2.19.0",
@@ -14552,6 +14575,7 @@
 			"version": "0.5.5",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
 			"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+			"dev": true,
 			"requires": {
 				"minimist": "^1.2.5"
 			}
@@ -14559,7 +14583,8 @@
 		"mkdirp-classic": {
 			"version": "0.5.2",
 			"resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.2.tgz",
-			"integrity": "sha512-ejdnDQcR75gwknmMw/tx02AuRs8jCtqFoFqDZMjiNxsu85sRIJVXDKHuLYvUUPRBUtV2FpSZa9bL1BUa3BdR2g=="
+			"integrity": "sha512-ejdnDQcR75gwknmMw/tx02AuRs8jCtqFoFqDZMjiNxsu85sRIJVXDKHuLYvUUPRBUtV2FpSZa9bL1BUa3BdR2g==",
+			"dev": true
 		},
 		"mkpath": {
 			"version": "0.1.0",
@@ -15089,17 +15114,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/mongodb-build-info/-/mongodb-build-info-1.1.0.tgz",
 			"integrity": "sha512-ZlbQlpXv8DCvYK2I6UmyRO4z9zb4fyoph+RhEN/MSSsigaqcfl6dePkbgavemquvuKVEq0BbIiVkHw1DKwChxA=="
-		},
-		"mongodb-client-encryption": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-1.0.1.tgz",
-			"integrity": "sha512-nHbezuBY1NQeksltSYGuqEES/i8U4zpVJ1D+YrQLTyzXfQtqiQX1fRYn5dtlCTuq+gBFKwXIRCH5InduIfIgkw==",
-			"requires": {
-				"bindings": "^1.5.0",
-				"bson": "^1.0.5",
-				"nan": "^2.14.0",
-				"prebuild-install": "^5.3.0"
-			}
 		},
 		"mongodb-collection-sample": {
 			"version": "4.5.1",
@@ -15953,7 +15967,9 @@
 		"nan": {
 			"version": "2.14.1",
 			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-			"integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
+			"integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
+			"dev": true,
+			"optional": true
 		},
 		"nanoassert": {
 			"version": "1.1.0",
@@ -16009,7 +16025,8 @@
 		"napi-build-utils": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
-			"integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg=="
+			"integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==",
+			"dev": true
 		},
 		"natural-compare": {
 			"version": "1.4.0",
@@ -16113,6 +16130,7 @@
 			"version": "2.16.0",
 			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.16.0.tgz",
 			"integrity": "sha512-+sa0XNlWDA6T+bDLmkCUYn6W5k5W6BPRL6mqzSCs6H/xUgtl4D5x2fORKDzopKiU6wsyn/+wXlRXwXeSp+mtoA==",
+			"dev": true,
 			"requires": {
 				"semver": "^5.4.1"
 			}
@@ -16270,7 +16288,8 @@
 		"noop-logger": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
-			"integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI="
+			"integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI=",
+			"dev": true
 		},
 		"nopt": {
 			"version": "3.0.6",
@@ -16336,6 +16355,7 @@
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
 			"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+			"dev": true,
 			"requires": {
 				"are-we-there-yet": "~1.1.2",
 				"console-control-strings": "~1.1.0",
@@ -16387,7 +16407,8 @@
 		"number-is-nan": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
+			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+			"dev": true
 		},
 		"nwsapi": {
 			"version": "2.2.0",
@@ -17628,6 +17649,7 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"dev": true,
 			"requires": {
 				"wrappy": "1"
 			}
@@ -20240,6 +20262,7 @@
 			"version": "5.3.3",
 			"resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.3.tgz",
 			"integrity": "sha512-GV+nsUXuPW2p8Zy7SarF/2W/oiK8bFQgJcncoJ0d7kRpekEA0ftChjfEaF9/Y+QJEc/wFR7RAEa8lYByuUIe2g==",
+			"dev": true,
 			"requires": {
 				"detect-libc": "^1.0.3",
 				"expand-template": "^2.0.3",
@@ -20262,6 +20285,7 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
 					"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+					"dev": true,
 					"requires": {
 						"end-of-stream": "^1.1.0",
 						"once": "^1.3.1"
@@ -20785,6 +20809,7 @@
 			"version": "1.2.8",
 			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
 			"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+			"dev": true,
 			"requires": {
 				"deep-extend": "^0.6.0",
 				"ini": "~1.3.0",
@@ -22088,7 +22113,8 @@
 		"set-blocking": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
+			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+			"dev": true
 		},
 		"set-value": {
 			"version": "2.0.1",
@@ -22207,17 +22233,20 @@
 		"signal-exit": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-			"integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
+			"integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+			"dev": true
 		},
 		"simple-concat": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
-			"integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY="
+			"integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY=",
+			"dev": true
 		},
 		"simple-get": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.0.tgz",
 			"integrity": "sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==",
+			"dev": true,
 			"requires": {
 				"decompress-response": "^4.2.0",
 				"once": "^1.3.1",
@@ -23023,6 +23052,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 			"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+			"dev": true,
 			"requires": {
 				"code-point-at": "^1.0.0",
 				"is-fullwidth-code-point": "^1.0.0",
@@ -23135,6 +23165,7 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+			"dev": true,
 			"requires": {
 				"ansi-regex": "^2.0.0"
 			}
@@ -23163,7 +23194,8 @@
 		"strip-json-comments": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
+			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+			"dev": true
 		},
 		"style-loader": {
 			"version": "0.18.2",
@@ -23360,6 +23392,7 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.0.1.tgz",
 			"integrity": "sha512-6tzWDMeroL87uF/+lin46k+Q+46rAJ0SyPGz7OW7wTgblI273hsBqk2C1j0/xNadNLKDTUL9BukSjB7cwgmlPA==",
+			"dev": true,
 			"requires": {
 				"chownr": "^1.1.1",
 				"mkdirp-classic": "^0.5.2",
@@ -23371,6 +23404,7 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
 					"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+					"dev": true,
 					"requires": {
 						"end-of-stream": "^1.1.0",
 						"once": "^1.3.1"
@@ -23382,6 +23416,7 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.2.tgz",
 			"integrity": "sha512-UaF6FoJ32WqALZGOIAApXx+OdxhekNMChu6axLJR85zMMjXKWFGjbIRe+J6P4UnRGg9rAwWvbTT0oI7hD/Un7Q==",
+			"dev": true,
 			"requires": {
 				"bl": "^4.0.1",
 				"end-of-stream": "^1.4.1",
@@ -23394,6 +23429,7 @@
 					"version": "4.0.2",
 					"resolved": "https://registry.npmjs.org/bl/-/bl-4.0.2.tgz",
 					"integrity": "sha512-j4OH8f6Qg2bGuWfRiltT2HYGx0e1QcBTrK9KAHNMwMZdQnDZFk0ZSYIpADjYCB3U12nicC5tVJwSIhwOWjb4RQ==",
+					"dev": true,
 					"requires": {
 						"buffer": "^5.5.0",
 						"inherits": "^2.0.4",
@@ -23404,6 +23440,7 @@
 					"version": "5.6.0",
 					"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
 					"integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+					"dev": true,
 					"requires": {
 						"base64-js": "^1.0.2",
 						"ieee754": "^1.1.4"
@@ -23413,6 +23450,7 @@
 					"version": "3.6.0",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
 					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+					"dev": true,
 					"requires": {
 						"inherits": "^2.0.3",
 						"string_decoder": "^1.1.1",
@@ -23821,6 +23859,7 @@
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+			"dev": true,
 			"requires": {
 				"safe-buffer": "^5.0.1"
 			}
@@ -25463,12 +25502,14 @@
 		"which-pm-runs": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
-			"integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs="
+			"integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=",
+			"dev": true
 		},
 		"wide-align": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
 			"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+			"dev": true,
 			"requires": {
 				"string-width": "^1.0.2 || 2"
 			}
@@ -25512,7 +25553,8 @@
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"dev": true
 		},
 		"write": {
 			"version": "1.0.3",

--- a/packages/compass-shell/package-lock.json
+++ b/packages/compass-shell/package-lock.json
@@ -25,7 +25,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
 			"integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
-			"dev": true,
 			"requires": {
 				"@babel/highlight": "^7.8.3"
 			}
@@ -45,7 +44,6 @@
 			"version": "7.9.0",
 			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.9.0.tgz",
 			"integrity": "sha512-kWc7L0fw1xwvI0zi8OKVBuxRVefwGOrKSQMvrQ3dW+bIIavBY3/NpXmpjMy7bQnLgwgzWQZ8TlM57YHpHNHz4w==",
-			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.8.3",
 				"@babel/generator": "^7.9.0",
@@ -69,7 +67,6 @@
 					"version": "4.1.1",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
 					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-					"dev": true,
 					"requires": {
 						"ms": "^2.1.1"
 					}
@@ -77,8 +74,7 @@
 				"ms": {
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-					"dev": true
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 				}
 			}
 		},
@@ -86,7 +82,6 @@
 			"version": "7.9.5",
 			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.5.tgz",
 			"integrity": "sha512-GbNIxVB3ZJe3tLeDm1HSn2AhuD/mVcyLDpgtLXa5tplmWrJdF/elxB56XNqCuD6szyNkDi6wuoKXln3QeBmCHQ==",
-			"dev": true,
 			"requires": {
 				"@babel/types": "^7.9.5",
 				"jsesc": "^2.5.1",
@@ -197,7 +192,6 @@
 			"version": "7.9.5",
 			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.9.5.tgz",
 			"integrity": "sha512-JVcQZeXM59Cd1qanDUxv9fgJpt3NeKUaqBqUEvfmQ+BCOKq2xUgaWZW2hr0dkbyJgezYuplEoh5knmrnS68efw==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-get-function-arity": "^7.8.3",
 				"@babel/template": "^7.8.3",
@@ -208,7 +202,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
 			"integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
-			"dev": true,
 			"requires": {
 				"@babel/types": "^7.8.3"
 			}
@@ -226,7 +219,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.8.3.tgz",
 			"integrity": "sha512-fO4Egq88utkQFjbPrSHGmGLFqmrshs11d46WI+WZDESt7Wu7wN2G2Iu+NMMZJFDOVRHAMIkB5SNh30NtwCA7RA==",
-			"dev": true,
 			"requires": {
 				"@babel/types": "^7.8.3"
 			}
@@ -235,7 +227,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.8.3.tgz",
 			"integrity": "sha512-R0Bx3jippsbAEtzkpZ/6FIiuzOURPcMjHp+Z6xPe6DtApDJx+w7UYyOLanZqO8+wKR9G10s/FmHXvxaMd9s6Kg==",
-			"dev": true,
 			"requires": {
 				"@babel/types": "^7.8.3"
 			}
@@ -244,7 +235,6 @@
 			"version": "7.9.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.9.0.tgz",
 			"integrity": "sha512-0FvKyu0gpPfIQ8EkxlrAydOWROdHpBmiCiRwLkUiBGhCUPRRbVD2/tm3sFr/c/GWFrQ/ffutGUAnx7V0FzT2wA==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-module-imports": "^7.8.3",
 				"@babel/helper-replace-supers": "^7.8.6",
@@ -259,7 +249,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.8.3.tgz",
 			"integrity": "sha512-Kag20n86cbO2AvHca6EJsvqAd82gc6VMGule4HwebwMlwkpXuVqrNRj6CkCV2sKxgi9MyAUnZVnZ6lJ1/vKhHQ==",
-			"dev": true,
 			"requires": {
 				"@babel/types": "^7.8.3"
 			}
@@ -267,8 +256,7 @@
 		"@babel/helper-plugin-utils": {
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
-			"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
-			"dev": true
+			"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ=="
 		},
 		"@babel/helper-regex": {
 			"version": "7.8.3",
@@ -296,7 +284,6 @@
 			"version": "7.8.6",
 			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.8.6.tgz",
 			"integrity": "sha512-PeMArdA4Sv/Wf4zXwBKPqVj7n9UF/xg6slNRtZW84FM7JpE1CbG8B612FyM4cxrf4fMAMGO0kR7voy1ForHHFA==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-member-expression-to-functions": "^7.8.3",
 				"@babel/helper-optimise-call-expression": "^7.8.3",
@@ -308,7 +295,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.8.3.tgz",
 			"integrity": "sha512-VNGUDjx5cCWg4vvCTR8qQ7YJYZ+HBjxOgXEl7ounz+4Sn7+LMD3CFrCTEU6/qXKbA2nKg21CwhhBzO0RpRbdCw==",
-			"dev": true,
 			"requires": {
 				"@babel/template": "^7.8.3",
 				"@babel/types": "^7.8.3"
@@ -318,7 +304,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
 			"integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
-			"dev": true,
 			"requires": {
 				"@babel/types": "^7.8.3"
 			}
@@ -326,8 +311,7 @@
 		"@babel/helper-validator-identifier": {
 			"version": "7.9.5",
 			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz",
-			"integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g==",
-			"dev": true
+			"integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g=="
 		},
 		"@babel/helper-wrap-function": {
 			"version": "7.8.3",
@@ -345,7 +329,6 @@
 			"version": "7.9.2",
 			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.9.2.tgz",
 			"integrity": "sha512-JwLvzlXVPjO8eU9c/wF9/zOIN7X6h8DYf7mG4CiFRZRvZNKEF5dQ3H3V+ASkHoIB3mWhatgl5ONhyqHRI6MppA==",
-			"dev": true,
 			"requires": {
 				"@babel/template": "^7.8.3",
 				"@babel/traverse": "^7.9.0",
@@ -356,7 +339,6 @@
 			"version": "7.9.0",
 			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.9.0.tgz",
 			"integrity": "sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-validator-identifier": "^7.9.0",
 				"chalk": "^2.0.0",
@@ -366,8 +348,7 @@
 		"@babel/parser": {
 			"version": "7.9.4",
 			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.4.tgz",
-			"integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA==",
-			"dev": true
+			"integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA=="
 		},
 		"@babel/plugin-proposal-async-generator-functions": {
 			"version": "7.8.3",
@@ -577,6 +558,14 @@
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.8.3.tgz",
 			"integrity": "sha512-kwj1j9lL/6Wd0hROD3b/OZZ7MSrZLqqn9RAZ5+cYYsflQ9HZBIKCUkr3+uL1MEJ1NePiUbf98jjiMQSv0NMR9g==",
 			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.3"
+			}
+		},
+		"@babel/plugin-syntax-typescript": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.8.3.tgz",
+			"integrity": "sha512-GO1MQ/SGGGoiEXY0e0bSpHimJvxqB7lktLLIq2pv8xG7WZ8IMEle74jIe1FhprHBWjwjZtXHkycDLZXIWM5Wfg==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.8.3"
 			}
@@ -941,6 +930,97 @@
 				"@babel/helper-plugin-utils": "^7.8.3"
 			}
 		},
+		"@babel/plugin-transform-typescript": {
+			"version": "7.9.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.9.6.tgz",
+			"integrity": "sha512-8OvsRdvpt3Iesf2qsAn+YdlwAJD7zJ+vhFZmDCa4b8dTp7MmHtKk5FF2mCsGxjZwuwsy/yIIay/nLmxST1ctVQ==",
+			"requires": {
+				"@babel/helper-create-class-features-plugin": "^7.9.6",
+				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/plugin-syntax-typescript": "^7.8.3"
+			},
+			"dependencies": {
+				"@babel/generator": {
+					"version": "7.9.6",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.6.tgz",
+					"integrity": "sha512-+htwWKJbH2bL72HRluF8zumBxzuX0ZZUFl3JLNyoUjM/Ho8wnVpPXM6aUz8cfKDqQ/h7zHqKt4xzJteUosckqQ==",
+					"requires": {
+						"@babel/types": "^7.9.6",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.13",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-create-class-features-plugin": {
+					"version": "7.9.6",
+					"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.9.6.tgz",
+					"integrity": "sha512-6N9IeuyHvMBRyjNYOMJHrhwtu4WJMrYf8hVbEHD3pbbbmNOk1kmXSQs7bA4dYDUaIx4ZEzdnvo6NwC3WHd/Qow==",
+					"requires": {
+						"@babel/helper-function-name": "^7.9.5",
+						"@babel/helper-member-expression-to-functions": "^7.8.3",
+						"@babel/helper-optimise-call-expression": "^7.8.3",
+						"@babel/helper-plugin-utils": "^7.8.3",
+						"@babel/helper-replace-supers": "^7.9.6",
+						"@babel/helper-split-export-declaration": "^7.8.3"
+					}
+				},
+				"@babel/helper-replace-supers": {
+					"version": "7.9.6",
+					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.9.6.tgz",
+					"integrity": "sha512-qX+chbxkbArLyCImk3bWV+jB5gTNU/rsze+JlcF6Nf8tVTigPJSI1o1oBow/9Resa1yehUO9lIipsmu9oG4RzA==",
+					"requires": {
+						"@babel/helper-member-expression-to-functions": "^7.8.3",
+						"@babel/helper-optimise-call-expression": "^7.8.3",
+						"@babel/traverse": "^7.9.6",
+						"@babel/types": "^7.9.6"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.9.6",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.6.tgz",
+					"integrity": "sha512-AoeIEJn8vt+d/6+PXDRPaksYhnlbMIiejioBZvvMQsOjW/JYK6k/0dKnvvP3EhK5GfMBWDPtrxRtegWdAcdq9Q=="
+				},
+				"@babel/traverse": {
+					"version": "7.9.6",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.9.6.tgz",
+					"integrity": "sha512-b3rAHSjbxy6VEAvlxM8OV/0X4XrG72zoxme6q1MOoe2vd0bEc+TwayhuC1+Dfgqh1QEG+pj7atQqvUprHIccsg==",
+					"requires": {
+						"@babel/code-frame": "^7.8.3",
+						"@babel/generator": "^7.9.6",
+						"@babel/helper-function-name": "^7.9.5",
+						"@babel/helper-split-export-declaration": "^7.8.3",
+						"@babel/parser": "^7.9.6",
+						"@babel/types": "^7.9.6",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.13"
+					}
+				},
+				"@babel/types": {
+					"version": "7.9.6",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.6.tgz",
+					"integrity": "sha512-qxXzvBO//jO9ZnoasKF1uJzHd2+M6Q2ZPIVfnFps8JJvXy0ZBbwbNOmE6SGIY5XOY6d1Bo5lb9d9RJ8nv3WSeA==",
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.9.5",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+				}
+			}
+		},
 		"@babel/plugin-transform-unicode-regex": {
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.8.3.tgz",
@@ -1056,6 +1136,15 @@
 				"@babel/plugin-transform-react-jsx-source": "^7.9.0"
 			}
 		},
+		"@babel/preset-typescript": {
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.9.0.tgz",
+			"integrity": "sha512-S4cueFnGrIbvYJgwsVFKdvOmpiL0XGw9MFW9D0vgRys5g36PBhZRL8NX8Gr2akz8XRtzq6HuDXPD/1nniagNUg==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/plugin-transform-typescript": "^7.9.0"
+			}
+		},
 		"@babel/register": {
 			"version": "7.9.0",
 			"resolved": "https://registry.npmjs.org/@babel/register/-/register-7.9.0.tgz",
@@ -1073,7 +1162,6 @@
 			"version": "7.9.2",
 			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
 			"integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
-			"dev": true,
 			"requires": {
 				"regenerator-runtime": "^0.13.4"
 			}
@@ -1102,7 +1190,6 @@
 			"version": "7.8.6",
 			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
 			"integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
-			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.8.3",
 				"@babel/parser": "^7.8.6",
@@ -1113,7 +1200,6 @@
 			"version": "7.9.5",
 			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.9.5.tgz",
 			"integrity": "sha512-c4gH3jsvSuGUezlP6rzSJ6jf8fYjLj3hsMZRx/nX0h+fmHN0w+ekubRrHPqnMec0meycA2nwCsJ7dC8IPem2FQ==",
-			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.8.3",
 				"@babel/generator": "^7.9.5",
@@ -1130,7 +1216,6 @@
 					"version": "4.1.1",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
 					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-					"dev": true,
 					"requires": {
 						"ms": "^2.1.1"
 					}
@@ -1138,8 +1223,7 @@
 				"ms": {
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-					"dev": true
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 				}
 			}
 		},
@@ -1147,12 +1231,69 @@
 			"version": "7.9.5",
 			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
 			"integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-validator-identifier": "^7.9.5",
 				"lodash": "^4.17.13",
 				"to-fast-properties": "^2.0.0"
 			}
+		},
+		"@emotion/cache": {
+			"version": "10.0.29",
+			"resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.29.tgz",
+			"integrity": "sha512-fU2VtSVlHiF27empSbxi1O2JFdNWZO+2NFHfwO0pxgTep6Xa3uGb+3pVKfLww2l/IBGLNEZl5Xf/++A4wAYDYQ==",
+			"requires": {
+				"@emotion/sheet": "0.9.4",
+				"@emotion/stylis": "0.8.5",
+				"@emotion/utils": "0.11.3",
+				"@emotion/weak-memoize": "0.2.5"
+			}
+		},
+		"@emotion/hash": {
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
+			"integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
+		},
+		"@emotion/memoize": {
+			"version": "0.7.4",
+			"resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
+			"integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
+		},
+		"@emotion/serialize": {
+			"version": "0.11.16",
+			"resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.11.16.tgz",
+			"integrity": "sha512-G3J4o8by0VRrO+PFeSc3js2myYNOXVJ3Ya+RGVxnshRYgsvErfAOglKAiy1Eo1vhzxqtUvjCyS5gtewzkmvSSg==",
+			"requires": {
+				"@emotion/hash": "0.8.0",
+				"@emotion/memoize": "0.7.4",
+				"@emotion/unitless": "0.7.5",
+				"@emotion/utils": "0.11.3",
+				"csstype": "^2.5.7"
+			}
+		},
+		"@emotion/sheet": {
+			"version": "0.9.4",
+			"resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-0.9.4.tgz",
+			"integrity": "sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA=="
+		},
+		"@emotion/stylis": {
+			"version": "0.8.5",
+			"resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
+			"integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ=="
+		},
+		"@emotion/unitless": {
+			"version": "0.7.5",
+			"resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
+			"integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
+		},
+		"@emotion/utils": {
+			"version": "0.11.3",
+			"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.3.tgz",
+			"integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw=="
+		},
+		"@emotion/weak-memoize": {
+			"version": "0.2.5",
+			"resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
+			"integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
 		},
 		"@hot-loader/react-dom": {
 			"version": "16.13.0",
@@ -1166,6 +1307,16 @@
 				"scheduler": "^0.19.0"
 			}
 		},
+		"@jest/types": {
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-24.9.0.tgz",
+			"integrity": "sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==",
+			"requires": {
+				"@types/istanbul-lib-coverage": "^2.0.0",
+				"@types/istanbul-reports": "^1.1.1",
+				"@types/yargs": "^13.0.0"
+			}
+		},
 		"@kadira/react-storybook-addon-info": {
 			"version": "3.4.0",
 			"resolved": "https://registry.npmjs.org/@kadira/react-storybook-addon-info/-/react-storybook-addon-info-3.4.0.tgz",
@@ -1177,17 +1328,365 @@
 				"react-addons-create-fragment": "^15.3.2"
 			}
 		},
+		"@leafygreen-ui/emotion": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@leafygreen-ui/emotion/-/emotion-2.0.1.tgz",
+			"integrity": "sha512-eswO+aWs6vbuiEDUpZz3tGjCBtgWr3hU4ndgrjFLNOQpWOsVOaW8zQzVu1XOMLHCjtfZy2/GDME7zQWVvcrVFg==",
+			"requires": {
+				"create-emotion": "^10.0.7",
+				"create-emotion-server": "10.0.27",
+				"emotion": "^10.0.7"
+			}
+		},
+		"@leafygreen-ui/icon": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/@leafygreen-ui/icon/-/icon-4.3.0.tgz",
+			"integrity": "sha512-6DOFKxj3U0hp2yQEq/Yq19qIiIIUXwRj2fH1ddOJFYLtAoeFOCSeuF6rE2dqXrXW/puQdjgpXV60w9J8gyXGog=="
+		},
+		"@leafygreen-ui/lib": {
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-4.4.1.tgz",
+			"integrity": "sha512-ZVa/LlcoWBXLpks5XQ6MsM/f3cMqxxsqD8iQlGkGncJZN8cJ7NnxqtyY7QsbGSHNQzSNJbOtHxg6dpYRuAWcPw==",
+			"requires": {
+				"@leafygreen-ui/emotion": "^2.0.1",
+				"@testing-library/react": "^8.0.1",
+				"facepaint": "^1.2.1",
+				"polished": "^2.3.0"
+			}
+		},
+		"@leafygreen-ui/palette": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-2.0.1.tgz",
+			"integrity": "sha512-xwD6kOokWvaygxF0T2gnf77HEu68G7EXr1ZrNiNtZzg80Y1V2hikhUNoESWij6g/A6qJZvAiwpseflVo3PnlHQ=="
+		},
+		"@leafygreen-ui/syntax": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/@leafygreen-ui/syntax/-/syntax-2.7.0.tgz",
+			"integrity": "sha512-bQRIFKPUwZsne39R49eQN5qEl556w88N/FjJfzAU/LjR2OVp+W5sWhx1PiacwCq+J1r/7wu/PKUh5rV/dpSgmQ==",
+			"requires": {
+				"@leafygreen-ui/lib": "^4.3.0",
+				"@leafygreen-ui/palette": "^2.0.1",
+				"highlight.js": "^9.15.6",
+				"highlightjs-graphql": "^1.0.1"
+			}
+		},
 		"@mongodb-js/triejs": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/@mongodb-js/triejs/-/triejs-0.1.5.tgz",
 			"integrity": "sha512-elh8S1OxmEGe8/wbr6ky//dHhV2ld6oZV8/M9lgozJsL/6Aqm8j5+ElquzoX9k9l3Q+dohuX/SIGR/kTRZHS4g==",
 			"dev": true
 		},
+		"@mongosh/async-rewriter": {
+			"version": "0.0.1-alpha.15",
+			"resolved": "https://registry.npmjs.org/@mongosh/async-rewriter/-/async-rewriter-0.0.1-alpha.15.tgz",
+			"integrity": "sha512-89ydztLoz4Dyl92Bptff8GkIXioei0qxX/Z2uMTV9G4/Esg/Vv2C2VAKhI68uAACxpLjISW+p+guVya5SXJgAA==",
+			"requires": {
+				"@babel/core": "^7.9.0",
+				"@babel/parser": "^7.9.4",
+				"@babel/preset-typescript": "^7.9.0",
+				"@babel/template": "^7.8.6",
+				"@babel/traverse": "^7.9.0",
+				"@babel/types": "^7.9.0",
+				"@mongosh/errors": "^0.0.1-alpha.15",
+				"@types/babel__core": "^7.1.6",
+				"@types/babel__traverse": "^7.0.9",
+				"ts-node": "^8.8.1",
+				"typescript": "^3.8.3"
+			}
+		},
+		"@mongosh/browser-repl": {
+			"version": "0.0.1-alpha.15",
+			"resolved": "https://registry.npmjs.org/@mongosh/browser-repl/-/browser-repl-0.0.1-alpha.15.tgz",
+			"integrity": "sha512-gMPq1+MyWTRxZsjHKtYN+YoFKc9OP9w6NOam2EROwTCwRmUKAg0W76obwdrZtTeFWMGiYt5QyxLNck9ldgmd1g==",
+			"requires": {
+				"@babel/generator": "^7.8.3",
+				"@babel/parser": "^7.8.3",
+				"@babel/runtime": "^7.8.3",
+				"@babel/template": "^7.8.3",
+				"@leafygreen-ui/icon": "^4.0.0",
+				"@leafygreen-ui/palette": "^2.0.0",
+				"@leafygreen-ui/syntax": "^2.2.0",
+				"@mongosh/browser-runtime-core": "^0.0.1-alpha.15",
+				"@mongosh/history": "^0.0.1-alpha.15",
+				"@mongosh/i18n": "^0.0.1-alpha.15",
+				"@mongosh/service-provider-core": "^0.0.1-alpha.15",
+				"pretty-bytes": "^5.3.0",
+				"text-table": "^0.2.0"
+			},
+			"dependencies": {
+				"pretty-bytes": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.3.0.tgz",
+					"integrity": "sha512-hjGrh+P926p4R4WbaB6OckyRtO0F0/lQBiT+0gnxjV+5kjPBrfVBFCsCLbMqVQeydvIoouYTCmmEURiH3R1Bdg=="
+				}
+			}
+		},
+		"@mongosh/browser-runtime-core": {
+			"version": "0.0.1-alpha.15",
+			"resolved": "https://registry.npmjs.org/@mongosh/browser-runtime-core/-/browser-runtime-core-0.0.1-alpha.15.tgz",
+			"integrity": "sha512-wpVgRx6KHkt/OZmLAUVYeJ6cqG6U+YClU6TU+3NnwBQ+NdPqEOG678fn2wwbq4EaR4V90X4GTS9E+4o4RfwnuQ==",
+			"requires": {
+				"@babel/generator": "^7.9.4",
+				"@babel/parser": "^7.9.4",
+				"@mongosh/cli-repl": "^0.0.1-alpha.15",
+				"@mongosh/service-provider-core": "^0.0.1-alpha.15",
+				"@mongosh/shell-evaluator": "^0.0.1-alpha.15"
+			}
+		},
+		"@mongosh/browser-runtime-electron": {
+			"version": "0.0.1-alpha.15",
+			"resolved": "https://registry.npmjs.org/@mongosh/browser-runtime-electron/-/browser-runtime-electron-0.0.1-alpha.15.tgz",
+			"integrity": "sha512-VpgACHP/UceG5fJ4/JHldA+wUEv8tJdU1xDyah1kcgLecOQZ1Yw24w5R82qVbF6ARI23UgiXjTTSxnYbMWNhjQ==",
+			"requires": {
+				"@mongosh/browser-runtime-core": "^0.0.1-alpha.15",
+				"@mongosh/service-provider-core": "^0.0.1-alpha.15"
+			}
+		},
+		"@mongosh/build": {
+			"version": "0.0.1-alpha.15",
+			"resolved": "https://registry.npmjs.org/@mongosh/build/-/build-0.0.1-alpha.15.tgz",
+			"integrity": "sha512-H0Y4dWiyZ2hPjow9rNt3ASkKBpASsx13mrP4q7oQvqA5yQpX6d18SM6jvYUnpQdq6RbhBxVdy4+AGmuEhJDI5Q==",
+			"requires": {
+				"adm-zip": "^0.4.14",
+				"aws-sdk": "^2.674.0",
+				"handlebars": "^4.7.6",
+				"pkg": "^4.4.3",
+				"tar": "^6.0.1"
+			},
+			"dependencies": {
+				"chownr": {
+					"version": "2.0.0",
+					"resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
+					"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="
+				},
+				"fs-minipass": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
+					"integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
+					"requires": {
+						"minipass": "^3.0.0"
+					}
+				},
+				"minipass": {
+					"version": "3.1.3",
+					"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
+					"integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
+					"requires": {
+						"yallist": "^4.0.0"
+					}
+				},
+				"minizlib": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.0.tgz",
+					"integrity": "sha512-EzTZN/fjSvifSX0SlqUERCN39o6T40AMarPbv0MrarSFtIITCBh7bi+dU8nxGFHuqs9jdIAeoYoKuQAAASsPPA==",
+					"requires": {
+						"minipass": "^3.0.0",
+						"yallist": "^4.0.0"
+					}
+				},
+				"mkdirp": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+					"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+				},
+				"tar": {
+					"version": "6.0.2",
+					"resolved": "https://registry.npmjs.org/tar/-/tar-6.0.2.tgz",
+					"integrity": "sha512-Glo3jkRtPcvpDlAs/0+hozav78yoXKFr+c4wgw62NNMO3oo4AaJdCo21Uu7lcwr55h39W2XD1LMERc64wtbItg==",
+					"requires": {
+						"chownr": "^2.0.0",
+						"fs-minipass": "^2.0.0",
+						"minipass": "^3.0.0",
+						"minizlib": "^2.1.0",
+						"mkdirp": "^1.0.3",
+						"yallist": "^4.0.0"
+					}
+				},
+				"yallist": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
+				}
+			}
+		},
+		"@mongosh/cli-repl": {
+			"version": "0.0.1-alpha.15",
+			"resolved": "https://registry.npmjs.org/@mongosh/cli-repl/-/cli-repl-0.0.1-alpha.15.tgz",
+			"integrity": "sha512-uZmXFi1Kjd1SMJNgkol5jXZcIJjrSqDbs1UOU/DAZcSkO+wLqYpIzEwYxKCAyq4apAbemTbLNyrLb+E6y2ifhA==",
+			"requires": {
+				"@mongosh/build": "^0.0.1-alpha.15",
+				"@mongosh/errors": "^0.0.1-alpha.15",
+				"@mongosh/history": "^0.0.1-alpha.15",
+				"@mongosh/i18n": "^0.0.1-alpha.15",
+				"@mongosh/service-provider-server": "^0.0.1-alpha.15",
+				"@mongosh/shell-api": "^0.0.1-alpha.15",
+				"@mongosh/shell-evaluator": "^0.0.1-alpha.15",
+				"acorn": "^7.1.1",
+				"acorn-class-fields": "^0.3.2",
+				"acorn-numeric-separator": "^0.3.0",
+				"acorn-private-methods": "^0.3.1",
+				"acorn-static-class-features": "^0.2.1",
+				"analytics-node": "^3.4.0-beta.1",
+				"ansi-escape-sequences": "^5.1.2",
+				"bson": "^4.0.4",
+				"is-recoverable-error": "^1.0.0",
+				"lodash.set": "^4.3.2",
+				"minimist": "^1.2.5",
+				"mkdirp": "^1.0.3",
+				"mongodb-ace-autocompleter": "^0.4.1",
+				"mongodb-build-info": "^1.0.0",
+				"mongodb-redact": "^0.2.0",
+				"nanobus": "^4.4.0",
+				"pino": "^5.16.0",
+				"pretty-bytes": "^5.3.0",
+				"pretty-repl": "^2.3.0",
+				"read": "^1.0.7",
+				"semver": "^7.1.2",
+				"text-table": "^0.2.0"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.2.0.tgz",
+					"integrity": "sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ=="
+				},
+				"bson": {
+					"version": "4.0.4",
+					"resolved": "https://registry.npmjs.org/bson/-/bson-4.0.4.tgz",
+					"integrity": "sha512-Ioi3TD0/1V3aI8+hPfC56TetYmzfq2H07jJa9A1lKTxWsFtHtYdLMGMXjtGEg9v0f72NSM07diRQEUNYhLupIA==",
+					"requires": {
+						"buffer": "^5.1.0",
+						"long": "^4.0.0"
+					}
+				},
+				"buffer": {
+					"version": "5.6.0",
+					"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+					"integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+					"requires": {
+						"base64-js": "^1.0.2",
+						"ieee754": "^1.1.4"
+					}
+				},
+				"mkdirp": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+					"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+				},
+				"pretty-bytes": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.3.0.tgz",
+					"integrity": "sha512-hjGrh+P926p4R4WbaB6OckyRtO0F0/lQBiT+0gnxjV+5kjPBrfVBFCsCLbMqVQeydvIoouYTCmmEURiH3R1Bdg=="
+				},
+				"semver": {
+					"version": "7.3.2",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
+				}
+			}
+		},
+		"@mongosh/errors": {
+			"version": "0.0.1-alpha.15",
+			"resolved": "https://registry.npmjs.org/@mongosh/errors/-/errors-0.0.1-alpha.15.tgz",
+			"integrity": "sha512-p1UhubC9Bvvb0HyxbnUzX1bl56ubH45gqlI4p5//cTjabwmMoA5gdErAZYvL7E8t9QYrneVmY1W/2/B7zd1h1A=="
+		},
+		"@mongosh/history": {
+			"version": "0.0.1-alpha.15",
+			"resolved": "https://registry.npmjs.org/@mongosh/history/-/history-0.0.1-alpha.15.tgz",
+			"integrity": "sha512-cIC/H2cecN3xm15L745kdfievsZEvDlGoZu5Oy/ed/ihsc5PeOBWJOra2pyuh0R6ZaXDq6bFaoiXk6JLoB2pqg==",
+			"requires": {
+				"mongodb-redact": "^0.2.0"
+			}
+		},
+		"@mongosh/i18n": {
+			"version": "0.0.1-alpha.15",
+			"resolved": "https://registry.npmjs.org/@mongosh/i18n/-/i18n-0.0.1-alpha.15.tgz",
+			"integrity": "sha512-BIactWfKx3zC7Z438lKDRqeaoErrTmn2mcHl4V3tx14/mw7m2s3DEBVgO0dju8p3oFviz4oSRhM+HL+FNegX7A==",
+			"requires": {
+				"mustache": "^4.0.0"
+			}
+		},
+		"@mongosh/mapper": {
+			"version": "0.0.1-alpha.15",
+			"resolved": "https://registry.npmjs.org/@mongosh/mapper/-/mapper-0.0.1-alpha.15.tgz",
+			"integrity": "sha512-nQh/2gcDbp1mh3uxk38T9Or0RilgBj7wR8/Lkk5OS3jMZZuKMyMRbn8GEtasU6RVoG6kSVLn9GGkQvyDBRi1cw==",
+			"requires": {
+				"@mongosh/errors": "^0.0.1-alpha.15",
+				"@mongosh/service-provider-core": "^0.0.1-alpha.15",
+				"@mongosh/shell-api": "^0.0.1-alpha.15",
+				"pretty-bytes": "^5.3.0",
+				"text-table": "^0.2.0"
+			},
+			"dependencies": {
+				"pretty-bytes": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.3.0.tgz",
+					"integrity": "sha512-hjGrh+P926p4R4WbaB6OckyRtO0F0/lQBiT+0gnxjV+5kjPBrfVBFCsCLbMqVQeydvIoouYTCmmEURiH3R1Bdg=="
+				}
+			}
+		},
+		"@mongosh/service-provider-core": {
+			"version": "0.0.1-alpha.15",
+			"resolved": "https://registry.npmjs.org/@mongosh/service-provider-core/-/service-provider-core-0.0.1-alpha.15.tgz",
+			"integrity": "sha512-weezX/uVVIpLYsVanKyhrlIBzkBc61smE4hndKzkj4FxwEArsUae0j0DHXeT3Jus0G5+bpAUrTB15u3E8qInTA=="
+		},
+		"@mongosh/service-provider-server": {
+			"version": "0.0.1-alpha.15",
+			"resolved": "https://registry.npmjs.org/@mongosh/service-provider-server/-/service-provider-server-0.0.1-alpha.15.tgz",
+			"integrity": "sha512-WxhDwB3x/E2Aiklx/tKtv7S/5MVQGZwBTt/GyurC7jI5G4m7ZBJjw7M6Ma0q60mLNDiS+8wgT3Jd/NVPxK57Xg==",
+			"requires": {
+				"@mongosh/errors": "^0.0.1-alpha.15",
+				"@mongosh/service-provider-core": "^0.0.1-alpha.15",
+				"@types/sinon": "^7.5.1",
+				"@types/sinon-chai": "^3.2.3",
+				"mongodb": "3.5.3 || ^3.5.5"
+			}
+		},
+		"@mongosh/shell-api": {
+			"version": "0.0.1-alpha.15",
+			"resolved": "https://registry.npmjs.org/@mongosh/shell-api/-/shell-api-0.0.1-alpha.15.tgz",
+			"integrity": "sha512-cM9xa0DnZuRZg1r6b42LOVue6EREP38/gR9823uzXMwKyOM8vPpF+ScDfCLp7/0+p+H20ij5WCtxWItRdDzJfA==",
+			"requires": {
+				"@mongosh/errors": "^0.0.1-alpha.15",
+				"@mongosh/i18n": "^0.0.1-alpha.15",
+				"bson": "^4.0.4"
+			},
+			"dependencies": {
+				"bson": {
+					"version": "4.0.4",
+					"resolved": "https://registry.npmjs.org/bson/-/bson-4.0.4.tgz",
+					"integrity": "sha512-Ioi3TD0/1V3aI8+hPfC56TetYmzfq2H07jJa9A1lKTxWsFtHtYdLMGMXjtGEg9v0f72NSM07diRQEUNYhLupIA==",
+					"requires": {
+						"buffer": "^5.1.0",
+						"long": "^4.0.0"
+					}
+				},
+				"buffer": {
+					"version": "5.6.0",
+					"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+					"integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+					"requires": {
+						"base64-js": "^1.0.2",
+						"ieee754": "^1.1.4"
+					}
+				}
+			}
+		},
+		"@mongosh/shell-evaluator": {
+			"version": "0.0.1-alpha.15",
+			"resolved": "https://registry.npmjs.org/@mongosh/shell-evaluator/-/shell-evaluator-0.0.1-alpha.15.tgz",
+			"integrity": "sha512-Uwslqbc7u2QJSAPKFE+otqb0K9NvWhU4YsdBqKAe7soOmLoueuYvtPTrtvlHiG3XJ8vaiMzogQxoFV1bDa9kyQ==",
+			"requires": {
+				"@mongosh/async-rewriter": "^0.0.1-alpha.15",
+				"@mongosh/mapper": "^0.0.1-alpha.15",
+				"@mongosh/service-provider-core": "^0.0.1-alpha.15",
+				"@mongosh/shell-api": "^0.0.1-alpha.15"
+			}
+		},
 		"@nodelib/fs.scandir": {
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
 			"integrity": "sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==",
-			"dev": true,
 			"requires": {
 				"@nodelib/fs.stat": "2.0.3",
 				"run-parallel": "^1.1.9"
@@ -1196,18 +1695,30 @@
 		"@nodelib/fs.stat": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
-			"integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
-			"dev": true
+			"integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA=="
 		},
 		"@nodelib/fs.walk": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
 			"integrity": "sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==",
-			"dev": true,
 			"requires": {
 				"@nodelib/fs.scandir": "2.1.3",
 				"fastq": "^1.6.0"
 			}
+		},
+		"@segment/loosely-validate-event": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@segment/loosely-validate-event/-/loosely-validate-event-2.0.0.tgz",
+			"integrity": "sha512-ZMCSfztDBqwotkl848ODgVcAmN4OItEWDCkshcKz0/W6gGSQayuuCtWV/MlodFivAZD793d6UgANd6wCXUfrIw==",
+			"requires": {
+				"component-type": "^1.2.1",
+				"join-component": "^1.1.0"
+			}
+		},
+		"@sheerun/mutationobserver-shim": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.3.tgz",
+			"integrity": "sha512-DetpxZw1fzPD5xUBrIAoplLChO2VB8DlL5Gg+I1IR9b2wPqYIca2WSUxL5g1vLeR4MsQq1NeWriXAVffV+U1Fw=="
 		},
 		"@sinonjs/commons": {
 			"version": "1.7.2",
@@ -1840,11 +2351,73 @@
 				"react-treebeard": "^2.1.0"
 			}
 		},
+		"@testing-library/dom": {
+			"version": "5.6.1",
+			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-5.6.1.tgz",
+			"integrity": "sha512-Y1T2bjtvQMewffn1CJ28kpgnuvPYKsBcZMagEH0ppfEMZPDc8AkkEnTk4smrGZKw0cblNB3lhM2FMnpfLExlHg==",
+			"requires": {
+				"@babel/runtime": "^7.5.5",
+				"@sheerun/mutationobserver-shim": "^0.3.2",
+				"aria-query": "3.0.0",
+				"pretty-format": "^24.8.0",
+				"wait-for-expect": "^1.2.0"
+			}
+		},
+		"@testing-library/react": {
+			"version": "8.0.9",
+			"resolved": "https://registry.npmjs.org/@testing-library/react/-/react-8.0.9.tgz",
+			"integrity": "sha512-I7zd+MW5wk8rQA5VopZgBfxGKUd91jgZ6Vzj2gMqFf2iGGtKwvI5SVTrIJcSFaOXK88T2EUsbsIKugDtoqOcZQ==",
+			"requires": {
+				"@babel/runtime": "^7.5.5",
+				"@testing-library/dom": "^5.6.1"
+			}
+		},
+		"@types/babel__core": {
+			"version": "7.1.7",
+			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.7.tgz",
+			"integrity": "sha512-RL62NqSFPCDK2FM1pSDH0scHpJvsXtZNiYlMB73DgPBaG1E38ZYVL+ei5EkWRbr+KC4YNiAUNBnRj+bgwpgjMw==",
+			"requires": {
+				"@babel/parser": "^7.1.0",
+				"@babel/types": "^7.0.0",
+				"@types/babel__generator": "*",
+				"@types/babel__template": "*",
+				"@types/babel__traverse": "*"
+			}
+		},
+		"@types/babel__generator": {
+			"version": "7.6.1",
+			"resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.1.tgz",
+			"integrity": "sha512-bBKm+2VPJcMRVwNhxKu8W+5/zT7pwNEqeokFOmbvVSqGzFneNxYcEBro9Ac7/N9tlsaPYnZLK8J1LWKkMsLAew==",
+			"requires": {
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@types/babel__template": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.0.2.tgz",
+			"integrity": "sha512-/K6zCpeW7Imzgab2bLkLEbz0+1JlFSrUMdw7KoIIu+IUdu51GWaBZpd3y1VXGVXzynvGa4DaIaxNZHiON3GXUg==",
+			"requires": {
+				"@babel/parser": "^7.1.0",
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@types/babel__traverse": {
+			"version": "7.0.11",
+			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.11.tgz",
+			"integrity": "sha512-ddHK5icION5U6q11+tV2f9Mo6CZVuT8GJKld2q9LqHSZbvLbH34Kcu2yFGckZut453+eQU6btIA3RihmnRgI+Q==",
+			"requires": {
+				"@babel/types": "^7.3.0"
+			}
+		},
+		"@types/chai": {
+			"version": "4.2.11",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.11.tgz",
+			"integrity": "sha512-t7uW6eFafjO+qJ3BIV2gGUyZs27egcNRkUdalkud+Qa3+kg//f129iuOFivHDXQ+vnU3fDXuwgv0cqMCbcE8sw=="
+		},
 		"@types/color-name": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-			"integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
-			"dev": true
+			"integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
 		},
 		"@types/events": {
 			"version": "3.0.0",
@@ -1863,6 +2436,28 @@
 				"@types/node": "*"
 			}
 		},
+		"@types/istanbul-lib-coverage": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.2.tgz",
+			"integrity": "sha512-rsZg7eL+Xcxsxk2XlBt9KcG8nOp9iYdKCOikY9x2RFJCyOdNj4MKPQty0e8oZr29vVAzKXr1BmR+kZauti3o1w=="
+		},
+		"@types/istanbul-lib-report": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+			"integrity": "sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==",
+			"requires": {
+				"@types/istanbul-lib-coverage": "*"
+			}
+		},
+		"@types/istanbul-reports": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
+			"integrity": "sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==",
+			"requires": {
+				"@types/istanbul-lib-coverage": "*",
+				"@types/istanbul-lib-report": "*"
+			}
+		},
 		"@types/minimatch": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -1878,8 +2473,34 @@
 		"@types/parse-json": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
-			"integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
-			"dev": true
+			"integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
+		},
+		"@types/sinon": {
+			"version": "7.5.2",
+			"resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-7.5.2.tgz",
+			"integrity": "sha512-T+m89VdXj/eidZyejvmoP9jivXgBDdkOSBVQjU9kF349NEx10QdPNGxHeZUaj1IlJ32/ewdyXJjnJxyxJroYwg=="
+		},
+		"@types/sinon-chai": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@types/sinon-chai/-/sinon-chai-3.2.4.tgz",
+			"integrity": "sha512-xq5KOWNg70PRC7dnR2VOxgYQ6paumW+4pTZP+6uTSdhpYsAUEeeT5bw6rRHHQrZ4KyR+M5ojOR+lje6TGSpUxA==",
+			"requires": {
+				"@types/chai": "*",
+				"@types/sinon": "*"
+			}
+		},
+		"@types/yargs": {
+			"version": "13.0.9",
+			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.9.tgz",
+			"integrity": "sha512-xrvhZ4DZewMDhoH1utLtOAwYQy60eYFoXeje30TzM3VOvQlBwQaEpKFq5m34k1wOw2AKIi2pwtiAjdmhvlBUzg==",
+			"requires": {
+				"@types/yargs-parser": "*"
+			}
+		},
+		"@types/yargs-parser": {
+			"version": "15.0.0",
+			"resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-15.0.0.tgz",
+			"integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw=="
 		},
 		"@typescript-eslint/typescript-estree": {
 			"version": "2.29.0",
@@ -2134,6 +2755,14 @@
 			"integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
 			"dev": true
 		},
+		"acorn-class-fields": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/acorn-class-fields/-/acorn-class-fields-0.3.2.tgz",
+			"integrity": "sha512-wyqXoqzXSOF42uxHo40TMuC/KfloI66AZz6S1TeK8D2HjKzI7Boq1mSH2pB5RwKEJWgHqnewGpRFRZwR0qQCyQ==",
+			"requires": {
+				"acorn-private-class-elements": "^0.2.5"
+			}
+		},
 		"acorn-dynamic-import": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz",
@@ -2200,6 +2829,32 @@
 				}
 			}
 		},
+		"acorn-numeric-separator": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/acorn-numeric-separator/-/acorn-numeric-separator-0.3.2.tgz",
+			"integrity": "sha512-ZNN1qnKvjWycDSQBfuD1TCiB81ItjjeGUPLHuqfP8X8HXwAodGTWsAaqSOQ1Nc9t+Wlb3tcEFdBrwUFUIzDiiA=="
+		},
+		"acorn-private-class-elements": {
+			"version": "0.2.5",
+			"resolved": "https://registry.npmjs.org/acorn-private-class-elements/-/acorn-private-class-elements-0.2.5.tgz",
+			"integrity": "sha512-3eApRrJmPjaxWB3XidP8YMeVq9pcswPFE0KsSWVuhceCU68ZS8fkcf0fTXGhCmnNd7n48NWWV27EKMFPeCoJLg=="
+		},
+		"acorn-private-methods": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/acorn-private-methods/-/acorn-private-methods-0.3.1.tgz",
+			"integrity": "sha512-IV5XZInFQaQK5ucjJy/HAk2UYvt+Buax00evzwo8NSuo8zhOBhW5v6VOjAljYUhAzQ/Hosi+Kaz6xJmvPiSM4Q==",
+			"requires": {
+				"acorn-private-class-elements": "^0.2.4"
+			}
+		},
+		"acorn-static-class-features": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/acorn-static-class-features/-/acorn-static-class-features-0.2.1.tgz",
+			"integrity": "sha512-eLIAEBFwu1bcZD+39u5PAcAargtkI5tY1uDRQV6SB3zY4JIO0vqvSdtZ8hz1GGZIVY/d3RDxkM9BLTPTNNVwGw==",
+			"requires": {
+				"acorn-private-class-elements": "^0.2.3"
+			}
+		},
 		"acorn-walk": {
 			"version": "6.2.0",
 			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
@@ -2211,6 +2866,11 @@
 			"resolved": "https://registry.npmjs.org/address/-/address-1.0.3.tgz",
 			"integrity": "sha512-z55ocwKBRLryBs394Sm3ushTtBeg6VAeuku7utSoSnsJKvKcnXFIyC6vh27n3rXyxSgkJBBCAvyOn7gSUcTYjg==",
 			"dev": true
+		},
+		"adm-zip": {
+			"version": "0.4.14",
+			"resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.14.tgz",
+			"integrity": "sha512-/9aQCnQHF+0IiCl0qhXoK7qs//SwYE7zX8lsr/DNk1BRAHYxeLZPL4pguwK29gUEqasYQjqPtEpDRSWEkdHn9g=="
 		},
 		"after": {
 			"version": "0.8.2",
@@ -2265,7 +2925,6 @@
 			"version": "6.12.2",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
 			"integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
-			"dev": true,
 			"requires": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -2462,11 +3121,46 @@
 				}
 			}
 		},
+		"analytics-node": {
+			"version": "3.4.0-beta.1",
+			"resolved": "https://registry.npmjs.org/analytics-node/-/analytics-node-3.4.0-beta.1.tgz",
+			"integrity": "sha512-+0F/y4Asc5S2qhWcYss+iCob6TTXQktwbqlIk02gcZaRxpekCbnTbJu/rcaRooVHxqp9WSzUXiWCesJYPJETZQ==",
+			"requires": {
+				"@segment/loosely-validate-event": "^2.0.0",
+				"axios": "^0.18.1",
+				"axios-retry": "^3.0.2",
+				"lodash.isstring": "^4.0.1",
+				"md5": "^2.2.1",
+				"ms": "^2.0.0",
+				"remove-trailing-slash": "^0.1.0",
+				"uuid": "^3.2.1"
+			},
+			"dependencies": {
+				"lodash.isstring": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+					"integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+				}
+			}
+		},
+		"ansi": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
+			"integrity": "sha1-DELU+xcWDVqa8eSEus4cZpIsGyE="
+		},
 		"ansi-colors": {
 			"version": "3.2.4",
 			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz",
 			"integrity": "sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA==",
 			"dev": true
+		},
+		"ansi-escape-sequences": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-5.1.2.tgz",
+			"integrity": "sha512-JcpoVp1W1bl1Qn4cVuiXEhD6+dyXKSOgCn2zlzE8inYgCJCBy1aPnUhlz6I4DFum8D4ovb9Qi/iAjUcGvG2lqw==",
+			"requires": {
+				"array-back": "^4.0.0"
+			}
 		},
 		"ansi-escapes": {
 			"version": "3.2.0",
@@ -2483,14 +3177,12 @@
 		"ansi-regex": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-			"dev": true
+			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
 		},
 		"ansi-styles": {
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-			"dev": true,
 			"requires": {
 				"color-convert": "^1.9.0"
 			}
@@ -2519,18 +3211,21 @@
 		"aproba": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
-			"dev": true
+			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
 		},
 		"are-we-there-yet": {
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
 			"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
-			"dev": true,
 			"requires": {
 				"delegates": "^1.0.0",
 				"readable-stream": "^2.0.6"
 			}
+		},
+		"arg": {
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
 		},
 		"argparse": {
 			"version": "1.0.10",
@@ -2539,6 +3234,22 @@
 			"dev": true,
 			"requires": {
 				"sprintf-js": "~1.0.2"
+			}
+		},
+		"aria-query": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-3.0.0.tgz",
+			"integrity": "sha1-ZbP8wcoRVajJrmTW7uKX8V1RM8w=",
+			"requires": {
+				"ast-types-flow": "0.0.7",
+				"commander": "^2.11.0"
+			},
+			"dependencies": {
+				"commander": {
+					"version": "2.20.3",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+				}
 			}
 		},
 		"arr-diff": {
@@ -2558,6 +3269,11 @@
 			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
 			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
 			"dev": true
+		},
+		"array-back": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.1.tgz",
+			"integrity": "sha512-Z/JnaVEXv+A9xabHzN43FiiiWEE7gPCRXMrVmRm00tWbjZRul1iHm7ECzlyNq1p4a4ATXz+G9FJ3GqGOkOV3fg=="
 		},
 		"array-equal": {
 			"version": "1.0.0",
@@ -2750,7 +3466,6 @@
 			"version": "0.2.4",
 			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
 			"integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
-			"dev": true,
 			"requires": {
 				"safer-buffer": "~2.1.0"
 			}
@@ -2796,8 +3511,7 @@
 		"assert-plus": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
-			"dev": true
+			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
 		},
 		"assertion-error": {
 			"version": "1.1.0",
@@ -2822,6 +3536,11 @@
 			"resolved": "https://registry.npmjs.org/ast-types/-/ast-types-0.11.7.tgz",
 			"integrity": "sha512-2mP3TwtkY/aTv5X3ZsMpNAbOnyoC/aMJwJSoaELPkHId0nSQgFcnU4dRW3isxiz7+zBexk0ym3WNVjMiQBnJSw==",
 			"dev": true
+		},
+		"ast-types-flow": {
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
+			"integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0="
 		},
 		"astral-regex": {
 			"version": "1.0.0",
@@ -2853,14 +3572,18 @@
 		"asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
-			"dev": true
+			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
 		},
 		"atob": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
 			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
 			"dev": true
+		},
+		"atomic-sleep": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+			"integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="
 		},
 		"autoprefixer": {
 			"version": "9.7.6",
@@ -2911,17 +3634,112 @@
 				}
 			}
 		},
+		"aws-sdk": {
+			"version": "2.679.0",
+			"resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.679.0.tgz",
+			"integrity": "sha512-bsbu3Mbwqz2DHpVSSgaSoFYsNrW+54vXN74iG++cCE7AAg9vOgCKzGul8yhR4jxxlOmGlfP9kCNrkCpjQ/Uqkg==",
+			"requires": {
+				"buffer": "4.9.1",
+				"events": "1.1.1",
+				"ieee754": "1.1.13",
+				"jmespath": "0.15.0",
+				"querystring": "0.2.0",
+				"sax": "1.2.1",
+				"url": "0.10.3",
+				"uuid": "3.3.2",
+				"xml2js": "0.4.19"
+			},
+			"dependencies": {
+				"buffer": {
+					"version": "4.9.1",
+					"resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
+					"integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
+					"requires": {
+						"base64-js": "^1.0.2",
+						"ieee754": "^1.1.4",
+						"isarray": "^1.0.0"
+					}
+				},
+				"events": {
+					"version": "1.1.1",
+					"resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
+					"integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
+				},
+				"punycode": {
+					"version": "1.3.2",
+					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
+					"integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
+				},
+				"sax": {
+					"version": "1.2.1",
+					"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
+					"integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
+				},
+				"url": {
+					"version": "0.10.3",
+					"resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
+					"integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
+					"requires": {
+						"punycode": "1.3.2",
+						"querystring": "0.2.0"
+					}
+				},
+				"uuid": {
+					"version": "3.3.2",
+					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
+					"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
+				}
+			}
+		},
 		"aws-sign2": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
-			"dev": true
+			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
 		},
 		"aws4": {
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
-			"integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==",
-			"dev": true
+			"integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
+		},
+		"axios": {
+			"version": "0.18.1",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-0.18.1.tgz",
+			"integrity": "sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==",
+			"requires": {
+				"follow-redirects": "1.5.10",
+				"is-buffer": "^2.0.2"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"follow-redirects": {
+					"version": "1.5.10",
+					"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+					"integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+					"requires": {
+						"debug": "=3.1.0"
+					}
+				},
+				"is-buffer": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+					"integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
+				}
+			}
+		},
+		"axios-retry": {
+			"version": "3.1.8",
+			"resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.1.8.tgz",
+			"integrity": "sha512-yPw5Y4Bg6Dgmhm35KaJFtlh23s1TecW0HsUerK4/IS1UKl0gtN2aJqdEKtVomiOS/bDo5w4P3sqgki/M10eF8Q==",
+			"requires": {
+				"is-retry-allowed": "^1.1.0"
+			}
 		},
 		"babel-code-frame": {
 			"version": "6.26.0",
@@ -3338,11 +4156,34 @@
 				"object.assign": "^4.1.0"
 			}
 		},
+		"babel-plugin-emotion": {
+			"version": "10.0.33",
+			"resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-10.0.33.tgz",
+			"integrity": "sha512-bxZbTTGz0AJQDHm8k6Rf3RQJ8tX2scsfsRyKVgAbiUPUNIRtlK+7JxP+TAd1kRLABFxe0CFm2VdK4ePkoA9FxQ==",
+			"requires": {
+				"@babel/helper-module-imports": "^7.0.0",
+				"@emotion/hash": "0.8.0",
+				"@emotion/memoize": "0.7.4",
+				"@emotion/serialize": "^0.11.16",
+				"babel-plugin-macros": "^2.0.0",
+				"babel-plugin-syntax-jsx": "^6.18.0",
+				"convert-source-map": "^1.5.0",
+				"escape-string-regexp": "^1.0.5",
+				"find-root": "^1.1.0",
+				"source-map": "^0.5.7"
+			},
+			"dependencies": {
+				"find-root": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+					"integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
+				}
+			}
+		},
 		"babel-plugin-macros": {
 			"version": "2.8.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz",
 			"integrity": "sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==",
-			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.7.2",
 				"cosmiconfig": "^6.0.0",
@@ -3353,7 +4194,6 @@
 					"version": "6.0.0",
 					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
 					"integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
-					"dev": true,
 					"requires": {
 						"@types/parse-json": "^4.0.0",
 						"import-fresh": "^3.1.0",
@@ -3366,7 +4206,6 @@
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
 					"integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
-					"dev": true,
 					"requires": {
 						"parent-module": "^1.0.0",
 						"resolve-from": "^4.0.0"
@@ -3376,7 +4215,6 @@
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
 					"integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
-					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.0.0",
 						"error-ex": "^1.3.1",
@@ -3387,14 +4225,12 @@
 				"path-type": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-					"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-					"dev": true
+					"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
 				},
 				"resolve-from": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-					"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-					"dev": true
+					"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
 				}
 			}
 		},
@@ -3573,8 +4409,7 @@
 		"babel-plugin-syntax-jsx": {
 			"version": "6.18.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-			"integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=",
-			"dev": true
+			"integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
 		},
 		"babel-plugin-syntax-object-rest-spread": {
 			"version": "6.13.0",
@@ -4472,8 +5307,7 @@
 		"base64-js": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
-			"dev": true
+			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
 		},
 		"base64id": {
 			"version": "1.0.0",
@@ -4491,7 +5325,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
 			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
-			"dev": true,
 			"requires": {
 				"tweetnacl": "^0.14.3"
 			}
@@ -4543,8 +5376,6 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
 			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-			"dev": true,
-			"optional": true,
 			"requires": {
 				"file-uri-to-path": "1.0.0"
 			}
@@ -4553,7 +5384,6 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/bl/-/bl-2.2.0.tgz",
 			"integrity": "sha512-wbgvOpqopSr7uq6fJrLH8EsvYMJf9gzfo2jCsL2eTy75qXPukA4pCgHamOQkZtY5vmfVtjB+P3LNlMHW5CEZXA==",
-			"dev": true,
 			"requires": {
 				"readable-stream": "^2.3.5",
 				"safe-buffer": "^5.1.1"
@@ -4816,8 +5646,7 @@
 		"bson": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/bson/-/bson-1.1.4.tgz",
-			"integrity": "sha512-S/yKGU1syOMzO86+dGpg2qGoDL0zvzcb262G+gqEy6TgP6rt6z6qxSFX/8X6vLC91P7G7C3nLs0+bvDzmvBA3Q==",
-			"dev": true
+			"integrity": "sha512-S/yKGU1syOMzO86+dGpg2qGoDL0zvzcb262G+gqEy6TgP6rt6z6qxSFX/8X6vLC91P7G7C3nLs0+bvDzmvBA3Q=="
 		},
 		"buffer": {
 			"version": "4.9.2",
@@ -4861,8 +5690,7 @@
 		"buffer-from": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-			"dev": true
+			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
 		},
 		"buffer-indexof": {
 			"version": "1.1.1",
@@ -4887,6 +5715,11 @@
 			"resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
 			"integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
 			"dev": true
+		},
+		"byline": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
+			"integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE="
 		},
 		"bytes": {
 			"version": "3.1.0",
@@ -5049,8 +5882,7 @@
 		"caseless": {
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
-			"dev": true
+			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
 		},
 		"center-align": {
 			"version": "0.1.3",
@@ -5098,7 +5930,6 @@
 			"version": "2.4.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
 			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-			"dev": true,
 			"requires": {
 				"ansi-styles": "^3.2.1",
 				"escape-string-regexp": "^1.0.5",
@@ -5110,6 +5941,11 @@
 			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
 			"integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
 			"dev": true
+		},
+		"charenc": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+			"integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
 		},
 		"check-error": {
 			"version": "1.0.2",
@@ -5178,8 +6014,7 @@
 		"chownr": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-			"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-			"dev": true
+			"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
 		},
 		"chrome-trace-event": {
 			"version": "1.0.2",
@@ -5355,8 +6190,7 @@
 		"code-point-at": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-			"dev": true
+			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
 		},
 		"collection-visit": {
 			"version": "1.0.0",
@@ -5383,7 +6217,6 @@
 			"version": "1.9.3",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
 			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-			"dev": true,
 			"requires": {
 				"color-name": "1.1.3"
 			}
@@ -5391,8 +6224,7 @@
 		"color-name": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-			"dev": true
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 		},
 		"color-string": {
 			"version": "0.3.0",
@@ -5450,7 +6282,6 @@
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
 			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
-			"dev": true,
 			"requires": {
 				"delayed-stream": "~1.0.0"
 			}
@@ -5496,6 +6327,11 @@
 			"resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
 			"integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM=",
 			"dev": true
+		},
+		"component-type": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/component-type/-/component-type-1.2.1.tgz",
+			"integrity": "sha1-ikeQFwAjjk/DIml3EjAibyS0Fak="
 		},
 		"compressible": {
 			"version": "2.0.18",
@@ -5594,8 +6430,7 @@
 		"console-control-strings": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-			"dev": true
+			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
 		},
 		"constants-browserify": {
 			"version": "1.0.0",
@@ -5622,7 +6457,6 @@
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
 			"integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
-			"dev": true,
 			"requires": {
 				"safe-buffer": "~5.1.1"
 			}
@@ -5692,8 +6526,7 @@
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-			"dev": true
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
 		},
 		"cosmiconfig": {
 			"version": "5.2.1",
@@ -5733,6 +6566,28 @@
 			"requires": {
 				"bn.js": "^4.1.0",
 				"elliptic": "^6.0.0"
+			}
+		},
+		"create-emotion": {
+			"version": "10.0.27",
+			"resolved": "https://registry.npmjs.org/create-emotion/-/create-emotion-10.0.27.tgz",
+			"integrity": "sha512-fIK73w82HPPn/RsAij7+Zt8eCE8SptcJ3WoRMfxMtjteYxud8GDTKKld7MYwAX2TVhrw29uR1N/bVGxeStHILg==",
+			"requires": {
+				"@emotion/cache": "^10.0.27",
+				"@emotion/serialize": "^0.11.15",
+				"@emotion/sheet": "0.9.4",
+				"@emotion/utils": "0.11.3"
+			}
+		},
+		"create-emotion-server": {
+			"version": "10.0.27",
+			"resolved": "https://registry.npmjs.org/create-emotion-server/-/create-emotion-server-10.0.27.tgz",
+			"integrity": "sha512-1EbZgdjiho9ue1BSTpAez8SIdfbTXomtz0bg+LPOEvf/5OV7xqCGJaoSCDCB+y7kZ73hwoEhLsoPmqKSGIQMXg==",
+			"requires": {
+				"@emotion/utils": "0.11.3",
+				"html-tokenize": "^2.0.0",
+				"multipipe": "^1.0.2",
+				"through": "^2.3.8"
 			}
 		},
 		"create-hash": {
@@ -5807,6 +6662,11 @@
 				"shebang-command": "^1.2.0",
 				"which": "^1.2.9"
 			}
+		},
+		"crypt": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+			"integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
 		},
 		"cryptiles": {
 			"version": "2.0.5",
@@ -6114,8 +6974,7 @@
 		"csstype": {
 			"version": "2.6.10",
 			"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.10.tgz",
-			"integrity": "sha512-D34BqZU4cIlMCY93rZHbrq9pjTAQJ3U8S8rfBqjwHxkGPThWFjzZDQpgMJY0QViLxth6ZKYiwFBo14RdN44U/w==",
-			"dev": true
+			"integrity": "sha512-D34BqZU4cIlMCY93rZHbrq9pjTAQJ3U8S8rfBqjwHxkGPThWFjzZDQpgMJY0QViLxth6ZKYiwFBo14RdN44U/w=="
 		},
 		"cuint": {
 			"version": "0.2.2",
@@ -6158,7 +7017,6 @@
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
-			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0"
 			}
@@ -6226,7 +7084,6 @@
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
 			"integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
-			"dev": true,
 			"requires": {
 				"mimic-response": "^2.0.0"
 			}
@@ -6298,14 +7155,12 @@
 		"deep-extend": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-			"dev": true
+			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
 		},
 		"deep-is": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
-			"dev": true
+			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
 		},
 		"default-gateway": {
 			"version": "4.2.0",
@@ -6472,20 +7327,17 @@
 		"delayed-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
-			"dev": true
+			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
 		},
 		"delegates": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-			"dev": true
+			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
 		},
 		"denque": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/denque/-/denque-1.4.1.tgz",
-			"integrity": "sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ==",
-			"dev": true
+			"integrity": "sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ=="
 		},
 		"depd": {
 			"version": "1.1.2",
@@ -6705,8 +7557,7 @@
 		"detect-libc": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-			"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
-			"dev": true
+			"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
 		},
 		"detect-node": {
 			"version": "2.0.4",
@@ -7161,6 +8012,14 @@
 			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
 			"dev": true
 		},
+		"duplexer2": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+			"integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+			"requires": {
+				"readable-stream": "^2.0.2"
+			}
+		},
 		"duplexify": {
 			"version": "3.7.1",
 			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
@@ -7177,7 +8036,6 @@
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
 			"integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
-			"dev": true,
 			"requires": {
 				"jsbn": "~0.1.0",
 				"safer-buffer": "^2.1.0"
@@ -7546,6 +8404,76 @@
 			"integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
 			"dev": true
 		},
+		"emotion": {
+			"version": "10.0.27",
+			"resolved": "https://registry.npmjs.org/emotion/-/emotion-10.0.27.tgz",
+			"integrity": "sha512-2xdDzdWWzue8R8lu4G76uWX5WhyQuzATon9LmNeCy/2BHVC6dsEpfhN1a0qhELgtDVdjyEA6J8Y/VlI5ZnaH0g==",
+			"requires": {
+				"babel-plugin-emotion": "^10.0.27",
+				"create-emotion": "^10.0.27"
+			}
+		},
+		"emphasize": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/emphasize/-/emphasize-3.0.0.tgz",
+			"integrity": "sha512-xhtAWvxdkxsQbcCLGVjlfB7cQ4bWSPYXeaGDwK5Bl7n2y/9R+MVK5UNBTmZ9N8m/YShsiyGgQBgFGcjOWCWXHQ==",
+			"requires": {
+				"chalk": "^3.0.0",
+				"highlight.js": "~9.12.0",
+				"lowlight": "~1.9.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+				},
+				"highlight.js": {
+					"version": "9.12.0",
+					"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.12.0.tgz",
+					"integrity": "sha1-5tnb5Xy+/mB1HwKvM2GVhwyQwB4="
+				},
+				"supports-color": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
+		},
 		"encodeurl": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -7565,7 +8493,6 @@
 			"version": "1.4.4",
 			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
 			"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-			"dev": true,
 			"requires": {
 				"once": "^1.4.0"
 			}
@@ -7786,7 +8713,6 @@
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
 			"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-			"dev": true,
 			"requires": {
 				"is-arrayish": "^0.2.1"
 			}
@@ -7990,14 +8916,12 @@
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-			"dev": true
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 		},
 		"escodegen": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.1.tgz",
 			"integrity": "sha512-Bmt7NcRySdIfNPfU2ZoXDrrXsG9ZjvDxcAlMfDUgRBjLOWTuIACXPBFJH7Z+cLb40JeQco5toikyc9t9P8E9SQ==",
-			"dev": true,
 			"requires": {
 				"esprima": "^4.0.1",
 				"estraverse": "^4.2.0",
@@ -8009,14 +8933,12 @@
 				"esprima": {
 					"version": "4.0.1",
 					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
-					"dev": true
+					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
 				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true,
 					"optional": true
 				}
 			}
@@ -8359,14 +9281,12 @@
 		"estraverse": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
-			"dev": true
+			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
 		},
 		"esutils": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
-			"dev": true
+			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
 		},
 		"etag": {
 			"version": "1.8.1",
@@ -8498,8 +9418,7 @@
 		"expand-template": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-			"integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-			"dev": true
+			"integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="
 		},
 		"expand-tilde": {
 			"version": "2.0.2",
@@ -8585,8 +9504,7 @@
 		"extend": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-			"dev": true
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
 		},
 		"extend-shallow": {
 			"version": "3.0.2",
@@ -8711,20 +9629,22 @@
 		"extsprintf": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
-			"dev": true
+			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+		},
+		"facepaint": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/facepaint/-/facepaint-1.2.1.tgz",
+			"integrity": "sha512-oNvBekbhsm/0PNSOWca5raHNAi6dG960Bx6LJgxDPNF59WpuspgQ17bN5MKwOr7JcFdQYc7StW3VZ28DBZLavQ=="
 		},
 		"fast-deep-equal": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-			"integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
-			"dev": true
+			"integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
 		},
 		"fast-glob": {
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.2.tgz",
 			"integrity": "sha512-UDV82o4uQyljznxwMxyVRJgZZt3O5wENYojjzbaGEGZgeOxkLFf+V4cnUD+krzb2F72E18RhamkMZ7AdeggF7A==",
-			"dev": true,
 			"requires": {
 				"@nodelib/fs.stat": "^2.0.2",
 				"@nodelib/fs.walk": "^1.2.3",
@@ -8738,7 +9658,6 @@
 					"version": "3.0.2",
 					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
 					"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
-					"dev": true,
 					"requires": {
 						"fill-range": "^7.0.1"
 					}
@@ -8747,7 +9666,6 @@
 					"version": "7.0.1",
 					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
 					"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
-					"dev": true,
 					"requires": {
 						"to-regex-range": "^5.0.1"
 					}
@@ -8756,7 +9674,6 @@
 					"version": "5.1.1",
 					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
 					"integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
-					"dev": true,
 					"requires": {
 						"is-glob": "^4.0.1"
 					}
@@ -8764,14 +9681,12 @@
 				"is-number": {
 					"version": "7.0.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
-					"dev": true
+					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
 				},
 				"micromatch": {
 					"version": "4.0.2",
 					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
 					"integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
-					"dev": true,
 					"requires": {
 						"braces": "^3.0.1",
 						"picomatch": "^2.0.5"
@@ -8781,7 +9696,6 @@
 					"version": "5.0.1",
 					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
 					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
-					"dev": true,
 					"requires": {
 						"is-number": "^7.0.0"
 					}
@@ -8791,20 +9705,28 @@
 		"fast-json-stable-stringify": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
-			"dev": true
+			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
 		},
 		"fast-levenshtein": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
-			"dev": true
+			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
 		},
 		"fast-memoize": {
 			"version": "2.5.2",
 			"resolved": "https://registry.npmjs.org/fast-memoize/-/fast-memoize-2.5.2.tgz",
 			"integrity": "sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw==",
 			"dev": true
+		},
+		"fast-redact": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-2.0.0.tgz",
+			"integrity": "sha512-zxpkULI9W9MNTK2sJ3BpPQrTEXFNESd2X6O1tXMFpK/XM0G5c5Rll2EVYZH2TqI3xRGK/VaJ+eEOt7pnENJpeA=="
+		},
+		"fast-safe-stringify": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+			"integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
 		},
 		"fastparse": {
 			"version": "1.1.2",
@@ -8816,9 +9738,16 @@
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.7.0.tgz",
 			"integrity": "sha512-YOadQRnHd5q6PogvAR/x62BGituF2ufiEA6s8aavQANw5YKHERI4AREboX6KotzP8oX2klxYF2wcV/7bn1clfQ==",
-			"dev": true,
 			"requires": {
 				"reusify": "^1.0.4"
+			}
+		},
+		"fault": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/fault/-/fault-1.0.4.tgz",
+			"integrity": "sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==",
+			"requires": {
+				"format": "^0.2.0"
 			}
 		},
 		"faye-websocket": {
@@ -8912,9 +9841,7 @@
 		"file-uri-to-path": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-			"dev": true,
-			"optional": true
+			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
 		},
 		"filesize": {
 			"version": "3.5.11",
@@ -9048,6 +9975,11 @@
 				}
 			}
 		},
+		"flatstr": {
+			"version": "1.0.12",
+			"resolved": "https://registry.npmjs.org/flatstr/-/flatstr-1.0.12.tgz",
+			"integrity": "sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw=="
+		},
 		"flatted": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
@@ -9094,19 +10026,22 @@
 		"forever-agent": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
-			"dev": true
+			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
 		},
 		"form-data": {
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
 			"integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
-			"dev": true,
 			"requires": {
 				"asynckit": "^0.4.0",
 				"combined-stream": "^1.0.6",
 				"mime-types": "^2.1.12"
 			}
+		},
+		"format": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
+			"integrity": "sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs="
 		},
 		"forwarded": {
 			"version": "0.1.2",
@@ -9139,7 +10074,6 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
 			"integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
-			"dev": true,
 			"requires": {
 				"inherits": "^2.0.1",
 				"readable-stream": "^2.0.0"
@@ -9148,8 +10082,7 @@
 		"fs-constants": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-			"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-			"dev": true
+			"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
 		},
 		"fs-extra": {
 			"version": "4.0.3",
@@ -9785,7 +10718,6 @@
 			"version": "2.7.4",
 			"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
 			"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-			"dev": true,
 			"requires": {
 				"aproba": "^1.0.3",
 				"console-control-strings": "^1.0.0",
@@ -9800,8 +10732,7 @@
 		"gensync": {
 			"version": "1.0.0-beta.1",
 			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
-			"integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==",
-			"dev": true
+			"integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg=="
 		},
 		"get-amd-module-type": {
 			"version": "3.0.0",
@@ -9870,7 +10801,6 @@
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
-			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0"
 			}
@@ -9878,8 +10808,7 @@
 		"github-from-package": {
 			"version": "0.0.0",
 			"resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-			"integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=",
-			"dev": true
+			"integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4="
 		},
 		"glamor": {
 			"version": "2.20.40",
@@ -9982,8 +10911,7 @@
 		"globals": {
 			"version": "11.12.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-			"dev": true
+			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
 		},
 		"globalthis": {
 			"version": "1.0.1",
@@ -10040,8 +10968,7 @@
 		"graceful-fs": {
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-			"integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
-			"dev": true
+			"integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
 		},
 		"graceful-readlink": {
 			"version": "1.0.1",
@@ -10128,17 +11055,54 @@
 			"integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==",
 			"dev": true
 		},
+		"handlebars": {
+			"version": "4.7.6",
+			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.6.tgz",
+			"integrity": "sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==",
+			"requires": {
+				"minimist": "^1.2.5",
+				"neo-async": "^2.6.0",
+				"source-map": "^0.6.1",
+				"uglify-js": "^3.1.4",
+				"wordwrap": "^1.0.0"
+			},
+			"dependencies": {
+				"commander": {
+					"version": "2.20.3",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+					"optional": true
+				},
+				"source-map": {
+					"version": "0.6.1",
+					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+				},
+				"uglify-js": {
+					"version": "3.9.3",
+					"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.9.3.tgz",
+					"integrity": "sha512-r5ImcL6QyzQGVimQoov3aL2ZScywrOgBXGndbWrdehKoSvGe/RmiE5Jpw/v+GvxODt6l2tpBXwA7n+qZVlHBMA==",
+					"optional": true,
+					"requires": {
+						"commander": "~2.20.3"
+					}
+				},
+				"wordwrap": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
+					"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
+				}
+			}
+		},
 		"har-schema": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
-			"dev": true
+			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
 		},
 		"har-validator": {
 			"version": "5.1.3",
 			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
 			"integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
-			"dev": true,
 			"requires": {
 				"ajv": "^6.5.5",
 				"har-schema": "^2.0.0"
@@ -10188,8 +11152,7 @@
 		"has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-			"dev": true
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 		},
 		"has-symbols": {
 			"version": "1.0.1",
@@ -10200,8 +11163,7 @@
 		"has-unicode": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-			"dev": true
+			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
 		},
 		"has-value": {
 			"version": "1.0.0",
@@ -10273,6 +11235,16 @@
 			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
 			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
 			"dev": true
+		},
+		"highlight.js": {
+			"version": "9.18.1",
+			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.18.1.tgz",
+			"integrity": "sha512-OrVKYz70LHsnCgmbXctv/bfuvntIKDz177h0Co37DQ5jamGZLVmoCVMtjMtNZY3X9DrCcKfklHPNeA0uPZhSJg=="
+		},
+		"highlightjs-graphql": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/highlightjs-graphql/-/highlightjs-graphql-1.0.1.tgz",
+			"integrity": "sha512-g5kt/orsUJTjIt5pgs/uvi78kXndpCtYwzE7H3D0d07r3ETs9oHSZHD0EGaRPndiQ/4EYXt12rnsDkljn3ilAA=="
 		},
 		"hmac-drbg": {
 			"version": "1.0.1",
@@ -10460,6 +11432,68 @@
 			"integrity": "sha512-aI5tKwNTBzOZApHIynaAwecLBv8TlZTEy/P4Sj2SzzAhBrGuI8yGZ0UIXVPQzOHGS+to2mjb04iy6VWt/8+d8A==",
 			"dev": true
 		},
+		"html-tokenize": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/html-tokenize/-/html-tokenize-2.0.1.tgz",
+			"integrity": "sha512-QY6S+hZ0f5m1WT8WffYN+Hg+xm/w5I8XeUcAq/ZYP5wVC8xbKi4Whhru3FtrAebD5EhBW8rmFzkDI6eCAuFe2w==",
+			"requires": {
+				"buffer-from": "~0.1.1",
+				"inherits": "~2.0.1",
+				"minimist": "~1.2.5",
+				"readable-stream": "~1.0.27-1",
+				"through2": "~0.4.1"
+			},
+			"dependencies": {
+				"buffer-from": {
+					"version": "0.1.2",
+					"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-0.1.2.tgz",
+					"integrity": "sha512-RiWIenusJsmI2KcvqQABB83tLxCByE3upSP8QU3rJDMVFGPWLvPQJt/O1Su9moRWeH7d+Q2HYb68f6+v+tw2vg=="
+				},
+				"isarray": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+				},
+				"object-keys": {
+					"version": "0.4.0",
+					"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+					"integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY="
+				},
+				"readable-stream": {
+					"version": "1.0.34",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+					"requires": {
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.1",
+						"isarray": "0.0.1",
+						"string_decoder": "~0.10.x"
+					}
+				},
+				"string_decoder": {
+					"version": "0.10.31",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+				},
+				"through2": {
+					"version": "0.4.2",
+					"resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
+					"integrity": "sha1-2/WGYDEVHsg1K7bE22SiKSqEC5s=",
+					"requires": {
+						"readable-stream": "~1.0.17",
+						"xtend": "~2.1.1"
+					}
+				},
+				"xtend": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+					"integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
+					"requires": {
+						"object-keys": "~0.4.0"
+					}
+				}
+			}
+		},
 		"html-webpack-plugin": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/html-webpack-plugin/-/html-webpack-plugin-3.2.0.tgz",
@@ -10624,7 +11658,6 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
 			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
-			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0",
 				"jsprim": "^1.2.2",
@@ -10670,8 +11703,7 @@
 		"ieee754": {
 			"version": "1.1.13",
 			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-			"integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
-			"dev": true
+			"integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
 		},
 		"iferr": {
 			"version": "0.1.5",
@@ -10794,14 +11826,12 @@
 		"inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-			"dev": true
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
 		},
 		"ini": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-			"dev": true
+			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
 		},
 		"inline-source-map": {
 			"version": "0.6.2",
@@ -10904,6 +11934,22 @@
 			"integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
 			"dev": true
 		},
+		"into-stream": {
+			"version": "5.1.1",
+			"resolved": "https://registry.npmjs.org/into-stream/-/into-stream-5.1.1.tgz",
+			"integrity": "sha512-krrAJ7McQxGGmvaYbB7Q1mcA+cRwg9Ij2RfWIeVesNBgVDZmzY/Fa4IpZUT3bmdRzMzdf/mzltCG2Dq99IZGBA==",
+			"requires": {
+				"from2": "^2.3.0",
+				"p-is-promise": "^3.0.0"
+			},
+			"dependencies": {
+				"p-is-promise": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-3.0.0.tgz",
+					"integrity": "sha512-Wo8VsW4IRQSKVXsJCn7TomUaVtyfjVDn3nUP7kE967BQk0CwFpdbZs0X0uk5sW9mkBa9eNM7hCMaG93WUAwxYQ=="
+				}
+			}
+		},
 		"invariant": {
 			"version": "2.2.4",
 			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
@@ -10972,8 +12018,7 @@
 		"is-arrayish": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-			"dev": true
+			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
 		},
 		"is-binary-path": {
 			"version": "1.0.1",
@@ -10993,8 +12038,7 @@
 		"is-buffer": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-			"dev": true
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
 		},
 		"is-callable": {
 			"version": "1.1.5",
@@ -11078,8 +12122,7 @@
 		"is-extglob": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
-			"dev": true
+			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
 		},
 		"is-finite": {
 			"version": "1.1.0",
@@ -11091,7 +12134,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 			"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-			"dev": true,
 			"requires": {
 				"number-is-nan": "^1.0.0"
 			}
@@ -11106,7 +12148,6 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
 			"integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
-			"dev": true,
 			"requires": {
 				"is-extglob": "^2.1.1"
 			}
@@ -11194,6 +12235,25 @@
 			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
 			"dev": true
 		},
+		"is-recoverable-error": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-recoverable-error/-/is-recoverable-error-1.0.1.tgz",
+			"integrity": "sha512-1v/3hIRd0hHzkmq9TU+otd8SlUJjr60KyX6RfgwJ6NVbeQafc3POajWZ/BcusPxhdX0ScN3xE9tTnn6xGpC3LA==",
+			"requires": {
+				"acorn": "^7.1.1",
+				"acorn-class-fields": "^0.3.2",
+				"acorn-numeric-separator": "^0.3.1",
+				"acorn-private-methods": "^0.3.1",
+				"acorn-static-class-features": "^0.2.1"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.2.0.tgz",
+					"integrity": "sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ=="
+				}
+			}
+		},
 		"is-regex": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
@@ -11211,6 +12271,11 @@
 			"requires": {
 				"is-unc-path": "^1.0.0"
 			}
+		},
+		"is-retry-allowed": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
+			"integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg=="
 		},
 		"is-root": {
 			"version": "1.0.0",
@@ -11263,8 +12328,7 @@
 		"is-typedarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
-			"dev": true
+			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
 		},
 		"is-unc-path": {
 			"version": "1.0.0",
@@ -11308,8 +12372,7 @@
 		"isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-			"dev": true
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 		},
 		"isbinaryfile": {
 			"version": "3.0.3",
@@ -11345,8 +12408,7 @@
 		"isstream": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
-			"dev": true
+			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
 		},
 		"istanbul-instrumenter-loader": {
 			"version": "3.0.1",
@@ -11432,6 +12494,16 @@
 				"iterate-iterator": "^1.0.1"
 			}
 		},
+		"jmespath": {
+			"version": "0.15.0",
+			"resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+			"integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
+		},
+		"join-component": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/join-component/-/join-component-1.1.0.tgz",
+			"integrity": "sha1-uEF7dQZho5K+4sJTfGiyqdSXfNU="
+		},
 		"js-base64": {
 			"version": "2.5.2",
 			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.2.tgz",
@@ -11447,8 +12519,7 @@
 		"js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-			"dev": true
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
 		},
 		"js-yaml": {
 			"version": "3.7.0",
@@ -11463,8 +12534,7 @@
 		"jsbn": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
-			"dev": true
+			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
 		},
 		"jsdom": {
 			"version": "11.12.0",
@@ -11517,8 +12587,7 @@
 		"jsesc": {
 			"version": "2.5.2",
 			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-			"dev": true
+			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
 		},
 		"json-loader": {
 			"version": "0.5.7",
@@ -11529,20 +12598,17 @@
 		"json-parse-better-errors": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
-			"dev": true
+			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
 		},
 		"json-schema": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
-			"dev": true
+			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
 		},
 		"json-schema-traverse": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
-			"dev": true
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
 		},
 		"json-stable-stringify": {
 			"version": "1.0.1",
@@ -11563,8 +12629,7 @@
 		"json-stringify-safe": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
-			"dev": true
+			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
 		},
 		"json3": {
 			"version": "3.3.3",
@@ -11576,7 +12641,6 @@
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
 			"integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
-			"dev": true,
 			"requires": {
 				"minimist": "^1.2.5"
 			}
@@ -11585,7 +12649,6 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
 			"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
-			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.6"
 			}
@@ -11600,7 +12663,6 @@
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
 			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
-			"dev": true,
 			"requires": {
 				"assert-plus": "1.0.0",
 				"extsprintf": "1.3.0",
@@ -12209,7 +13271,6 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
 			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-			"dev": true,
 			"requires": {
 				"prelude-ls": "~1.1.2",
 				"type-check": "~0.3.2"
@@ -12227,8 +13288,7 @@
 		"lines-and-columns": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
-			"integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
-			"dev": true
+			"integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA="
 		},
 		"load-json-file": {
 			"version": "2.0.0",
@@ -12309,8 +13369,7 @@
 		"lodash": {
 			"version": "4.17.15",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-			"dev": true
+			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
 		},
 		"lodash-es": {
 			"version": "4.17.15",
@@ -12820,6 +13879,11 @@
 				"lodash.isfunction": "^3.0.0"
 			}
 		},
+		"lodash.set": {
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+			"integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
+		},
 		"lodash.some": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
@@ -12918,8 +13982,7 @@
 		"long": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-			"integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
-			"dev": true
+			"integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
 		},
 		"longest": {
 			"version": "1.0.1",
@@ -12952,6 +14015,22 @@
 			"integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
 			"dev": true
 		},
+		"lowlight": {
+			"version": "1.9.2",
+			"resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.9.2.tgz",
+			"integrity": "sha512-Ek18ElVCf/wF/jEm1b92gTnigh94CtBNWiZ2ad+vTgW7cTmQxUY3I98BjHK68gZAJEWmybGBZgx9qv3QxLQB/Q==",
+			"requires": {
+				"fault": "^1.0.2",
+				"highlight.js": "~9.12.0"
+			},
+			"dependencies": {
+				"highlight.js": {
+					"version": "9.12.0",
+					"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.12.0.tgz",
+					"integrity": "sha1-5tnb5Xy+/mB1HwKvM2GVhwyQwB4="
+				}
+			}
+		},
 		"lru-cache": {
 			"version": "4.1.5",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
@@ -12975,8 +14054,7 @@
 		"make-error": {
 			"version": "1.3.6",
 			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-			"dev": true
+			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
 		},
 		"map-age-cleaner": {
 			"version": "0.1.3",
@@ -13046,6 +14124,16 @@
 			"integrity": "sha512-L0j0tFVZBQQLeEjmWOvDLoRciIY8gQGWahvkztXUal8jH8R5Rlqo9GCvgqvXcy9LQhEWdQCVvzqAbxgYNt4blQ==",
 			"dev": true
 		},
+		"md5": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
+			"integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
+			"requires": {
+				"charenc": "~0.0.1",
+				"crypt": "~0.0.1",
+				"is-buffer": "~1.1.1"
+			}
+		},
 		"md5.js": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -13092,7 +14180,6 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
 			"integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
-			"dev": true,
 			"optional": true
 		},
 		"meow": {
@@ -13212,8 +14299,7 @@
 		"merge2": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.3.0.tgz",
-			"integrity": "sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==",
-			"dev": true
+			"integrity": "sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw=="
 		},
 		"methods": {
 			"version": "1.1.2",
@@ -13261,14 +14347,12 @@
 		"mime-db": {
 			"version": "1.43.0",
 			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
-			"integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ==",
-			"dev": true
+			"integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
 		},
 		"mime-types": {
 			"version": "2.1.26",
 			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
 			"integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
-			"dev": true,
 			"requires": {
 				"mime-db": "1.43.0"
 			}
@@ -13282,8 +14366,7 @@
 		"mimic-response": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
-			"integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
-			"dev": true
+			"integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA=="
 		},
 		"min-document": {
 			"version": "2.19.0",
@@ -13359,8 +14442,7 @@
 		"minimist": {
 			"version": "1.2.5",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-			"dev": true
+			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
 		},
 		"minipass": {
 			"version": "2.9.0",
@@ -13452,7 +14534,6 @@
 			"version": "0.5.5",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
 			"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-			"dev": true,
 			"requires": {
 				"minimist": "^1.2.5"
 			}
@@ -13460,8 +14541,7 @@
 		"mkdirp-classic": {
 			"version": "0.5.2",
 			"resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.2.tgz",
-			"integrity": "sha512-ejdnDQcR75gwknmMw/tx02AuRs8jCtqFoFqDZMjiNxsu85sRIJVXDKHuLYvUUPRBUtV2FpSZa9bL1BUa3BdR2g==",
-			"dev": true
+			"integrity": "sha512-ejdnDQcR75gwknmMw/tx02AuRs8jCtqFoFqDZMjiNxsu85sRIJVXDKHuLYvUUPRBUtV2FpSZa9bL1BUa3BdR2g=="
 		},
 		"mkpath": {
 			"version": "0.1.0",
@@ -13963,7 +15043,6 @@
 			"version": "3.5.6",
 			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.5.6.tgz",
 			"integrity": "sha512-sh3q3GLDLT4QmoDLamxtAECwC3RGjq+oNuK1ENV8+tnipIavss6sMYt77hpygqlMOCt0Sla5cl7H4SKCVBCGEg==",
-			"dev": true,
 			"requires": {
 				"bl": "^2.2.0",
 				"bson": "^1.1.4",
@@ -13971,6 +15050,37 @@
 				"require_optional": "^1.0.1",
 				"safe-buffer": "^5.1.2",
 				"saslprep": "^1.0.0"
+			}
+		},
+		"mongodb-ace-autocompleter": {
+			"version": "0.4.8",
+			"resolved": "https://registry.npmjs.org/mongodb-ace-autocompleter/-/mongodb-ace-autocompleter-0.4.8.tgz",
+			"integrity": "sha512-OMDiHtrMt5z7RxQKZKl4kLJqUDbe0xTUSBQT0r+DNHKzsQoyk5RlUK6jsMWmFYn1ADFGGAejVJWbcnlG4WGH8w==",
+			"requires": {
+				"semver": "^7.1.1"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "7.3.2",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
+				}
+			}
+		},
+		"mongodb-build-info": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/mongodb-build-info/-/mongodb-build-info-1.1.0.tgz",
+			"integrity": "sha512-ZlbQlpXv8DCvYK2I6UmyRO4z9zb4fyoph+RhEN/MSSsigaqcfl6dePkbgavemquvuKVEq0BbIiVkHw1DKwChxA=="
+		},
+		"mongodb-client-encryption": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-1.0.1.tgz",
+			"integrity": "sha512-nHbezuBY1NQeksltSYGuqEES/i8U4zpVJ1D+YrQLTyzXfQtqiQX1fRYn5dtlCTuq+gBFKwXIRCH5InduIfIgkw==",
+			"requires": {
+				"bindings": "^1.5.0",
+				"bson": "^1.0.5",
+				"nan": "^2.14.0",
+				"prebuild-install": "^5.3.0"
 			}
 		},
 		"mongodb-collection-sample": {
@@ -14684,6 +15794,14 @@
 			"integrity": "sha512-sch/9jd74VjRCmB5U+Fj4WJnkmAtDQgxqJkBInO7zEknXE+lnDEuNBT5/Wp59HMrWUabssGGq08r6Y6F7pkvVA==",
 			"dev": true
 		},
+		"mongodb-redact": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/mongodb-redact/-/mongodb-redact-0.2.0.tgz",
+			"integrity": "sha512-kGoR02HsTzNYHFXLklvbEg7mSJZu5+L1JdaYUuSlmVUAXxzhxUBvoFoYulfqqvokE+ilAXGYywdMJStB0lPhCw==",
+			"requires": {
+				"lodash": "^4.17.15"
+			}
+		},
 		"mongodb-reflux-store": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/mongodb-reflux-store/-/mongodb-reflux-store-0.0.1.tgz",
@@ -14768,8 +15886,7 @@
 		"ms": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-			"dev": true
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 		},
 		"multicast-dns": {
 			"version": "6.2.3",
@@ -14787,18 +15904,53 @@
 			"integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
 			"dev": true
 		},
+		"multipipe": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/multipipe/-/multipipe-1.0.2.tgz",
+			"integrity": "sha1-zBPv2DPJzamfIk+GhGG44aP9k50=",
+			"requires": {
+				"duplexer2": "^0.1.2",
+				"object-assign": "^4.1.0"
+			}
+		},
+		"multistream": {
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/multistream/-/multistream-2.1.1.tgz",
+			"integrity": "sha512-xasv76hl6nr1dEy3lPvy7Ej7K/Lx3O/FCvwge8PeVJpciPPoNCbaANcNiBug3IpdvTveZUcAV0DJzdnUDMesNQ==",
+			"requires": {
+				"inherits": "^2.0.1",
+				"readable-stream": "^2.0.5"
+			}
+		},
+		"mustache": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/mustache/-/mustache-4.0.1.tgz",
+			"integrity": "sha512-yL5VE97+OXn4+Er3THSmTdCFCtx5hHWzrolvH+JObZnUYwuaG7XV+Ch4fR2cIrcYI0tFHxS7iyFYl14bW8y2sA=="
+		},
 		"mute-stream": {
 			"version": "0.0.7",
 			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
-			"dev": true
+			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
 		},
 		"nan": {
 			"version": "2.14.1",
 			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-			"integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
-			"dev": true,
-			"optional": true
+			"integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
+		},
+		"nanoassert": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/nanoassert/-/nanoassert-1.1.0.tgz",
+			"integrity": "sha1-TzFS4JVA/eKMdvRLGbvNHVpCR40="
+		},
+		"nanobus": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/nanobus/-/nanobus-4.4.0.tgz",
+			"integrity": "sha512-Hv9USGyH8EsPy0o8pPWE7x3YRIfuZDgMBirzjU6XLebhiSK2g53JlfqgolD0c39ne6wXAfaBNcIAvYe22Bav+Q==",
+			"requires": {
+				"nanoassert": "^1.1.0",
+				"nanotiming": "^7.2.0",
+				"remove-array-items": "^1.0.0"
+			}
 		},
 		"nanomatch": {
 			"version": "1.2.13",
@@ -14819,11 +15971,27 @@
 				"to-regex": "^3.0.1"
 			}
 		},
+		"nanoscheduler": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/nanoscheduler/-/nanoscheduler-1.0.3.tgz",
+			"integrity": "sha512-jBbrF3qdU9321r8n9X7yu18DjP31Do2ItJm3mWrt90wJTrnDO+HXpoV7ftaUglAtjgj9s+OaCxGufbvx6pvbEQ==",
+			"requires": {
+				"nanoassert": "^1.1.0"
+			}
+		},
+		"nanotiming": {
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/nanotiming/-/nanotiming-7.3.1.tgz",
+			"integrity": "sha512-l3lC7v/PfOuRWQa8vV29Jo6TG10wHtnthLElFXs4Te4Aas57Fo4n1Q8LH9n+NDh9riOzTVvb2QNBhTS4JUKNjw==",
+			"requires": {
+				"nanoassert": "^1.1.0",
+				"nanoscheduler": "^1.0.2"
+			}
+		},
 		"napi-build-utils": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
-			"integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==",
-			"dev": true
+			"integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg=="
 		},
 		"natural-compare": {
 			"version": "1.4.0",
@@ -14861,8 +16029,7 @@
 		"neo-async": {
 			"version": "2.6.1",
 			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
-			"integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
-			"dev": true
+			"integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw=="
 		},
 		"next-tick": {
 			"version": "1.0.0",
@@ -14928,7 +16095,6 @@
 			"version": "2.16.0",
 			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.16.0.tgz",
 			"integrity": "sha512-+sa0XNlWDA6T+bDLmkCUYn6W5k5W6BPRL6mqzSCs6H/xUgtl4D5x2fORKDzopKiU6wsyn/+wXlRXwXeSp+mtoA==",
-			"dev": true,
 			"requires": {
 				"semver": "^5.4.1"
 			}
@@ -15086,8 +16252,7 @@
 		"noop-logger": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
-			"integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI=",
-			"dev": true
+			"integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI="
 		},
 		"nopt": {
 			"version": "3.0.6",
@@ -15153,7 +16318,6 @@
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
 			"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-			"dev": true,
 			"requires": {
 				"are-we-there-yet": "~1.1.2",
 				"console-control-strings": "~1.1.0",
@@ -15205,8 +16369,7 @@
 		"number-is-nan": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-			"dev": true
+			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
 		},
 		"nwsapi": {
 			"version": "2.2.0",
@@ -16280,14 +17443,12 @@
 		"oauth-sign": {
 			"version": "0.9.0",
 			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-			"dev": true
+			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
 		},
 		"object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-			"dev": true
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
 		},
 		"object-component": {
 			"version": "0.0.3",
@@ -16449,7 +17610,6 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-			"dev": true,
 			"requires": {
 				"wrappy": "1"
 			}
@@ -16500,7 +17660,6 @@
 			"version": "0.8.3",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
 			"integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
-			"dev": true,
 			"requires": {
 				"deep-is": "~0.1.3",
 				"fast-levenshtein": "~2.0.6",
@@ -16582,8 +17741,7 @@
 		"os-tmpdir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
-			"dev": true
+			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
 		},
 		"osenv": {
 			"version": "0.1.5",
@@ -16682,7 +17840,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
 			"integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-			"dev": true,
 			"requires": {
 				"callsites": "^3.0.0"
 			},
@@ -16690,8 +17847,7 @@
 				"callsites": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-					"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-					"dev": true
+					"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
 				}
 			}
 		},
@@ -16809,8 +17965,7 @@
 		"path-parse": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-			"dev": true
+			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
 		},
 		"path-to-regexp": {
 			"version": "0.1.7",
@@ -16878,14 +18033,12 @@
 		"performance-now": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
-			"dev": true
+			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
 		},
 		"picomatch": {
 			"version": "2.2.2",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-			"integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
-			"dev": true
+			"integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg=="
 		},
 		"pify": {
 			"version": "4.0.1",
@@ -16908,6 +18061,24 @@
 				"pinkie": "^2.0.0"
 			}
 		},
+		"pino": {
+			"version": "5.17.0",
+			"resolved": "https://registry.npmjs.org/pino/-/pino-5.17.0.tgz",
+			"integrity": "sha512-LqrqmRcJz8etUjyV0ddqB6OTUutCgQULPFg2b4dtijRHUsucaAdBgSUW58vY6RFSX+NT8963F+q0tM6lNwGShA==",
+			"requires": {
+				"fast-redact": "^2.0.0",
+				"fast-safe-stringify": "^2.0.7",
+				"flatstr": "^1.0.12",
+				"pino-std-serializers": "^2.4.2",
+				"quick-format-unescaped": "^3.0.3",
+				"sonic-boom": "^0.7.5"
+			}
+		},
+		"pino-std-serializers": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-2.4.2.tgz",
+			"integrity": "sha512-WaL504dO8eGs+vrK+j4BuQQq6GLKeCCcHaMB2ItygzVURcL1CycwNEUHTD/lHFHs/NL5qAz2UKrjYWXKSf4aMQ=="
+		},
 		"pirates": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz",
@@ -16915,6 +18086,123 @@
 			"dev": true,
 			"requires": {
 				"node-modules-regexp": "^1.0.0"
+			}
+		},
+		"pkg": {
+			"version": "4.4.8",
+			"resolved": "https://registry.npmjs.org/pkg/-/pkg-4.4.8.tgz",
+			"integrity": "sha512-Fqqv0iaX48U3CFZxd6Dq6JKe7BrAWbgRAqMJkz/m8W3H5cqJ6suvsUWe5AJPRlN/AhbBYXBJ0XG9QlYPTXcVFA==",
+			"requires": {
+				"@babel/parser": "^7.9.4",
+				"@babel/runtime": "^7.9.2",
+				"chalk": "^3.0.0",
+				"escodegen": "^1.14.1",
+				"fs-extra": "^8.1.0",
+				"globby": "^11.0.0",
+				"into-stream": "^5.1.1",
+				"minimist": "^1.2.5",
+				"multistream": "^2.1.1",
+				"pkg-fetch": "^2.6.7",
+				"progress": "^2.0.3",
+				"resolve": "^1.15.1",
+				"stream-meter": "^1.0.4"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"array-union": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
+					"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="
+				},
+				"chalk": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+				},
+				"dir-glob": {
+					"version": "3.0.1",
+					"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
+					"integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
+					"requires": {
+						"path-type": "^4.0.0"
+					}
+				},
+				"fs-extra": {
+					"version": "8.1.0",
+					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+					"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+					"requires": {
+						"graceful-fs": "^4.2.0",
+						"jsonfile": "^4.0.0",
+						"universalify": "^0.1.0"
+					}
+				},
+				"globby": {
+					"version": "11.0.0",
+					"resolved": "https://registry.npmjs.org/globby/-/globby-11.0.0.tgz",
+					"integrity": "sha512-iuehFnR3xu5wBBtm4xi0dMe92Ob87ufyu/dHwpDYfbcpYpIbrO5OnS8M1vWvrBhSGEJ3/Ecj7gnX76P8YxpPEg==",
+					"requires": {
+						"array-union": "^2.1.0",
+						"dir-glob": "^3.0.1",
+						"fast-glob": "^3.1.1",
+						"ignore": "^5.1.4",
+						"merge2": "^1.3.0",
+						"slash": "^3.0.0"
+					}
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+				},
+				"ignore": {
+					"version": "5.1.4",
+					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
+					"integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A=="
+				},
+				"path-type": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
+					"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
+				},
+				"slash": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
+					"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
+				},
+				"supports-color": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
 			}
 		},
 		"pkg-dir": {
@@ -16971,6 +18259,85 @@
 				}
 			}
 		},
+		"pkg-fetch": {
+			"version": "2.6.8",
+			"resolved": "https://registry.npmjs.org/pkg-fetch/-/pkg-fetch-2.6.8.tgz",
+			"integrity": "sha512-CFG7jOeVD38lltLGA7xCJxYsD//GKLjl1P9tc/n9By2a4WEHQjfkBMrYdMS8WOHVP+r9L20fsZNbaKcubDAiQg==",
+			"requires": {
+				"@babel/runtime": "^7.9.2",
+				"byline": "^5.0.0",
+				"chalk": "^3.0.0",
+				"expand-template": "^2.0.3",
+				"fs-extra": "^8.1.0",
+				"minimist": "^1.2.5",
+				"progress": "^2.0.3",
+				"request": "^2.88.0",
+				"request-progress": "^3.0.0",
+				"semver": "^6.3.0",
+				"unique-temp-dir": "^1.0.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+				},
+				"fs-extra": {
+					"version": "8.1.0",
+					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
+					"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
+					"requires": {
+						"graceful-fs": "^4.2.0",
+						"jsonfile": "^4.0.0",
+						"universalify": "^0.1.0"
+					}
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+				},
+				"supports-color": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
+		},
 		"pkg-up": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/pkg-up/-/pkg-up-2.0.0.tgz",
@@ -17010,6 +18377,14 @@
 			"resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
 			"integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
 			"dev": true
+		},
+		"polished": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/polished/-/polished-2.3.3.tgz",
+			"integrity": "sha512-59V4fDbdxtH4I1m9TWxFsoGJbC8nnOpUYo5uFmvMfKp9Qh+6suo4VMUle1TGIIUZIGxfkW+Rs485zPk0wcwR2Q==",
+			"requires": {
+				"@babel/runtime": "^7.2.0"
+			}
 		},
 		"portfinder": {
 			"version": "1.0.25",
@@ -18847,7 +20222,6 @@
 			"version": "5.3.3",
 			"resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.3.tgz",
 			"integrity": "sha512-GV+nsUXuPW2p8Zy7SarF/2W/oiK8bFQgJcncoJ0d7kRpekEA0ftChjfEaF9/Y+QJEc/wFR7RAEa8lYByuUIe2g==",
-			"dev": true,
 			"requires": {
 				"detect-libc": "^1.0.3",
 				"expand-template": "^2.0.3",
@@ -18870,7 +20244,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
 					"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-					"dev": true,
 					"requires": {
 						"end-of-stream": "^1.1.0",
 						"once": "^1.3.1"
@@ -18925,8 +20298,7 @@
 		"prelude-ls": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
-			"dev": true
+			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
 		},
 		"prepend-http": {
 			"version": "1.0.4",
@@ -18954,6 +20326,86 @@
 				"utila": "~0.4"
 			}
 		},
+		"pretty-format": {
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",
+			"integrity": "sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==",
+			"requires": {
+				"@jest/types": "^24.9.0",
+				"ansi-regex": "^4.0.0",
+				"ansi-styles": "^3.2.0",
+				"react-is": "^16.8.4"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+				}
+			}
+		},
+		"pretty-repl": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/pretty-repl/-/pretty-repl-2.3.0.tgz",
+			"integrity": "sha512-h7iNPLXpJPnbZZS0YIp1+EGD+oY9STelL70X8nwzrbglqP5nOUi0YxK+OJ8n6xopVHoLNQZrytYTmHrWcB1O/w==",
+			"requires": {
+				"ansi": "^0.3.1",
+				"chalk": "^4.0.0",
+				"emphasize": "^3.0.0",
+				"semver": "^7.2.2"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.0.0.tgz",
+					"integrity": "sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==",
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+				},
+				"semver": {
+					"version": "7.3.2",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
+				},
+				"supports-color": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
+		},
 		"private": {
 			"version": "0.1.8",
 			"resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
@@ -18969,14 +20421,12 @@
 		"process-nextick-args": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-			"dev": true
+			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
 		},
 		"progress": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-			"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
-			"dev": true
+			"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
 		},
 		"progress-stream": {
 			"version": "1.2.0",
@@ -19135,8 +20585,7 @@
 		"psl": {
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-			"integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
-			"dev": true
+			"integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
 		},
 		"public-encrypt": {
 			"version": "4.0.3",
@@ -19176,8 +20625,7 @@
 		"punycode": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-			"dev": true
+			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
 		},
 		"q": {
 			"version": "1.5.1",
@@ -19210,8 +20658,7 @@
 		"querystring": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-			"integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
-			"dev": true
+			"integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
 		},
 		"querystring-es3": {
 			"version": "0.2.1",
@@ -19224,6 +20671,11 @@
 			"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
 			"integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==",
 			"dev": true
+		},
+		"quick-format-unescaped": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-3.0.3.tgz",
+			"integrity": "sha512-dy1yjycmn9blucmJLXOfZDx1ikZJUi6E8bBZLnhPG5gBrVhHXx2xVyqqgKBubVNEXmx51dBACMHpoMQK/N/AXQ=="
 		},
 		"radium": {
 			"version": "0.19.6",
@@ -19315,7 +20767,6 @@
 			"version": "1.2.8",
 			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
 			"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-			"dev": true,
 			"requires": {
 				"deep-extend": "^0.6.0",
 				"ini": "~1.3.0",
@@ -19328,6 +20779,15 @@
 			"resolved": "https://registry.npmjs.org/rcedit/-/rcedit-0.9.0.tgz",
 			"integrity": "sha1-ORDfVzRTmeKwMl9KUZAH+J5V7xw=",
 			"dev": true
+		},
+		"re-resizable": {
+			"version": "6.3.2",
+			"resolved": "https://registry.npmjs.org/re-resizable/-/re-resizable-6.3.2.tgz",
+			"integrity": "sha512-ngxe4XBSb46vfwXjAwpURacVDig/pPt1kHRhcKlRRIoGICmo4aQHr725jurezepp1pm5jSC6iQhyLYfx3zOC3w==",
+			"dev": true,
+			"requires": {
+				"fast-memoize": "^2.5.1"
+			}
 		},
 		"react": {
 			"version": "16.13.1",
@@ -19573,8 +21033,7 @@
 		"react-is": {
 			"version": "16.13.1",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-			"dev": true
+			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
 		},
 		"react-lifecycles-compat": {
 			"version": "3.0.4",
@@ -19753,6 +21212,14 @@
 				}
 			}
 		},
+		"read": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+			"integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
+			"requires": {
+				"mute-stream": "~0.0.4"
+			}
+		},
 		"read-package-json": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.1.1.tgz",
@@ -19791,7 +21258,6 @@
 			"version": "2.3.7",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
 			"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-			"dev": true,
 			"requires": {
 				"core-util-is": "~1.0.0",
 				"inherits": "~2.0.3",
@@ -19975,8 +21441,7 @@
 		"regenerator-runtime": {
 			"version": "0.13.5",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-			"integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
-			"dev": true
+			"integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
 		},
 		"regenerator-transform": {
 			"version": "0.14.4",
@@ -20057,11 +21522,21 @@
 			"integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
 			"dev": true
 		},
+		"remove-array-items": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/remove-array-items/-/remove-array-items-1.1.1.tgz",
+			"integrity": "sha512-MXW/jtHyl5F1PZI7NbpS8SOtympdLuF20aoWJT5lELR1p/HJDd5nqW8Eu9uLh/hCRY3FgvrIT5AwDCgBODklcA=="
+		},
 		"remove-trailing-separator": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
 			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
 			"dev": true
+		},
+		"remove-trailing-slash": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/remove-trailing-slash/-/remove-trailing-slash-0.1.0.tgz",
+			"integrity": "sha1-FJjl3wmEwn5Jt26/Boh8otARUNI="
 		},
 		"renderkid": {
 			"version": "2.0.3",
@@ -20101,7 +21576,6 @@
 			"version": "2.88.2",
 			"resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
 			"integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
-			"dev": true,
 			"requires": {
 				"aws-sign2": "~0.7.0",
 				"aws4": "^1.8.0",
@@ -20128,8 +21602,22 @@
 				"qs": {
 					"version": "6.5.2",
 					"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-					"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
-					"dev": true
+					"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
+				}
+			}
+		},
+		"request-progress": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/request-progress/-/request-progress-3.0.0.tgz",
+			"integrity": "sha1-TKdUCBx/7GP1BeT6qCWqBs1mnb4=",
+			"requires": {
+				"throttleit": "^1.0.0"
+			},
+			"dependencies": {
+				"throttleit": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz",
+					"integrity": "sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw="
 				}
 			}
 		},
@@ -20169,7 +21657,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
 			"integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
-			"dev": true,
 			"requires": {
 				"resolve-from": "^2.0.0",
 				"semver": "^5.1.0"
@@ -20178,8 +21665,7 @@
 				"resolve-from": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-					"integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
-					"dev": true
+					"integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
 				}
 			}
 		},
@@ -20199,7 +21685,6 @@
 			"version": "1.17.0",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
 			"integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
-			"dev": true,
 			"requires": {
 				"path-parse": "^1.0.6"
 			}
@@ -20260,8 +21745,7 @@
 		"reusify": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-			"integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
-			"dev": true
+			"integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw=="
 		},
 		"rfdc": {
 			"version": "1.1.4",
@@ -20319,8 +21803,7 @@
 		"run-parallel": {
 			"version": "1.1.9",
 			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
-			"integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
-			"dev": true
+			"integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q=="
 		},
 		"run-queue": {
 			"version": "1.0.3",
@@ -20364,8 +21847,7 @@
 		"safe-buffer": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 		},
 		"safe-regex": {
 			"version": "1.1.0",
@@ -20379,8 +21861,7 @@
 		"safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-			"dev": true
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
 		},
 		"sanitize-filename": {
 			"version": "1.6.3",
@@ -20395,7 +21876,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
 			"integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
-			"dev": true,
 			"optional": true,
 			"requires": {
 				"sparse-bitfield": "^3.0.3"
@@ -20404,8 +21884,7 @@
 		"sax": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
-			"dev": true
+			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
 		},
 		"scheduler": {
 			"version": "0.19.1",
@@ -20445,8 +21924,7 @@
 		"semver": {
 			"version": "5.7.1",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-			"dev": true
+			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
 		},
 		"send": {
 			"version": "0.17.1",
@@ -20592,8 +22070,7 @@
 		"set-blocking": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-			"dev": true
+			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
 		},
 		"set-value": {
 			"version": "2.0.1",
@@ -20712,20 +22189,17 @@
 		"signal-exit": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-			"integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
-			"dev": true
+			"integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
 		},
 		"simple-concat": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
-			"integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY=",
-			"dev": true
+			"integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY="
 		},
 		"simple-get": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.0.tgz",
 			"integrity": "sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==",
-			"dev": true,
 			"requires": {
 				"decompress-response": "^4.2.0",
 				"once": "^1.3.1",
@@ -21063,6 +22537,15 @@
 				}
 			}
 		},
+		"sonic-boom": {
+			"version": "0.7.7",
+			"resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-0.7.7.tgz",
+			"integrity": "sha512-Ei5YOo5J64GKClHIL/5evJPgASXFVpfVYbJV9PILZQytTK6/LCwHvsZJW2Ig4p9FMC2OrBrMnXKgRN/OEoAWfg==",
+			"requires": {
+				"atomic-sleep": "^1.0.0",
+				"flatstr": "^1.0.12"
+			}
+		},
 		"sort-keys": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
@@ -21081,8 +22564,7 @@
 		"source-map": {
 			"version": "0.5.7",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-			"dev": true
+			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
 		},
 		"source-map-resolve": {
 			"version": "0.5.3",
@@ -21101,7 +22583,6 @@
 			"version": "0.5.18",
 			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.18.tgz",
 			"integrity": "sha512-9luZr/BZ2QeU6tO2uG8N2aZpVSli4TSAOAqFOyTO51AJcD9P99c0K1h6dD6r6qo5dyT44BR5exweOaLLeldTkQ==",
-			"dev": true,
 			"requires": {
 				"buffer-from": "^1.0.0",
 				"source-map": "^0.6.0"
@@ -21110,8 +22591,7 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
@@ -21125,7 +22605,6 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
 			"integrity": "sha1-/0rm5oZWBWuks+eSqzM004JzyhE=",
-			"dev": true,
 			"optional": true,
 			"requires": {
 				"memory-pager": "^1.0.2"
@@ -21321,7 +22800,6 @@
 			"version": "1.16.1",
 			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
 			"integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
-			"dev": true,
 			"requires": {
 				"asn1": "~0.2.3",
 				"assert-plus": "^1.0.0",
@@ -21471,6 +22949,14 @@
 				"xtend": "^4.0.0"
 			}
 		},
+		"stream-meter": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/stream-meter/-/stream-meter-1.0.4.tgz",
+			"integrity": "sha1-Uq+Vql6nYKJJFxZwTb/5D3Ov3R0=",
+			"requires": {
+				"readable-stream": "^2.1.4"
+			}
+		},
 		"stream-shift": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
@@ -21519,7 +23005,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 			"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-			"dev": true,
 			"requires": {
 				"code-point-at": "^1.0.0",
 				"is-fullwidth-code-point": "^1.0.0",
@@ -21617,7 +23102,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-			"dev": true,
 			"requires": {
 				"safe-buffer": "~5.1.0"
 			}
@@ -21633,7 +23117,6 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-			"dev": true,
 			"requires": {
 				"ansi-regex": "^2.0.0"
 			}
@@ -21662,8 +23145,7 @@
 		"strip-json-comments": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-			"dev": true
+			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
 		},
 		"style-loader": {
 			"version": "0.18.2",
@@ -21734,7 +23216,6 @@
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-			"dev": true,
 			"requires": {
 				"has-flag": "^3.0.0"
 			}
@@ -21861,7 +23342,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.0.1.tgz",
 			"integrity": "sha512-6tzWDMeroL87uF/+lin46k+Q+46rAJ0SyPGz7OW7wTgblI273hsBqk2C1j0/xNadNLKDTUL9BukSjB7cwgmlPA==",
-			"dev": true,
 			"requires": {
 				"chownr": "^1.1.1",
 				"mkdirp-classic": "^0.5.2",
@@ -21873,7 +23353,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
 					"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-					"dev": true,
 					"requires": {
 						"end-of-stream": "^1.1.0",
 						"once": "^1.3.1"
@@ -21885,7 +23364,6 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.2.tgz",
 			"integrity": "sha512-UaF6FoJ32WqALZGOIAApXx+OdxhekNMChu6axLJR85zMMjXKWFGjbIRe+J6P4UnRGg9rAwWvbTT0oI7hD/Un7Q==",
-			"dev": true,
 			"requires": {
 				"bl": "^4.0.1",
 				"end-of-stream": "^1.4.1",
@@ -21898,7 +23376,6 @@
 					"version": "4.0.2",
 					"resolved": "https://registry.npmjs.org/bl/-/bl-4.0.2.tgz",
 					"integrity": "sha512-j4OH8f6Qg2bGuWfRiltT2HYGx0e1QcBTrK9KAHNMwMZdQnDZFk0ZSYIpADjYCB3U12nicC5tVJwSIhwOWjb4RQ==",
-					"dev": true,
 					"requires": {
 						"buffer": "^5.5.0",
 						"inherits": "^2.0.4",
@@ -21909,7 +23386,6 @@
 					"version": "5.6.0",
 					"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
 					"integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
-					"dev": true,
 					"requires": {
 						"base64-js": "^1.0.2",
 						"ieee754": "^1.1.4"
@@ -21919,7 +23395,6 @@
 					"version": "3.6.0",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
 					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-					"dev": true,
 					"requires": {
 						"inherits": "^2.0.3",
 						"string_decoder": "^1.1.1",
@@ -22089,8 +23564,7 @@
 		"text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
-			"dev": true
+			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
 		},
 		"throttleit": {
 			"version": "0.0.2",
@@ -22101,8 +23575,7 @@
 		"through": {
 			"version": "2.3.8",
 			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-			"dev": true
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
 		},
 		"through2": {
 			"version": "2.0.5",
@@ -22159,8 +23632,7 @@
 		"to-fast-properties": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-			"dev": true
+			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
 		},
 		"to-object-path": {
 			"version": "0.3.0",
@@ -22240,7 +23712,6 @@
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
 			"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
-			"dev": true,
 			"requires": {
 				"psl": "^1.1.28",
 				"punycode": "^2.1.1"
@@ -22288,6 +23759,25 @@
 			"integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==",
 			"dev": true
 		},
+		"ts-node": {
+			"version": "8.10.1",
+			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.10.1.tgz",
+			"integrity": "sha512-bdNz1L4ekHiJul6SHtZWs1ujEKERJnHs4HxN7rjTyyVOFf3HaJ6sLqe6aPG62XTzAB/63pKRh5jTSWL0D7bsvw==",
+			"requires": {
+				"arg": "^4.1.0",
+				"diff": "^4.0.1",
+				"make-error": "^1.1.1",
+				"source-map-support": "^0.5.17",
+				"yn": "3.1.1"
+			},
+			"dependencies": {
+				"diff": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+					"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
+				}
+			}
+		},
 		"tslib": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
@@ -22313,7 +23803,6 @@
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-			"dev": true,
 			"requires": {
 				"safe-buffer": "^5.0.1"
 			}
@@ -22321,8 +23810,7 @@
 		"tweetnacl": {
 			"version": "0.14.5",
 			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
-			"dev": true
+			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
 		},
 		"type": {
 			"version": "1.2.0",
@@ -22334,7 +23822,6 @@
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
 			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-			"dev": true,
 			"requires": {
 				"prelude-ls": "~1.1.2"
 			}
@@ -22373,8 +23860,7 @@
 		"typescript": {
 			"version": "3.8.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
-			"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
-			"dev": true
+			"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w=="
 		},
 		"ua-parser-js": {
 			"version": "0.7.21",
@@ -22499,6 +23985,11 @@
 				}
 			}
 		},
+		"uid2": {
+			"version": "0.0.3",
+			"resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
+			"integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I="
+		},
 		"ultron": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
@@ -22590,11 +24081,20 @@
 				"imurmurhash": "^0.1.4"
 			}
 		},
+		"unique-temp-dir": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/unique-temp-dir/-/unique-temp-dir-1.0.0.tgz",
+			"integrity": "sha1-bc6VsmgcoAPuv7MEpBX5y6vMU4U=",
+			"requires": {
+				"mkdirp": "^0.5.1",
+				"os-tmpdir": "^1.0.1",
+				"uid2": "0.0.3"
+			}
+		},
 		"universalify": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
-			"dev": true
+			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
 		},
 		"unpipe": {
 			"version": "1.0.0",
@@ -22658,7 +24158,6 @@
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
 			"integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
-			"dev": true,
 			"requires": {
 				"punycode": "^2.1.0"
 			}
@@ -22769,8 +24268,7 @@
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-			"dev": true
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
 		},
 		"util.promisify": {
 			"version": "1.0.1",
@@ -22799,8 +24297,7 @@
 		"uuid": {
 			"version": "3.4.0",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-			"dev": true
+			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
 		},
 		"v8-compile-cache": {
 			"version": "2.0.3",
@@ -22852,7 +24349,6 @@
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
-			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0",
 				"core-util-is": "1.0.2",
@@ -22879,6 +24375,11 @@
 			"requires": {
 				"browser-process-hrtime": "^1.0.0"
 			}
+		},
+		"wait-for-expect": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/wait-for-expect/-/wait-for-expect-1.3.0.tgz",
+			"integrity": "sha512-8fJU7jiA96HfGPt+P/UilelSAZfhMBJ52YhKzlmZQvKEZU2EcD1GQ0yqGB6liLdHjYtYAoGVigYwdxr5rktvzA=="
 		},
 		"warning": {
 			"version": "4.0.3",
@@ -23944,14 +25445,12 @@
 		"which-pm-runs": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
-			"integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=",
-			"dev": true
+			"integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs="
 		},
 		"wide-align": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
 			"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-			"dev": true,
 			"requires": {
 				"string-width": "^1.0.2 || 2"
 			}
@@ -23965,8 +25464,7 @@
 		"word-wrap": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-			"integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
-			"dev": true
+			"integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
 		},
 		"wordwrap": {
 			"version": "0.0.2",
@@ -23996,8 +25494,7 @@
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-			"dev": true
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		},
 		"write": {
 			"version": "1.0.3",
@@ -24065,11 +25562,19 @@
 			"integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
 			"dev": true
 		},
+		"xml2js": {
+			"version": "0.4.19",
+			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
+			"integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
+			"requires": {
+				"sax": ">=0.6.0",
+				"xmlbuilder": "~9.0.1"
+			}
+		},
 		"xmlbuilder": {
 			"version": "9.0.7",
 			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-			"integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
-			"dev": true
+			"integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
 		},
 		"xmldom": {
 			"version": "0.1.31",
@@ -24114,7 +25619,6 @@
 			"version": "1.9.2",
 			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.9.2.tgz",
 			"integrity": "sha512-HPT7cGGI0DuRcsO51qC1j9O16Dh1mZ2bnXwsi0jrSpsLz0WxOLSLXfkABVl6bZO629py3CU+OMJtpNHDLB97kg==",
-			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.9.2"
 			}
@@ -24399,6 +25903,11 @@
 			"resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
 			"integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk=",
 			"dev": true
+		},
+		"yn": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="
 		}
 	}
 }

--- a/packages/compass-shell/package-lock.json
+++ b/packages/compass-shell/package-lock.json
@@ -44,6 +44,7 @@
 			"version": "7.9.0",
 			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.9.0.tgz",
 			"integrity": "sha512-kWc7L0fw1xwvI0zi8OKVBuxRVefwGOrKSQMvrQ3dW+bIIavBY3/NpXmpjMy7bQnLgwgzWQZ8TlM57YHpHNHz4w==",
+			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.8.3",
 				"@babel/generator": "^7.9.0",
@@ -67,6 +68,7 @@
 					"version": "4.1.1",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
 					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
 					"requires": {
 						"ms": "^2.1.1"
 					}
@@ -74,7 +76,8 @@
 				"ms": {
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
 				}
 			}
 		},
@@ -82,6 +85,7 @@
 			"version": "7.9.5",
 			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.5.tgz",
 			"integrity": "sha512-GbNIxVB3ZJe3tLeDm1HSn2AhuD/mVcyLDpgtLXa5tplmWrJdF/elxB56XNqCuD6szyNkDi6wuoKXln3QeBmCHQ==",
+			"dev": true,
 			"requires": {
 				"@babel/types": "^7.9.5",
 				"jsesc": "^2.5.1",
@@ -192,6 +196,7 @@
 			"version": "7.9.5",
 			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.9.5.tgz",
 			"integrity": "sha512-JVcQZeXM59Cd1qanDUxv9fgJpt3NeKUaqBqUEvfmQ+BCOKq2xUgaWZW2hr0dkbyJgezYuplEoh5knmrnS68efw==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-get-function-arity": "^7.8.3",
 				"@babel/template": "^7.8.3",
@@ -202,6 +207,7 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
 			"integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
+			"dev": true,
 			"requires": {
 				"@babel/types": "^7.8.3"
 			}
@@ -219,6 +225,7 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.8.3.tgz",
 			"integrity": "sha512-fO4Egq88utkQFjbPrSHGmGLFqmrshs11d46WI+WZDESt7Wu7wN2G2Iu+NMMZJFDOVRHAMIkB5SNh30NtwCA7RA==",
+			"dev": true,
 			"requires": {
 				"@babel/types": "^7.8.3"
 			}
@@ -235,6 +242,7 @@
 			"version": "7.9.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.9.0.tgz",
 			"integrity": "sha512-0FvKyu0gpPfIQ8EkxlrAydOWROdHpBmiCiRwLkUiBGhCUPRRbVD2/tm3sFr/c/GWFrQ/ffutGUAnx7V0FzT2wA==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-module-imports": "^7.8.3",
 				"@babel/helper-replace-supers": "^7.8.6",
@@ -249,6 +257,7 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.8.3.tgz",
 			"integrity": "sha512-Kag20n86cbO2AvHca6EJsvqAd82gc6VMGule4HwebwMlwkpXuVqrNRj6CkCV2sKxgi9MyAUnZVnZ6lJ1/vKhHQ==",
+			"dev": true,
 			"requires": {
 				"@babel/types": "^7.8.3"
 			}
@@ -256,7 +265,8 @@
 		"@babel/helper-plugin-utils": {
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
-			"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ=="
+			"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
+			"dev": true
 		},
 		"@babel/helper-regex": {
 			"version": "7.8.3",
@@ -284,6 +294,7 @@
 			"version": "7.8.6",
 			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.8.6.tgz",
 			"integrity": "sha512-PeMArdA4Sv/Wf4zXwBKPqVj7n9UF/xg6slNRtZW84FM7JpE1CbG8B612FyM4cxrf4fMAMGO0kR7voy1ForHHFA==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-member-expression-to-functions": "^7.8.3",
 				"@babel/helper-optimise-call-expression": "^7.8.3",
@@ -295,6 +306,7 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.8.3.tgz",
 			"integrity": "sha512-VNGUDjx5cCWg4vvCTR8qQ7YJYZ+HBjxOgXEl7ounz+4Sn7+LMD3CFrCTEU6/qXKbA2nKg21CwhhBzO0RpRbdCw==",
+			"dev": true,
 			"requires": {
 				"@babel/template": "^7.8.3",
 				"@babel/types": "^7.8.3"
@@ -304,6 +316,7 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
 			"integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
+			"dev": true,
 			"requires": {
 				"@babel/types": "^7.8.3"
 			}
@@ -329,6 +342,7 @@
 			"version": "7.9.2",
 			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.9.2.tgz",
 			"integrity": "sha512-JwLvzlXVPjO8eU9c/wF9/zOIN7X6h8DYf7mG4CiFRZRvZNKEF5dQ3H3V+ASkHoIB3mWhatgl5ONhyqHRI6MppA==",
+			"dev": true,
 			"requires": {
 				"@babel/template": "^7.8.3",
 				"@babel/traverse": "^7.9.0",
@@ -348,7 +362,8 @@
 		"@babel/parser": {
 			"version": "7.9.4",
 			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.4.tgz",
-			"integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA=="
+			"integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA==",
+			"dev": true
 		},
 		"@babel/plugin-proposal-async-generator-functions": {
 			"version": "7.8.3",
@@ -558,14 +573,6 @@
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.8.3.tgz",
 			"integrity": "sha512-kwj1j9lL/6Wd0hROD3b/OZZ7MSrZLqqn9RAZ5+cYYsflQ9HZBIKCUkr3+uL1MEJ1NePiUbf98jjiMQSv0NMR9g==",
 			"dev": true,
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.8.3"
-			}
-		},
-		"@babel/plugin-syntax-typescript": {
-			"version": "7.8.3",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.8.3.tgz",
-			"integrity": "sha512-GO1MQ/SGGGoiEXY0e0bSpHimJvxqB7lktLLIq2pv8xG7WZ8IMEle74jIe1FhprHBWjwjZtXHkycDLZXIWM5Wfg==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.8.3"
 			}
@@ -930,97 +937,6 @@
 				"@babel/helper-plugin-utils": "^7.8.3"
 			}
 		},
-		"@babel/plugin-transform-typescript": {
-			"version": "7.9.6",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.9.6.tgz",
-			"integrity": "sha512-8OvsRdvpt3Iesf2qsAn+YdlwAJD7zJ+vhFZmDCa4b8dTp7MmHtKk5FF2mCsGxjZwuwsy/yIIay/nLmxST1ctVQ==",
-			"requires": {
-				"@babel/helper-create-class-features-plugin": "^7.9.6",
-				"@babel/helper-plugin-utils": "^7.8.3",
-				"@babel/plugin-syntax-typescript": "^7.8.3"
-			},
-			"dependencies": {
-				"@babel/generator": {
-					"version": "7.9.6",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.6.tgz",
-					"integrity": "sha512-+htwWKJbH2bL72HRluF8zumBxzuX0ZZUFl3JLNyoUjM/Ho8wnVpPXM6aUz8cfKDqQ/h7zHqKt4xzJteUosckqQ==",
-					"requires": {
-						"@babel/types": "^7.9.6",
-						"jsesc": "^2.5.1",
-						"lodash": "^4.17.13",
-						"source-map": "^0.5.0"
-					}
-				},
-				"@babel/helper-create-class-features-plugin": {
-					"version": "7.9.6",
-					"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.9.6.tgz",
-					"integrity": "sha512-6N9IeuyHvMBRyjNYOMJHrhwtu4WJMrYf8hVbEHD3pbbbmNOk1kmXSQs7bA4dYDUaIx4ZEzdnvo6NwC3WHd/Qow==",
-					"requires": {
-						"@babel/helper-function-name": "^7.9.5",
-						"@babel/helper-member-expression-to-functions": "^7.8.3",
-						"@babel/helper-optimise-call-expression": "^7.8.3",
-						"@babel/helper-plugin-utils": "^7.8.3",
-						"@babel/helper-replace-supers": "^7.9.6",
-						"@babel/helper-split-export-declaration": "^7.8.3"
-					}
-				},
-				"@babel/helper-replace-supers": {
-					"version": "7.9.6",
-					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.9.6.tgz",
-					"integrity": "sha512-qX+chbxkbArLyCImk3bWV+jB5gTNU/rsze+JlcF6Nf8tVTigPJSI1o1oBow/9Resa1yehUO9lIipsmu9oG4RzA==",
-					"requires": {
-						"@babel/helper-member-expression-to-functions": "^7.8.3",
-						"@babel/helper-optimise-call-expression": "^7.8.3",
-						"@babel/traverse": "^7.9.6",
-						"@babel/types": "^7.9.6"
-					}
-				},
-				"@babel/parser": {
-					"version": "7.9.6",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.6.tgz",
-					"integrity": "sha512-AoeIEJn8vt+d/6+PXDRPaksYhnlbMIiejioBZvvMQsOjW/JYK6k/0dKnvvP3EhK5GfMBWDPtrxRtegWdAcdq9Q=="
-				},
-				"@babel/traverse": {
-					"version": "7.9.6",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.9.6.tgz",
-					"integrity": "sha512-b3rAHSjbxy6VEAvlxM8OV/0X4XrG72zoxme6q1MOoe2vd0bEc+TwayhuC1+Dfgqh1QEG+pj7atQqvUprHIccsg==",
-					"requires": {
-						"@babel/code-frame": "^7.8.3",
-						"@babel/generator": "^7.9.6",
-						"@babel/helper-function-name": "^7.9.5",
-						"@babel/helper-split-export-declaration": "^7.8.3",
-						"@babel/parser": "^7.9.6",
-						"@babel/types": "^7.9.6",
-						"debug": "^4.1.0",
-						"globals": "^11.1.0",
-						"lodash": "^4.17.13"
-					}
-				},
-				"@babel/types": {
-					"version": "7.9.6",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.6.tgz",
-					"integrity": "sha512-qxXzvBO//jO9ZnoasKF1uJzHd2+M6Q2ZPIVfnFps8JJvXy0ZBbwbNOmE6SGIY5XOY6d1Bo5lb9d9RJ8nv3WSeA==",
-					"requires": {
-						"@babel/helper-validator-identifier": "^7.9.5",
-						"lodash": "^4.17.13",
-						"to-fast-properties": "^2.0.0"
-					}
-				},
-				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-				}
-			}
-		},
 		"@babel/plugin-transform-unicode-regex": {
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.8.3.tgz",
@@ -1136,15 +1052,6 @@
 				"@babel/plugin-transform-react-jsx-source": "^7.9.0"
 			}
 		},
-		"@babel/preset-typescript": {
-			"version": "7.9.0",
-			"resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.9.0.tgz",
-			"integrity": "sha512-S4cueFnGrIbvYJgwsVFKdvOmpiL0XGw9MFW9D0vgRys5g36PBhZRL8NX8Gr2akz8XRtzq6HuDXPD/1nniagNUg==",
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.8.3",
-				"@babel/plugin-transform-typescript": "^7.9.0"
-			}
-		},
 		"@babel/register": {
 			"version": "7.9.0",
 			"resolved": "https://registry.npmjs.org/@babel/register/-/register-7.9.0.tgz",
@@ -1190,6 +1097,7 @@
 			"version": "7.8.6",
 			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
 			"integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
+			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.8.3",
 				"@babel/parser": "^7.8.6",
@@ -1200,6 +1108,7 @@
 			"version": "7.9.5",
 			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.9.5.tgz",
 			"integrity": "sha512-c4gH3jsvSuGUezlP6rzSJ6jf8fYjLj3hsMZRx/nX0h+fmHN0w+ekubRrHPqnMec0meycA2nwCsJ7dC8IPem2FQ==",
+			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.8.3",
 				"@babel/generator": "^7.9.5",
@@ -1216,6 +1125,7 @@
 					"version": "4.1.1",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
 					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
 					"requires": {
 						"ms": "^2.1.1"
 					}
@@ -1223,7 +1133,8 @@
 				"ms": {
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
 				}
 			}
 		},
@@ -1372,339 +1283,17 @@
 			"resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-2.0.1.tgz",
 			"integrity": "sha512-xwD6kOokWvaygxF0T2gnf77HEu68G7EXr1ZrNiNtZzg80Y1V2hikhUNoESWij6g/A6qJZvAiwpseflVo3PnlHQ=="
 		},
-		"@leafygreen-ui/syntax": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/@leafygreen-ui/syntax/-/syntax-2.7.0.tgz",
-			"integrity": "sha512-bQRIFKPUwZsne39R49eQN5qEl556w88N/FjJfzAU/LjR2OVp+W5sWhx1PiacwCq+J1r/7wu/PKUh5rV/dpSgmQ==",
-			"requires": {
-				"@leafygreen-ui/lib": "^4.3.0",
-				"@leafygreen-ui/palette": "^2.0.1",
-				"highlight.js": "^9.15.6",
-				"highlightjs-graphql": "^1.0.1"
-			}
-		},
 		"@mongodb-js/triejs": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/@mongodb-js/triejs/-/triejs-0.1.5.tgz",
 			"integrity": "sha512-elh8S1OxmEGe8/wbr6ky//dHhV2ld6oZV8/M9lgozJsL/6Aqm8j5+ElquzoX9k9l3Q+dohuX/SIGR/kTRZHS4g==",
 			"dev": true
 		},
-		"@mongosh/async-rewriter": {
-			"version": "0.0.1-alpha.15",
-			"resolved": "https://registry.npmjs.org/@mongosh/async-rewriter/-/async-rewriter-0.0.1-alpha.15.tgz",
-			"integrity": "sha512-89ydztLoz4Dyl92Bptff8GkIXioei0qxX/Z2uMTV9G4/Esg/Vv2C2VAKhI68uAACxpLjISW+p+guVya5SXJgAA==",
-			"requires": {
-				"@babel/core": "^7.9.0",
-				"@babel/parser": "^7.9.4",
-				"@babel/preset-typescript": "^7.9.0",
-				"@babel/template": "^7.8.6",
-				"@babel/traverse": "^7.9.0",
-				"@babel/types": "^7.9.0",
-				"@mongosh/errors": "^0.0.1-alpha.15",
-				"@types/babel__core": "^7.1.6",
-				"@types/babel__traverse": "^7.0.9",
-				"ts-node": "^8.8.1",
-				"typescript": "^3.8.3"
-			}
-		},
-		"@mongosh/browser-repl": {
-			"version": "0.0.1-alpha.15",
-			"resolved": "https://registry.npmjs.org/@mongosh/browser-repl/-/browser-repl-0.0.1-alpha.15.tgz",
-			"integrity": "sha512-gMPq1+MyWTRxZsjHKtYN+YoFKc9OP9w6NOam2EROwTCwRmUKAg0W76obwdrZtTeFWMGiYt5QyxLNck9ldgmd1g==",
-			"requires": {
-				"@babel/generator": "^7.8.3",
-				"@babel/parser": "^7.8.3",
-				"@babel/runtime": "^7.8.3",
-				"@babel/template": "^7.8.3",
-				"@leafygreen-ui/icon": "^4.0.0",
-				"@leafygreen-ui/palette": "^2.0.0",
-				"@leafygreen-ui/syntax": "^2.2.0",
-				"@mongosh/browser-runtime-core": "^0.0.1-alpha.15",
-				"@mongosh/history": "^0.0.1-alpha.15",
-				"@mongosh/i18n": "^0.0.1-alpha.15",
-				"@mongosh/service-provider-core": "^0.0.1-alpha.15",
-				"pretty-bytes": "^5.3.0",
-				"text-table": "^0.2.0"
-			},
-			"dependencies": {
-				"@leafygreen-ui/icon": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/@leafygreen-ui/icon/-/icon-4.3.0.tgz",
-					"integrity": "sha512-6DOFKxj3U0hp2yQEq/Yq19qIiIIUXwRj2fH1ddOJFYLtAoeFOCSeuF6rE2dqXrXW/puQdjgpXV60w9J8gyXGog=="
-				},
-				"pretty-bytes": {
-					"version": "5.3.0",
-					"resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.3.0.tgz",
-					"integrity": "sha512-hjGrh+P926p4R4WbaB6OckyRtO0F0/lQBiT+0gnxjV+5kjPBrfVBFCsCLbMqVQeydvIoouYTCmmEURiH3R1Bdg=="
-				}
-			}
-		},
-		"@mongosh/browser-runtime-core": {
-			"version": "0.0.1-alpha.15",
-			"resolved": "https://registry.npmjs.org/@mongosh/browser-runtime-core/-/browser-runtime-core-0.0.1-alpha.15.tgz",
-			"integrity": "sha512-wpVgRx6KHkt/OZmLAUVYeJ6cqG6U+YClU6TU+3NnwBQ+NdPqEOG678fn2wwbq4EaR4V90X4GTS9E+4o4RfwnuQ==",
-			"requires": {
-				"@babel/generator": "^7.9.4",
-				"@babel/parser": "^7.9.4",
-				"@mongosh/cli-repl": "^0.0.1-alpha.15",
-				"@mongosh/service-provider-core": "^0.0.1-alpha.15",
-				"@mongosh/shell-evaluator": "^0.0.1-alpha.15"
-			}
-		},
-		"@mongosh/browser-runtime-electron": {
-			"version": "0.0.1-alpha.15",
-			"resolved": "https://registry.npmjs.org/@mongosh/browser-runtime-electron/-/browser-runtime-electron-0.0.1-alpha.15.tgz",
-			"integrity": "sha512-VpgACHP/UceG5fJ4/JHldA+wUEv8tJdU1xDyah1kcgLecOQZ1Yw24w5R82qVbF6ARI23UgiXjTTSxnYbMWNhjQ==",
-			"requires": {
-				"@mongosh/browser-runtime-core": "^0.0.1-alpha.15",
-				"@mongosh/service-provider-core": "^0.0.1-alpha.15"
-			}
-		},
-		"@mongosh/build": {
-			"version": "0.0.1-alpha.15",
-			"resolved": "https://registry.npmjs.org/@mongosh/build/-/build-0.0.1-alpha.15.tgz",
-			"integrity": "sha512-H0Y4dWiyZ2hPjow9rNt3ASkKBpASsx13mrP4q7oQvqA5yQpX6d18SM6jvYUnpQdq6RbhBxVdy4+AGmuEhJDI5Q==",
-			"requires": {
-				"adm-zip": "^0.4.14",
-				"aws-sdk": "^2.674.0",
-				"handlebars": "^4.7.6",
-				"pkg": "^4.4.3",
-				"tar": "^6.0.1"
-			},
-			"dependencies": {
-				"chownr": {
-					"version": "2.0.0",
-					"resolved": "https://registry.npmjs.org/chownr/-/chownr-2.0.0.tgz",
-					"integrity": "sha512-bIomtDF5KGpdogkLd9VspvFzk9KfpyyGlS8YFVZl7TGPBHL5snIOnxeshwVgPteQ9b4Eydl+pVbIyE1DcvCWgQ=="
-				},
-				"fs-minipass": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/fs-minipass/-/fs-minipass-2.1.0.tgz",
-					"integrity": "sha512-V/JgOLFCS+R6Vcq0slCuaeWEdNC3ouDlJMNIsacH2VtALiu9mV4LPrHc5cDl8k5aw6J8jwgWWpiTo5RYhmIzvg==",
-					"requires": {
-						"minipass": "^3.0.0"
-					}
-				},
-				"minipass": {
-					"version": "3.1.3",
-					"resolved": "https://registry.npmjs.org/minipass/-/minipass-3.1.3.tgz",
-					"integrity": "sha512-Mgd2GdMVzY+x3IJ+oHnVM+KG3lA5c8tnabyJKmHSaG2kAGpudxuOf8ToDkhumF7UzME7DecbQE9uOZhNm7PuJg==",
-					"requires": {
-						"yallist": "^4.0.0"
-					}
-				},
-				"minizlib": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/minizlib/-/minizlib-2.1.0.tgz",
-					"integrity": "sha512-EzTZN/fjSvifSX0SlqUERCN39o6T40AMarPbv0MrarSFtIITCBh7bi+dU8nxGFHuqs9jdIAeoYoKuQAAASsPPA==",
-					"requires": {
-						"minipass": "^3.0.0",
-						"yallist": "^4.0.0"
-					}
-				},
-				"mkdirp": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-					"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
-				},
-				"tar": {
-					"version": "6.0.2",
-					"resolved": "https://registry.npmjs.org/tar/-/tar-6.0.2.tgz",
-					"integrity": "sha512-Glo3jkRtPcvpDlAs/0+hozav78yoXKFr+c4wgw62NNMO3oo4AaJdCo21Uu7lcwr55h39W2XD1LMERc64wtbItg==",
-					"requires": {
-						"chownr": "^2.0.0",
-						"fs-minipass": "^2.0.0",
-						"minipass": "^3.0.0",
-						"minizlib": "^2.1.0",
-						"mkdirp": "^1.0.3",
-						"yallist": "^4.0.0"
-					}
-				},
-				"yallist": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-					"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
-				}
-			}
-		},
-		"@mongosh/cli-repl": {
-			"version": "0.0.1-alpha.15",
-			"resolved": "https://registry.npmjs.org/@mongosh/cli-repl/-/cli-repl-0.0.1-alpha.15.tgz",
-			"integrity": "sha512-uZmXFi1Kjd1SMJNgkol5jXZcIJjrSqDbs1UOU/DAZcSkO+wLqYpIzEwYxKCAyq4apAbemTbLNyrLb+E6y2ifhA==",
-			"requires": {
-				"@mongosh/build": "^0.0.1-alpha.15",
-				"@mongosh/errors": "^0.0.1-alpha.15",
-				"@mongosh/history": "^0.0.1-alpha.15",
-				"@mongosh/i18n": "^0.0.1-alpha.15",
-				"@mongosh/service-provider-server": "^0.0.1-alpha.15",
-				"@mongosh/shell-api": "^0.0.1-alpha.15",
-				"@mongosh/shell-evaluator": "^0.0.1-alpha.15",
-				"acorn": "^7.1.1",
-				"acorn-class-fields": "^0.3.2",
-				"acorn-numeric-separator": "^0.3.0",
-				"acorn-private-methods": "^0.3.1",
-				"acorn-static-class-features": "^0.2.1",
-				"analytics-node": "^3.4.0-beta.1",
-				"ansi-escape-sequences": "^5.1.2",
-				"bson": "^4.0.4",
-				"is-recoverable-error": "^1.0.0",
-				"lodash.set": "^4.3.2",
-				"minimist": "^1.2.5",
-				"mkdirp": "^1.0.3",
-				"mongodb-ace-autocompleter": "^0.4.1",
-				"mongodb-build-info": "^1.0.0",
-				"mongodb-redact": "^0.2.0",
-				"nanobus": "^4.4.0",
-				"pino": "^5.16.0",
-				"pretty-bytes": "^5.3.0",
-				"pretty-repl": "^2.3.0",
-				"read": "^1.0.7",
-				"semver": "^7.1.2",
-				"text-table": "^0.2.0"
-			},
-			"dependencies": {
-				"acorn": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.2.0.tgz",
-					"integrity": "sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ=="
-				},
-				"bson": {
-					"version": "4.0.4",
-					"resolved": "https://registry.npmjs.org/bson/-/bson-4.0.4.tgz",
-					"integrity": "sha512-Ioi3TD0/1V3aI8+hPfC56TetYmzfq2H07jJa9A1lKTxWsFtHtYdLMGMXjtGEg9v0f72NSM07diRQEUNYhLupIA==",
-					"requires": {
-						"buffer": "^5.1.0",
-						"long": "^4.0.0"
-					}
-				},
-				"buffer": {
-					"version": "5.6.0",
-					"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
-					"integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
-					"requires": {
-						"base64-js": "^1.0.2",
-						"ieee754": "^1.1.4"
-					}
-				},
-				"mkdirp": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-					"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
-				},
-				"pretty-bytes": {
-					"version": "5.3.0",
-					"resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.3.0.tgz",
-					"integrity": "sha512-hjGrh+P926p4R4WbaB6OckyRtO0F0/lQBiT+0gnxjV+5kjPBrfVBFCsCLbMqVQeydvIoouYTCmmEURiH3R1Bdg=="
-				},
-				"semver": {
-					"version": "7.3.2",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
-				}
-			}
-		},
-		"@mongosh/errors": {
-			"version": "0.0.1-alpha.15",
-			"resolved": "https://registry.npmjs.org/@mongosh/errors/-/errors-0.0.1-alpha.15.tgz",
-			"integrity": "sha512-p1UhubC9Bvvb0HyxbnUzX1bl56ubH45gqlI4p5//cTjabwmMoA5gdErAZYvL7E8t9QYrneVmY1W/2/B7zd1h1A=="
-		},
-		"@mongosh/history": {
-			"version": "0.0.1-alpha.15",
-			"resolved": "https://registry.npmjs.org/@mongosh/history/-/history-0.0.1-alpha.15.tgz",
-			"integrity": "sha512-cIC/H2cecN3xm15L745kdfievsZEvDlGoZu5Oy/ed/ihsc5PeOBWJOra2pyuh0R6ZaXDq6bFaoiXk6JLoB2pqg==",
-			"requires": {
-				"mongodb-redact": "^0.2.0"
-			}
-		},
-		"@mongosh/i18n": {
-			"version": "0.0.1-alpha.15",
-			"resolved": "https://registry.npmjs.org/@mongosh/i18n/-/i18n-0.0.1-alpha.15.tgz",
-			"integrity": "sha512-BIactWfKx3zC7Z438lKDRqeaoErrTmn2mcHl4V3tx14/mw7m2s3DEBVgO0dju8p3oFviz4oSRhM+HL+FNegX7A==",
-			"requires": {
-				"mustache": "^4.0.0"
-			}
-		},
-		"@mongosh/mapper": {
-			"version": "0.0.1-alpha.15",
-			"resolved": "https://registry.npmjs.org/@mongosh/mapper/-/mapper-0.0.1-alpha.15.tgz",
-			"integrity": "sha512-nQh/2gcDbp1mh3uxk38T9Or0RilgBj7wR8/Lkk5OS3jMZZuKMyMRbn8GEtasU6RVoG6kSVLn9GGkQvyDBRi1cw==",
-			"requires": {
-				"@mongosh/errors": "^0.0.1-alpha.15",
-				"@mongosh/service-provider-core": "^0.0.1-alpha.15",
-				"@mongosh/shell-api": "^0.0.1-alpha.15",
-				"pretty-bytes": "^5.3.0",
-				"text-table": "^0.2.0"
-			},
-			"dependencies": {
-				"pretty-bytes": {
-					"version": "5.3.0",
-					"resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.3.0.tgz",
-					"integrity": "sha512-hjGrh+P926p4R4WbaB6OckyRtO0F0/lQBiT+0gnxjV+5kjPBrfVBFCsCLbMqVQeydvIoouYTCmmEURiH3R1Bdg=="
-				}
-			}
-		},
-		"@mongosh/service-provider-core": {
-			"version": "0.0.1-alpha.15",
-			"resolved": "https://registry.npmjs.org/@mongosh/service-provider-core/-/service-provider-core-0.0.1-alpha.15.tgz",
-			"integrity": "sha512-weezX/uVVIpLYsVanKyhrlIBzkBc61smE4hndKzkj4FxwEArsUae0j0DHXeT3Jus0G5+bpAUrTB15u3E8qInTA=="
-		},
-		"@mongosh/service-provider-server": {
-			"version": "0.0.1-alpha.15",
-			"resolved": "https://registry.npmjs.org/@mongosh/service-provider-server/-/service-provider-server-0.0.1-alpha.15.tgz",
-			"integrity": "sha512-WxhDwB3x/E2Aiklx/tKtv7S/5MVQGZwBTt/GyurC7jI5G4m7ZBJjw7M6Ma0q60mLNDiS+8wgT3Jd/NVPxK57Xg==",
-			"requires": {
-				"@mongosh/errors": "^0.0.1-alpha.15",
-				"@mongosh/service-provider-core": "^0.0.1-alpha.15",
-				"@types/sinon": "^7.5.1",
-				"@types/sinon-chai": "^3.2.3",
-				"mongodb": "3.5.3 || ^3.5.5"
-			}
-		},
-		"@mongosh/shell-api": {
-			"version": "0.0.1-alpha.15",
-			"resolved": "https://registry.npmjs.org/@mongosh/shell-api/-/shell-api-0.0.1-alpha.15.tgz",
-			"integrity": "sha512-cM9xa0DnZuRZg1r6b42LOVue6EREP38/gR9823uzXMwKyOM8vPpF+ScDfCLp7/0+p+H20ij5WCtxWItRdDzJfA==",
-			"requires": {
-				"@mongosh/errors": "^0.0.1-alpha.15",
-				"@mongosh/i18n": "^0.0.1-alpha.15",
-				"bson": "^4.0.4"
-			},
-			"dependencies": {
-				"bson": {
-					"version": "4.0.4",
-					"resolved": "https://registry.npmjs.org/bson/-/bson-4.0.4.tgz",
-					"integrity": "sha512-Ioi3TD0/1V3aI8+hPfC56TetYmzfq2H07jJa9A1lKTxWsFtHtYdLMGMXjtGEg9v0f72NSM07diRQEUNYhLupIA==",
-					"requires": {
-						"buffer": "^5.1.0",
-						"long": "^4.0.0"
-					}
-				},
-				"buffer": {
-					"version": "5.6.0",
-					"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
-					"integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
-					"requires": {
-						"base64-js": "^1.0.2",
-						"ieee754": "^1.1.4"
-					}
-				}
-			}
-		},
-		"@mongosh/shell-evaluator": {
-			"version": "0.0.1-alpha.15",
-			"resolved": "https://registry.npmjs.org/@mongosh/shell-evaluator/-/shell-evaluator-0.0.1-alpha.15.tgz",
-			"integrity": "sha512-Uwslqbc7u2QJSAPKFE+otqb0K9NvWhU4YsdBqKAe7soOmLoueuYvtPTrtvlHiG3XJ8vaiMzogQxoFV1bDa9kyQ==",
-			"requires": {
-				"@mongosh/async-rewriter": "^0.0.1-alpha.15",
-				"@mongosh/mapper": "^0.0.1-alpha.15",
-				"@mongosh/service-provider-core": "^0.0.1-alpha.15",
-				"@mongosh/shell-api": "^0.0.1-alpha.15"
-			}
-		},
 		"@nodelib/fs.scandir": {
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.3.tgz",
 			"integrity": "sha512-eGmwYQn3gxo4r7jdQnkrrN6bY478C3P+a/y72IJukF8LjB6ZHeB3c+Ehacj3sYeSmUXGlnA67/PmbM9CVwL7Dw==",
+			"dev": true,
 			"requires": {
 				"@nodelib/fs.stat": "2.0.3",
 				"run-parallel": "^1.1.9"
@@ -1713,24 +1302,17 @@
 		"@nodelib/fs.stat": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.stat/-/fs.stat-2.0.3.tgz",
-			"integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA=="
+			"integrity": "sha512-bQBFruR2TAwoevBEd/NWMoAAtNGzTRgdrqnYCc7dhzfoNvqPzLyqlEQnzZ3kVnNrSp25iyxE00/3h2fqGAGArA==",
+			"dev": true
 		},
 		"@nodelib/fs.walk": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/@nodelib/fs.walk/-/fs.walk-1.2.4.tgz",
 			"integrity": "sha512-1V9XOY4rDW0rehzbrcqAmHnz8e7SKvX27gh8Gt2WgB0+pdzdiLV83p72kZPU+jvMbS1qU5mauP2iOvO8rhmurQ==",
+			"dev": true,
 			"requires": {
 				"@nodelib/fs.scandir": "2.1.3",
 				"fastq": "^1.6.0"
-			}
-		},
-		"@segment/loosely-validate-event": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@segment/loosely-validate-event/-/loosely-validate-event-2.0.0.tgz",
-			"integrity": "sha512-ZMCSfztDBqwotkl848ODgVcAmN4OItEWDCkshcKz0/W6gGSQayuuCtWV/MlodFivAZD793d6UgANd6wCXUfrIw==",
-			"requires": {
-				"component-type": "^1.2.1",
-				"join-component": "^1.1.0"
 			}
 		},
 		"@sheerun/mutationobserver-shim": {
@@ -2390,52 +1972,11 @@
 				"@testing-library/dom": "^5.6.1"
 			}
 		},
-		"@types/babel__core": {
-			"version": "7.1.7",
-			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.7.tgz",
-			"integrity": "sha512-RL62NqSFPCDK2FM1pSDH0scHpJvsXtZNiYlMB73DgPBaG1E38ZYVL+ei5EkWRbr+KC4YNiAUNBnRj+bgwpgjMw==",
-			"requires": {
-				"@babel/parser": "^7.1.0",
-				"@babel/types": "^7.0.0",
-				"@types/babel__generator": "*",
-				"@types/babel__template": "*",
-				"@types/babel__traverse": "*"
-			}
-		},
-		"@types/babel__generator": {
-			"version": "7.6.1",
-			"resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.1.tgz",
-			"integrity": "sha512-bBKm+2VPJcMRVwNhxKu8W+5/zT7pwNEqeokFOmbvVSqGzFneNxYcEBro9Ac7/N9tlsaPYnZLK8J1LWKkMsLAew==",
-			"requires": {
-				"@babel/types": "^7.0.0"
-			}
-		},
-		"@types/babel__template": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.0.2.tgz",
-			"integrity": "sha512-/K6zCpeW7Imzgab2bLkLEbz0+1JlFSrUMdw7KoIIu+IUdu51GWaBZpd3y1VXGVXzynvGa4DaIaxNZHiON3GXUg==",
-			"requires": {
-				"@babel/parser": "^7.1.0",
-				"@babel/types": "^7.0.0"
-			}
-		},
-		"@types/babel__traverse": {
-			"version": "7.0.11",
-			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.11.tgz",
-			"integrity": "sha512-ddHK5icION5U6q11+tV2f9Mo6CZVuT8GJKld2q9LqHSZbvLbH34Kcu2yFGckZut453+eQU6btIA3RihmnRgI+Q==",
-			"requires": {
-				"@babel/types": "^7.3.0"
-			}
-		},
-		"@types/chai": {
-			"version": "4.2.11",
-			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.11.tgz",
-			"integrity": "sha512-t7uW6eFafjO+qJ3BIV2gGUyZs27egcNRkUdalkud+Qa3+kg//f129iuOFivHDXQ+vnU3fDXuwgv0cqMCbcE8sw=="
-		},
 		"@types/color-name": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-			"integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
+			"integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
+			"dev": true
 		},
 		"@types/events": {
 			"version": "3.0.0",
@@ -2492,20 +2033,6 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
 			"integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
-		},
-		"@types/sinon": {
-			"version": "7.5.2",
-			"resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-7.5.2.tgz",
-			"integrity": "sha512-T+m89VdXj/eidZyejvmoP9jivXgBDdkOSBVQjU9kF349NEx10QdPNGxHeZUaj1IlJ32/ewdyXJjnJxyxJroYwg=="
-		},
-		"@types/sinon-chai": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/@types/sinon-chai/-/sinon-chai-3.2.4.tgz",
-			"integrity": "sha512-xq5KOWNg70PRC7dnR2VOxgYQ6paumW+4pTZP+6uTSdhpYsAUEeeT5bw6rRHHQrZ4KyR+M5ojOR+lje6TGSpUxA==",
-			"requires": {
-				"@types/chai": "*",
-				"@types/sinon": "*"
-			}
 		},
 		"@types/yargs": {
 			"version": "13.0.9",
@@ -2773,14 +2300,6 @@
 			"integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
 			"dev": true
 		},
-		"acorn-class-fields": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/acorn-class-fields/-/acorn-class-fields-0.3.2.tgz",
-			"integrity": "sha512-wyqXoqzXSOF42uxHo40TMuC/KfloI66AZz6S1TeK8D2HjKzI7Boq1mSH2pB5RwKEJWgHqnewGpRFRZwR0qQCyQ==",
-			"requires": {
-				"acorn-private-class-elements": "^0.2.5"
-			}
-		},
 		"acorn-dynamic-import": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz",
@@ -2847,32 +2366,6 @@
 				}
 			}
 		},
-		"acorn-numeric-separator": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/acorn-numeric-separator/-/acorn-numeric-separator-0.3.2.tgz",
-			"integrity": "sha512-ZNN1qnKvjWycDSQBfuD1TCiB81ItjjeGUPLHuqfP8X8HXwAodGTWsAaqSOQ1Nc9t+Wlb3tcEFdBrwUFUIzDiiA=="
-		},
-		"acorn-private-class-elements": {
-			"version": "0.2.5",
-			"resolved": "https://registry.npmjs.org/acorn-private-class-elements/-/acorn-private-class-elements-0.2.5.tgz",
-			"integrity": "sha512-3eApRrJmPjaxWB3XidP8YMeVq9pcswPFE0KsSWVuhceCU68ZS8fkcf0fTXGhCmnNd7n48NWWV27EKMFPeCoJLg=="
-		},
-		"acorn-private-methods": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/acorn-private-methods/-/acorn-private-methods-0.3.1.tgz",
-			"integrity": "sha512-IV5XZInFQaQK5ucjJy/HAk2UYvt+Buax00evzwo8NSuo8zhOBhW5v6VOjAljYUhAzQ/Hosi+Kaz6xJmvPiSM4Q==",
-			"requires": {
-				"acorn-private-class-elements": "^0.2.4"
-			}
-		},
-		"acorn-static-class-features": {
-			"version": "0.2.1",
-			"resolved": "https://registry.npmjs.org/acorn-static-class-features/-/acorn-static-class-features-0.2.1.tgz",
-			"integrity": "sha512-eLIAEBFwu1bcZD+39u5PAcAargtkI5tY1uDRQV6SB3zY4JIO0vqvSdtZ8hz1GGZIVY/d3RDxkM9BLTPTNNVwGw==",
-			"requires": {
-				"acorn-private-class-elements": "^0.2.3"
-			}
-		},
 		"acorn-walk": {
 			"version": "6.2.0",
 			"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-6.2.0.tgz",
@@ -2884,11 +2377,6 @@
 			"resolved": "https://registry.npmjs.org/address/-/address-1.0.3.tgz",
 			"integrity": "sha512-z55ocwKBRLryBs394Sm3ushTtBeg6VAeuku7utSoSnsJKvKcnXFIyC6vh27n3rXyxSgkJBBCAvyOn7gSUcTYjg==",
 			"dev": true
-		},
-		"adm-zip": {
-			"version": "0.4.14",
-			"resolved": "https://registry.npmjs.org/adm-zip/-/adm-zip-0.4.14.tgz",
-			"integrity": "sha512-/9aQCnQHF+0IiCl0qhXoK7qs//SwYE7zX8lsr/DNk1BRAHYxeLZPL4pguwK29gUEqasYQjqPtEpDRSWEkdHn9g=="
 		},
 		"after": {
 			"version": "0.8.2",
@@ -2943,6 +2431,7 @@
 			"version": "6.12.2",
 			"resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.2.tgz",
 			"integrity": "sha512-k+V+hzjm5q/Mr8ef/1Y9goCmlsK4I6Sm74teeyGvFk1XrOsbsKLjEdrvny42CZ+a8sXbk8KWpY/bDwS+FLL2UQ==",
+			"dev": true,
 			"requires": {
 				"fast-deep-equal": "^3.1.1",
 				"fast-json-stable-stringify": "^2.0.0",
@@ -3139,46 +2628,11 @@
 				}
 			}
 		},
-		"analytics-node": {
-			"version": "3.4.0-beta.1",
-			"resolved": "https://registry.npmjs.org/analytics-node/-/analytics-node-3.4.0-beta.1.tgz",
-			"integrity": "sha512-+0F/y4Asc5S2qhWcYss+iCob6TTXQktwbqlIk02gcZaRxpekCbnTbJu/rcaRooVHxqp9WSzUXiWCesJYPJETZQ==",
-			"requires": {
-				"@segment/loosely-validate-event": "^2.0.0",
-				"axios": "^0.18.1",
-				"axios-retry": "^3.0.2",
-				"lodash.isstring": "^4.0.1",
-				"md5": "^2.2.1",
-				"ms": "^2.0.0",
-				"remove-trailing-slash": "^0.1.0",
-				"uuid": "^3.2.1"
-			},
-			"dependencies": {
-				"lodash.isstring": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-					"integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
-				}
-			}
-		},
-		"ansi": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
-			"integrity": "sha1-DELU+xcWDVqa8eSEus4cZpIsGyE="
-		},
 		"ansi-colors": {
 			"version": "3.2.4",
 			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz",
 			"integrity": "sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA==",
 			"dev": true
-		},
-		"ansi-escape-sequences": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-5.1.2.tgz",
-			"integrity": "sha512-JcpoVp1W1bl1Qn4cVuiXEhD6+dyXKSOgCn2zlzE8inYgCJCBy1aPnUhlz6I4DFum8D4ovb9Qi/iAjUcGvG2lqw==",
-			"requires": {
-				"array-back": "^4.0.0"
-			}
 		},
 		"ansi-escapes": {
 			"version": "3.2.0",
@@ -3195,8 +2649,7 @@
 		"ansi-regex": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-			"dev": true
+			"integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
 		},
 		"ansi-styles": {
 			"version": "3.2.1",
@@ -3230,23 +2683,16 @@
 		"aproba": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
-			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
-			"dev": true
+			"integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw=="
 		},
 		"are-we-there-yet": {
 			"version": "1.1.5",
 			"resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
 			"integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
-			"dev": true,
 			"requires": {
 				"delegates": "^1.0.0",
 				"readable-stream": "^2.0.6"
 			}
-		},
-		"arg": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
 		},
 		"argparse": {
 			"version": "1.0.10",
@@ -3290,11 +2736,6 @@
 			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
 			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
 			"dev": true
-		},
-		"array-back": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.1.tgz",
-			"integrity": "sha512-Z/JnaVEXv+A9xabHzN43FiiiWEE7gPCRXMrVmRm00tWbjZRul1iHm7ECzlyNq1p4a4ATXz+G9FJ3GqGOkOV3fg=="
 		},
 		"array-equal": {
 			"version": "1.0.0",
@@ -3487,6 +2928,7 @@
 			"version": "0.2.4",
 			"resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.4.tgz",
 			"integrity": "sha512-jxwzQpLQjSmWXgwaCZE9Nz+glAG01yF1QnWgbhGwHI5A6FRIEY6IVqtHhIepHqI7/kyEyQEagBC5mBEFlIYvdg==",
+			"dev": true,
 			"requires": {
 				"safer-buffer": "~2.1.0"
 			}
@@ -3532,7 +2974,8 @@
 		"assert-plus": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU="
+			"integrity": "sha1-8S4PPF13sLHN2RRpQuTpbB5N1SU=",
+			"dev": true
 		},
 		"assertion-error": {
 			"version": "1.1.0",
@@ -3593,18 +3036,14 @@
 		"asynckit": {
 			"version": "0.4.0",
 			"resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k="
+			"integrity": "sha1-x57Zf380y48robyXkLzDZkdLS3k=",
+			"dev": true
 		},
 		"atob": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
 			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
 			"dev": true
-		},
-		"atomic-sleep": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
-			"integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="
 		},
 		"autoprefixer": {
 			"version": "9.7.6",
@@ -3655,112 +3094,17 @@
 				}
 			}
 		},
-		"aws-sdk": {
-			"version": "2.679.0",
-			"resolved": "https://registry.npmjs.org/aws-sdk/-/aws-sdk-2.679.0.tgz",
-			"integrity": "sha512-bsbu3Mbwqz2DHpVSSgaSoFYsNrW+54vXN74iG++cCE7AAg9vOgCKzGul8yhR4jxxlOmGlfP9kCNrkCpjQ/Uqkg==",
-			"requires": {
-				"buffer": "4.9.1",
-				"events": "1.1.1",
-				"ieee754": "1.1.13",
-				"jmespath": "0.15.0",
-				"querystring": "0.2.0",
-				"sax": "1.2.1",
-				"url": "0.10.3",
-				"uuid": "3.3.2",
-				"xml2js": "0.4.19"
-			},
-			"dependencies": {
-				"buffer": {
-					"version": "4.9.1",
-					"resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
-					"integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
-					"requires": {
-						"base64-js": "^1.0.2",
-						"ieee754": "^1.1.4",
-						"isarray": "^1.0.0"
-					}
-				},
-				"events": {
-					"version": "1.1.1",
-					"resolved": "https://registry.npmjs.org/events/-/events-1.1.1.tgz",
-					"integrity": "sha1-nr23Y1rQmccNzEwqH1AEKI6L2SQ="
-				},
-				"punycode": {
-					"version": "1.3.2",
-					"resolved": "https://registry.npmjs.org/punycode/-/punycode-1.3.2.tgz",
-					"integrity": "sha1-llOgNvt8HuQjQvIyXM7v6jkmxI0="
-				},
-				"sax": {
-					"version": "1.2.1",
-					"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.1.tgz",
-					"integrity": "sha1-e45lYZCyKOgaZq6nSEgNgozS03o="
-				},
-				"url": {
-					"version": "0.10.3",
-					"resolved": "https://registry.npmjs.org/url/-/url-0.10.3.tgz",
-					"integrity": "sha1-Ah5NnHcF8hu/N9A861h2dAJ3TGQ=",
-					"requires": {
-						"punycode": "1.3.2",
-						"querystring": "0.2.0"
-					}
-				},
-				"uuid": {
-					"version": "3.3.2",
-					"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.3.2.tgz",
-					"integrity": "sha512-yXJmeNaw3DnnKAOKJE51sL/ZaYfWJRl1pK9dr19YFCu0ObS231AB1/LbqTKRAQ5kw8A90rA6fr4riOUpTZvQZA=="
-				}
-			}
-		},
 		"aws-sign2": {
 			"version": "0.7.0",
 			"resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg="
+			"integrity": "sha1-tG6JCTSpWR8tL2+G1+ap8bP+dqg=",
+			"dev": true
 		},
 		"aws4": {
 			"version": "1.9.1",
 			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
-			"integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
-		},
-		"axios": {
-			"version": "0.18.1",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.18.1.tgz",
-			"integrity": "sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==",
-			"requires": {
-				"follow-redirects": "1.5.10",
-				"is-buffer": "^2.0.2"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"follow-redirects": {
-					"version": "1.5.10",
-					"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-					"integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-					"requires": {
-						"debug": "=3.1.0"
-					}
-				},
-				"is-buffer": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-					"integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
-				}
-			}
-		},
-		"axios-retry": {
-			"version": "3.1.8",
-			"resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.1.8.tgz",
-			"integrity": "sha512-yPw5Y4Bg6Dgmhm35KaJFtlh23s1TecW0HsUerK4/IS1UKl0gtN2aJqdEKtVomiOS/bDo5w4P3sqgki/M10eF8Q==",
-			"requires": {
-				"is-retry-allowed": "^1.1.0"
-			}
+			"integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==",
+			"dev": true
 		},
 		"babel-code-frame": {
 			"version": "6.26.0",
@@ -5346,6 +4690,7 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
 			"integrity": "sha1-pDAdOJtqQ/m2f/PKEaP2Y342Dp4=",
+			"dev": true,
 			"requires": {
 				"tweetnacl": "^0.14.3"
 			}
@@ -5397,8 +4742,6 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
 			"integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
-			"dev": true,
-			"optional": true,
 			"requires": {
 				"file-uri-to-path": "1.0.0"
 			}
@@ -5407,6 +4750,7 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/bl/-/bl-2.2.0.tgz",
 			"integrity": "sha512-wbgvOpqopSr7uq6fJrLH8EsvYMJf9gzfo2jCsL2eTy75qXPukA4pCgHamOQkZtY5vmfVtjB+P3LNlMHW5CEZXA==",
+			"dev": true,
 			"requires": {
 				"readable-stream": "^2.3.5",
 				"safe-buffer": "^5.1.1"
@@ -5713,7 +5057,8 @@
 		"buffer-from": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+			"dev": true
 		},
 		"buffer-indexof": {
 			"version": "1.1.1",
@@ -5738,11 +5083,6 @@
 			"resolved": "https://registry.npmjs.org/builtin-status-codes/-/builtin-status-codes-3.0.0.tgz",
 			"integrity": "sha1-hZgoeOIbmOHGZCXgPQF0eI9Wnug=",
 			"dev": true
-		},
-		"byline": {
-			"version": "5.0.0",
-			"resolved": "https://registry.npmjs.org/byline/-/byline-5.0.0.tgz",
-			"integrity": "sha1-dBxSFkaOrcRXsDQQEYrXfejB3bE="
 		},
 		"bytes": {
 			"version": "3.1.0",
@@ -5905,7 +5245,8 @@
 		"caseless": {
 			"version": "0.12.0",
 			"resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw="
+			"integrity": "sha1-G2gcIf+EAzyCZUMJBolCDRhxUdw=",
+			"dev": true
 		},
 		"center-align": {
 			"version": "0.1.3",
@@ -5964,11 +5305,6 @@
 			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
 			"integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
 			"dev": true
-		},
-		"charenc": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-			"integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
 		},
 		"check-error": {
 			"version": "1.0.2",
@@ -6037,8 +5373,7 @@
 		"chownr": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
-			"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
-			"dev": true
+			"integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg=="
 		},
 		"chrome-trace-event": {
 			"version": "1.0.2",
@@ -6214,8 +5549,7 @@
 		"code-point-at": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
-			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
-			"dev": true
+			"integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c="
 		},
 		"collection-visit": {
 			"version": "1.0.0",
@@ -6307,6 +5641,7 @@
 			"version": "1.0.8",
 			"resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
 			"integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+			"dev": true,
 			"requires": {
 				"delayed-stream": "~1.0.0"
 			}
@@ -6352,11 +5687,6 @@
 			"resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
 			"integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM=",
 			"dev": true
-		},
-		"component-type": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/component-type/-/component-type-1.2.1.tgz",
-			"integrity": "sha1-ikeQFwAjjk/DIml3EjAibyS0Fak="
 		},
 		"compressible": {
 			"version": "2.0.18",
@@ -6455,8 +5785,7 @@
 		"console-control-strings": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
-			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
-			"dev": true
+			"integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4="
 		},
 		"constants-browserify": {
 			"version": "1.0.0",
@@ -6688,11 +6017,6 @@
 				"shebang-command": "^1.2.0",
 				"which": "^1.2.9"
 			}
-		},
-		"crypt": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-			"integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
 		},
 		"cryptiles": {
 			"version": "2.0.5",
@@ -7043,6 +6367,7 @@
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
 			"integrity": "sha1-hTz6D3y+L+1d4gMmuN1YEDX24vA=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0"
 			}
@@ -7110,7 +6435,6 @@
 			"version": "4.2.1",
 			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
 			"integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
-			"dev": true,
 			"requires": {
 				"mimic-response": "^2.0.0"
 			}
@@ -7182,13 +6506,13 @@
 		"deep-extend": {
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
-			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-			"dev": true
+			"integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA=="
 		},
 		"deep-is": {
 			"version": "0.1.3",
 			"resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.3.tgz",
-			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ="
+			"integrity": "sha1-s2nW+128E+7PUk+RsHD+7cNXzzQ=",
+			"dev": true
 		},
 		"default-gateway": {
 			"version": "4.2.0",
@@ -7355,18 +6679,19 @@
 		"delayed-stream": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
-			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk="
+			"integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
+			"dev": true
 		},
 		"delegates": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
-			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
-			"dev": true
+			"integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o="
 		},
 		"denque": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/denque/-/denque-1.4.1.tgz",
-			"integrity": "sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ=="
+			"integrity": "sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ==",
+			"dev": true
 		},
 		"depd": {
 			"version": "1.1.2",
@@ -7586,8 +6911,7 @@
 		"detect-libc": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
-			"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
-			"dev": true
+			"integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups="
 		},
 		"detect-node": {
 			"version": "2.0.4",
@@ -8066,6 +7390,7 @@
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
 			"integrity": "sha1-OoOpBOVDUyh4dMVkt1SThoSamMk=",
+			"dev": true,
 			"requires": {
 				"jsbn": "~0.1.0",
 				"safer-buffer": "^2.1.0"
@@ -8443,67 +7768,6 @@
 				"create-emotion": "^10.0.27"
 			}
 		},
-		"emphasize": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/emphasize/-/emphasize-3.0.0.tgz",
-			"integrity": "sha512-xhtAWvxdkxsQbcCLGVjlfB7cQ4bWSPYXeaGDwK5Bl7n2y/9R+MVK5UNBTmZ9N8m/YShsiyGgQBgFGcjOWCWXHQ==",
-			"requires": {
-				"chalk": "^3.0.0",
-				"highlight.js": "~9.12.0",
-				"lowlight": "~1.9.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-				},
-				"highlight.js": {
-					"version": "9.12.0",
-					"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.12.0.tgz",
-					"integrity": "sha1-5tnb5Xy+/mB1HwKvM2GVhwyQwB4="
-				},
-				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
-			}
-		},
 		"encodeurl": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -8523,7 +7787,6 @@
 			"version": "1.4.4",
 			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
 			"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-			"dev": true,
 			"requires": {
 				"once": "^1.4.0"
 			}
@@ -8953,6 +8216,7 @@
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/escodegen/-/escodegen-1.14.1.tgz",
 			"integrity": "sha512-Bmt7NcRySdIfNPfU2ZoXDrrXsG9ZjvDxcAlMfDUgRBjLOWTuIACXPBFJH7Z+cLb40JeQco5toikyc9t9P8E9SQ==",
+			"dev": true,
 			"requires": {
 				"esprima": "^4.0.1",
 				"estraverse": "^4.2.0",
@@ -8964,12 +8228,14 @@
 				"esprima": {
 					"version": "4.0.1",
 					"resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
-					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="
+					"integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
+					"dev": true
 				},
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
 					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true,
 					"optional": true
 				}
 			}
@@ -9312,12 +8578,14 @@
 		"estraverse": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/estraverse/-/estraverse-4.3.0.tgz",
-			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw=="
+			"integrity": "sha512-39nnKffWz8xN1BU/2c79n9nB9HDzo0niYUqx6xyqUnyoAnQyyWpOTdZEeiCch8BBu515t4wp9ZmgVfVhn9EBpw==",
+			"dev": true
 		},
 		"esutils": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
-			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="
+			"integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
+			"dev": true
 		},
 		"etag": {
 			"version": "1.8.1",
@@ -9449,8 +8717,7 @@
 		"expand-template": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
-			"integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-			"dev": true
+			"integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg=="
 		},
 		"expand-tilde": {
 			"version": "2.0.2",
@@ -9536,7 +8803,8 @@
 		"extend": {
 			"version": "3.0.2",
 			"resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
-			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
+			"integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
+			"dev": true
 		},
 		"extend-shallow": {
 			"version": "3.0.2",
@@ -9661,7 +8929,8 @@
 		"extsprintf": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU="
+			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
+			"dev": true
 		},
 		"facepaint": {
 			"version": "1.2.1",
@@ -9671,12 +8940,14 @@
 		"fast-deep-equal": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
-			"integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA=="
+			"integrity": "sha512-8UEa58QDLauDNfpbrX55Q9jrGHThw2ZMdOky5Gl1CDtVeJDPVrG4Jxx1N8jw2gkWaff5UUuX1KJd+9zGe2B+ZA==",
+			"dev": true
 		},
 		"fast-glob": {
 			"version": "3.2.2",
 			"resolved": "https://registry.npmjs.org/fast-glob/-/fast-glob-3.2.2.tgz",
 			"integrity": "sha512-UDV82o4uQyljznxwMxyVRJgZZt3O5wENYojjzbaGEGZgeOxkLFf+V4cnUD+krzb2F72E18RhamkMZ7AdeggF7A==",
+			"dev": true,
 			"requires": {
 				"@nodelib/fs.stat": "^2.0.2",
 				"@nodelib/fs.walk": "^1.2.3",
@@ -9690,6 +8961,7 @@
 					"version": "3.0.2",
 					"resolved": "https://registry.npmjs.org/braces/-/braces-3.0.2.tgz",
 					"integrity": "sha512-b8um+L1RzM3WDSzvhm6gIz1yfTbBt6YTlcEKAvsmqCZZFw46z626lVj9j1yEPW33H5H+lBQpZMP1k8l+78Ha0A==",
+					"dev": true,
 					"requires": {
 						"fill-range": "^7.0.1"
 					}
@@ -9698,6 +8970,7 @@
 					"version": "7.0.1",
 					"resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.0.1.tgz",
 					"integrity": "sha512-qOo9F+dMUmC2Lcb4BbVvnKJxTPjCm+RRpe4gDuGrzkL7mEVl/djYSu2OdQ2Pa302N4oqkSg9ir6jaLWJ2USVpQ==",
+					"dev": true,
 					"requires": {
 						"to-regex-range": "^5.0.1"
 					}
@@ -9706,6 +8979,7 @@
 					"version": "5.1.1",
 					"resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-5.1.1.tgz",
 					"integrity": "sha512-FnI+VGOpnlGHWZxthPGR+QhR78fuiK0sNLkHQv+bL9fQi57lNNdquIbna/WrfROrolq8GK5Ek6BiMwqL/voRYQ==",
+					"dev": true,
 					"requires": {
 						"is-glob": "^4.0.1"
 					}
@@ -9713,12 +8987,14 @@
 				"is-number": {
 					"version": "7.0.0",
 					"resolved": "https://registry.npmjs.org/is-number/-/is-number-7.0.0.tgz",
-					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng=="
+					"integrity": "sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==",
+					"dev": true
 				},
 				"micromatch": {
 					"version": "4.0.2",
 					"resolved": "https://registry.npmjs.org/micromatch/-/micromatch-4.0.2.tgz",
 					"integrity": "sha512-y7FpHSbMUMoyPbYUSzO6PaZ6FyRnQOpHuKwbo1G+Knck95XVU4QAiKdGEnj5wwoS7PlOgthX/09u5iFJ+aYf5Q==",
+					"dev": true,
 					"requires": {
 						"braces": "^3.0.1",
 						"picomatch": "^2.0.5"
@@ -9728,6 +9004,7 @@
 					"version": "5.0.1",
 					"resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-5.0.1.tgz",
 					"integrity": "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==",
+					"dev": true,
 					"requires": {
 						"is-number": "^7.0.0"
 					}
@@ -9737,28 +9014,20 @@
 		"fast-json-stable-stringify": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/fast-json-stable-stringify/-/fast-json-stable-stringify-2.1.0.tgz",
-			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="
+			"integrity": "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw==",
+			"dev": true
 		},
 		"fast-levenshtein": {
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz",
-			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc="
+			"integrity": "sha1-PYpcZog6FqMMqGQ+hR8Zuqd5eRc=",
+			"dev": true
 		},
 		"fast-memoize": {
 			"version": "2.5.2",
 			"resolved": "https://registry.npmjs.org/fast-memoize/-/fast-memoize-2.5.2.tgz",
 			"integrity": "sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw==",
 			"dev": true
-		},
-		"fast-redact": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-2.0.0.tgz",
-			"integrity": "sha512-zxpkULI9W9MNTK2sJ3BpPQrTEXFNESd2X6O1tXMFpK/XM0G5c5Rll2EVYZH2TqI3xRGK/VaJ+eEOt7pnENJpeA=="
-		},
-		"fast-safe-stringify": {
-			"version": "2.0.7",
-			"resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
-			"integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
 		},
 		"fastparse": {
 			"version": "1.1.2",
@@ -9770,16 +9039,9 @@
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/fastq/-/fastq-1.7.0.tgz",
 			"integrity": "sha512-YOadQRnHd5q6PogvAR/x62BGituF2ufiEA6s8aavQANw5YKHERI4AREboX6KotzP8oX2klxYF2wcV/7bn1clfQ==",
+			"dev": true,
 			"requires": {
 				"reusify": "^1.0.4"
-			}
-		},
-		"fault": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/fault/-/fault-1.0.4.tgz",
-			"integrity": "sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==",
-			"requires": {
-				"format": "^0.2.0"
 			}
 		},
 		"faye-websocket": {
@@ -9873,9 +9135,7 @@
 		"file-uri-to-path": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
-			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
-			"dev": true,
-			"optional": true
+			"integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw=="
 		},
 		"filesize": {
 			"version": "3.5.11",
@@ -10009,11 +9269,6 @@
 				}
 			}
 		},
-		"flatstr": {
-			"version": "1.0.12",
-			"resolved": "https://registry.npmjs.org/flatstr/-/flatstr-1.0.12.tgz",
-			"integrity": "sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw=="
-		},
 		"flatted": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
@@ -10060,22 +9315,19 @@
 		"forever-agent": {
 			"version": "0.6.1",
 			"resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE="
+			"integrity": "sha1-+8cfDEGt6zf5bFd60e1C2P2sypE=",
+			"dev": true
 		},
 		"form-data": {
 			"version": "2.3.3",
 			"resolved": "https://registry.npmjs.org/form-data/-/form-data-2.3.3.tgz",
 			"integrity": "sha512-1lLKB2Mu3aGP1Q/2eCOx0fNbRMe7XdwktwOruhfqqd0rIJWwN4Dh+E3hrPSlDCXnSR7UtZ1N38rVXm+6+MEhJQ==",
+			"dev": true,
 			"requires": {
 				"asynckit": "^0.4.0",
 				"combined-stream": "^1.0.6",
 				"mime-types": "^2.1.12"
 			}
-		},
-		"format": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
-			"integrity": "sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs="
 		},
 		"forwarded": {
 			"version": "0.1.2",
@@ -10108,6 +9360,7 @@
 			"version": "2.3.0",
 			"resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
 			"integrity": "sha1-i/tVAr3kpNNs/e6gB/zKIdfjgq8=",
+			"dev": true,
 			"requires": {
 				"inherits": "^2.0.1",
 				"readable-stream": "^2.0.0"
@@ -10116,8 +9369,7 @@
 		"fs-constants": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
-			"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
-			"dev": true
+			"integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow=="
 		},
 		"fs-extra": {
 			"version": "4.0.3",
@@ -10753,7 +10005,6 @@
 			"version": "2.7.4",
 			"resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
 			"integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
-			"dev": true,
 			"requires": {
 				"aproba": "^1.0.3",
 				"console-control-strings": "^1.0.0",
@@ -10768,7 +10019,8 @@
 		"gensync": {
 			"version": "1.0.0-beta.1",
 			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
-			"integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg=="
+			"integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==",
+			"dev": true
 		},
 		"get-amd-module-type": {
 			"version": "3.0.0",
@@ -10837,6 +10089,7 @@
 			"version": "0.1.7",
 			"resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
 			"integrity": "sha1-Xv+OPmhNVprkyysSgmBOi6YhSfo=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0"
 			}
@@ -10844,8 +10097,7 @@
 		"github-from-package": {
 			"version": "0.0.0",
 			"resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
-			"integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=",
-			"dev": true
+			"integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4="
 		},
 		"glamor": {
 			"version": "2.20.40",
@@ -10948,7 +10200,8 @@
 		"globals": {
 			"version": "11.12.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
+			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+			"dev": true
 		},
 		"globalthis": {
 			"version": "1.0.1",
@@ -11005,7 +10258,8 @@
 		"graceful-fs": {
 			"version": "4.2.3",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.3.tgz",
-			"integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ=="
+			"integrity": "sha512-a30VEBm4PEdx1dRB7MFK7BejejvCvBronbLjht+sHuGYj8PHs7M/5Z+rt5lw551vZ7yfTCj4Vuyy3mSJytDWRQ==",
+			"dev": true
 		},
 		"graceful-readlink": {
 			"version": "1.0.1",
@@ -11092,54 +10346,17 @@
 			"integrity": "sha512-9Qn4yBxelxoh2Ow62nP+Ka/kMnOXRi8BXnRaUwezLNhqelnN49xKz4F/dPP8OYLxLxq6JDtZb2i9XznUQbNPTg==",
 			"dev": true
 		},
-		"handlebars": {
-			"version": "4.7.6",
-			"resolved": "https://registry.npmjs.org/handlebars/-/handlebars-4.7.6.tgz",
-			"integrity": "sha512-1f2BACcBfiwAfStCKZNrUCgqNZkGsAT7UM3kkYtXuLo0KnaVfjKOyf7PRzB6++aK9STyT1Pd2ZCPe3EGOXleXA==",
-			"requires": {
-				"minimist": "^1.2.5",
-				"neo-async": "^2.6.0",
-				"source-map": "^0.6.1",
-				"uglify-js": "^3.1.4",
-				"wordwrap": "^1.0.0"
-			},
-			"dependencies": {
-				"commander": {
-					"version": "2.20.3",
-					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-					"optional": true
-				},
-				"source-map": {
-					"version": "0.6.1",
-					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
-				},
-				"uglify-js": {
-					"version": "3.9.3",
-					"resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.9.3.tgz",
-					"integrity": "sha512-r5ImcL6QyzQGVimQoov3aL2ZScywrOgBXGndbWrdehKoSvGe/RmiE5Jpw/v+GvxODt6l2tpBXwA7n+qZVlHBMA==",
-					"optional": true,
-					"requires": {
-						"commander": "~2.20.3"
-					}
-				},
-				"wordwrap": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/wordwrap/-/wordwrap-1.0.0.tgz",
-					"integrity": "sha1-J1hIEIkUVqQXHI0CJkQa3pDLyus="
-				}
-			}
-		},
 		"har-schema": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI="
+			"integrity": "sha1-qUwiJOvKwEeCoNkDVSHyRzW37JI=",
+			"dev": true
 		},
 		"har-validator": {
 			"version": "5.1.3",
 			"resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.3.tgz",
 			"integrity": "sha512-sNvOCzEQNr/qrvJgc3UG/kD4QtlHycrzwS+6mfTrrSq97BvaYcPZZI1ZSqGSPR73Cxn4LKTD4PttRwfU7jWq5g==",
+			"dev": true,
 			"requires": {
 				"ajv": "^6.5.5",
 				"har-schema": "^2.0.0"
@@ -11200,8 +10417,7 @@
 		"has-unicode": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
-			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
-			"dev": true
+			"integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk="
 		},
 		"has-value": {
 			"version": "1.0.0",
@@ -11273,16 +10489,6 @@
 			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
 			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
 			"dev": true
-		},
-		"highlight.js": {
-			"version": "9.18.1",
-			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.18.1.tgz",
-			"integrity": "sha512-OrVKYz70LHsnCgmbXctv/bfuvntIKDz177h0Co37DQ5jamGZLVmoCVMtjMtNZY3X9DrCcKfklHPNeA0uPZhSJg=="
-		},
-		"highlightjs-graphql": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/highlightjs-graphql/-/highlightjs-graphql-1.0.1.tgz",
-			"integrity": "sha512-g5kt/orsUJTjIt5pgs/uvi78kXndpCtYwzE7H3D0d07r3ETs9oHSZHD0EGaRPndiQ/4EYXt12rnsDkljn3ilAA=="
 		},
 		"hmac-drbg": {
 			"version": "1.0.1",
@@ -11696,6 +10902,7 @@
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
 			"integrity": "sha1-muzZJRFHcvPZW2WmCruPfBj7rOE=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0",
 				"jsprim": "^1.2.2",
@@ -11869,8 +11076,7 @@
 		"ini": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/ini/-/ini-1.3.5.tgz",
-			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw==",
-			"dev": true
+			"integrity": "sha512-RZY5huIKCMRWDUqZlEi72f/lmXKMvuszcMBduliQ3nnWbx9X/ZBQO7DijMEYS9EhHBb2qacRUMtC7svLwe0lcw=="
 		},
 		"inline-source-map": {
 			"version": "0.6.2",
@@ -11973,22 +11179,6 @@
 			"integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
 			"dev": true
 		},
-		"into-stream": {
-			"version": "5.1.1",
-			"resolved": "https://registry.npmjs.org/into-stream/-/into-stream-5.1.1.tgz",
-			"integrity": "sha512-krrAJ7McQxGGmvaYbB7Q1mcA+cRwg9Ij2RfWIeVesNBgVDZmzY/Fa4IpZUT3bmdRzMzdf/mzltCG2Dq99IZGBA==",
-			"requires": {
-				"from2": "^2.3.0",
-				"p-is-promise": "^3.0.0"
-			},
-			"dependencies": {
-				"p-is-promise": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/p-is-promise/-/p-is-promise-3.0.0.tgz",
-					"integrity": "sha512-Wo8VsW4IRQSKVXsJCn7TomUaVtyfjVDn3nUP7kE967BQk0CwFpdbZs0X0uk5sW9mkBa9eNM7hCMaG93WUAwxYQ=="
-				}
-			}
-		},
 		"invariant": {
 			"version": "2.2.4",
 			"resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
@@ -12077,7 +11267,8 @@
 		"is-buffer": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+			"dev": true
 		},
 		"is-callable": {
 			"version": "1.1.5",
@@ -12161,7 +11352,8 @@
 		"is-extglob": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
-			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI="
+			"integrity": "sha1-qIwCU1eR8C7TfHahueqXc8gz+MI=",
+			"dev": true
 		},
 		"is-finite": {
 			"version": "1.1.0",
@@ -12173,7 +11365,6 @@
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
 			"integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-			"dev": true,
 			"requires": {
 				"number-is-nan": "^1.0.0"
 			}
@@ -12188,6 +11379,7 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/is-glob/-/is-glob-4.0.1.tgz",
 			"integrity": "sha512-5G0tKtBTFImOqDnLB2hG6Bp2qcKEFduo4tZu9MT/H6NQv/ghhy30o55ufafxJ/LdH79LLs2Kfrn85TLKyA7BUg==",
+			"dev": true,
 			"requires": {
 				"is-extglob": "^2.1.1"
 			}
@@ -12275,25 +11467,6 @@
 			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
 			"dev": true
 		},
-		"is-recoverable-error": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-recoverable-error/-/is-recoverable-error-1.0.1.tgz",
-			"integrity": "sha512-1v/3hIRd0hHzkmq9TU+otd8SlUJjr60KyX6RfgwJ6NVbeQafc3POajWZ/BcusPxhdX0ScN3xE9tTnn6xGpC3LA==",
-			"requires": {
-				"acorn": "^7.1.1",
-				"acorn-class-fields": "^0.3.2",
-				"acorn-numeric-separator": "^0.3.1",
-				"acorn-private-methods": "^0.3.1",
-				"acorn-static-class-features": "^0.2.1"
-			},
-			"dependencies": {
-				"acorn": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.2.0.tgz",
-					"integrity": "sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ=="
-				}
-			}
-		},
 		"is-regex": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
@@ -12311,11 +11484,6 @@
 			"requires": {
 				"is-unc-path": "^1.0.0"
 			}
-		},
-		"is-retry-allowed": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
-			"integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg=="
 		},
 		"is-root": {
 			"version": "1.0.0",
@@ -12368,7 +11536,8 @@
 		"is-typedarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo="
+			"integrity": "sha1-5HnICFjfDBsR3dppQPlgEfzaSpo=",
+			"dev": true
 		},
 		"is-unc-path": {
 			"version": "1.0.0",
@@ -12448,7 +11617,8 @@
 		"isstream": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo="
+			"integrity": "sha1-R+Y/evVa+m+S4VAOaQ64uFKcCZo=",
+			"dev": true
 		},
 		"istanbul-instrumenter-loader": {
 			"version": "3.0.1",
@@ -12534,16 +11704,6 @@
 				"iterate-iterator": "^1.0.1"
 			}
 		},
-		"jmespath": {
-			"version": "0.15.0",
-			"resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
-			"integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
-		},
-		"join-component": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/join-component/-/join-component-1.1.0.tgz",
-			"integrity": "sha1-uEF7dQZho5K+4sJTfGiyqdSXfNU="
-		},
 		"js-base64": {
 			"version": "2.5.2",
 			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.2.tgz",
@@ -12574,7 +11734,8 @@
 		"jsbn": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM="
+			"integrity": "sha1-peZUwuWi3rXyAdls77yoDA7y9RM=",
+			"dev": true
 		},
 		"jsdom": {
 			"version": "11.12.0",
@@ -12627,7 +11788,8 @@
 		"jsesc": {
 			"version": "2.5.2",
 			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
+			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+			"dev": true
 		},
 		"json-loader": {
 			"version": "0.5.7",
@@ -12643,12 +11805,14 @@
 		"json-schema": {
 			"version": "0.2.3",
 			"resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.2.3.tgz",
-			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM="
+			"integrity": "sha1-tIDIkuWaLwWVTOcnvT8qTogvnhM=",
+			"dev": true
 		},
 		"json-schema-traverse": {
 			"version": "0.4.1",
 			"resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-0.4.1.tgz",
-			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="
+			"integrity": "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==",
+			"dev": true
 		},
 		"json-stable-stringify": {
 			"version": "1.0.1",
@@ -12669,7 +11833,8 @@
 		"json-stringify-safe": {
 			"version": "5.0.1",
 			"resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus="
+			"integrity": "sha1-Epai1Y/UXxmg9s4B1lcB4sc1tus=",
+			"dev": true
 		},
 		"json3": {
 			"version": "3.3.3",
@@ -12681,6 +11846,7 @@
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
 			"integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+			"dev": true,
 			"requires": {
 				"minimist": "^1.2.5"
 			}
@@ -12689,6 +11855,7 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
 			"integrity": "sha1-h3Gq4HmbZAdrdmQPygWPnBDjPss=",
+			"dev": true,
 			"requires": {
 				"graceful-fs": "^4.1.6"
 			}
@@ -12703,6 +11870,7 @@
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.1.tgz",
 			"integrity": "sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "1.0.0",
 				"extsprintf": "1.3.0",
@@ -13311,6 +12479,7 @@
 			"version": "0.3.0",
 			"resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
 			"integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
+			"dev": true,
 			"requires": {
 				"prelude-ls": "~1.1.2",
 				"type-check": "~0.3.2"
@@ -13919,11 +13088,6 @@
 				"lodash.isfunction": "^3.0.0"
 			}
 		},
-		"lodash.set": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
-			"integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
-		},
 		"lodash.some": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
@@ -14022,7 +13186,8 @@
 		"long": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-			"integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+			"integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+			"dev": true
 		},
 		"longest": {
 			"version": "1.0.1",
@@ -14055,22 +13220,6 @@
 			"integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
 			"dev": true
 		},
-		"lowlight": {
-			"version": "1.9.2",
-			"resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.9.2.tgz",
-			"integrity": "sha512-Ek18ElVCf/wF/jEm1b92gTnigh94CtBNWiZ2ad+vTgW7cTmQxUY3I98BjHK68gZAJEWmybGBZgx9qv3QxLQB/Q==",
-			"requires": {
-				"fault": "^1.0.2",
-				"highlight.js": "~9.12.0"
-			},
-			"dependencies": {
-				"highlight.js": {
-					"version": "9.12.0",
-					"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.12.0.tgz",
-					"integrity": "sha1-5tnb5Xy+/mB1HwKvM2GVhwyQwB4="
-				}
-			}
-		},
 		"lru-cache": {
 			"version": "4.1.5",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
@@ -14094,7 +13243,8 @@
 		"make-error": {
 			"version": "1.3.6",
 			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
+			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+			"dev": true
 		},
 		"map-age-cleaner": {
 			"version": "0.1.3",
@@ -14164,16 +13314,6 @@
 			"integrity": "sha512-L0j0tFVZBQQLeEjmWOvDLoRciIY8gQGWahvkztXUal8jH8R5Rlqo9GCvgqvXcy9LQhEWdQCVvzqAbxgYNt4blQ==",
 			"dev": true
 		},
-		"md5": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
-			"integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
-			"requires": {
-				"charenc": "~0.0.1",
-				"crypt": "~0.0.1",
-				"is-buffer": "~1.1.1"
-			}
-		},
 		"md5.js": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -14220,6 +13360,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
 			"integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+			"dev": true,
 			"optional": true
 		},
 		"meow": {
@@ -14339,7 +13480,8 @@
 		"merge2": {
 			"version": "1.3.0",
 			"resolved": "https://registry.npmjs.org/merge2/-/merge2-1.3.0.tgz",
-			"integrity": "sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw=="
+			"integrity": "sha512-2j4DAdlBOkiSZIsaXk4mTE3sRS02yBHAtfy127xRV3bQUFqXkjHCHLW6Scv7DwNRbIWNHH8zpnz9zMaKXIdvYw==",
+			"dev": true
 		},
 		"methods": {
 			"version": "1.1.2",
@@ -14387,12 +13529,14 @@
 		"mime-db": {
 			"version": "1.43.0",
 			"resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.43.0.tgz",
-			"integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ=="
+			"integrity": "sha512-+5dsGEEovYbT8UY9yD7eE4XTc4UwJ1jBYlgaQQF38ENsKR3wj/8q8RFZrF9WIZpB2V1ArTVFUva8sAul1NzRzQ==",
+			"dev": true
 		},
 		"mime-types": {
 			"version": "2.1.26",
 			"resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.26.tgz",
 			"integrity": "sha512-01paPWYgLrkqAyrlDorC1uDwl2p3qZT7yl806vW7DvDoxwXi46jsjFbg+WdwotBIk6/MbEhO/dh5aZ5sNj/dWQ==",
+			"dev": true,
 			"requires": {
 				"mime-db": "1.43.0"
 			}
@@ -14406,8 +13550,7 @@
 		"mimic-response": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
-			"integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
-			"dev": true
+			"integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA=="
 		},
 		"min-document": {
 			"version": "2.19.0",
@@ -14575,7 +13718,6 @@
 			"version": "0.5.5",
 			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
 			"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-			"dev": true,
 			"requires": {
 				"minimist": "^1.2.5"
 			}
@@ -14583,8 +13725,7 @@
 		"mkdirp-classic": {
 			"version": "0.5.2",
 			"resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.2.tgz",
-			"integrity": "sha512-ejdnDQcR75gwknmMw/tx02AuRs8jCtqFoFqDZMjiNxsu85sRIJVXDKHuLYvUUPRBUtV2FpSZa9bL1BUa3BdR2g==",
-			"dev": true
+			"integrity": "sha512-ejdnDQcR75gwknmMw/tx02AuRs8jCtqFoFqDZMjiNxsu85sRIJVXDKHuLYvUUPRBUtV2FpSZa9bL1BUa3BdR2g=="
 		},
 		"mkpath": {
 			"version": "0.1.0",
@@ -15086,6 +14227,7 @@
 			"version": "3.5.6",
 			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.5.6.tgz",
 			"integrity": "sha512-sh3q3GLDLT4QmoDLamxtAECwC3RGjq+oNuK1ENV8+tnipIavss6sMYt77hpygqlMOCt0Sla5cl7H4SKCVBCGEg==",
+			"dev": true,
 			"requires": {
 				"bl": "^2.2.0",
 				"bson": "^1.1.4",
@@ -15095,25 +14237,16 @@
 				"saslprep": "^1.0.0"
 			}
 		},
-		"mongodb-ace-autocompleter": {
-			"version": "0.4.8",
-			"resolved": "https://registry.npmjs.org/mongodb-ace-autocompleter/-/mongodb-ace-autocompleter-0.4.8.tgz",
-			"integrity": "sha512-OMDiHtrMt5z7RxQKZKl4kLJqUDbe0xTUSBQT0r+DNHKzsQoyk5RlUK6jsMWmFYn1ADFGGAejVJWbcnlG4WGH8w==",
+		"mongodb-client-encryption": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-1.0.1.tgz",
+			"integrity": "sha512-nHbezuBY1NQeksltSYGuqEES/i8U4zpVJ1D+YrQLTyzXfQtqiQX1fRYn5dtlCTuq+gBFKwXIRCH5InduIfIgkw==",
 			"requires": {
-				"semver": "^7.1.1"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "7.3.2",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
-				}
+				"bindings": "^1.5.0",
+				"bson": "^1.0.5",
+				"nan": "^2.14.0",
+				"prebuild-install": "^5.3.0"
 			}
-		},
-		"mongodb-build-info": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/mongodb-build-info/-/mongodb-build-info-1.1.0.tgz",
-			"integrity": "sha512-ZlbQlpXv8DCvYK2I6UmyRO4z9zb4fyoph+RhEN/MSSsigaqcfl6dePkbgavemquvuKVEq0BbIiVkHw1DKwChxA=="
 		},
 		"mongodb-collection-sample": {
 			"version": "4.5.1",
@@ -15826,14 +14959,6 @@
 			"integrity": "sha512-sch/9jd74VjRCmB5U+Fj4WJnkmAtDQgxqJkBInO7zEknXE+lnDEuNBT5/Wp59HMrWUabssGGq08r6Y6F7pkvVA==",
 			"dev": true
 		},
-		"mongodb-redact": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/mongodb-redact/-/mongodb-redact-0.2.0.tgz",
-			"integrity": "sha512-kGoR02HsTzNYHFXLklvbEg7mSJZu5+L1JdaYUuSlmVUAXxzhxUBvoFoYulfqqvokE+ilAXGYywdMJStB0lPhCw==",
-			"requires": {
-				"lodash": "^4.17.15"
-			}
-		},
 		"mongodb-reflux-store": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/mongodb-reflux-store/-/mongodb-reflux-store-0.0.1.tgz",
@@ -15918,7 +15043,8 @@
 		"ms": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+			"dev": true
 		},
 		"multicast-dns": {
 			"version": "6.2.3",
@@ -15945,46 +15071,16 @@
 				"object-assign": "^4.1.0"
 			}
 		},
-		"multistream": {
-			"version": "2.1.1",
-			"resolved": "https://registry.npmjs.org/multistream/-/multistream-2.1.1.tgz",
-			"integrity": "sha512-xasv76hl6nr1dEy3lPvy7Ej7K/Lx3O/FCvwge8PeVJpciPPoNCbaANcNiBug3IpdvTveZUcAV0DJzdnUDMesNQ==",
-			"requires": {
-				"inherits": "^2.0.1",
-				"readable-stream": "^2.0.5"
-			}
-		},
-		"mustache": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/mustache/-/mustache-4.0.1.tgz",
-			"integrity": "sha512-yL5VE97+OXn4+Er3THSmTdCFCtx5hHWzrolvH+JObZnUYwuaG7XV+Ch4fR2cIrcYI0tFHxS7iyFYl14bW8y2sA=="
-		},
 		"mute-stream": {
 			"version": "0.0.7",
 			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
+			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+			"dev": true
 		},
 		"nan": {
 			"version": "2.14.1",
 			"resolved": "https://registry.npmjs.org/nan/-/nan-2.14.1.tgz",
-			"integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
-			"dev": true,
-			"optional": true
-		},
-		"nanoassert": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/nanoassert/-/nanoassert-1.1.0.tgz",
-			"integrity": "sha1-TzFS4JVA/eKMdvRLGbvNHVpCR40="
-		},
-		"nanobus": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/nanobus/-/nanobus-4.4.0.tgz",
-			"integrity": "sha512-Hv9USGyH8EsPy0o8pPWE7x3YRIfuZDgMBirzjU6XLebhiSK2g53JlfqgolD0c39ne6wXAfaBNcIAvYe22Bav+Q==",
-			"requires": {
-				"nanoassert": "^1.1.0",
-				"nanotiming": "^7.2.0",
-				"remove-array-items": "^1.0.0"
-			}
+			"integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw=="
 		},
 		"nanomatch": {
 			"version": "1.2.13",
@@ -16005,28 +15101,10 @@
 				"to-regex": "^3.0.1"
 			}
 		},
-		"nanoscheduler": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/nanoscheduler/-/nanoscheduler-1.0.3.tgz",
-			"integrity": "sha512-jBbrF3qdU9321r8n9X7yu18DjP31Do2ItJm3mWrt90wJTrnDO+HXpoV7ftaUglAtjgj9s+OaCxGufbvx6pvbEQ==",
-			"requires": {
-				"nanoassert": "^1.1.0"
-			}
-		},
-		"nanotiming": {
-			"version": "7.3.1",
-			"resolved": "https://registry.npmjs.org/nanotiming/-/nanotiming-7.3.1.tgz",
-			"integrity": "sha512-l3lC7v/PfOuRWQa8vV29Jo6TG10wHtnthLElFXs4Te4Aas57Fo4n1Q8LH9n+NDh9riOzTVvb2QNBhTS4JUKNjw==",
-			"requires": {
-				"nanoassert": "^1.1.0",
-				"nanoscheduler": "^1.0.2"
-			}
-		},
 		"napi-build-utils": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
-			"integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==",
-			"dev": true
+			"integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg=="
 		},
 		"natural-compare": {
 			"version": "1.4.0",
@@ -16064,7 +15142,8 @@
 		"neo-async": {
 			"version": "2.6.1",
 			"resolved": "https://registry.npmjs.org/neo-async/-/neo-async-2.6.1.tgz",
-			"integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw=="
+			"integrity": "sha512-iyam8fBuCUpWeKPGpaNMetEocMt364qkCsfL9JuhjXX6dRnguRVOfk2GZaDpPjcOKiiXCPINZC1GczQ7iTq3Zw==",
+			"dev": true
 		},
 		"next-tick": {
 			"version": "1.0.0",
@@ -16130,7 +15209,6 @@
 			"version": "2.16.0",
 			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.16.0.tgz",
 			"integrity": "sha512-+sa0XNlWDA6T+bDLmkCUYn6W5k5W6BPRL6mqzSCs6H/xUgtl4D5x2fORKDzopKiU6wsyn/+wXlRXwXeSp+mtoA==",
-			"dev": true,
 			"requires": {
 				"semver": "^5.4.1"
 			}
@@ -16288,8 +15366,7 @@
 		"noop-logger": {
 			"version": "0.1.1",
 			"resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
-			"integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI=",
-			"dev": true
+			"integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI="
 		},
 		"nopt": {
 			"version": "3.0.6",
@@ -16355,7 +15432,6 @@
 			"version": "4.1.2",
 			"resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
 			"integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
-			"dev": true,
 			"requires": {
 				"are-we-there-yet": "~1.1.2",
 				"console-control-strings": "~1.1.0",
@@ -16407,8 +15483,7 @@
 		"number-is-nan": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
-			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
-			"dev": true
+			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0="
 		},
 		"nwsapi": {
 			"version": "2.2.0",
@@ -17482,7 +16557,8 @@
 		"oauth-sign": {
 			"version": "0.9.0",
 			"resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
+			"integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+			"dev": true
 		},
 		"object-assign": {
 			"version": "4.1.1",
@@ -17649,7 +16725,6 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-			"dev": true,
 			"requires": {
 				"wrappy": "1"
 			}
@@ -17700,6 +16775,7 @@
 			"version": "0.8.3",
 			"resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.3.tgz",
 			"integrity": "sha512-+IW9pACdk3XWmmTXG8m3upGUJst5XRGzxMRjXzAuJ1XnIFNvfhjjIuYkDvysnPQ7qzqVzLt78BCruntqRhWQbA==",
+			"dev": true,
 			"requires": {
 				"deep-is": "~0.1.3",
 				"fast-levenshtein": "~2.0.6",
@@ -17781,7 +16857,8 @@
 		"os-tmpdir": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ="
+			"integrity": "sha1-u+Z0BseaqFxc/sdm/lc0VV36EnQ=",
+			"dev": true
 		},
 		"osenv": {
 			"version": "0.1.5",
@@ -18073,12 +17150,14 @@
 		"performance-now": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
+			"integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns=",
+			"dev": true
 		},
 		"picomatch": {
 			"version": "2.2.2",
 			"resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.2.2.tgz",
-			"integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg=="
+			"integrity": "sha512-q0M/9eZHzmr0AulXyPwNfZjtwZ/RBZlbN3K3CErVrk50T2ASYI7Bye0EvekFY3IP1Nt2DHu0re+V2ZHIpMkuWg==",
+			"dev": true
 		},
 		"pify": {
 			"version": "4.0.1",
@@ -18101,24 +17180,6 @@
 				"pinkie": "^2.0.0"
 			}
 		},
-		"pino": {
-			"version": "5.17.0",
-			"resolved": "https://registry.npmjs.org/pino/-/pino-5.17.0.tgz",
-			"integrity": "sha512-LqrqmRcJz8etUjyV0ddqB6OTUutCgQULPFg2b4dtijRHUsucaAdBgSUW58vY6RFSX+NT8963F+q0tM6lNwGShA==",
-			"requires": {
-				"fast-redact": "^2.0.0",
-				"fast-safe-stringify": "^2.0.7",
-				"flatstr": "^1.0.12",
-				"pino-std-serializers": "^2.4.2",
-				"quick-format-unescaped": "^3.0.3",
-				"sonic-boom": "^0.7.5"
-			}
-		},
-		"pino-std-serializers": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-2.4.2.tgz",
-			"integrity": "sha512-WaL504dO8eGs+vrK+j4BuQQq6GLKeCCcHaMB2ItygzVURcL1CycwNEUHTD/lHFHs/NL5qAz2UKrjYWXKSf4aMQ=="
-		},
 		"pirates": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/pirates/-/pirates-4.0.1.tgz",
@@ -18126,123 +17187,6 @@
 			"dev": true,
 			"requires": {
 				"node-modules-regexp": "^1.0.0"
-			}
-		},
-		"pkg": {
-			"version": "4.4.8",
-			"resolved": "https://registry.npmjs.org/pkg/-/pkg-4.4.8.tgz",
-			"integrity": "sha512-Fqqv0iaX48U3CFZxd6Dq6JKe7BrAWbgRAqMJkz/m8W3H5cqJ6suvsUWe5AJPRlN/AhbBYXBJ0XG9QlYPTXcVFA==",
-			"requires": {
-				"@babel/parser": "^7.9.4",
-				"@babel/runtime": "^7.9.2",
-				"chalk": "^3.0.0",
-				"escodegen": "^1.14.1",
-				"fs-extra": "^8.1.0",
-				"globby": "^11.0.0",
-				"into-stream": "^5.1.1",
-				"minimist": "^1.2.5",
-				"multistream": "^2.1.1",
-				"pkg-fetch": "^2.6.7",
-				"progress": "^2.0.3",
-				"resolve": "^1.15.1",
-				"stream-meter": "^1.0.4"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"array-union": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/array-union/-/array-union-2.1.0.tgz",
-					"integrity": "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="
-				},
-				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-				},
-				"dir-glob": {
-					"version": "3.0.1",
-					"resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-3.0.1.tgz",
-					"integrity": "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA==",
-					"requires": {
-						"path-type": "^4.0.0"
-					}
-				},
-				"fs-extra": {
-					"version": "8.1.0",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-					"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-					"requires": {
-						"graceful-fs": "^4.2.0",
-						"jsonfile": "^4.0.0",
-						"universalify": "^0.1.0"
-					}
-				},
-				"globby": {
-					"version": "11.0.0",
-					"resolved": "https://registry.npmjs.org/globby/-/globby-11.0.0.tgz",
-					"integrity": "sha512-iuehFnR3xu5wBBtm4xi0dMe92Ob87ufyu/dHwpDYfbcpYpIbrO5OnS8M1vWvrBhSGEJ3/Ecj7gnX76P8YxpPEg==",
-					"requires": {
-						"array-union": "^2.1.0",
-						"dir-glob": "^3.0.1",
-						"fast-glob": "^3.1.1",
-						"ignore": "^5.1.4",
-						"merge2": "^1.3.0",
-						"slash": "^3.0.0"
-					}
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-				},
-				"ignore": {
-					"version": "5.1.4",
-					"resolved": "https://registry.npmjs.org/ignore/-/ignore-5.1.4.tgz",
-					"integrity": "sha512-MzbUSahkTW1u7JpKKjY7LCARd1fU5W2rLdxlM4kdkayuCwZImjkpluF9CM1aLewYJguPDqewLam18Y6AU69A8A=="
-				},
-				"path-type": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-					"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
-				},
-				"slash": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/slash/-/slash-3.0.0.tgz",
-					"integrity": "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="
-				},
-				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
 			}
 		},
 		"pkg-dir": {
@@ -18296,85 +17240,6 @@
 					"resolved": "https://registry.npmjs.org/p-try/-/p-try-2.2.0.tgz",
 					"integrity": "sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==",
 					"dev": true
-				}
-			}
-		},
-		"pkg-fetch": {
-			"version": "2.6.8",
-			"resolved": "https://registry.npmjs.org/pkg-fetch/-/pkg-fetch-2.6.8.tgz",
-			"integrity": "sha512-CFG7jOeVD38lltLGA7xCJxYsD//GKLjl1P9tc/n9By2a4WEHQjfkBMrYdMS8WOHVP+r9L20fsZNbaKcubDAiQg==",
-			"requires": {
-				"@babel/runtime": "^7.9.2",
-				"byline": "^5.0.0",
-				"chalk": "^3.0.0",
-				"expand-template": "^2.0.3",
-				"fs-extra": "^8.1.0",
-				"minimist": "^1.2.5",
-				"progress": "^2.0.3",
-				"request": "^2.88.0",
-				"request-progress": "^3.0.0",
-				"semver": "^6.3.0",
-				"unique-temp-dir": "^1.0.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-				},
-				"fs-extra": {
-					"version": "8.1.0",
-					"resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-8.1.0.tgz",
-					"integrity": "sha512-yhlQgA6mnOJUKOsRUFsgJdQCvkKhcz8tlZG5HBQfReYZy46OwLcY+Zia0mtdHsOo9y/hP+CxMN0TU9QxoOtG4g==",
-					"requires": {
-						"graceful-fs": "^4.2.0",
-						"jsonfile": "^4.0.0",
-						"universalify": "^0.1.0"
-					}
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-				},
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-				},
-				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
 				}
 			}
 		},
@@ -20262,7 +19127,6 @@
 			"version": "5.3.3",
 			"resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.3.tgz",
 			"integrity": "sha512-GV+nsUXuPW2p8Zy7SarF/2W/oiK8bFQgJcncoJ0d7kRpekEA0ftChjfEaF9/Y+QJEc/wFR7RAEa8lYByuUIe2g==",
-			"dev": true,
 			"requires": {
 				"detect-libc": "^1.0.3",
 				"expand-template": "^2.0.3",
@@ -20285,7 +19149,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
 					"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-					"dev": true,
 					"requires": {
 						"end-of-stream": "^1.1.0",
 						"once": "^1.3.1"
@@ -20340,7 +19203,8 @@
 		"prelude-ls": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.1.2.tgz",
-			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ="
+			"integrity": "sha1-IZMqVJ9eUv/ZqCf1cOBL5iqX2lQ=",
+			"dev": true
 		},
 		"prepend-http": {
 			"version": "1.0.4",
@@ -20386,68 +19250,6 @@
 				}
 			}
 		},
-		"pretty-repl": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/pretty-repl/-/pretty-repl-2.3.0.tgz",
-			"integrity": "sha512-h7iNPLXpJPnbZZS0YIp1+EGD+oY9STelL70X8nwzrbglqP5nOUi0YxK+OJ8n6xopVHoLNQZrytYTmHrWcB1O/w==",
-			"requires": {
-				"ansi": "^0.3.1",
-				"chalk": "^4.0.0",
-				"emphasize": "^3.0.0",
-				"semver": "^7.2.2"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.0.0.tgz",
-					"integrity": "sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==",
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-				},
-				"semver": {
-					"version": "7.3.2",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
-				},
-				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
-			}
-		},
 		"private": {
 			"version": "0.1.8",
 			"resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
@@ -20468,7 +19270,8 @@
 		"progress": {
 			"version": "2.0.3",
 			"resolved": "https://registry.npmjs.org/progress/-/progress-2.0.3.tgz",
-			"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA=="
+			"integrity": "sha512-7PiHtLll5LdnKIMw100I+8xJXR5gW2QwWYkT6iJva0bXitZKa/XMrSbdmg3r2Xnaidz9Qumd0VPaMrZlF9V9sA==",
+			"dev": true
 		},
 		"progress-stream": {
 			"version": "1.2.0",
@@ -20627,7 +19430,8 @@
 		"psl": {
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/psl/-/psl-1.8.0.tgz",
-			"integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ=="
+			"integrity": "sha512-RIdOzyoavK+hA18OGGWDqUTsCLhtA7IcZ/6NCs4fFJaHBDab+pDDmDIByWFRQJq2Cd7r1OoQxBGKOaztq+hjIQ==",
+			"dev": true
 		},
 		"public-encrypt": {
 			"version": "4.0.3",
@@ -20667,7 +19471,8 @@
 		"punycode": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+			"dev": true
 		},
 		"q": {
 			"version": "1.5.1",
@@ -20700,7 +19505,8 @@
 		"querystring": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/querystring/-/querystring-0.2.0.tgz",
-			"integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA="
+			"integrity": "sha1-sgmEkgO7Jd+CDadW50cAWHhSFiA=",
+			"dev": true
 		},
 		"querystring-es3": {
 			"version": "0.2.1",
@@ -20713,11 +19519,6 @@
 			"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
 			"integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==",
 			"dev": true
-		},
-		"quick-format-unescaped": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-3.0.3.tgz",
-			"integrity": "sha512-dy1yjycmn9blucmJLXOfZDx1ikZJUi6E8bBZLnhPG5gBrVhHXx2xVyqqgKBubVNEXmx51dBACMHpoMQK/N/AXQ=="
 		},
 		"radium": {
 			"version": "0.19.6",
@@ -20809,7 +19610,6 @@
 			"version": "1.2.8",
 			"resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
 			"integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-			"dev": true,
 			"requires": {
 				"deep-extend": "^0.6.0",
 				"ini": "~1.3.0",
@@ -21255,14 +20055,6 @@
 				}
 			}
 		},
-		"read": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
-			"integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
-			"requires": {
-				"mute-stream": "~0.0.4"
-			}
-		},
 		"read-package-json": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.1.1.tgz",
@@ -21565,21 +20357,11 @@
 			"integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
 			"dev": true
 		},
-		"remove-array-items": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/remove-array-items/-/remove-array-items-1.1.1.tgz",
-			"integrity": "sha512-MXW/jtHyl5F1PZI7NbpS8SOtympdLuF20aoWJT5lELR1p/HJDd5nqW8Eu9uLh/hCRY3FgvrIT5AwDCgBODklcA=="
-		},
 		"remove-trailing-separator": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
 			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
 			"dev": true
-		},
-		"remove-trailing-slash": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/remove-trailing-slash/-/remove-trailing-slash-0.1.0.tgz",
-			"integrity": "sha1-FJjl3wmEwn5Jt26/Boh8otARUNI="
 		},
 		"renderkid": {
 			"version": "2.0.3",
@@ -21619,6 +20401,7 @@
 			"version": "2.88.2",
 			"resolved": "https://registry.npmjs.org/request/-/request-2.88.2.tgz",
 			"integrity": "sha512-MsvtOrfG9ZcrOwAW+Qi+F6HbD0CWXEh9ou77uOb7FM2WPhwT7smM833PzanhJLsgXjN89Ir6V2PczXNnMpwKhw==",
+			"dev": true,
 			"requires": {
 				"aws-sign2": "~0.7.0",
 				"aws4": "^1.8.0",
@@ -21645,22 +20428,8 @@
 				"qs": {
 					"version": "6.5.2",
 					"resolved": "https://registry.npmjs.org/qs/-/qs-6.5.2.tgz",
-					"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA=="
-				}
-			}
-		},
-		"request-progress": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/request-progress/-/request-progress-3.0.0.tgz",
-			"integrity": "sha1-TKdUCBx/7GP1BeT6qCWqBs1mnb4=",
-			"requires": {
-				"throttleit": "^1.0.0"
-			},
-			"dependencies": {
-				"throttleit": {
-					"version": "1.0.0",
-					"resolved": "https://registry.npmjs.org/throttleit/-/throttleit-1.0.0.tgz",
-					"integrity": "sha1-nnhYNtr0Z0MUWlmEtiaNgoUorGw="
+					"integrity": "sha512-N5ZAX4/LxJmF+7wN74pUD6qAh9/wnvdQcjq9TZjevvXzSUo7bfmw91saqMjzGS2xq91/odN2dW/WOl7qQHNDGA==",
+					"dev": true
 				}
 			}
 		},
@@ -21700,6 +20469,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
 			"integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
+			"dev": true,
 			"requires": {
 				"resolve-from": "^2.0.0",
 				"semver": "^5.1.0"
@@ -21708,7 +20478,8 @@
 				"resolve-from": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-					"integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
+					"integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
+					"dev": true
 				}
 			}
 		},
@@ -21788,7 +20559,8 @@
 		"reusify": {
 			"version": "1.0.4",
 			"resolved": "https://registry.npmjs.org/reusify/-/reusify-1.0.4.tgz",
-			"integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw=="
+			"integrity": "sha512-U9nH88a3fc/ekCF1l0/UP1IosiuIjyTh7hBvXVMHYgVcfGvt897Xguj2UOLDeI5BG2m7/uwyaLVT6fbtCwTyzw==",
+			"dev": true
 		},
 		"rfdc": {
 			"version": "1.1.4",
@@ -21846,7 +20618,8 @@
 		"run-parallel": {
 			"version": "1.1.9",
 			"resolved": "https://registry.npmjs.org/run-parallel/-/run-parallel-1.1.9.tgz",
-			"integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q=="
+			"integrity": "sha512-DEqnSRTDw/Tc3FXf49zedI638Z9onwUotBMiUFKmrO2sdFKIbXamXGQ3Axd4qgphxKB4kw/qP1w5kTxnfU1B9Q==",
+			"dev": true
 		},
 		"run-queue": {
 			"version": "1.0.3",
@@ -21904,7 +20677,8 @@
 		"safer-buffer": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
-			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
+			"integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+			"dev": true
 		},
 		"sanitize-filename": {
 			"version": "1.6.3",
@@ -21919,6 +20693,7 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
 			"integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"sparse-bitfield": "^3.0.3"
@@ -21927,7 +20702,8 @@
 		"sax": {
 			"version": "1.2.4",
 			"resolved": "https://registry.npmjs.org/sax/-/sax-1.2.4.tgz",
-			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw=="
+			"integrity": "sha512-NqVDv9TpANUjFm0N8uM5GxL36UgKi9/atZw+x7YFnQ8ckwFGKrl4xX4yWtrey3UJm5nP1kUbnYgLopqWNSRhWw==",
+			"dev": true
 		},
 		"scheduler": {
 			"version": "0.19.1",
@@ -22113,8 +20889,7 @@
 		"set-blocking": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
-			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
-			"dev": true
+			"integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc="
 		},
 		"set-value": {
 			"version": "2.0.1",
@@ -22233,20 +21008,17 @@
 		"signal-exit": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
-			"integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
-			"dev": true
+			"integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA=="
 		},
 		"simple-concat": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.0.tgz",
-			"integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY=",
-			"dev": true
+			"integrity": "sha1-c0TLuLbib7J9ZrL8hvn21Zl1IcY="
 		},
 		"simple-get": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.0.tgz",
 			"integrity": "sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==",
-			"dev": true,
 			"requires": {
 				"decompress-response": "^4.2.0",
 				"once": "^1.3.1",
@@ -22584,15 +21356,6 @@
 				}
 			}
 		},
-		"sonic-boom": {
-			"version": "0.7.7",
-			"resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-0.7.7.tgz",
-			"integrity": "sha512-Ei5YOo5J64GKClHIL/5evJPgASXFVpfVYbJV9PILZQytTK6/LCwHvsZJW2Ig4p9FMC2OrBrMnXKgRN/OEoAWfg==",
-			"requires": {
-				"atomic-sleep": "^1.0.0",
-				"flatstr": "^1.0.12"
-			}
-		},
 		"sort-keys": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
@@ -22630,6 +21393,7 @@
 			"version": "0.5.18",
 			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.18.tgz",
 			"integrity": "sha512-9luZr/BZ2QeU6tO2uG8N2aZpVSli4TSAOAqFOyTO51AJcD9P99c0K1h6dD6r6qo5dyT44BR5exweOaLLeldTkQ==",
+			"dev": true,
 			"requires": {
 				"buffer-from": "^1.0.0",
 				"source-map": "^0.6.0"
@@ -22638,7 +21402,8 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
 				}
 			}
 		},
@@ -22652,6 +21417,7 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
 			"integrity": "sha1-/0rm5oZWBWuks+eSqzM004JzyhE=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"memory-pager": "^1.0.2"
@@ -22847,6 +21613,7 @@
 			"version": "1.16.1",
 			"resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.16.1.tgz",
 			"integrity": "sha512-HXXqVUq7+pcKeLqqZj6mHFUMvXtOJt1uoUx09pFW6011inTMxqI8BA8PM95myrIyyKwdnzjdFjLiE6KBPVtJIg==",
+			"dev": true,
 			"requires": {
 				"asn1": "~0.2.3",
 				"assert-plus": "^1.0.0",
@@ -22996,14 +21763,6 @@
 				"xtend": "^4.0.0"
 			}
 		},
-		"stream-meter": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/stream-meter/-/stream-meter-1.0.4.tgz",
-			"integrity": "sha1-Uq+Vql6nYKJJFxZwTb/5D3Ov3R0=",
-			"requires": {
-				"readable-stream": "^2.1.4"
-			}
-		},
 		"stream-shift": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.1.tgz",
@@ -23052,7 +21811,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
 			"integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-			"dev": true,
 			"requires": {
 				"code-point-at": "^1.0.0",
 				"is-fullwidth-code-point": "^1.0.0",
@@ -23165,7 +21923,6 @@
 			"version": "3.0.1",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
 			"integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-			"dev": true,
 			"requires": {
 				"ansi-regex": "^2.0.0"
 			}
@@ -23194,8 +21951,7 @@
 		"strip-json-comments": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
-			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
-			"dev": true
+			"integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo="
 		},
 		"style-loader": {
 			"version": "0.18.2",
@@ -23392,7 +22148,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.0.1.tgz",
 			"integrity": "sha512-6tzWDMeroL87uF/+lin46k+Q+46rAJ0SyPGz7OW7wTgblI273hsBqk2C1j0/xNadNLKDTUL9BukSjB7cwgmlPA==",
-			"dev": true,
 			"requires": {
 				"chownr": "^1.1.1",
 				"mkdirp-classic": "^0.5.2",
@@ -23404,7 +22159,6 @@
 					"version": "3.0.0",
 					"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
 					"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-					"dev": true,
 					"requires": {
 						"end-of-stream": "^1.1.0",
 						"once": "^1.3.1"
@@ -23416,7 +22170,6 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.1.2.tgz",
 			"integrity": "sha512-UaF6FoJ32WqALZGOIAApXx+OdxhekNMChu6axLJR85zMMjXKWFGjbIRe+J6P4UnRGg9rAwWvbTT0oI7hD/Un7Q==",
-			"dev": true,
 			"requires": {
 				"bl": "^4.0.1",
 				"end-of-stream": "^1.4.1",
@@ -23429,7 +22182,6 @@
 					"version": "4.0.2",
 					"resolved": "https://registry.npmjs.org/bl/-/bl-4.0.2.tgz",
 					"integrity": "sha512-j4OH8f6Qg2bGuWfRiltT2HYGx0e1QcBTrK9KAHNMwMZdQnDZFk0ZSYIpADjYCB3U12nicC5tVJwSIhwOWjb4RQ==",
-					"dev": true,
 					"requires": {
 						"buffer": "^5.5.0",
 						"inherits": "^2.0.4",
@@ -23440,7 +22192,6 @@
 					"version": "5.6.0",
 					"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
 					"integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
-					"dev": true,
 					"requires": {
 						"base64-js": "^1.0.2",
 						"ieee754": "^1.1.4"
@@ -23450,7 +22201,6 @@
 					"version": "3.6.0",
 					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
 					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-					"dev": true,
 					"requires": {
 						"inherits": "^2.0.3",
 						"string_decoder": "^1.1.1",
@@ -23620,7 +22370,8 @@
 		"text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+			"dev": true
 		},
 		"throttleit": {
 			"version": "0.0.2",
@@ -23768,6 +22519,7 @@
 			"version": "2.5.0",
 			"resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
 			"integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+			"dev": true,
 			"requires": {
 				"psl": "^1.1.28",
 				"punycode": "^2.1.1"
@@ -23815,25 +22567,6 @@
 			"integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==",
 			"dev": true
 		},
-		"ts-node": {
-			"version": "8.10.1",
-			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.10.1.tgz",
-			"integrity": "sha512-bdNz1L4ekHiJul6SHtZWs1ujEKERJnHs4HxN7rjTyyVOFf3HaJ6sLqe6aPG62XTzAB/63pKRh5jTSWL0D7bsvw==",
-			"requires": {
-				"arg": "^4.1.0",
-				"diff": "^4.0.1",
-				"make-error": "^1.1.1",
-				"source-map-support": "^0.5.17",
-				"yn": "3.1.1"
-			},
-			"dependencies": {
-				"diff": {
-					"version": "4.0.2",
-					"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-					"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
-				}
-			}
-		},
 		"tslib": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
@@ -23859,7 +22592,6 @@
 			"version": "0.6.0",
 			"resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
 			"integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
-			"dev": true,
 			"requires": {
 				"safe-buffer": "^5.0.1"
 			}
@@ -23867,7 +22599,8 @@
 		"tweetnacl": {
 			"version": "0.14.5",
 			"resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q="
+			"integrity": "sha1-WuaBd/GS1EViadEIr6k/+HQ/T2Q=",
+			"dev": true
 		},
 		"type": {
 			"version": "1.2.0",
@@ -23879,6 +22612,7 @@
 			"version": "0.3.2",
 			"resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
 			"integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
+			"dev": true,
 			"requires": {
 				"prelude-ls": "~1.1.2"
 			}
@@ -23917,7 +22651,8 @@
 		"typescript": {
 			"version": "3.8.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
-			"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w=="
+			"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+			"dev": true
 		},
 		"ua-parser-js": {
 			"version": "0.7.21",
@@ -24042,11 +22777,6 @@
 				}
 			}
 		},
-		"uid2": {
-			"version": "0.0.3",
-			"resolved": "https://registry.npmjs.org/uid2/-/uid2-0.0.3.tgz",
-			"integrity": "sha1-SDEm4Rd03y9xuLY53NeZw3YWK4I="
-		},
 		"ultron": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/ultron/-/ultron-1.1.1.tgz",
@@ -24138,20 +22868,11 @@
 				"imurmurhash": "^0.1.4"
 			}
 		},
-		"unique-temp-dir": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/unique-temp-dir/-/unique-temp-dir-1.0.0.tgz",
-			"integrity": "sha1-bc6VsmgcoAPuv7MEpBX5y6vMU4U=",
-			"requires": {
-				"mkdirp": "^0.5.1",
-				"os-tmpdir": "^1.0.1",
-				"uid2": "0.0.3"
-			}
-		},
 		"universalify": {
 			"version": "0.1.2",
 			"resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
-			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg=="
+			"integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+			"dev": true
 		},
 		"unpipe": {
 			"version": "1.0.0",
@@ -24215,6 +22936,7 @@
 			"version": "4.2.2",
 			"resolved": "https://registry.npmjs.org/uri-js/-/uri-js-4.2.2.tgz",
 			"integrity": "sha512-KY9Frmirql91X2Qgjry0Wd4Y+YTdrdZheS8TFwvkbLWf/G5KNJDCh6pKL5OZctEW4+0Baa5idK2ZQuELRwPznQ==",
+			"dev": true,
 			"requires": {
 				"punycode": "^2.1.0"
 			}
@@ -24354,7 +23076,8 @@
 		"uuid": {
 			"version": "3.4.0",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+			"dev": true
 		},
 		"v8-compile-cache": {
 			"version": "2.0.3",
@@ -24406,6 +23129,7 @@
 			"version": "1.10.0",
 			"resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
 			"integrity": "sha1-OhBcoXBTr1XW4nDB+CiGguGNpAA=",
+			"dev": true,
 			"requires": {
 				"assert-plus": "^1.0.0",
 				"core-util-is": "1.0.2",
@@ -25502,14 +24226,12 @@
 		"which-pm-runs": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
-			"integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=",
-			"dev": true
+			"integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs="
 		},
 		"wide-align": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
 			"integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
-			"dev": true,
 			"requires": {
 				"string-width": "^1.0.2 || 2"
 			}
@@ -25523,7 +24245,8 @@
 		"word-wrap": {
 			"version": "1.2.3",
 			"resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.3.tgz",
-			"integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ=="
+			"integrity": "sha512-Hz/mrNwitNRh/HUAtM/VT/5VH+ygD6DV7mYKZAtHOrbs8U7lvPS6xf7EJKMF0uW1KJCl0H701g3ZGus+muE5vQ==",
+			"dev": true
 		},
 		"wordwrap": {
 			"version": "0.0.2",
@@ -25553,8 +24276,7 @@
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-			"dev": true
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		},
 		"write": {
 			"version": "1.0.3",
@@ -25622,19 +24344,11 @@
 			"integrity": "sha512-A5CUptxDsvxKJEU3yO6DuWBSJz/qizqzJKOMIfUJHETbBw/sFaDxgd6fxm1ewUaM0jZ444Fc5vC5ROYurg/4Pw==",
 			"dev": true
 		},
-		"xml2js": {
-			"version": "0.4.19",
-			"resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.4.19.tgz",
-			"integrity": "sha512-esZnJZJOiJR9wWKMyuvSE1y6Dq5LCuJanqhxslH2bxM6duahNZ+HMpCLhBQGZkbX6xRf8x1Y2eJlgt2q3qo49Q==",
-			"requires": {
-				"sax": ">=0.6.0",
-				"xmlbuilder": "~9.0.1"
-			}
-		},
 		"xmlbuilder": {
 			"version": "9.0.7",
 			"resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-9.0.7.tgz",
-			"integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0="
+			"integrity": "sha1-Ey7mPS7FVlxVfiD0wi35rKaGsQ0=",
+			"dev": true
 		},
 		"xmldom": {
 			"version": "0.1.31",
@@ -25963,11 +24677,6 @@
 			"resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
 			"integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk=",
 			"dev": true
-		},
-		"yn": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="
 		}
 	}
 }

--- a/packages/compass-shell/package.json
+++ b/packages/compass-shell/package.json
@@ -52,16 +52,10 @@
  "dependencies": {
   "@leafygreen-ui/icon": "^5.1.0",
   "@leafygreen-ui/icon-button": "^5.0.2",
-<<<<<<< HEAD
   "@mongosh/browser-repl": "^0.0.1-alpha.15",
   "@mongosh/browser-runtime-electron": "^0.0.1-alpha.15",
   "@mongosh/service-provider-server": "^0.0.1-alpha.15",
   "mongodb-client-encryption": "^1.0.1"
-=======
-  "@mongosh/browser-repl": "^0.0.1-alpha.14",
-  "@mongosh/browser-runtime-electron": "^0.0.1-alpha.14",
-  "@mongosh/service-provider-server": "^0.0.1-alpha.14"
->>>>>>> Remove extra dependency
  },
  "peerDependencies": {
   "hadron-ipc": "^1.1.0",

--- a/packages/compass-shell/package.json
+++ b/packages/compass-shell/package.json
@@ -52,10 +52,16 @@
  "dependencies": {
   "@leafygreen-ui/icon": "^5.1.0",
   "@leafygreen-ui/icon-button": "^5.0.2",
+<<<<<<< HEAD
   "@mongosh/browser-repl": "^0.0.1-alpha.15",
   "@mongosh/browser-runtime-electron": "^0.0.1-alpha.15",
   "@mongosh/service-provider-server": "^0.0.1-alpha.15",
   "mongodb-client-encryption": "^1.0.1"
+=======
+  "@mongosh/browser-repl": "^0.0.1-alpha.14",
+  "@mongosh/browser-runtime-electron": "^0.0.1-alpha.14",
+  "@mongosh/service-provider-server": "^0.0.1-alpha.14"
+>>>>>>> Remove extra dependency
  },
  "peerDependencies": {
   "hadron-ipc": "^1.1.0",

--- a/packages/compass-shell/package.json
+++ b/packages/compass-shell/package.json
@@ -50,6 +50,8 @@
   "access": "public"
  },
  "dependencies": {
+  "@leafygreen-ui/icon": "^5.1.0",
+  "@leafygreen-ui/icon-button": "^5.0.2",
   "@mongosh/browser-repl": "^0.0.1-alpha.15",
   "@mongosh/browser-runtime-electron": "^0.0.1-alpha.15",
   "@mongosh/service-provider-server": "^0.0.1-alpha.15",

--- a/packages/compass-shell/package.json
+++ b/packages/compass-shell/package.json
@@ -52,7 +52,8 @@
  "dependencies": {
   "@mongosh/browser-repl": "^0.0.1-alpha.15",
   "@mongosh/browser-runtime-electron": "^0.0.1-alpha.15",
-  "@mongosh/service-provider-server": "^0.0.1-alpha.15"
+  "@mongosh/service-provider-server": "^0.0.1-alpha.15",
+  "mongodb-client-encryption": "^1.0.1"
  },
  "peerDependencies": {
   "hadron-ipc": "^1.1.0",
@@ -128,6 +129,7 @@
   "postcss-loader": "^2.0.6",
   "pre-commit": "^1.1.3",
   "prop-types": "^15.7.2",
+  "re-resizable": "^6.3.2",
   "react": "^16.8.0",
   "react-ace": "^6.6.0",
   "react-bootstrap": "^0.32.1",

--- a/packages/compass-shell/scripts/run-in-compass.js
+++ b/packages/compass-shell/scripts/run-in-compass.js
@@ -56,9 +56,9 @@ function resetCompass() {
     return;
   }
 
-  // execSync('git checkout master', { cwd: compassPath });
-  // execSync('git fetch', { cwd: compassPath });
-  // execSync('git reset --hard origin/master', { cwd: compassPath });
+  execSync('git checkout master', { cwd: compassPath });
+  execSync('git fetch', { cwd: compassPath });
+  execSync('git reset --hard origin/master', { cwd: compassPath });
 }
 
 function cloneCompass() {

--- a/packages/compass-shell/scripts/run-in-compass.js
+++ b/packages/compass-shell/scripts/run-in-compass.js
@@ -56,9 +56,9 @@ function resetCompass() {
     return;
   }
 
-  execSync('git checkout master', { cwd: compassPath });
-  execSync('git fetch', { cwd: compassPath });
-  execSync('git reset --hard origin/master', { cwd: compassPath });
+  // execSync('git checkout master', { cwd: compassPath });
+  // execSync('git fetch', { cwd: compassPath });
+  // execSync('git reset --hard origin/master', { cwd: compassPath });
 }
 
 function cloneCompass() {

--- a/packages/compass-shell/src/components/compass-shell/compass-shell.jsx
+++ b/packages/compass-shell/src/components/compass-shell/compass-shell.jsx
@@ -4,11 +4,15 @@ import styles from './compass-shell.less';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Resizable } from 're-resizable';
+import IconButton from '@leafygreen-ui/icon-button';
+import Icon from '@leafygreen-ui/icon';
 
 import { Shell } from '@mongosh/browser-repl';
 
+import { ResizeHandle } from '../resize-handle';
+
 const resizeableDirections = {
-  top: true,
+  top: false, // This property is controlled in the component.
   right: false,
   bottom: false,
   left: false,
@@ -17,6 +21,9 @@ const resizeableDirections = {
   bottomLeft: false,
   topLeft: false
 };
+
+const defaultShellHeightClosed = 24;
+const defaultShellHeightOpened = 240;
 
 export class CompassShell extends Component {
   static propTypes = {
@@ -27,18 +34,21 @@ export class CompassShell extends Component {
   static defaultProps = {
     runtime: null
   };
-
   constructor(props) {
     super(props);
 
     this.state = {
-      initialHistory: this.props.historyStorage ? null : []
+      initialHistory: this.props.historyStorage ? null : [],
+      isExpanded: false
     };
   }
 
   componentDidMount() {
     this.loadHistory();
   }
+
+  resizableRef = null;
+  lastOpenHeight = defaultShellHeightOpened;
 
   saveHistory = async(history) => {
     if (!this.props.historyStorage) {
@@ -72,32 +82,87 @@ export class CompassShell extends Component {
     }
   }
 
+  shellToggleClicked = () => {
+    if (this.state.isExpanded) {
+      this.lastOpenHeight = this.resizableRef.sizeStyle.height;
+
+      this.resizableRef.updateSize({
+        width: '100%',
+        height: defaultShellHeightClosed
+      });
+    } else {
+      this.resizableRef.updateSize({
+        width: '100%',
+        height: this.lastOpenHeight
+      });
+    }
+
+    this.setState({
+      isExpanded: !this.state.isExpanded
+    });
+  }
+
   /**
    * Render CompassShell component.
    *
    * @returns {React.Component} The rendered component.
    */
   render() {
+    const {
+      isExpanded
+    } = this.state;
+
     if (!this.props.runtime || !this.state.initialHistory) {
       return (<div />);
     }
 
     return (
       <Resizable
-        className={classnames(styles['compass-shell'])}
+        className={styles['compass-shell']}
         defaultSize={{
           width: '100%',
-          height: 240
+          height: defaultShellHeightClosed
         }}
         id="content"
-        minHeight={30}
-        enable={resizeableDirections}
+        minHeight={defaultShellHeightClosed}
+        enable={{
+          ...resizeableDirections,
+          top: isExpanded
+        }}
+        ref={c => { this.resizableRef = c; }}
+        handleComponent={{
+          top: <ResizeHandle />,
+        }}
       >
-        <Shell
-          runtime={this.props.runtime}
-          initialHistory={this.state.initialHistory}
-          onHistoryChanged={this.saveHistory}
-        />
+        <div className={styles['compass-shell-header']}>
+          <button
+            className={styles['compass-shell-toggle']}
+            onClick={this.shellToggleClicked}
+          >
+            &gt;_MongoSH v0.9 Beta
+          </button>
+          {isExpanded && (
+            <div>
+              <IconButton
+                className={styles['compass-shell-close-btn']}
+                variant="dark"
+                aria-label="Some Menu"
+                onClick={this.shellToggleClicked}
+              >
+                <Icon glyph="X" />
+              </IconButton>
+            </div>
+          )}
+        </div>
+        {isExpanded && (
+          <div className={classnames(styles['compass-shell-shell-container'])}>
+            <Shell
+              runtime={this.props.runtime}
+              initialHistory={this.state.initialHistory}
+              onHistoryChanged={this.saveHistory}
+            />
+          </div>
+        )}
       </Resizable>
     );
   }

--- a/packages/compass-shell/src/components/compass-shell/compass-shell.jsx
+++ b/packages/compass-shell/src/components/compass-shell/compass-shell.jsx
@@ -125,6 +125,7 @@ export class CompassShell extends Component {
         }}
         id="content"
         minHeight={defaultShellHeightClosed}
+        maxHeight={800}
         enable={{
           ...resizeableDirections,
           top: isExpanded

--- a/packages/compass-shell/src/components/compass-shell/compass-shell.jsx
+++ b/packages/compass-shell/src/components/compass-shell/compass-shell.jsx
@@ -3,8 +3,20 @@ import classnames from 'classnames';
 import styles from './compass-shell.less';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
+import { Resizable } from 're-resizable';
 
 import { Shell } from '@mongosh/browser-repl';
+
+const resizeableDirections = {
+  top: true,
+  right: false,
+  bottom: false,
+  left: false,
+  topRight: false,
+  bottomRight: false,
+  bottomLeft: false,
+  topLeft: false
+};
 
 export class CompassShell extends Component {
   static propTypes = {
@@ -71,11 +83,22 @@ export class CompassShell extends Component {
     }
 
     return (
-      <div className={classnames(styles.container)}>
-        <Shell runtime={this.props.runtime}
+      <Resizable
+        className={classnames(styles['compass-shell'])}
+        defaultSize={{
+          width: '100%',
+          height: 240
+        }}
+        id="content"
+        minHeight={30}
+        enable={resizeableDirections}
+      >
+        <Shell
+          runtime={this.props.runtime}
           initialHistory={this.state.initialHistory}
-          onHistoryChanged={this.saveHistory} />
-      </div>
+          onHistoryChanged={this.saveHistory}
+        />
+      </Resizable>
     );
   }
 }

--- a/packages/compass-shell/src/components/compass-shell/compass-shell.jsx
+++ b/packages/compass-shell/src/components/compass-shell/compass-shell.jsx
@@ -4,12 +4,11 @@ import styles from './compass-shell.less';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Resizable } from 're-resizable';
-import IconButton from '@leafygreen-ui/icon-button';
-import Icon from '@leafygreen-ui/icon';
 
 import { Shell } from '@mongosh/browser-repl';
 
-import { ResizeHandle } from '../resize-handle';
+import ResizeHandle from '../resize-handle';
+import ShellHeader from '../shell-header';
 
 const resizeableDirections = {
   top: false, // This property is controlled in the component.
@@ -27,6 +26,7 @@ const defaultShellHeightOpened = 240;
 
 export class CompassShell extends Component {
   static propTypes = {
+    isExpanded: PropTypes.bool,
     runtime: PropTypes.object,
     historyStorage: PropTypes.object
   };
@@ -39,7 +39,7 @@ export class CompassShell extends Component {
 
     this.state = {
       initialHistory: this.props.historyStorage ? null : [],
-      isExpanded: false
+      isExpanded: !!this.props.isExpanded
     };
   }
 
@@ -135,26 +135,10 @@ export class CompassShell extends Component {
           top: <ResizeHandle />,
         }}
       >
-        <div className={styles['compass-shell-header']}>
-          <button
-            className={styles['compass-shell-toggle']}
-            onClick={this.shellToggleClicked}
-          >
-            &gt;_MongoSH v0.9 Beta
-          </button>
-          {isExpanded && (
-            <div>
-              <IconButton
-                className={styles['compass-shell-close-btn']}
-                variant="dark"
-                aria-label="Some Menu"
-                onClick={this.shellToggleClicked}
-              >
-                <Icon glyph="X" />
-              </IconButton>
-            </div>
-          )}
-        </div>
+        <ShellHeader
+          isExpanded={isExpanded}
+          onShellToggleClicked={this.shellToggleClicked}
+        />
         {isExpanded && (
           <div className={classnames(styles['compass-shell-shell-container'])}>
             <Shell

--- a/packages/compass-shell/src/components/compass-shell/compass-shell.less
+++ b/packages/compass-shell/src/components/compass-shell/compass-shell.less
@@ -9,30 +9,10 @@
   position: relative;
   flex-direction: column;
 
-  &-header {
-    width: 100%;
-    height: 24px;
-    display: flex;
-    color: @leafygreen__gray--light-1;
-  }
-
-  &-close-btn {
-    position: absolute;
-    right: 2px;
-    top: -2px;
-  }
-
   &-shell-container {
     flex-grow: 1;
     display: flex;
     overflow: auto;
     border-top: 1px solid @leafygreen__gray--dark-2;
-  }
-
-  &-toggle {
-    background: none;
-    border: none;
-    cursor: pointer;
-    padding: 1px 8px;
   }
 }

--- a/packages/compass-shell/src/components/compass-shell/compass-shell.less
+++ b/packages/compass-shell/src/components/compass-shell/compass-shell.less
@@ -8,6 +8,7 @@
   overflow: hidden;
   position: relative;
   flex-direction: column;
+  z-index: 1;
 
   &-shell-container {
     flex-grow: 1;

--- a/packages/compass-shell/src/components/compass-shell/compass-shell.less
+++ b/packages/compass-shell/src/components/compass-shell/compass-shell.less
@@ -1,37 +1,38 @@
+@import '~@leafygreen-ui/palette/dist/ui-colors.less';
+
 .compass-shell {
   width: 100%;
-  background: #4C5259;
-  color: #bfbfbe;
-  // height: 30%; // NOTE: This is needed for re-resizable to work properly.
+  background-color: @leafygreen__gray--dark-3;
   display: flex;
   flex-basis: auto;
-  // flex-direction: row;
-  // flex-grow: 0;
-  // flex-shrink: 0;
-  // margin: 0;
   overflow: hidden;
-  // transition: flex-basis 400ms ease;
   position: relative;
+  flex-direction: column;
 
-  &-toggle {
-    position: absolute;
-    left: 4px;
-    top: -4px;
-    width: 14px;
-    border-left: 0;
-    transition: all 150ms ease;
-    border-bottom-left-radius: 0;
-    border-top-left-radius: 0;
-    top: 4px;
-    padding: 0;
-    cursor: pointer;
-    z-index: 1000;
-    &:hover, &:focus {
-      border-left: 0;
-    }
+  &-header {
+    width: 100%;
+    height: 24px;
+    display: flex;
+    color: @leafygreen__gray--light-1;
   }
 
-  // &-expanded {
-  //   flex-basis: 250px;
-  // }
+  &-close-btn {
+    position: absolute;
+    right: 2px;
+    top: -2px;
+  }
+
+  &-shell-container {
+    flex-grow: 1;
+    display: flex;
+    overflow: auto;
+    border-top: 1px solid @leafygreen__gray--dark-2;
+  }
+
+  &-toggle {
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 1px 8px;
+  }
 }

--- a/packages/compass-shell/src/components/compass-shell/compass-shell.less
+++ b/packages/compass-shell/src/components/compass-shell/compass-shell.less
@@ -1,4 +1,37 @@
-.container {
+.compass-shell {
   width: 100%;
-  height: 240px;
+  background: #4C5259;
+  color: #bfbfbe;
+  // height: 30%; // NOTE: This is needed for re-resizable to work properly.
+  display: flex;
+  flex-basis: auto;
+  // flex-direction: row;
+  // flex-grow: 0;
+  // flex-shrink: 0;
+  // margin: 0;
+  overflow: hidden;
+  // transition: flex-basis 400ms ease;
+  position: relative;
+
+  &-toggle {
+    position: absolute;
+    left: 4px;
+    top: -4px;
+    width: 14px;
+    border-left: 0;
+    transition: all 150ms ease;
+    border-bottom-left-radius: 0;
+    border-top-left-radius: 0;
+    top: 4px;
+    padding: 0;
+    cursor: pointer;
+    z-index: 1000;
+    &:hover, &:focus {
+      border-left: 0;
+    }
+  }
+
+  // &-expanded {
+  //   flex-basis: 250px;
+  // }
 }

--- a/packages/compass-shell/src/components/compass-shell/compass-shell.spec.js
+++ b/packages/compass-shell/src/components/compass-shell/compass-shell.spec.js
@@ -66,6 +66,74 @@ describe('CompassShell', () => {
         expect(wrapper.find(Shell).prop('initialHistory')).to.deep.equal([]);
       });
     });
+
+    context('when it is clicked to collapse', () => {
+      it('sets the collapsed height to 24', () => {
+        const shell = new CompassShell({ isExpanded: true });
+        let sizeSetTo = {};
+        shell.resizableRef = {
+          sizeStyle: {
+            height: 100
+          },
+          updateSize: newSize => {
+            sizeSetTo = newSize;
+          }
+        };
+        shell.shellToggleClicked();
+
+        expect(sizeSetTo).to.deep.equal({
+          width: '100%',
+          height: 24
+        });
+      });
+
+      it('sets the state to collapsed', () => {
+        const shell = new CompassShell({ isExpanded: true });
+        shell.setState = stateUpdate => {
+          shell.state = {
+            ...shell.state,
+            ...stateUpdate
+          };
+        };
+        shell.resizableRef = {
+          sizeStyle: {
+            height: 100
+          },
+          updateSize: () => { }
+        };
+        shell.shellToggleClicked();
+
+        expect(shell.state.isExpanded).to.equal(false);
+      });
+
+      context('when it is expanded again', () => {
+        it('resumes its previous height', () => {
+          const shell = new CompassShell({ isExpanded: true });
+          shell.setState = stateUpdate => {
+            shell.state = {
+              ...shell.state,
+              ...stateUpdate
+            };
+          };
+          let sizeSetTo = {};
+          shell.resizableRef = {
+            sizeStyle: {
+              height: 99
+            },
+            updateSize: newSize => {
+              sizeSetTo = newSize;
+            }
+          };
+          shell.shellToggleClicked();
+          shell.shellToggleClicked();
+
+          expect(sizeSetTo).to.deep.equal({
+            width: '100%',
+            height: 99
+          });
+        });
+      });
+    });
   });
 
   context('when historyStorage is present', () => {

--- a/packages/compass-shell/src/components/compass-shell/compass-shell.spec.js
+++ b/packages/compass-shell/src/components/compass-shell/compass-shell.spec.js
@@ -2,8 +2,10 @@ import sinon from 'sinon';
 import React from 'react';
 import { shallow } from 'enzyme';
 import { Shell } from '@mongosh/browser-repl';
+import { Resizable } from 're-resizable';
 
 import { CompassShell } from './compass-shell';
+import ResizeHandle from '../resize-handle';
 import ShellHeader from '../shell-header';
 
 function updateAndWaitAsync(wrapper) {
@@ -39,6 +41,20 @@ describe('CompassShell', () => {
         const fakeRuntime = {};
         const wrapper = shallow(<CompassShell runtime={fakeRuntime} isExpanded />);
         expect(wrapper.find(ShellHeader).exists()).to.equal(true);
+      });
+
+      it('renders a Resizable component', () => {
+        const fakeRuntime = {};
+        const wrapper = shallow(<CompassShell runtime={fakeRuntime} isExpanded />);
+        expect(wrapper.find(Resizable)).to.be.present();
+      });
+
+      it('passes the resize handle component to the Resizable component', () => {
+        const fakeRuntime = {};
+        const wrapper = shallow(<CompassShell runtime={fakeRuntime} isExpanded />);
+        expect(wrapper.find(Resizable).prop('handleComponent')).to.deep.equal({
+          top: <ResizeHandle />,
+        });
       });
     });
 

--- a/packages/compass-shell/src/components/compass-shell/compass-shell.spec.js
+++ b/packages/compass-shell/src/components/compass-shell/compass-shell.spec.js
@@ -1,6 +1,6 @@
 import sinon from 'sinon';
 import React from 'react';
-import { mount } from 'enzyme';
+import { shallow } from 'enzyme';
 import { Shell } from '@mongosh/browser-repl';
 
 import { CompassShell } from './compass-shell';
@@ -15,7 +15,7 @@ describe('CompassShell', () => {
   context('when the prop isExpanded is false', () => {
     it('does not render a shell', () => {
       const fakeRuntime = {};
-      const wrapper = mount(<CompassShell runtime={fakeRuntime} isExpanded={false} />);
+      const wrapper = shallow(<CompassShell runtime={fakeRuntime} isExpanded={false} />);
       expect(wrapper.find(Shell)).to.have.lengthOf(0);
     });
   });
@@ -23,7 +23,7 @@ describe('CompassShell', () => {
   context('when the prop isExpanded is true', () => {
     context('when runtime property is not present', () => {
       it('does not render a shell if runtime is null', () => {
-        const wrapper = mount(<CompassShell runtime={null} isExpanded />);
+        const wrapper = shallow(<CompassShell runtime={null} isExpanded />);
         expect(wrapper.find(Shell)).to.have.lengthOf(0);
       });
     });
@@ -31,21 +31,21 @@ describe('CompassShell', () => {
     context('when runtime property is present', () => {
       it('renders the Shell', () => {
         const fakeRuntime = {};
-        const wrapper = mount(<CompassShell runtime={fakeRuntime} isExpanded />);
+        const wrapper = shallow(<CompassShell runtime={fakeRuntime} isExpanded />);
         expect(wrapper.find(Shell).prop('runtime')).to.equal(fakeRuntime);
       });
 
       it('renders the ShellHeader component', () => {
         const fakeRuntime = {};
-        const wrapper = mount(<CompassShell runtime={fakeRuntime} isExpanded />);
-        expect(wrapper.find(ShellHeader).exists()).to.be(true);
+        const wrapper = shallow(<CompassShell runtime={fakeRuntime} isExpanded />);
+        expect(wrapper.find(ShellHeader).exists()).to.equal(true);
       });
     });
 
     context('when historyStorage is not present', () => {
       it('passes an empty history to the Shell', () => {
         const fakeRuntime = {};
-        const wrapper = mount(<CompassShell runtime={fakeRuntime} isExpanded />);
+        const wrapper = shallow(<CompassShell runtime={fakeRuntime} isExpanded />);
 
         expect(wrapper.find(Shell).prop('initialHistory')).to.deep.equal([]);
       });
@@ -68,9 +68,11 @@ describe('CompassShell', () => {
     it('passes the loaded history as initialHistory to Shell', async() => {
       fakeStorage.load = sinon.spy(() => Promise.resolve(['line1']));
 
-      const wrapper = mount(<CompassShell
+      const wrapper = shallow(<CompassShell
         runtime={fakeRuntime}
-        historyStorage={fakeStorage} />);
+        historyStorage={fakeStorage}
+        isExpanded
+      />);
 
       await updateAndWaitAsync(wrapper);
 
@@ -78,9 +80,11 @@ describe('CompassShell', () => {
     });
 
     it('saves the history when history changes', async() => {
-      const wrapper = mount(<CompassShell
+      const wrapper = shallow(<CompassShell
         runtime={fakeRuntime}
-        historyStorage={fakeStorage} />);
+        historyStorage={fakeStorage}
+        isExpanded
+      />);
 
       await updateAndWaitAsync(wrapper);
 

--- a/packages/compass-shell/src/components/compass-shell/compass-shell.spec.js
+++ b/packages/compass-shell/src/components/compass-shell/compass-shell.spec.js
@@ -1,8 +1,10 @@
 import sinon from 'sinon';
 import React from 'react';
-import { shallow } from 'enzyme';
+import { mount } from 'enzyme';
 import { Shell } from '@mongosh/browser-repl';
+
 import { CompassShell } from './compass-shell';
+import ShellHeader from '../shell-header';
 
 function updateAndWaitAsync(wrapper) {
   wrapper.update();
@@ -10,27 +12,43 @@ function updateAndWaitAsync(wrapper) {
 }
 
 describe('CompassShell', () => {
-  context('when runtime property is not present', () => {
-    it('does not render a shell if runtime is null', () => {
-      const wrapper = shallow(<CompassShell runtime={null} />);
+  context('when the prop isExpanded is false', () => {
+    it('does not render a shell', () => {
+      const fakeRuntime = {};
+      const wrapper = mount(<CompassShell runtime={fakeRuntime} isExpanded={false} />);
       expect(wrapper.find(Shell)).to.have.lengthOf(0);
     });
   });
 
-  context('when runtime property is present', () => {
-    it('renders the Shell', () => {
-      const fakeRuntime = {};
-      const wrapper = shallow(<CompassShell runtime={fakeRuntime} />);
-      expect(wrapper.find(Shell).prop('runtime')).to.equal(fakeRuntime);
+  context('when the prop isExpanded is true', () => {
+    context('when runtime property is not present', () => {
+      it('does not render a shell if runtime is null', () => {
+        const wrapper = mount(<CompassShell runtime={null} isExpanded />);
+        expect(wrapper.find(Shell)).to.have.lengthOf(0);
+      });
     });
-  });
 
-  context('when historyStorage is not present', () => {
-    it('passes an empty history to the Shell', () => {
-      const fakeRuntime = {};
-      const wrapper = shallow(<CompassShell runtime={fakeRuntime} />);
+    context('when runtime property is present', () => {
+      it('renders the Shell', () => {
+        const fakeRuntime = {};
+        const wrapper = mount(<CompassShell runtime={fakeRuntime} isExpanded />);
+        expect(wrapper.find(Shell).prop('runtime')).to.equal(fakeRuntime);
+      });
 
-      expect(wrapper.find(Shell).prop('initialHistory')).to.deep.equal([]);
+      it('renders the ShellHeader component', () => {
+        const fakeRuntime = {};
+        const wrapper = mount(<CompassShell runtime={fakeRuntime} isExpanded />);
+        expect(wrapper.find(ShellHeader).exists()).to.be(true);
+      });
+    });
+
+    context('when historyStorage is not present', () => {
+      it('passes an empty history to the Shell', () => {
+        const fakeRuntime = {};
+        const wrapper = mount(<CompassShell runtime={fakeRuntime} isExpanded />);
+
+        expect(wrapper.find(Shell).prop('initialHistory')).to.deep.equal([]);
+      });
     });
   });
 
@@ -50,7 +68,7 @@ describe('CompassShell', () => {
     it('passes the loaded history as initialHistory to Shell', async() => {
       fakeStorage.load = sinon.spy(() => Promise.resolve(['line1']));
 
-      const wrapper = shallow(<CompassShell
+      const wrapper = mount(<CompassShell
         runtime={fakeRuntime}
         historyStorage={fakeStorage} />);
 
@@ -60,7 +78,7 @@ describe('CompassShell', () => {
     });
 
     it('saves the history when history changes', async() => {
-      const wrapper = shallow(<CompassShell
+      const wrapper = mount(<CompassShell
         runtime={fakeRuntime}
         historyStorage={fakeStorage} />);
 

--- a/packages/compass-shell/src/components/resize-handle/index.js
+++ b/packages/compass-shell/src/components/resize-handle/index.js
@@ -1,0 +1,4 @@
+import ResizeHandle from './resize-handle';
+
+export default ResizeHandle;
+export { ResizeHandle };

--- a/packages/compass-shell/src/components/resize-handle/resize-handle.jsx
+++ b/packages/compass-shell/src/components/resize-handle/resize-handle.jsx
@@ -1,0 +1,10 @@
+import React, { PureComponent } from 'react';
+import styles from './resize-handle.less';
+
+export default class ResizeHandle extends PureComponent {
+  render() {
+    return (
+      <div className={styles['resize-handle']} />
+    );
+  }
+}

--- a/packages/compass-shell/src/components/resize-handle/resize-handle.less
+++ b/packages/compass-shell/src/components/resize-handle/resize-handle.less
@@ -1,0 +1,30 @@
+@import '~@leafygreen-ui/palette/dist/ui-colors.less';
+
+@handle-width: 30px;
+@handle-half-width: 15px;
+@handle-width-with-padding: 34px;
+@handle-half-width-width-padding: 17px;
+
+.resize-handle {
+  position: absolute;
+  left: -@handle-half-width-width-padding;
+  margin-left: 50%;
+  width: @handle-width-with-padding;
+  height: 24px;
+}
+
+.resize-handle::after {
+  content: "";
+  position: absolute;
+  left: -@handle-half-width;
+  top: 8px;
+  margin-left: 50%;
+  margin-top: 4px;
+  width: @handle-width;
+  height: 1px;
+  background: @leafygreen__gray--dark-1;
+
+  box-shadow: 
+    0 4px 0 0 @leafygreen__gray--dark-1,
+    0 8px 0 0 @leafygreen__gray--dark-1;
+}

--- a/packages/compass-shell/src/components/shell-header/index.js
+++ b/packages/compass-shell/src/components/shell-header/index.js
@@ -1,0 +1,4 @@
+import ShellHeader from './shell-header';
+
+export default ShellHeader;
+export { ShellHeader };

--- a/packages/compass-shell/src/components/shell-header/shell-header.jsx
+++ b/packages/compass-shell/src/components/shell-header/shell-header.jsx
@@ -28,26 +28,28 @@ export default class CompassShell extends Component {
         >
           &gt;_MongoSH Beta
         </button>
-        {isExpanded && (
-          <div className={styles['compass-shell-header-right-actions']}>
-            <IconButton
-              className={styles['compass-shell-header-info-btn']}
-              variant="dark"
-              aria-label="Open Shell Information"
-              onClick={() => alert('Coming soon')}
-            >
-              <Icon glyph="InfoWithCircle" />
-            </IconButton>
+        <div className={styles['compass-shell-header-right-actions']}>
+          {isExpanded && (
             <IconButton
               className={styles['compass-shell-header-close-btn']}
               variant="dark"
               aria-label="Close Shell"
               onClick={onShellToggleClicked}
             >
-              <Icon glyph="X" />
+              <Icon glyph="ChevronDown" />
             </IconButton>
-          </div>
-        )}
+          )}
+          {!isExpanded && (
+            <IconButton
+              className={styles['compass-shell-header-open-btn']}
+              variant="dark"
+              aria-label="Open Shell"
+              onClick={onShellToggleClicked}
+            >
+              <Icon glyph="ChevronUp" />
+            </IconButton>
+          )}
+        </div>
       </div>
     );
   }

--- a/packages/compass-shell/src/components/shell-header/shell-header.jsx
+++ b/packages/compass-shell/src/components/shell-header/shell-header.jsx
@@ -1,10 +1,10 @@
 import React, { Component } from 'react';
-import styles from './compass-shell.less';
+import styles from './shell-header.less';
 import PropTypes from 'prop-types';
 import IconButton from '@leafygreen-ui/icon-button';
 import Icon from '@leafygreen-ui/icon';
 
-export class CompassShell extends Component {
+export default class CompassShell extends Component {
   static propTypes = {
     isExpanded: PropTypes.bool.isRequired,
     onShellToggleClicked: PropTypes.func.isRequired
@@ -16,26 +16,37 @@ export class CompassShell extends Component {
    */
   render() {
     const {
-      isExpanded
+      isExpanded,
+      onShellToggleClicked
     } = this.props;
 
     return (
       <div className={styles['compass-shell-header']}>
         <button
           className={styles['compass-shell-header-toggle']}
-          onClick={this.onShellToggleClicked}
+          onClick={onShellToggleClicked}
         >
-          &gt;_MongoSH v0.9 Beta
+          &gt;_MongoSH Beta
         </button>
         {isExpanded && (
-          <IconButton
-            className={styles['compass-shell-header-close-btn']}
-            variant="dark"
-            aria-label="Some Menu"
-            onClick={this.onShellToggleClicked}
-          >
-            <Icon glyph="X" />
-          </IconButton>
+          <div className={styles['compass-shell-header-right-actions']}>
+            <IconButton
+              className={styles['compass-shell-header-info-btn']}
+              variant="dark"
+              aria-label="Open Shell Information"
+              onClick={() => alert('Coming soon')}
+            >
+              <Icon glyph="InfoWithCircle" />
+            </IconButton>
+            <IconButton
+              className={styles['compass-shell-header-close-btn']}
+              variant="dark"
+              aria-label="Close Shell"
+              onClick={onShellToggleClicked}
+            >
+              <Icon glyph="X" />
+            </IconButton>
+          </div>
         )}
       </div>
     );

--- a/packages/compass-shell/src/components/shell-header/shell-header.jsx
+++ b/packages/compass-shell/src/components/shell-header/shell-header.jsx
@@ -1,0 +1,43 @@
+import React, { Component } from 'react';
+import styles from './compass-shell.less';
+import PropTypes from 'prop-types';
+import IconButton from '@leafygreen-ui/icon-button';
+import Icon from '@leafygreen-ui/icon';
+
+export class CompassShell extends Component {
+  static propTypes = {
+    isExpanded: PropTypes.bool.isRequired,
+    onShellToggleClicked: PropTypes.func.isRequired
+  };
+  /**
+   * Render ShellHeader component.
+   *
+   * @returns {React.Component} The rendered component.
+   */
+  render() {
+    const {
+      isExpanded
+    } = this.props;
+
+    return (
+      <div className={styles['compass-shell-header']}>
+        <button
+          className={styles['compass-shell-header-toggle']}
+          onClick={this.onShellToggleClicked}
+        >
+          &gt;_MongoSH v0.9 Beta
+        </button>
+        {isExpanded && (
+          <IconButton
+            className={styles['compass-shell-header-close-btn']}
+            variant="dark"
+            aria-label="Some Menu"
+            onClick={this.onShellToggleClicked}
+          >
+            <Icon glyph="X" />
+          </IconButton>
+        )}
+      </div>
+    );
+  }
+}

--- a/packages/compass-shell/src/components/shell-header/shell-header.less
+++ b/packages/compass-shell/src/components/shell-header/shell-header.less
@@ -1,0 +1,20 @@
+
+.compass-shell-header {
+  width: 100%;
+  height: 24px;
+  display: flex;
+  color: @leafygreen__gray--light-1;
+
+  &-close-btn {
+    position: absolute;
+    right: 2px;
+    top: -2px;
+  }
+
+  &-toggle {
+    background: none;
+    border: none;
+    cursor: pointer;
+    padding: 1px 8px;
+  }
+}

--- a/packages/compass-shell/src/components/shell-header/shell-header.less
+++ b/packages/compass-shell/src/components/shell-header/shell-header.less
@@ -1,3 +1,4 @@
+@import '~@leafygreen-ui/palette/dist/ui-colors.less';
 
 .compass-shell-header {
   width: 100%;
@@ -5,10 +6,15 @@
   display: flex;
   color: @leafygreen__gray--light-1;
 
-  &-close-btn {
+  &-right-actions {
     position: absolute;
-    right: 2px;
+    right: 4px;
     top: -2px;
+    text-align: right;
+  }
+
+  &-info-button {
+    margin-right: 4px;
   }
 
   &-toggle {
@@ -16,5 +22,12 @@
     border: none;
     cursor: pointer;
     padding: 1px 8px;
+
+    transition: all 200ms;
+    user-select: none;
+
+    &:hover {
+      color: @leafygreen__gray--light-3;
+    }  
   }
 }

--- a/packages/compass-shell/src/components/shell-header/shell-header.less
+++ b/packages/compass-shell/src/components/shell-header/shell-header.less
@@ -13,10 +13,6 @@
     text-align: right;
   }
 
-  &-info-button {
-    margin-right: 4px;
-  }
-
   &-toggle {
     background: none;
     border: none;

--- a/packages/compass-shell/src/components/shell-header/shell-header.spec.js
+++ b/packages/compass-shell/src/components/shell-header/shell-header.spec.js
@@ -1,34 +1,52 @@
 import React from 'react';
-import { mount } from 'enzyme';
+import { mount, shallow } from 'enzyme';
 import IconButton from '@leafygreen-ui/icon-button';
 
 import ShellHeader from './shell-header';
+import styles from './shell-header.less';
 
 describe('ShellHeader', () => {
   context('when isExpanded prop is true', () => {
-    it('renders an X button to close', () => {
-      const wrapper = mount(<ShellHeader isExpanded />);
+    it('renders a close button', () => {
+      const wrapper = mount(<ShellHeader
+        isExpanded
+        onShellToggleClicked={() => {}}
+      />);
 
-      expect(wrapper.find(IconButton).exists()).toBe(true);
-      expect(wrapper.find('.compass-shell-header-close-btn').exists()).toBe(true);
+      expect(wrapper.find(IconButton).exists()).to.equal(true);
+    });
+
+    it('renders an actions area', () => {
+      const wrapper = mount(<ShellHeader
+        isExpanded
+        onShellToggleClicked={() => {}}
+      />);
+
+      expect(wrapper.find(`.${styles['compass-shell-header-right-actions']}`)).to.be.present();
     });
   });
 
   context('when isExpanded prop is false', () => {
     it('does not render an X button', () => {
-      const wrapper = mount(<ShellHeader isExpanded={false} />);
+      const wrapper = shallow(<ShellHeader
+        isExpanded={false}
+        onShellToggleClicked={() => {}}
+      />);
 
-      expect(wrapper.find(IconButton).exists()).toBe(false);
-      expect(wrapper.find('.compass-shell-header-close-btn').exists()).toBe(false);
+      expect(wrapper.find(IconButton).exists()).to.equal(false);
+      expect(wrapper.find(`.${styles['compass-shell-header-close-btn']}`).exists()).to.equal(false);
     });
   });
 
   context('when rendered', () => {
     it('has a button to toggle the container', async() => {
-      const wrapper = mount(<div className="some-class" />);
+      const wrapper = shallow(<ShellHeader
+        isExpanded={false}
+        onShellToggleClicked={() => {}}
+      />);
 
-      expect(wrapper.find('button').exists()).toBe(true);
-      expect(wrapper.find('.compass-shell-header-toggle').exists()).toBe(true);
+      expect(wrapper.find('button').exists()).to.equal(true);
+      expect(wrapper.find(`.${styles['compass-shell-header-toggle']}`)).to.be.present();
     });
   });
 });

--- a/packages/compass-shell/src/components/shell-header/shell-header.spec.js
+++ b/packages/compass-shell/src/components/shell-header/shell-header.spec.js
@@ -1,5 +1,6 @@
 import React from 'react';
 import { mount, shallow } from 'enzyme';
+import Icon from '@leafygreen-ui/icon';
 import IconButton from '@leafygreen-ui/icon-button';
 
 import ShellHeader from './shell-header';
@@ -7,13 +8,14 @@ import styles from './shell-header.less';
 
 describe('ShellHeader', () => {
   context('when isExpanded prop is true', () => {
-    it('renders a close button', () => {
+    it('renders a close chevron button', () => {
       const wrapper = mount(<ShellHeader
         isExpanded
         onShellToggleClicked={() => {}}
       />);
 
       expect(wrapper.find(IconButton).exists()).to.equal(true);
+      expect(wrapper.find(Icon).prop('glyph')).to.equal('ChevronDown');
     });
 
     it('renders an actions area', () => {
@@ -27,14 +29,14 @@ describe('ShellHeader', () => {
   });
 
   context('when isExpanded prop is false', () => {
-    it('does not render an X button', () => {
-      const wrapper = shallow(<ShellHeader
+    it('renders an open chevron button', () => {
+      const wrapper = mount(<ShellHeader
         isExpanded={false}
         onShellToggleClicked={() => {}}
       />);
 
-      expect(wrapper.find(IconButton).exists()).to.equal(false);
-      expect(wrapper.find(`.${styles['compass-shell-header-close-btn']}`).exists()).to.equal(false);
+      expect(wrapper.find(IconButton).exists()).to.equal(true);
+      expect(wrapper.find(Icon).prop('glyph')).to.equal('ChevronUp');
     });
   });
 

--- a/packages/compass-shell/src/components/shell-header/shell-header.spec.js
+++ b/packages/compass-shell/src/components/shell-header/shell-header.spec.js
@@ -1,0 +1,35 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import IconButton from '@leafygreen-ui/icon-button';
+
+import ShellHeader from './shell-header';
+
+describe('ShellHeader', () => {
+  context('when isExpanded prop is true', () => {
+    it('renders an X button to close', () => {
+      const wrapper = mount(<ShellHeader isExpanded />);
+
+      expect(wrapper.find(IconButton).exists()).toBe(true);
+      expect(wrapper.find('.compass-shell-header-close-btn').exists()).toBe(true);
+    });
+  });
+
+  context('when isExpanded prop is false', () => {
+    it('does not render an X button', () => {
+      const wrapper = mount(<ShellHeader isExpanded={false} />);
+
+      expect(wrapper.find(IconButton).exists()).toBe(false);
+      expect(wrapper.find('.compass-shell-header-close-btn').exists()).toBe(false);
+    });
+  });
+
+  context('when rendered', () => {
+    it('has a button to toggle the container', async() => {
+      const wrapper = mount(<div className="some-class" />);
+
+      expect(wrapper.find('button').exists()).toBe(true);
+      expect(wrapper.find('.compass-shell-header-toggle').exists()).toBe(true);
+    });
+  });
+});
+

--- a/packages/compass-shell/src/index.js
+++ b/packages/compass-shell/src/index.js
@@ -10,8 +10,6 @@ const {
  * @param {Object} appRegistry - The Hadron appRegisrty to activate this plugin with.
  **/
 function activate(appRegistry) {
-  console.log('Activated mongo shell and registered its role.');
-
   // Register the shell plugin's role in Compass.
   appRegistry.registerComponent('Global.Shell', Plugin);
   appRegistry.registerStore('CompassShell.Store', store);

--- a/packages/compass-shell/src/index.js
+++ b/packages/compass-shell/src/index.js
@@ -5,26 +5,15 @@ const {
   Plugin
 } = createPlugin();
 
-const ROLE = {
-  name: 'Shell',
-  component: Plugin
-};
-
 /**
  * Activate all the components in the Compass Shell package.
  * @param {Object} appRegistry - The Hadron appRegisrty to activate this plugin with.
  **/
 function activate(appRegistry) {
-  // Register the CompassShellPlugin as a role in Compass
-  //
-  // Available roles are:
-  //   - Instance.Tab: { name: <String>, component: <React.Component>, order: <Number> }
-  //   - Database.Tab: { name: <String>, component: <React.Component>, order: <Number> }
-  //   - Collection.Tab: { name: <String>, component: <React.Component>, order: <Number> }
-  //   - CollectionHUD.Item: { name <String>, component: <React.Component> }
-  //   - Header.Item: { name: <String>, component: <React.Component>, alignment: <String> }
+  console.log('Activated mongo shell and registered its role.');
 
-  appRegistry.registerRole('Instance.Tab', ROLE);
+  // Register the shell plugin's role in Compass.
+  appRegistry.registerComponent('Global.Shell', Plugin);
   appRegistry.registerStore('CompassShell.Store', store);
 }
 
@@ -33,7 +22,7 @@ function activate(appRegistry) {
  * @param {Object} appRegistry - The Hadron appRegisrty to deactivate this plugin with.
  **/
 function deactivate(appRegistry) {
-  appRegistry.deregisterRole('Instance.Tab', ROLE);
+  appRegistry.registerComponent('Global.Shell', Plugin);
   appRegistry.deregisterStore('CompassShell.Store');
 }
 


### PR DESCRIPTION
https://jira.mongodb.org/browse/MONGOSH-89

Mocks for reference: https://mongodb.invisionapp.com/share/RZVV94NAY6B#/screens/403867881

This PR updates the shell plugin to register as a global component for use in `compass-home`.

It also configures the styling of the component so that it can be clicked to toggle open and clicked to toggle closed. It is resize-able by dragging the triple bar in the middle as a handler, as well as the bar that separates it from the rest of the page. It has a max height of 800px, and a min height of 24px. We use this package for resizing: https://github.com/bokuweb/re-resizable I found it did the job nicely and haven't gotten into too many issues, the dependencies on it seem slim too. One thing we could improve is when compass is zoomed in a lot (ctrl + '+') and the shell is toggled open & closed, the resumed height is not relative to the zooming. I don't think this is a breaking bug but something we could address in future.

Toggling the shell clears it (history is maintained from Maurizio's work). Should we make it persist? What would you expect?

Here's where we add in the global plugin shell role and do some styling to make sure existing plugins scroll nicely vertically: https://github.com/mongodb-js/compass-home/pull/112

I'd like to wait for the PRs on `compass-home` and `compass` to be merged in before we merge this but I'm opening it now so we can take a look. Going to try some weird things to try and break it in the meantime. Currently to manually test I'm pulling the `compass-home` changes into the `compass` node modules in this repo and running `npm run start-compass`.

The 'i' info button is not yet added. Ticket for that: https://jira.mongodb.org/browse/COMPASS-4292

__Screenshots__
![May-12-2020 19-58-01](https://user-images.githubusercontent.com/1791149/81728637-12808900-948b-11ea-9243-68ff3fdf5584.gif)
