### PR TITLE
fix: use provider.updateOne for coll.updateOne

### DIFF
--- a/packages/mapper/src/mapper.ts
+++ b/packages/mapper/src/mapper.ts
@@ -1249,25 +1249,23 @@ export default class Mapper {
    *
    * @returns {UpdateResult} The promise of the result.
    */
-  async collection_updateOne(collection, filter, update, options: any = {}): Promise<any> {
+  async collection_updateOne(
+    collection: Collection,
+    filter: Document,
+    update: Document,
+    options: Document = {}
+  ): Promise<any> {
+    this._emitCollectionApiCall(collection, 'updateOne', { filter, options });
+
     const dbOptions: DatabaseOptions = {};
-    const db = collection._database._name;
-    const coll = collection._name;
-    this.messageBus.emit(
-      'mongosh:api-call',
-      {
-        method: 'updateMany',
-        class: 'Collection',
-        db, coll, arguments: { filter, options }
-      }
-    );
 
     if ('writeConcern' in options) {
       Object.assign(dbOptions, options.writeConcern);
     }
-    const result = await this.serviceProvider.updateMany(
-      db,
-      coll,
+
+    const result = await this.serviceProvider.updateOne(
+      collection._database._name,
+      collection._name,
       filter,
       update,
       options,


### PR DESCRIPTION
Use `provider.updateOne` to implement `coll.updateOne`.

NOTE: the `insertedId` field in the update result is not an `ObjectId` as in the old shell. 

```
> db.coll1.updateOne({x: 1}, {$set: {y: 2}})
{
  acknowleged: 1,
  matchedCount: 1,
  modifiedCount: 1,
  upsertedCount: 0,
  insertedId: null
}
> db.coll1.updateOne({x: 112312323}, {$set: {y: 2}}, {upsert: true})
{
  acknowleged: 1,
  matchedCount: 0,
  modifiedCount: 0,
  upsertedCount: 1,
  insertedId: { index: 0, _id: '5ebbfb6d836db564d1bbb588' }
}
```