### PR TITLE
chore: fix bootstrap concurrency and use npm ci

### DIFF
--- a/.evergreen/.install_node
+++ b/.evergreen/.install_node
@@ -15,12 +15,12 @@ if [[ $OSTYPE == "cygwin" ]]; then
   rm -rf npm npx npm.cmd npx.cmd
   mv node_modules/npm node_modules/npm2
   chmod +x ./node.exe
-  
+
   ./node.exe node_modules/npm2/bin/npm-cli.js i -g npm@latest
   rm -rf node_modules/npm2/
   chmod +x npm.cmd npm
   cd ..
-  npm run bootstrap
+  npm run bootstrap-ci
 else
   curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash
   export NVM_DIR="$HOME/.nvm"
@@ -30,5 +30,5 @@ else
   nvm install $NODE_JS_VERSION
   nvm alias default $NODE_JS_VERSION
   npm install -g npm@latest
-  npm run bootstrap
+  npm run bootstrap-ci
 fi

--- a/package.json
+++ b/package.json
@@ -4,8 +4,10 @@
   "main": "index.js",
   "bin": "packages/cli-repl/bin/mongosh.js",
   "scripts": {
-    "prebootstrap": "npm install",
-    "bootstrap": "lerna bootstrap",
+    "prebootstrap": "npm i",
+    "bootstrap": "lerna bootstrap --concurrency=1",
+    "prebootstrap-ci": "npm ci",
+    "bootstrap-ci": "lerna bootstrap --ci --concurrency=1",
     "clean": "lerna clean -y && rm -Rf node_modules",
     "check": "lerna run check --since HEAD --exclude-dependents",
     "check-ci": "lerna run check",


### PR DESCRIPTION
- Fixes the bootstrap concurrency to 1 so to avoid cache lock issues. 
- Uses `npm ci` and `lerna bootstrap --ci` in evergreen to prevent unexpected version bump with dependencies.