### PR TITLE
fix: use setupRepl when connecting with username/password

### DIFF
--- a/packages/cli-repl/src/cli-repl.ts
+++ b/packages/cli-repl/src/cli-repl.ts
@@ -336,10 +336,17 @@ class CliRepl {
       replace: '*'
     };
     read(readOptions, (error, password) => {
-      if (error) return console.log(formatError(error));
+      if (error) {
+        this.bus.emit('mongosh:error', error);
+        return console.log(formatError(error));
+      }
 
       driverOptions.auth.password = password;
-      this.connect(driverUri, driverOptions);
+      this.setupRepl(driverUri, driverOptions).catch((e) => {
+        this.bus.emit('mongosh:error', e);
+        console.log(formatError(e));
+        return;
+      });
     });
   }
 }


### PR DESCRIPTION
## Description
When requiring password, make sure we:
1. use `setupRepl()` instead of `connect()` function
2. catch and log the errors when setting up the REPL and when reading password
options.