### PR TITLE
Cursor methods fixes

### DIFF
--- a/.evergreen/.install_node
+++ b/.evergreen/.install_node
@@ -15,6 +15,7 @@ if [[ $OSTYPE == "cygwin" ]]; then
   rm -rf npm npx npm.cmd npx.cmd
   mv node_modules/npm node_modules/npm2
   chmod +x ./node.exe
+  
   ./node.exe node_modules/npm2/bin/npm-cli.js i -g npm@latest
   rm -rf node_modules/npm2/
   chmod +x npm.cmd npm

--- a/.evergreen/.install_node
+++ b/.evergreen/.install_node
@@ -20,7 +20,7 @@ if [[ $OSTYPE == "cygwin" ]]; then
   rm -rf node_modules/npm2/
   chmod +x npm.cmd npm
   cd ..
-  npm run bootstrap-ci
+  npm run bootstrap
 else
   curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.35.3/install.sh | bash
   export NVM_DIR="$HOME/.nvm"
@@ -30,5 +30,5 @@ else
   nvm install $NODE_JS_VERSION
   nvm alias default $NODE_JS_VERSION
   npm install -g npm@latest
-  npm run bootstrap-ci
+  npm run bootstrap
 fi

--- a/.evergreen/.install_node
+++ b/.evergreen/.install_node
@@ -15,7 +15,6 @@ if [[ $OSTYPE == "cygwin" ]]; then
   rm -rf npm npx npm.cmd npx.cmd
   mv node_modules/npm node_modules/npm2
   chmod +x ./node.exe
-
   ./node.exe node_modules/npm2/bin/npm-cli.js i -g npm@latest
   rm -rf node_modules/npm2/
   chmod +x npm.cmd npm

--- a/package.json
+++ b/package.json
@@ -5,9 +5,7 @@
   "bin": "packages/cli-repl/bin/mongosh.js",
   "scripts": {
     "prebootstrap": "npm i",
-    "bootstrap": "lerna bootstrap --concurrency=1",
-    "prebootstrap-ci": "npm ci",
-    "bootstrap-ci": "lerna bootstrap --ci --concurrency=1",
+    "bootstrap": "lerna bootstrap",
     "clean": "lerna clean -y && rm -Rf node_modules",
     "check": "lerna run check --since HEAD --exclude-dependents",
     "check-ci": "lerna run check",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "main": "index.js",
   "bin": "packages/cli-repl/bin/mongosh.js",
   "scripts": {
-    "prebootstrap": "npm i",
+    "prebootstrap": "npm install",
     "bootstrap": "lerna bootstrap",
     "clean": "lerna clean -y && rm -Rf node_modules",
     "check": "lerna run check --since HEAD --exclude-dependents",

--- a/packages/service-provider-browser/src/unsupported-cursor.ts
+++ b/packages/service-provider-browser/src/unsupported-cursor.ts
@@ -103,7 +103,7 @@ class UnsupportedCursor implements Cursor {
     throw new Error("Method not implemented.");
   }
 
-  readPref(preference: string): Cursor {
+  readPref(preference: string, tagSet?: Document[]): Cursor {
     throw new Error("Method not implemented.");
   }
 

--- a/packages/service-provider-core/src/cursor.ts
+++ b/packages/service-provider-core/src/cursor.ts
@@ -65,6 +65,7 @@ interface Cursor {
    */
   count(): Promise<number>;
 
+
   forEach(f): Promise<void>;
 
   /**
@@ -157,15 +158,6 @@ interface Cursor {
   projection(spec: Document): Cursor;
 
   /**
-   * Set the read preference.
-   *
-   * @param {string} preference - The read preference.
-   *
-   * @returns {Cursor} The cursor.
-   */
-  readPref(preference: string): Cursor;
-
-  /**
    * Set the cursor to return the index field.
    *
    * @param {boolean} enabled - Whether to enable return key.
@@ -200,6 +192,15 @@ interface Cursor {
    * @returns {Cursor} The cursor.
    */
   tailable(): Cursor;
+
+  /**
+   * Set read preference for the cursor.
+   *
+   * @param {string} mode - the read preference mode
+   * @param {Document[]} [tagSet] - the tag set
+   * @returns {Cursor}
+   */
+  readPref(mode: string, tagSet?: Document[]): Cursor;
 
   /**
    * Get the documents from the cursor as an array of objects.

--- a/packages/service-provider-server/package-lock.json
+++ b/packages/service-provider-server/package-lock.json
@@ -4,6 +4,25 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@types/chai": {
+			"version": "4.2.11",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.11.tgz",
+			"integrity": "sha512-t7uW6eFafjO+qJ3BIV2gGUyZs27egcNRkUdalkud+Qa3+kg//f129iuOFivHDXQ+vnU3fDXuwgv0cqMCbcE8sw=="
+		},
+		"@types/sinon": {
+			"version": "7.5.2",
+			"resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-7.5.2.tgz",
+			"integrity": "sha512-T+m89VdXj/eidZyejvmoP9jivXgBDdkOSBVQjU9kF349NEx10QdPNGxHeZUaj1IlJ32/ewdyXJjnJxyxJroYwg=="
+		},
+		"@types/sinon-chai": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@types/sinon-chai/-/sinon-chai-3.2.4.tgz",
+			"integrity": "sha512-xq5KOWNg70PRC7dnR2VOxgYQ6paumW+4pTZP+6uTSdhpYsAUEeeT5bw6rRHHQrZ4KyR+M5ojOR+lje6TGSpUxA==",
+			"requires": {
+				"@types/chai": "*",
+				"@types/sinon": "*"
+			}
+		},
 		"bl": {
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/bl/-/bl-2.2.0.tgz",

--- a/packages/service-provider-server/package.json
+++ b/packages/service-provider-server/package.json
@@ -40,6 +40,9 @@
   },
   "dependencies": {
     "@mongosh/service-provider-core": "^0.0.1-alpha.14",
-    "mongodb": "3.5.3 || ^3.5.5"
+    "@mongosh/errors": "^0.0.1-alpha.14",
+    "mongodb": "3.5.3 || ^3.5.5",
+    "@types/sinon": "^7.5.1",
+    "@types/sinon-chai": "^3.2.3"
   }
 }

--- a/packages/service-provider-server/src/cli-service-provider.spec.ts
+++ b/packages/service-provider-server/src/cli-service-provider.spec.ts
@@ -56,7 +56,7 @@ describe('CliServiceProvider', () => {
       const cursor = await serviceProvider.aggregate('music', 'bands', pipeline);
       const result = await cursor.toArray();
       expect(result).to.deep.equal(aggResult);
-      aggMock.verify();
+      (aggMock as any).verify();
     });
   });
 
@@ -75,7 +75,7 @@ describe('CliServiceProvider', () => {
     it('executes the command against the database', async() => {
       const result = await serviceProvider.bulkWrite('music', 'bands', requests);
       expect(result).to.deep.equal(commandResult);
-      bulkMock.verify();
+      (bulkMock as any).verify();
     });
   });
 
@@ -93,7 +93,7 @@ describe('CliServiceProvider', () => {
     it('executes the command against the database', async() => {
       const result = await serviceProvider.countDocuments('music', 'bands');
       expect(result).to.deep.equal(countResult);
-      countMock.verify();
+      (countMock as any).verify();
     });
   });
 
@@ -111,7 +111,7 @@ describe('CliServiceProvider', () => {
     it('executes the command against the database', async() => {
       const result = await serviceProvider.deleteMany('music', 'bands', {});
       expect(result).to.deep.equal(commandResult);
-      deleteMock.verify();
+      (deleteMock as any).verify();
     });
   });
 
@@ -129,7 +129,7 @@ describe('CliServiceProvider', () => {
     it('executes the command against the database', async() => {
       const result = await serviceProvider.deleteOne('music', 'bands', {});
       expect(result).to.deep.equal(commandResult);
-      deleteMock.verify();
+      (deleteMock as any).verify();
     });
   });
 
@@ -148,7 +148,7 @@ describe('CliServiceProvider', () => {
     it('executes the command against the database', async() => {
       const result = await serviceProvider.distinct('music', 'bands', 'name');
       expect(result).to.deep.equal(distinctResult);
-      distinctMock.verify();
+      (distinctMock as any).verify();
     });
   });
 
@@ -166,7 +166,7 @@ describe('CliServiceProvider', () => {
     it('executes the command against the database', async() => {
       const result = await serviceProvider.estimatedDocumentCount('music', 'bands');
       expect(result).to.deep.equal(countResult);
-      countMock.verify();
+      (countMock as any).verify();
     });
   });
 
@@ -187,7 +187,7 @@ describe('CliServiceProvider', () => {
       const cursor = await serviceProvider.find('music', 'bands', filter);
       const result = await cursor.toArray();
       expect(result).to.deep.equal(findResult);
-      findMock.verify();
+      (findMock as any).verify();
     });
   });
 
@@ -216,7 +216,7 @@ describe('CliServiceProvider', () => {
         { options: 1 }
       );
       expect(result).to.deep.equal(commandResult);
-      findMock.verify();
+      (findMock as any).verify();
     });
   });
 
@@ -234,7 +234,7 @@ describe('CliServiceProvider', () => {
     it('executes the command against the database', async() => {
       const result = await serviceProvider.findOneAndDelete('music', 'bands', {});
       expect(result).to.deep.equal(commandResult);
-      findMock.verify();
+      (findMock as any).verify();
     });
   });
 
@@ -256,7 +256,7 @@ describe('CliServiceProvider', () => {
       const result = await serviceProvider.
         findOneAndReplace('music', 'bands', filter, replacement);
       expect(result).to.deep.equal(commandResult);
-      findMock.verify();
+      (findMock as any).verify();
     });
   });
 
@@ -278,7 +278,7 @@ describe('CliServiceProvider', () => {
       const result = await serviceProvider.
         findOneAndUpdate('music', 'bands', filter, update);
       expect(result).to.deep.equal(commandResult);
-      findMock.verify();
+      (findMock as any).verify();
     });
   });
 
@@ -297,7 +297,7 @@ describe('CliServiceProvider', () => {
     it('executes the command against the database', async() => {
       const result = await serviceProvider.insertMany('music', 'bands', [ doc ]);
       expect(result).to.deep.equal(commandResult);
-      insertMock.verify();
+      (insertMock as any).verify();
     });
   });
 
@@ -316,7 +316,7 @@ describe('CliServiceProvider', () => {
     it('executes the command against the database', async() => {
       const result = await serviceProvider.insertOne('music', 'bands', doc);
       expect(result).to.deep.equal(commandResult);
-      insertMock.verify();
+      (insertMock as any).verify();
     });
   });
 
@@ -337,7 +337,7 @@ describe('CliServiceProvider', () => {
     it('executes the command against the database', async() => {
       const result = await serviceProvider.replaceOne('music', 'bands', filter, replacement);
       expect(result).to.deep.equal(commandResult);
-      replaceMock.verify();
+      (replaceMock as any).verify();
     });
   });
 
@@ -367,7 +367,7 @@ describe('CliServiceProvider', () => {
     it('executes the command against the database', async() => {
       const result = await serviceProvider.runCommand('admin', { ismaster: 1 });
       expect(result).to.deep.equal(commandResult);
-      commandMock.verify();
+      (commandMock as any).verify();
     });
   });
 
@@ -388,7 +388,7 @@ describe('CliServiceProvider', () => {
     it('executes the command against the database', async() => {
       const result = await serviceProvider.updateOne('music', 'bands', filter, update);
       expect(result).to.deep.equal(commandResult);
-      updateMock.verify();
+      (updateMock as any).verify();
     });
   });
 
@@ -409,7 +409,7 @@ describe('CliServiceProvider', () => {
     it('executes the command against the database', async() => {
       const result = await serviceProvider.updateMany('music', 'bands', filter, update);
       expect(result).to.deep.equal(commandResult);
-      updateMock.verify();
+      (updateMock as any).verify();
     });
   });
 
@@ -453,7 +453,7 @@ describe('CliServiceProvider', () => {
         await serviceProvider.dropDatabase('db1');
         expect((clientStub.db as any).calledOnce);
         expect((clientStub.db as any).calledWith('db1'));
-        dropDatabaseMock.verify();
+        (dropDatabaseMock as any).verify();
       });
     });
 
@@ -463,7 +463,7 @@ describe('CliServiceProvider', () => {
         await serviceProvider.dropDatabase('db1', { w: 1 });
         expect((clientStub.db as any).calledOnce);
         expect((clientStub.db as any).calledWith('db1'));
-        dropDatabaseMock.verify();
+        (dropDatabaseMock as any).verify();
       });
     });
   });
@@ -503,8 +503,8 @@ describe('CliServiceProvider', () => {
     it('executes the command against the admin database', async() => {
       const result = await serviceProvider.buildInfo();
       expect(result).to.deep.equal(buildInfoResult);
-      dbMock.verify();
-      commandMock.verify();
+      (dbMock as any).verify();
+      (commandMock as any).verify();
     });
   });
 
@@ -549,8 +549,8 @@ describe('CliServiceProvider', () => {
     it('executes getCmdLineOpts against an admin db', async() => {
       const result = await serviceProvider.getCmdLineOpts();
       expect(result).to.deep.equal(cmdLineOptsResult);
-      dbMock.verify();
-      commandMock.verify();
+      (dbMock as any).verify();
+      (commandMock as any).verify();
     });
   });
 
@@ -582,8 +582,8 @@ describe('CliServiceProvider', () => {
     it('executes the command', async() => {
       const result = await serviceProvider.convertToCapped('db1', 'coll1', 1000);
       expect(result).to.deep.equal({ ok: 1 });
-      dbMock.verify();
-      commandMock.verify();
+      (dbMock as any).verify();
+      (commandMock as any).verify();
     });
   });
 
@@ -620,7 +620,7 @@ describe('CliServiceProvider', () => {
         'coll1',
         indexSpecs);
       expect(result).to.deep.equal(nativeMethodResult);
-      nativeMethodMock.verify();
+      (nativeMethodMock as any).verify();
     });
   });
 
@@ -655,7 +655,7 @@ describe('CliServiceProvider', () => {
       );
 
       expect(result).to.deep.equal(indexSpecs);
-      nativeMethodMock.verify();
+      (nativeMethodMock as any).verify();
     });
   });
 
@@ -687,8 +687,8 @@ describe('CliServiceProvider', () => {
     it('executes the command', async() => {
       const result = await serviceProvider.dropIndexes('db1', 'coll1', ['index-1']);
       expect(result).to.deep.equal({ ok: 1 });
-      dbMock.verify();
-      commandMock.verify();
+      (dbMock as any).verify();
+      (commandMock as any).verify();
     });
   });
 
@@ -733,8 +733,8 @@ describe('CliServiceProvider', () => {
         }
       ]);
 
-      dbMock.verify();
-      commandMock.verify();
+      (dbMock as any).verify();
+      (commandMock as any).verify();
     });
   });
 
@@ -758,7 +758,7 @@ describe('CliServiceProvider', () => {
     it('executes the command against the database', async() => {
       const result = await serviceProvider.stats('db1', 'coll1', options);
       expect(result).to.deep.equal(expectedResult);
-      statsMock.verify();
+      (statsMock as any).verify();
     });
   });
 
@@ -790,8 +790,8 @@ describe('CliServiceProvider', () => {
     it('executes the command against the database', async() => {
       const result = await serviceProvider.reIndex('db1', 'coll1');
       expect(result).to.deep.equal({ ok: 1 });
-      dbMock.verify();
-      commandMock.verify();
+      (dbMock as any).verify();
+      (commandMock as any).verify();
     });
   });
 
@@ -834,8 +834,8 @@ describe('CliServiceProvider', () => {
         { dropTarget: true, session: 1 }
       );
       expect(result).to.deep.equal({ ok: 1 });
-      dbMock.verify();
-      commandMock.verify();
+      (dbMock as any).verify();
+      (commandMock as any).verify();
     });
   });
 });

--- a/packages/service-provider-server/src/node/node-cursor.spec.ts
+++ b/packages/service-provider-server/src/node/node-cursor.spec.ts
@@ -1,11 +1,15 @@
+import sinon, { SinonStubbedInstance } from 'sinon';
+import chai from 'chai';
+import sinonChai from 'sinon-chai';
+chai.use(sinonChai);
+const { expect } = chai;
+
 import NodeCursor, { Flag } from './node-cursor';
 import { Cursor } from 'mongodb';
-import { expect } from 'chai';
-import sinon from 'sinon';
 
 describe('NodeCursor', () => {
   describe('#addOption', () => {
-    let cursor;
+    let cursor: SinonStubbedInstance<Cursor>;
     let nodeCursor;
     let mock;
 
@@ -21,10 +25,18 @@ describe('NodeCursor', () => {
       expect(nodeCursor.addOption(2)).to.equal(nodeCursor);
       mock.verify();
     });
+
+    it('throws if a SlaveOk flag passed', () => {
+      expect(() => nodeCursor.addOption(4)).to.throw('the slaveOk option is not yet supported.');
+    });
+
+    it('throws if an unknown flag passed', () => {
+      expect(() => nodeCursor.addOption(123123)).to.throw('Unknown option flag number: 123123');
+    });
   });
 
   describe('#allowPartialResults', () => {
-    let cursor;
+    let cursor: SinonStubbedInstance<Cursor>;
     let nodeCursor;
     let mock;
 
@@ -43,7 +55,7 @@ describe('NodeCursor', () => {
   });
 
   describe('#batchSize', () => {
-    let cursor;
+    let cursor: SinonStubbedInstance<Cursor>;
     let nodeCursor;
     let mock;
 
@@ -62,7 +74,7 @@ describe('NodeCursor', () => {
   });
 
   describe('#close', () => {
-    let cursor;
+    let cursor: SinonStubbedInstance<Cursor>;
     let nodeCursor;
     let mock;
     const options = { skipKillCursors: true };
@@ -82,7 +94,7 @@ describe('NodeCursor', () => {
   });
 
   describe('#collation', () => {
-    let cursor;
+    let cursor: SinonStubbedInstance<Cursor>;
     let nodeCursor;
     let mock;
     const coll = { locale: 'en' };
@@ -102,7 +114,7 @@ describe('NodeCursor', () => {
   });
 
   describe('#comment', () => {
-    let cursor;
+    let cursor: SinonStubbedInstance<Cursor>;
     let nodeCursor;
     let mock;
     const cmt = 'hi';
@@ -122,7 +134,7 @@ describe('NodeCursor', () => {
   });
 
   describe('#count', () => {
-    let cursor;
+    let cursor: SinonStubbedInstance<Cursor>;
     let nodeCursor;
     let mock;
 
@@ -141,7 +153,7 @@ describe('NodeCursor', () => {
   });
 
   describe('#hasNext', () => {
-    let cursor;
+    let cursor: SinonStubbedInstance<Cursor>;
     let nodeCursor;
     let mock;
 
@@ -160,7 +172,7 @@ describe('NodeCursor', () => {
   });
 
   describe('#isExhausted', () => {
-    let cursor;
+    let cursor: SinonStubbedInstance<Cursor>;
     let nodeCursor: NodeCursor;
     let hasNextMock;
     let isClosedMock;
@@ -195,7 +207,7 @@ describe('NodeCursor', () => {
   });
 
   describe('#hint', () => {
-    let cursor;
+    let cursor: SinonStubbedInstance<Cursor>;
     let nodeCursor;
     let mock;
     const index = 'a_1';
@@ -215,7 +227,7 @@ describe('NodeCursor', () => {
   });
 
   describe('#limit', () => {
-    let cursor;
+    let cursor: SinonStubbedInstance<Cursor>;
     let nodeCursor;
     let mock;
     const value = 6;
@@ -235,7 +247,7 @@ describe('NodeCursor', () => {
   });
 
   describe('#max', () => {
-    let cursor;
+    let cursor: SinonStubbedInstance<Cursor>;
     let nodeCursor;
     let mock;
     const value = { a: 1 };
@@ -255,7 +267,7 @@ describe('NodeCursor', () => {
   });
 
   describe('#maxTimeMS', () => {
-    let cursor;
+    let cursor: SinonStubbedInstance<Cursor>;
     let nodeCursor;
     let mock;
     const value = 5000;
@@ -275,7 +287,7 @@ describe('NodeCursor', () => {
   });
 
   describe('#min', () => {
-    let cursor;
+    let cursor: SinonStubbedInstance<Cursor>;
     let nodeCursor;
     let mock;
     const value = { a: 1 };
@@ -295,7 +307,7 @@ describe('NodeCursor', () => {
   });
 
   describe('#noCursorTimeout', () => {
-    let cursor;
+    let cursor: SinonStubbedInstance<Cursor>;
     let nodeCursor;
     let mock;
 
@@ -314,7 +326,7 @@ describe('NodeCursor', () => {
   });
 
   describe('#oplogReplay', () => {
-    let cursor;
+    let cursor: SinonStubbedInstance<Cursor>;
     let nodeCursor;
     let mock;
 
@@ -333,7 +345,7 @@ describe('NodeCursor', () => {
   });
 
   describe('#projection', () => {
-    let cursor;
+    let cursor: SinonStubbedInstance<Cursor>;
     let nodeCursor;
     let mock;
     const value = { a: 1 };
@@ -353,7 +365,7 @@ describe('NodeCursor', () => {
   });
 
   describe('#readPref', () => {
-    let cursor;
+    let cursor: SinonStubbedInstance<Cursor>;
     let nodeCursor;
     let mock;
     const value = 'primary';
@@ -370,10 +382,14 @@ describe('NodeCursor', () => {
       expect(nodeCursor.readPref(value)).to.equal(nodeCursor);
       mock.verify();
     });
+
+    it('throws MongoshUnimplementedError if tagset is passed', () => {
+      expect(() => nodeCursor.readPref(value, [])).to.throw('the tagSet argument is not yet supported.');
+    });
   });
 
   describe('#returnKey', () => {
-    let cursor;
+    let cursor: SinonStubbedInstance<Cursor>;
     let nodeCursor;
     let mock;
     const value = true;
@@ -392,49 +408,8 @@ describe('NodeCursor', () => {
     });
   });
 
-  // TODO: fix implementation
-  // describe('#showDiskLoc', () => {
-  //   let cursor;
-  //   let nodeCursor;
-  //   let mock;
-
-  //   beforeEach(() => {
-  //     mock = sinon.mock().withArgs(true);
-  //     cursor = sinon.createStubInstance(Cursor, {
-  //       showRecordId: mock
-  //     });
-  //     nodeCursor = new NodeCursor(cursor);
-  //   });
-
-  //   it('fluidly sets the show disk location flag', () => {
-  //     expect(nodeCursor.showDiskLoc()).to.equal(nodeCursor);
-  //     mock.verify();
-  //   });
-  // });
-
-  // TODO: fix implementation
-  // describe('#showRecordId', () => {
-  //   let cursor;
-  //   let nodeCursor;
-  //   let mock;
-  //   const value = true;
-
-  //   beforeEach(() => {
-  //     mock = sinon.mock().withArgs(value);
-  //     cursor = sinon.createStubInstance(Cursor, {
-  //       showRecordId: mock
-  //     });
-  //     nodeCursor = new NodeCursor(cursor);
-  //   });
-
-  //   it('fluidly sets the show record id value', () => {
-  //     expect(nodeCursor.showRecordId(value)).to.equal(nodeCursor);
-  //     mock.verify();
-  //   });
-  // });
-
   describe('#skip', () => {
-    let cursor;
+    let cursor: SinonStubbedInstance<Cursor>;
     let nodeCursor;
     let mock;
     const value = 6;
@@ -454,7 +429,7 @@ describe('NodeCursor', () => {
   });
 
   describe('#sort', () => {
-    let cursor;
+    let cursor: SinonStubbedInstance<Cursor>;
     let nodeCursor;
     let mock;
     const value = { a: 1 };
@@ -474,7 +449,7 @@ describe('NodeCursor', () => {
   });
 
   describe('#tailable', () => {
-    let cursor;
+    let cursor: SinonStubbedInstance<Cursor>;
     let nodeCursor;
     let mock;
 
@@ -489,6 +464,25 @@ describe('NodeCursor', () => {
     it('fluidly adds the cursor flag', () => {
       expect(nodeCursor.tailable()).to.equal(nodeCursor);
       mock.verify();
+    });
+  });
+
+  describe('#itcount', () => {
+    let cursor: SinonStubbedInstance<Cursor>;
+    let nodeCursor;
+
+    beforeEach(() => {
+      cursor = sinon.createStubInstance(Cursor);
+      nodeCursor = new NodeCursor(cursor);
+    });
+
+    it('returns the iteration count', async() => {
+      cursor.hasNext.onCall(0).resolves(true);
+      cursor.hasNext.onCall(1).resolves(true);
+      cursor.hasNext.onCall(2).resolves(false);
+      cursor.next.resolves({});
+
+      expect(await nodeCursor.itcount()).to.equal(2);
     });
   });
 

--- a/packages/shell-api/yaml/AggregationCursor.yaml
+++ b/packages/shell-api/yaml/AggregationCursor.yaml
@@ -9,7 +9,6 @@ class:
         wrappee: _cursor
         firstArg: ''
     __hasAsyncChild: true
-    # bsonsize: *__defaultMethod # TODO
     close:
         <<: *__defaultMethod
         returnsPromise: true
@@ -33,11 +32,12 @@ class:
     next:
         <<: *__defaultMethod
         returnsPromise: true
-    # objsLeftInBatch:
-    #     <<: *__defaultMethod
     toArray:
         <<: *__defaultMethod
         returnsPromise: true
     explain:
         <<: *__defaultMethod
         returnsPromise: true
+    # objsLeftInBatch:
+    #     <<: *__defaultMethod
+    # bsonsize: *__defaultMethod # TODO

--- a/packages/shell-api/yaml/Cursor.yaml
+++ b/packages/shell-api/yaml/Cursor.yaml
@@ -57,8 +57,6 @@ class:
     forEach:
         <<: *__defaultMethod
         returnsPromise: true
-    # getQueryPlan:  # TODO: not implemented
-    #     <<: *__defaultMethod
     hasNext:
         <<: *__defaultMethod
         returnsPromise: true
@@ -73,9 +71,6 @@ class:
     itcount:
         <<: *__defaultMethod
         returnsPromise: true
-    # length: # Not implemented / not documented
-    #     <<: *__defaultMethod
-    #     returnsPromise: true
     limit:
         <<: *__defaultMethod
         __fluent: true
@@ -88,13 +83,6 @@ class:
         <<: *__defaultMethod
         __fluent: true
         returnType: 'Cursor'
-    # maxScan: # Not implemented / not documented
-    #     <<: *__defaultMethod
-    #     __fluent: true
-    #     returnType: 'Cursor'
-    #     serverVersions:
-    #         - *ServerVersions.earliest
-    #         - '4.0.0'
     maxTimeMS:
         <<: *__defaultMethod
         __fluent: true
@@ -103,8 +91,6 @@ class:
         <<: *__defaultMethod
         __fluent: true
         returnType: 'Cursor'
-    # modifiers: # not implemented / not documented
-    #     <<: *__defaultMethod
     next:
         <<: *__defaultMethod
         returnsPromise: true
@@ -112,8 +98,6 @@ class:
         <<: *__defaultMethod
         __fluent: true
         returnType: 'Cursor'
-    # objsLeftInBatch: # not implemented
-    #     <<: *__defaultMethod
     oplogReplay: # not documented
         <<: *__defaultMethod
         __fluent: true
@@ -122,19 +106,6 @@ class:
         <<: *__defaultMethod
         __fluent: true
         returnType: 'Cursor'
-    # pretty:
-    #     <<: *__defaultMethod
-    #     __fluent: true
-    #     returnType: 'Cursor'
-    # readConcern:
-    #     <<: *__defaultMethod
-    #     __fluent: true
-    #     returnType: 'Cursor'
-    #     serverVersions:
-    #         - '3.2.0'
-    #         - *ServerVersions.latest
-    # readOnly: # not documented
-    #     <<: *__defaultMethod
     readPref:
         <<: *__defaultMethod
         __fluent: true
@@ -146,14 +117,6 @@ class:
         serverVersions:
             - '3.2.0'
             - *ServerVersions.latest
-    # showDiskLoc: # not documented
-    #     <<: *__defaultMethod
-    #     __fluent: true
-    #     returnType: 'Cursor'
-    # showRecordId:
-    #     <<: *__defaultMethod
-    #     __fluent: true
-    #     returnType: 'Cursor'
     size:
         <<: *__defaultMethod
         returnsPromise: true
@@ -161,13 +124,6 @@ class:
         <<: *__defaultMethod
         __fluent: true
         returnType: 'Cursor'
-    # snapshot: # not implemented / not documented
-    #     <<: *__defaultMethod
-    #     __fluent: true
-    #     returnType: 'Cursor'
-    #     serverVersions:
-    #         - *ServerVersions.earliest
-    #         - '4.0.0'
     sort:
         <<: *__defaultMethod
         __fluent: true
@@ -182,3 +138,42 @@ class:
     toArray:
         <<: *__defaultMethod
         returnsPromise: true
+    # showDiskLoc: # not documented
+    #     <<: *__defaultMethod
+    #     __fluent: true
+    #     returnType: 'Cursor'
+    # showRecordId:
+    #     <<: *__defaultMethod
+    #     __fluent: true
+    #     returnType: 'Cursor'
+    # snapshot: # not implemented / not documented
+    #     <<: *__defaultMethod
+    #     __fluent: true
+    #     returnType: 'Cursor'
+    #     serverVersions:
+    #         - *ServerVersions.earliest
+    #         - '4.0.0'
+    # pretty:
+    #     <<: *__defaultMethod
+    #     __fluent: true
+    #     returnType: 'Cursor'
+    # objsLeftInBatch: # not implemented
+    #     <<: *__defaultMethod
+    # modifiers: # not implemented / not documented
+    #     <<: *__defaultMethod
+    # maxScan: # Not implemented / not documented
+    #     <<: *__defaultMethod
+    #     __fluent: true
+    #     returnType: 'Cursor'
+    #     serverVersions:
+    #         - *ServerVersions.earliest
+    #         - '4.0.0'
+    # getQueryPlan:  # TODO: not implemented
+    #     <<: *__defaultMethod
+    # readConcern:
+    #     <<: *__defaultMethod
+    #     __fluent: true
+    #     returnType: 'Cursor'
+    #     serverVersions:
+    #         - '3.2.0'
+    #         - *ServerVersions.latest


### PR DESCRIPTION
Fixes few issues in the cursor implementation:

- Add `tagSet?` with parameter to `readPref`, with `NotImplementedError`.
- addOption throws `NotImplementedError` if a SlaveOk flag passed and `InvalidInputError` if an unknown flag is passed.
- Reimplement `itcount` to match the old shell behaviour.
- Fix 'noCursorTimeout' flag name
- Clean up comments in YAML  and service provider.
