### PR TITLE
adjust telemetry names for connect event

### DIFF
--- a/packages/cli-repl/package-lock.json
+++ b/packages/cli-repl/package-lock.json
@@ -374,9 +374,9 @@
 			}
 		},
 		"mongodb-build-info": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/mongodb-build-info/-/mongodb-build-info-1.0.0.tgz",
-			"integrity": "sha512-ZFcBteBQMoGyMV3+FmjPRRI4X2ZR8TNPGlylNuGU1yg/TTC7eXFcd2VhL7SslRM0/tGsx7pIjLEqwjd9CtWSlA=="
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/mongodb-build-info/-/mongodb-build-info-1.1.0.tgz",
+			"integrity": "sha512-ZlbQlpXv8DCvYK2I6UmyRO4z9zb4fyoph+RhEN/MSSsigaqcfl6dePkbgavemquvuKVEq0BbIiVkHw1DKwChxA=="
 		},
 		"mongodb-redact": {
 			"version": "0.2.0",

--- a/packages/cli-repl/package.json
+++ b/packages/cli-repl/package.json
@@ -52,7 +52,7 @@
     "minimist": "^1.2.5",
     "mkdirp": "^1.0.3",
     "mongodb-ace-autocompleter": "^0.4.1",
-    "mongodb-build-info": "^1.0.0",
+    "mongodb-build-info": "^1.1.0",
     "mongodb-redact": "^0.2.0",
     "nanobus": "^4.4.0",
     "pino": "^5.16.0",

--- a/packages/cli-repl/src/connect-info.spec.ts
+++ b/packages/cli-repl/src/connect-info.spec.ts
@@ -1,3 +1,4 @@
+/* eslint camelcase: 0, @typescript-eslint/camelcase: 0 */
 import { expect } from 'chai';
 import getConnectInfo from './connect-info';
 
@@ -74,15 +75,17 @@ describe('getConnectInfo', function() {
 
   it('reports on an enterprise version >=3.2 of mongodb with credentials', function() {
     const output = {
-      isAtlas: true,
-      isLocalhost: false,
-      serverVersion: '3.2.0-rc2',
-      isEnterprise: true,
-      authType: 'LDAP',
-      isDataLake: false,
-      dlVersion: null,
-      isGenuine: true,
-      serverName: 'mongodb',
+      is_atlas: true,
+      is_localhost: false,
+      server_version: '3.2.0-rc2',
+      is_enterprise: true,
+      auth_type: 'LDAP',
+      is_data_lake: false,
+      dl_version: null,
+      is_genuine: true,
+      non_genuine_server_name: 'mongodb',
+      server_arch: 'x86_64',
+      server_os: 'osx',
       uri: ATLAS_URI
     };
     expect(getConnectInfo(
@@ -94,15 +97,17 @@ describe('getConnectInfo', function() {
 
   it('reports on an enterprise version >=3.2 of mongodb with no credentials', function() {
     const output = {
-      isAtlas: true,
-      isLocalhost: false,
-      serverVersion: '3.2.0-rc2',
-      isEnterprise: true,
-      authType: null,
-      isDataLake: false,
-      dlVersion: null,
-      isGenuine: true,
-      serverName: 'mongodb',
+      is_atlas: true,
+      is_localhost: false,
+      server_version: '3.2.0-rc2',
+      is_enterprise: true,
+      auth_type: null,
+      is_data_lake: false,
+      dl_version: null,
+      is_genuine: true,
+      non_genuine_server_name: 'mongodb',
+      server_arch: 'x86_64',
+      server_os: 'osx',
       uri: ATLAS_URI
     };
     expect(getConnectInfo(

--- a/packages/cli-repl/src/connect-info.ts
+++ b/packages/cli-repl/src/connect-info.ts
@@ -1,38 +1,48 @@
+/* eslint camelcase: 0, @typescript-eslint/camelcase: 0 */
+// ^ segment data is in snake_case: forgive me javascript, for i have sinned.
+
 import getBuildInfo from 'mongodb-build-info';
 
 interface ConnectInfo {
-  isAtlas: boolean;
-  isLocalhost: boolean;
-  serverVersion: string;
-  isEnterprise: boolean;
+  is_atlas: boolean;
+  is_localhost: boolean;
+  server_version: string;
+  server_os?: string;
+  server_arch?: string;
+  is_enterprise: boolean;
+  auth_type?: string;
+  is_data_lake: boolean;
+  dl_version?: string;
+  is_genuine: boolean;
+  non_genuine_server_name: string;
   uri: string;
-  authType?: string;
-  isDataLake: boolean;
-  dlVersion?: string;
-  isGenuine: boolean;
-  serverName: string;
 }
 
 export default function getConnectInfo(uri: string, buildInfo: any, cmdLineOpts: any, topology: any): ConnectInfo {
-  const { isGenuine, serverName } =
+  const { isGenuine: is_genuine, serverName: non_genuine_server_name } =
     getBuildInfo.getGenuineMongoDB(buildInfo, cmdLineOpts);
-  const { isDataLake, dlVersion } = getBuildInfo.getDataLake(buildInfo);
+  const { isDataLake: is_data_lake, dlVersion: dl_version }
+    = getBuildInfo.getDataLake(buildInfo);
 
   // get this information from topology rather than cmdLineOpts, since not all
   // connections are able to run getCmdLineOpts command
-  const authType = topology.s.credentials
+  const auth_type = topology.s.credentials
     ? topology.s.credentials.mechanism : null;
+  const { serverOs: server_os, serverArch: server_arch }
+    = getBuildInfo.getBuildEnv(buildInfo);
 
   return {
-    isAtlas: getBuildInfo.isAtlas(uri),
-    isLocalhost: getBuildInfo.isLocalhost(uri),
-    serverVersion: buildInfo.version,
-    isEnterprise: getBuildInfo.isEnterprise(buildInfo),
+    is_atlas: getBuildInfo.isAtlas(uri),
+    is_localhost: getBuildInfo.isLocalhost(uri),
+    server_version: buildInfo.version,
+    server_os,
     uri,
-    authType,
-    isDataLake,
-    dlVersion,
-    isGenuine,
-    serverName
+    server_arch,
+    is_enterprise: getBuildInfo.isEnterprise(buildInfo),
+    auth_type,
+    is_data_lake,
+    dl_version,
+    is_genuine,
+    non_genuine_server_name
   };
 }

--- a/packages/cli-repl/src/logger.ts
+++ b/packages/cli-repl/src/logger.ts
@@ -61,7 +61,7 @@ export default function logger(bus: any, logDir: string): void {
   const logDest = path.join(logDir, `${session_id}_log`);
   const log = pino({ name: 'monogsh' }, pino.destination(logDest));
   console.log(`Current sessionID: ${session_id}`);
-  let userID;
+  let userId;
   let telemetry;
 
   let analytics = new NoopAnalytics();
@@ -76,26 +76,26 @@ export default function logger(bus: any, logDir: string): void {
   bus.on('mongosh:connect', function(args: ConnectEvent) {
     const connectionUri = redactPwd(args.uri);
     delete args.uri;
-    const params = { session_id, userID, connectionUri, ...args };
+    const params = { session_id, userId, connectionUri, ...args };
     log.info('mongosh:connect', params);
 
     if (telemetry) {
       analytics.track({
-        userID,
-        event: 'mongosh:connect',
+        userId,
+        event: 'New Connection',
         properties: { session_id, ...args }
       });
     }
   });
 
   bus.on('mongosh:new-user', function(id, enableTelemetry) {
-    userID = id;
+    userId = id;
     telemetry = enableTelemetry;
-    if (telemetry) analytics.identify({ userID });
+    if (telemetry) analytics.identify({ userId });
   });
 
   bus.on('mongosh:update-user', function(id, enableTelemetry) {
-    userID = id;
+    userId = id;
     telemetry = enableTelemetry;
     log.info('mongosh:update-user', { enableTelemetry });
   });
@@ -106,8 +106,8 @@ export default function logger(bus: any, logDir: string): void {
 
     if (telemetry && error.name.includes('Mongosh')) {
       analytics.track({
-        userID,
-        event: 'mongosh:error',
+        userId,
+        event: 'Error',
         properties: { error }
       });
     }
@@ -118,8 +118,8 @@ export default function logger(bus: any, logDir: string): void {
 
     if (telemetry) {
       analytics.track({
-        userID,
-        event: 'mongosh:help'
+        userId,
+        event: 'Help'
       });
     }
   });
@@ -133,8 +133,8 @@ export default function logger(bus: any, logDir: string): void {
 
     if (telemetry) {
       analytics.track({
-        userID,
-        event: 'mongosh:use'
+        userId,
+        event: 'Use'
       });
     }
   });
@@ -144,8 +144,8 @@ export default function logger(bus: any, logDir: string): void {
 
     if (telemetry) {
       analytics.track({
-        userID,
-        event: 'mongosh:show',
+        userId,
+        event: 'Show',
         properties: { method: args.method }
       });
     }
@@ -167,8 +167,8 @@ export default function logger(bus: any, logDir: string): void {
 
     if (telemetry) {
       analytics.track({
-        userID,
-        event: 'mongosh:api-call',
+        userId,
+        event: 'Api Call',
         properties: redactInfo(properties)
       });
     }


### PR DESCRIPTION
## Description
As per @mmarcon's request, changing telemetry events to be snake_cased instead
of camelCased.

This PR also adds `server_os` and `server_arch` information to `Connect` event.