### PR TITLE
fix: add babel transform regenerator runtime

### DIFF
--- a/packages/compass-shell/.babelrc
+++ b/packages/compass-shell/.babelrc
@@ -35,6 +35,7 @@
     "@babel/plugin-syntax-object-rest-spread",
     "@babel/plugin-proposal-object-rest-spread",
     "@babel/plugin-proposal-class-properties",
-    "@babel/plugin-syntax-dynamic-import"
+    "@babel/plugin-syntax-dynamic-import",
+    ["@babel/plugin-transform-runtime", { "regenerator": true } ]
   ]
 }

--- a/packages/compass-shell/package-lock.json
+++ b/packages/compass-shell/package-lock.json
@@ -25,7 +25,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
 			"integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
-			"dev": true,
 			"requires": {
 				"@babel/highlight": "^7.8.3"
 			}
@@ -45,7 +44,6 @@
 			"version": "7.9.0",
 			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.9.0.tgz",
 			"integrity": "sha512-kWc7L0fw1xwvI0zi8OKVBuxRVefwGOrKSQMvrQ3dW+bIIavBY3/NpXmpjMy7bQnLgwgzWQZ8TlM57YHpHNHz4w==",
-			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.8.3",
 				"@babel/generator": "^7.9.0",
@@ -69,7 +67,6 @@
 					"version": "4.1.1",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
 					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-					"dev": true,
 					"requires": {
 						"ms": "^2.1.1"
 					}
@@ -77,8 +74,7 @@
 				"ms": {
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-					"dev": true
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 				}
 			}
 		},
@@ -86,7 +82,6 @@
 			"version": "7.9.5",
 			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.5.tgz",
 			"integrity": "sha512-GbNIxVB3ZJe3tLeDm1HSn2AhuD/mVcyLDpgtLXa5tplmWrJdF/elxB56XNqCuD6szyNkDi6wuoKXln3QeBmCHQ==",
-			"dev": true,
 			"requires": {
 				"@babel/types": "^7.9.5",
 				"jsesc": "^2.5.1",
@@ -197,7 +192,6 @@
 			"version": "7.9.5",
 			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.9.5.tgz",
 			"integrity": "sha512-JVcQZeXM59Cd1qanDUxv9fgJpt3NeKUaqBqUEvfmQ+BCOKq2xUgaWZW2hr0dkbyJgezYuplEoh5knmrnS68efw==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-get-function-arity": "^7.8.3",
 				"@babel/template": "^7.8.3",
@@ -208,7 +202,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
 			"integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
-			"dev": true,
 			"requires": {
 				"@babel/types": "^7.8.3"
 			}
@@ -226,7 +219,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.8.3.tgz",
 			"integrity": "sha512-fO4Egq88utkQFjbPrSHGmGLFqmrshs11d46WI+WZDESt7Wu7wN2G2Iu+NMMZJFDOVRHAMIkB5SNh30NtwCA7RA==",
-			"dev": true,
 			"requires": {
 				"@babel/types": "^7.8.3"
 			}
@@ -235,7 +227,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.8.3.tgz",
 			"integrity": "sha512-R0Bx3jippsbAEtzkpZ/6FIiuzOURPcMjHp+Z6xPe6DtApDJx+w7UYyOLanZqO8+wKR9G10s/FmHXvxaMd9s6Kg==",
-			"dev": true,
 			"requires": {
 				"@babel/types": "^7.8.3"
 			}
@@ -244,7 +235,6 @@
 			"version": "7.9.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.9.0.tgz",
 			"integrity": "sha512-0FvKyu0gpPfIQ8EkxlrAydOWROdHpBmiCiRwLkUiBGhCUPRRbVD2/tm3sFr/c/GWFrQ/ffutGUAnx7V0FzT2wA==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-module-imports": "^7.8.3",
 				"@babel/helper-replace-supers": "^7.8.6",
@@ -259,7 +249,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.8.3.tgz",
 			"integrity": "sha512-Kag20n86cbO2AvHca6EJsvqAd82gc6VMGule4HwebwMlwkpXuVqrNRj6CkCV2sKxgi9MyAUnZVnZ6lJ1/vKhHQ==",
-			"dev": true,
 			"requires": {
 				"@babel/types": "^7.8.3"
 			}
@@ -267,8 +256,7 @@
 		"@babel/helper-plugin-utils": {
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.8.3.tgz",
-			"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ==",
-			"dev": true
+			"integrity": "sha512-j+fq49Xds2smCUNYmEHF9kGNkhbet6yVIBp4e6oeQpH1RUs/Ir06xUKzDjDkGcaaokPiTNs2JBWHjaE4csUkZQ=="
 		},
 		"@babel/helper-regex": {
 			"version": "7.8.3",
@@ -296,7 +284,6 @@
 			"version": "7.8.6",
 			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.8.6.tgz",
 			"integrity": "sha512-PeMArdA4Sv/Wf4zXwBKPqVj7n9UF/xg6slNRtZW84FM7JpE1CbG8B612FyM4cxrf4fMAMGO0kR7voy1ForHHFA==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-member-expression-to-functions": "^7.8.3",
 				"@babel/helper-optimise-call-expression": "^7.8.3",
@@ -308,7 +295,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.8.3.tgz",
 			"integrity": "sha512-VNGUDjx5cCWg4vvCTR8qQ7YJYZ+HBjxOgXEl7ounz+4Sn7+LMD3CFrCTEU6/qXKbA2nKg21CwhhBzO0RpRbdCw==",
-			"dev": true,
 			"requires": {
 				"@babel/template": "^7.8.3",
 				"@babel/types": "^7.8.3"
@@ -318,7 +304,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
 			"integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
-			"dev": true,
 			"requires": {
 				"@babel/types": "^7.8.3"
 			}
@@ -326,8 +311,7 @@
 		"@babel/helper-validator-identifier": {
 			"version": "7.9.5",
 			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz",
-			"integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g==",
-			"dev": true
+			"integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g=="
 		},
 		"@babel/helper-wrap-function": {
 			"version": "7.8.3",
@@ -345,7 +329,6 @@
 			"version": "7.9.2",
 			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.9.2.tgz",
 			"integrity": "sha512-JwLvzlXVPjO8eU9c/wF9/zOIN7X6h8DYf7mG4CiFRZRvZNKEF5dQ3H3V+ASkHoIB3mWhatgl5ONhyqHRI6MppA==",
-			"dev": true,
 			"requires": {
 				"@babel/template": "^7.8.3",
 				"@babel/traverse": "^7.9.0",
@@ -356,7 +339,6 @@
 			"version": "7.9.0",
 			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.9.0.tgz",
 			"integrity": "sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-validator-identifier": "^7.9.0",
 				"chalk": "^2.0.0",
@@ -366,8 +348,7 @@
 		"@babel/parser": {
 			"version": "7.9.4",
 			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.4.tgz",
-			"integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA==",
-			"dev": true
+			"integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA=="
 		},
 		"@babel/plugin-proposal-async-generator-functions": {
 			"version": "7.8.3",
@@ -577,6 +558,14 @@
 			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-top-level-await/-/plugin-syntax-top-level-await-7.8.3.tgz",
 			"integrity": "sha512-kwj1j9lL/6Wd0hROD3b/OZZ7MSrZLqqn9RAZ5+cYYsflQ9HZBIKCUkr3+uL1MEJ1NePiUbf98jjiMQSv0NMR9g==",
 			"dev": true,
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.3"
+			}
+		},
+		"@babel/plugin-syntax-typescript": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.8.3.tgz",
+			"integrity": "sha512-GO1MQ/SGGGoiEXY0e0bSpHimJvxqB7lktLLIq2pv8xG7WZ8IMEle74jIe1FhprHBWjwjZtXHkycDLZXIWM5Wfg==",
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.8.3"
 			}
@@ -882,6 +871,18 @@
 				"@babel/helper-plugin-utils": "^7.8.3"
 			}
 		},
+		"@babel/plugin-transform-runtime": {
+			"version": "7.9.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-runtime/-/plugin-transform-runtime-7.9.6.tgz",
+			"integrity": "sha512-qcmiECD0mYOjOIt8YHNsAP1SxPooC/rDmfmiSK9BNY72EitdSc7l44WTEklaWuFtbOEBjNhWWyph/kOImbNJ4w==",
+			"dev": true,
+			"requires": {
+				"@babel/helper-module-imports": "^7.8.3",
+				"@babel/helper-plugin-utils": "^7.8.3",
+				"resolve": "^1.8.1",
+				"semver": "^5.5.1"
+			}
+		},
 		"@babel/plugin-transform-shorthand-properties": {
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.8.3.tgz",
@@ -927,6 +928,97 @@
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.8.3"
+			}
+		},
+		"@babel/plugin-transform-typescript": {
+			"version": "7.9.6",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.9.6.tgz",
+			"integrity": "sha512-8OvsRdvpt3Iesf2qsAn+YdlwAJD7zJ+vhFZmDCa4b8dTp7MmHtKk5FF2mCsGxjZwuwsy/yIIay/nLmxST1ctVQ==",
+			"requires": {
+				"@babel/helper-create-class-features-plugin": "^7.9.6",
+				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/plugin-syntax-typescript": "^7.8.3"
+			},
+			"dependencies": {
+				"@babel/generator": {
+					"version": "7.9.6",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.6.tgz",
+					"integrity": "sha512-+htwWKJbH2bL72HRluF8zumBxzuX0ZZUFl3JLNyoUjM/Ho8wnVpPXM6aUz8cfKDqQ/h7zHqKt4xzJteUosckqQ==",
+					"requires": {
+						"@babel/types": "^7.9.6",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.13",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-create-class-features-plugin": {
+					"version": "7.9.6",
+					"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.9.6.tgz",
+					"integrity": "sha512-6N9IeuyHvMBRyjNYOMJHrhwtu4WJMrYf8hVbEHD3pbbbmNOk1kmXSQs7bA4dYDUaIx4ZEzdnvo6NwC3WHd/Qow==",
+					"requires": {
+						"@babel/helper-function-name": "^7.9.5",
+						"@babel/helper-member-expression-to-functions": "^7.8.3",
+						"@babel/helper-optimise-call-expression": "^7.8.3",
+						"@babel/helper-plugin-utils": "^7.8.3",
+						"@babel/helper-replace-supers": "^7.9.6",
+						"@babel/helper-split-export-declaration": "^7.8.3"
+					}
+				},
+				"@babel/helper-replace-supers": {
+					"version": "7.9.6",
+					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.9.6.tgz",
+					"integrity": "sha512-qX+chbxkbArLyCImk3bWV+jB5gTNU/rsze+JlcF6Nf8tVTigPJSI1o1oBow/9Resa1yehUO9lIipsmu9oG4RzA==",
+					"requires": {
+						"@babel/helper-member-expression-to-functions": "^7.8.3",
+						"@babel/helper-optimise-call-expression": "^7.8.3",
+						"@babel/traverse": "^7.9.6",
+						"@babel/types": "^7.9.6"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.9.6",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.6.tgz",
+					"integrity": "sha512-AoeIEJn8vt+d/6+PXDRPaksYhnlbMIiejioBZvvMQsOjW/JYK6k/0dKnvvP3EhK5GfMBWDPtrxRtegWdAcdq9Q=="
+				},
+				"@babel/traverse": {
+					"version": "7.9.6",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.9.6.tgz",
+					"integrity": "sha512-b3rAHSjbxy6VEAvlxM8OV/0X4XrG72zoxme6q1MOoe2vd0bEc+TwayhuC1+Dfgqh1QEG+pj7atQqvUprHIccsg==",
+					"requires": {
+						"@babel/code-frame": "^7.8.3",
+						"@babel/generator": "^7.9.6",
+						"@babel/helper-function-name": "^7.9.5",
+						"@babel/helper-split-export-declaration": "^7.8.3",
+						"@babel/parser": "^7.9.6",
+						"@babel/types": "^7.9.6",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.13"
+					}
+				},
+				"@babel/types": {
+					"version": "7.9.6",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.6.tgz",
+					"integrity": "sha512-qxXzvBO//jO9ZnoasKF1uJzHd2+M6Q2ZPIVfnFps8JJvXy0ZBbwbNOmE6SGIY5XOY6d1Bo5lb9d9RJ8nv3WSeA==",
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.9.5",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+				}
 			}
 		},
 		"@babel/plugin-transform-unicode-regex": {
@@ -1044,6 +1136,15 @@
 				"@babel/plugin-transform-react-jsx-source": "^7.9.0"
 			}
 		},
+		"@babel/preset-typescript": {
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.9.0.tgz",
+			"integrity": "sha512-S4cueFnGrIbvYJgwsVFKdvOmpiL0XGw9MFW9D0vgRys5g36PBhZRL8NX8Gr2akz8XRtzq6HuDXPD/1nniagNUg==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.8.3",
+				"@babel/plugin-transform-typescript": "^7.9.0"
+			}
+		},
 		"@babel/register": {
 			"version": "7.9.0",
 			"resolved": "https://registry.npmjs.org/@babel/register/-/register-7.9.0.tgz",
@@ -1061,7 +1162,6 @@
 			"version": "7.9.2",
 			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.9.2.tgz",
 			"integrity": "sha512-NE2DtOdufG7R5vnfQUTehdTfNycfUANEtCa9PssN9O/xmTzP4E08UI797ixaei6hBEVL9BI/PsdJS5x7mWoB9Q==",
-			"dev": true,
 			"requires": {
 				"regenerator-runtime": "^0.13.4"
 			}
@@ -1090,7 +1190,6 @@
 			"version": "7.8.6",
 			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
 			"integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
-			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.8.3",
 				"@babel/parser": "^7.8.6",
@@ -1101,7 +1200,6 @@
 			"version": "7.9.5",
 			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.9.5.tgz",
 			"integrity": "sha512-c4gH3jsvSuGUezlP6rzSJ6jf8fYjLj3hsMZRx/nX0h+fmHN0w+ekubRrHPqnMec0meycA2nwCsJ7dC8IPem2FQ==",
-			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.8.3",
 				"@babel/generator": "^7.9.5",
@@ -1118,7 +1216,6 @@
 					"version": "4.1.1",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
 					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-					"dev": true,
 					"requires": {
 						"ms": "^2.1.1"
 					}
@@ -1126,8 +1223,7 @@
 				"ms": {
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-					"dev": true
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 				}
 			}
 		},
@@ -1135,12 +1231,69 @@
 			"version": "7.9.5",
 			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
 			"integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-validator-identifier": "^7.9.5",
 				"lodash": "^4.17.13",
 				"to-fast-properties": "^2.0.0"
 			}
+		},
+		"@emotion/cache": {
+			"version": "10.0.29",
+			"resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.29.tgz",
+			"integrity": "sha512-fU2VtSVlHiF27empSbxi1O2JFdNWZO+2NFHfwO0pxgTep6Xa3uGb+3pVKfLww2l/IBGLNEZl5Xf/++A4wAYDYQ==",
+			"requires": {
+				"@emotion/sheet": "0.9.4",
+				"@emotion/stylis": "0.8.5",
+				"@emotion/utils": "0.11.3",
+				"@emotion/weak-memoize": "0.2.5"
+			}
+		},
+		"@emotion/hash": {
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/@emotion/hash/-/hash-0.8.0.tgz",
+			"integrity": "sha512-kBJtf7PH6aWwZ6fka3zQ0p6SBYzx4fl1LoZXE2RrnYST9Xljm7WfKJrU4g/Xr3Beg72MLrp1AWNUmuYJTL7Cow=="
+		},
+		"@emotion/memoize": {
+			"version": "0.7.4",
+			"resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
+			"integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
+		},
+		"@emotion/serialize": {
+			"version": "0.11.16",
+			"resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.11.16.tgz",
+			"integrity": "sha512-G3J4o8by0VRrO+PFeSc3js2myYNOXVJ3Ya+RGVxnshRYgsvErfAOglKAiy1Eo1vhzxqtUvjCyS5gtewzkmvSSg==",
+			"requires": {
+				"@emotion/hash": "0.8.0",
+				"@emotion/memoize": "0.7.4",
+				"@emotion/unitless": "0.7.5",
+				"@emotion/utils": "0.11.3",
+				"csstype": "^2.5.7"
+			}
+		},
+		"@emotion/sheet": {
+			"version": "0.9.4",
+			"resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-0.9.4.tgz",
+			"integrity": "sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA=="
+		},
+		"@emotion/stylis": {
+			"version": "0.8.5",
+			"resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
+			"integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ=="
+		},
+		"@emotion/unitless": {
+			"version": "0.7.5",
+			"resolved": "https://registry.npmjs.org/@emotion/unitless/-/unitless-0.7.5.tgz",
+			"integrity": "sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg=="
+		},
+		"@emotion/utils": {
+			"version": "0.11.3",
+			"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.3.tgz",
+			"integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw=="
+		},
+		"@emotion/weak-memoize": {
+			"version": "0.2.5",
+			"resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
+			"integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
 		},
 		"@hot-loader/react-dom": {
 			"version": "16.13.0",
@@ -1154,6 +1307,16 @@
 				"scheduler": "^0.19.0"
 			}
 		},
+		"@jest/types": {
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/@jest/types/-/types-24.9.0.tgz",
+			"integrity": "sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==",
+			"requires": {
+				"@types/istanbul-lib-coverage": "^2.0.0",
+				"@types/istanbul-reports": "^1.1.1",
+				"@types/yargs": "^13.0.0"
+			}
+		},
 		"@kadira/react-storybook-addon-info": {
 			"version": "3.4.0",
 			"resolved": "https://registry.npmjs.org/@kadira/react-storybook-addon-info/-/react-storybook-addon-info-3.4.0.tgz",
@@ -1165,11 +1328,289 @@
 				"react-addons-create-fragment": "^15.3.2"
 			}
 		},
+		"@leafygreen-ui/emotion": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@leafygreen-ui/emotion/-/emotion-2.0.1.tgz",
+			"integrity": "sha512-eswO+aWs6vbuiEDUpZz3tGjCBtgWr3hU4ndgrjFLNOQpWOsVOaW8zQzVu1XOMLHCjtfZy2/GDME7zQWVvcrVFg==",
+			"requires": {
+				"create-emotion": "^10.0.7",
+				"create-emotion-server": "10.0.27",
+				"emotion": "^10.0.7"
+			}
+		},
+		"@leafygreen-ui/icon": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/@leafygreen-ui/icon/-/icon-4.3.0.tgz",
+			"integrity": "sha512-6DOFKxj3U0hp2yQEq/Yq19qIiIIUXwRj2fH1ddOJFYLtAoeFOCSeuF6rE2dqXrXW/puQdjgpXV60w9J8gyXGog=="
+		},
+		"@leafygreen-ui/lib": {
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-4.4.1.tgz",
+			"integrity": "sha512-ZVa/LlcoWBXLpks5XQ6MsM/f3cMqxxsqD8iQlGkGncJZN8cJ7NnxqtyY7QsbGSHNQzSNJbOtHxg6dpYRuAWcPw==",
+			"requires": {
+				"@leafygreen-ui/emotion": "^2.0.1",
+				"@testing-library/react": "^8.0.1",
+				"facepaint": "^1.2.1",
+				"polished": "^2.3.0"
+			}
+		},
+		"@leafygreen-ui/palette": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-2.0.1.tgz",
+			"integrity": "sha512-xwD6kOokWvaygxF0T2gnf77HEu68G7EXr1ZrNiNtZzg80Y1V2hikhUNoESWij6g/A6qJZvAiwpseflVo3PnlHQ=="
+		},
+		"@leafygreen-ui/syntax": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/@leafygreen-ui/syntax/-/syntax-2.7.0.tgz",
+			"integrity": "sha512-bQRIFKPUwZsne39R49eQN5qEl556w88N/FjJfzAU/LjR2OVp+W5sWhx1PiacwCq+J1r/7wu/PKUh5rV/dpSgmQ==",
+			"requires": {
+				"@leafygreen-ui/lib": "^4.3.0",
+				"@leafygreen-ui/palette": "^2.0.1",
+				"highlight.js": "^9.15.6",
+				"highlightjs-graphql": "^1.0.1"
+			}
+		},
 		"@mongodb-js/triejs": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/@mongodb-js/triejs/-/triejs-0.1.5.tgz",
 			"integrity": "sha512-elh8S1OxmEGe8/wbr6ky//dHhV2ld6oZV8/M9lgozJsL/6Aqm8j5+ElquzoX9k9l3Q+dohuX/SIGR/kTRZHS4g==",
 			"dev": true
+		},
+		"@mongosh/async-rewriter": {
+			"version": "0.0.1-alpha.14",
+			"resolved": "https://registry.npmjs.org/@mongosh/async-rewriter/-/async-rewriter-0.0.1-alpha.14.tgz",
+			"integrity": "sha512-Bo2WxKaHo0i+9fyCopYzQFGQlPUcpLCOhz3nTOAkFOVZbIGVwrTnKu3cVAovRs/Lxn8CIenxVAvDOJ0CO4dRwg==",
+			"requires": {
+				"@babel/core": "^7.9.0",
+				"@babel/parser": "^7.9.4",
+				"@babel/preset-typescript": "^7.9.0",
+				"@babel/template": "^7.8.6",
+				"@babel/traverse": "^7.9.0",
+				"@babel/types": "^7.9.0",
+				"@mongosh/errors": "^0.0.1-alpha.14",
+				"@types/babel__core": "^7.1.6",
+				"@types/babel__traverse": "^7.0.9",
+				"ts-node": "^8.8.1",
+				"typescript": "^3.8.3"
+			}
+		},
+		"@mongosh/browser-repl": {
+			"version": "0.0.1-alpha.14",
+			"resolved": "https://registry.npmjs.org/@mongosh/browser-repl/-/browser-repl-0.0.1-alpha.14.tgz",
+			"integrity": "sha512-+zitcvptvUMsOZo/5ZpoCiEc23rqKn+aMazKovYLzGdk981vyOGhyzc+iTW7ErfOU2pq5eYLvA++nylY8kZHrw==",
+			"requires": {
+				"@babel/generator": "^7.8.3",
+				"@babel/parser": "^7.8.3",
+				"@babel/runtime": "^7.8.3",
+				"@babel/template": "^7.8.3",
+				"@leafygreen-ui/icon": "^4.0.0",
+				"@leafygreen-ui/palette": "^2.0.0",
+				"@leafygreen-ui/syntax": "^2.2.0",
+				"@mongosh/browser-runtime-core": "^0.0.1-alpha.14",
+				"@mongosh/history": "^0.0.1-alpha.14",
+				"@mongosh/i18n": "^0.0.1-alpha.14",
+				"@mongosh/service-provider-core": "^0.0.1-alpha.14",
+				"pretty-bytes": "^5.3.0",
+				"text-table": "^0.2.0"
+			},
+			"dependencies": {
+				"pretty-bytes": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.3.0.tgz",
+					"integrity": "sha512-hjGrh+P926p4R4WbaB6OckyRtO0F0/lQBiT+0gnxjV+5kjPBrfVBFCsCLbMqVQeydvIoouYTCmmEURiH3R1Bdg=="
+				}
+			}
+		},
+		"@mongosh/browser-runtime-core": {
+			"version": "0.0.1-alpha.14",
+			"resolved": "https://registry.npmjs.org/@mongosh/browser-runtime-core/-/browser-runtime-core-0.0.1-alpha.14.tgz",
+			"integrity": "sha512-qs44qbMncnI3LHn7QnbNWBQAlmgGjuALC+bsuOSlFkK+zt53ikpX4AeQiS/plQAVijAq1wbHqdyk2Y12xhA+YA==",
+			"requires": {
+				"@babel/generator": "^7.9.4",
+				"@babel/parser": "^7.9.4",
+				"@mongosh/cli-repl": "^0.0.1-alpha.14",
+				"@mongosh/service-provider-core": "^0.0.1-alpha.14",
+				"@mongosh/shell-evaluator": "^0.0.1-alpha.14"
+			}
+		},
+		"@mongosh/browser-runtime-electron": {
+			"version": "0.0.1-alpha.14",
+			"resolved": "https://registry.npmjs.org/@mongosh/browser-runtime-electron/-/browser-runtime-electron-0.0.1-alpha.14.tgz",
+			"integrity": "sha512-BK4bYyU2L5IvT9fHR3B+NzcSFxuG2oqkymM0het5hNcsUuxwppwls2qhaMbFlflXSC6dkOZDae6sfWY79cB5lA==",
+			"requires": {
+				"@mongosh/browser-runtime-core": "^0.0.1-alpha.14",
+				"@mongosh/service-provider-core": "^0.0.1-alpha.14"
+			}
+		},
+		"@mongosh/cli-repl": {
+			"version": "0.0.1-alpha.14",
+			"resolved": "https://registry.npmjs.org/@mongosh/cli-repl/-/cli-repl-0.0.1-alpha.14.tgz",
+			"integrity": "sha512-DmN7Gz9tlj6C+hNXa80ca6cOKjnfRg4hOkoaJppqKpu/zmUTdkEHsK+K3TF8mw7xutvkuFYN2OOewhirF+le7Q==",
+			"requires": {
+				"@mongosh/errors": "^0.0.1-alpha.14",
+				"@mongosh/history": "^0.0.1-alpha.14",
+				"@mongosh/i18n": "^0.0.1-alpha.14",
+				"@mongosh/service-provider-server": "^0.0.1-alpha.14",
+				"@mongosh/shell-api": "^0.0.1-alpha.14",
+				"@mongosh/shell-evaluator": "^0.0.1-alpha.14",
+				"acorn": "^7.1.1",
+				"acorn-class-fields": "^0.3.2",
+				"acorn-numeric-separator": "^0.3.0",
+				"acorn-private-methods": "^0.3.1",
+				"acorn-static-class-features": "^0.2.1",
+				"analytics-node": "^3.4.0-beta.1",
+				"ansi-escape-sequences": "^5.1.2",
+				"bson": "^4.0.4",
+				"is-recoverable-error": "^1.0.0",
+				"lodash.set": "^4.3.2",
+				"minimist": "^1.2.5",
+				"mkdirp": "^1.0.3",
+				"mongodb-ace-autocompleter": "^0.4.1",
+				"mongodb-build-info": "^1.0.0",
+				"mongodb-redact": "^0.2.0",
+				"nanobus": "^4.4.0",
+				"pino": "^5.16.0",
+				"pretty-bytes": "^5.3.0",
+				"pretty-repl": "^2.3.0",
+				"read": "^1.0.7",
+				"semver": "^7.1.2",
+				"text-table": "^0.2.0"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.2.0.tgz",
+					"integrity": "sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ=="
+				},
+				"bson": {
+					"version": "4.0.4",
+					"resolved": "https://registry.npmjs.org/bson/-/bson-4.0.4.tgz",
+					"integrity": "sha512-Ioi3TD0/1V3aI8+hPfC56TetYmzfq2H07jJa9A1lKTxWsFtHtYdLMGMXjtGEg9v0f72NSM07diRQEUNYhLupIA==",
+					"requires": {
+						"buffer": "^5.1.0",
+						"long": "^4.0.0"
+					}
+				},
+				"buffer": {
+					"version": "5.6.0",
+					"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+					"integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+					"requires": {
+						"base64-js": "^1.0.2",
+						"ieee754": "^1.1.4"
+					}
+				},
+				"mkdirp": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+					"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+				},
+				"pretty-bytes": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.3.0.tgz",
+					"integrity": "sha512-hjGrh+P926p4R4WbaB6OckyRtO0F0/lQBiT+0gnxjV+5kjPBrfVBFCsCLbMqVQeydvIoouYTCmmEURiH3R1Bdg=="
+				},
+				"semver": {
+					"version": "7.3.2",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
+				}
+			}
+		},
+		"@mongosh/errors": {
+			"version": "0.0.1-alpha.14",
+			"resolved": "https://registry.npmjs.org/@mongosh/errors/-/errors-0.0.1-alpha.14.tgz",
+			"integrity": "sha512-cjiIbqbMNvOmj048xZkuINcfj/NBlru5Eq2cb5PFP1YcDCLwKhL+sw2KidbQZ3K5+of6IFNCLJ1H0kAInEXREQ=="
+		},
+		"@mongosh/history": {
+			"version": "0.0.1-alpha.14",
+			"resolved": "https://registry.npmjs.org/@mongosh/history/-/history-0.0.1-alpha.14.tgz",
+			"integrity": "sha512-q4EJN8lOIsXOMM9mQ89Cy5mzE6MyM8isyvtbFYm9TDbzgcMiO9Tzeh1cVpKDk+fd3HFGeYfoijtL6lOu0BmyNw==",
+			"requires": {
+				"mongodb-redact": "^0.2.0"
+			}
+		},
+		"@mongosh/i18n": {
+			"version": "0.0.1-alpha.14",
+			"resolved": "https://registry.npmjs.org/@mongosh/i18n/-/i18n-0.0.1-alpha.14.tgz",
+			"integrity": "sha512-At1NP1/c1by4CCR25uEmJHMdbXAKZoeef2m3EZQMqTklXPoIQtCYItlRmF+yHD0B5ObIm4TZLss2NrLtLKiOrw==",
+			"requires": {
+				"mustache": "^4.0.0"
+			}
+		},
+		"@mongosh/mapper": {
+			"version": "0.0.1-alpha.14",
+			"resolved": "https://registry.npmjs.org/@mongosh/mapper/-/mapper-0.0.1-alpha.14.tgz",
+			"integrity": "sha512-JijmqyAeuO1ZpSRnBG9RzGRV8ZhNhqdwDhBk3QRlz8ze/Z4XONRFiFUKH4wnwBFj79qw3y+r+SiwnXnv975v8Q==",
+			"requires": {
+				"@mongosh/errors": "^0.0.1-alpha.14",
+				"@mongosh/service-provider-core": "^0.0.1-alpha.14",
+				"@mongosh/shell-api": "^0.0.1-alpha.14",
+				"pretty-bytes": "^5.3.0",
+				"text-table": "^0.2.0"
+			},
+			"dependencies": {
+				"pretty-bytes": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.3.0.tgz",
+					"integrity": "sha512-hjGrh+P926p4R4WbaB6OckyRtO0F0/lQBiT+0gnxjV+5kjPBrfVBFCsCLbMqVQeydvIoouYTCmmEURiH3R1Bdg=="
+				}
+			}
+		},
+		"@mongosh/service-provider-core": {
+			"version": "0.0.1-alpha.14",
+			"resolved": "https://registry.npmjs.org/@mongosh/service-provider-core/-/service-provider-core-0.0.1-alpha.14.tgz",
+			"integrity": "sha512-/kY/6wPM6/C6JprN3D48AUKUeRJVFc2geEyyABxNbyFfizHjtK4HhRzPylkTO/v8GIC3pY9tZRB6MGX+m4kcQw=="
+		},
+		"@mongosh/service-provider-server": {
+			"version": "0.0.1-alpha.14",
+			"resolved": "https://registry.npmjs.org/@mongosh/service-provider-server/-/service-provider-server-0.0.1-alpha.14.tgz",
+			"integrity": "sha512-gl3h6nXV6DsQa1JQNYmgub/5bR9GYIgL7+YSm5mUCOE6A1Xy92jKaoaJ624XSM9/6B6SnqULR63vEMVBMrnfJw==",
+			"requires": {
+				"@mongosh/service-provider-core": "^0.0.1-alpha.14",
+				"mongodb": "3.5.3 || ^3.5.5"
+			}
+		},
+		"@mongosh/shell-api": {
+			"version": "0.0.1-alpha.14",
+			"resolved": "https://registry.npmjs.org/@mongosh/shell-api/-/shell-api-0.0.1-alpha.14.tgz",
+			"integrity": "sha512-XoOEaQ8H7Wn4ZPYkIZeK0eWAHcwZSXyNkxkPDUM3ug7Jl7AgT6R0SLuYH0BhJtRcG4WlvUNGobJnL1EaWOjxMQ==",
+			"requires": {
+				"@mongosh/errors": "^0.0.1-alpha.14",
+				"@mongosh/i18n": "^0.0.1-alpha.14",
+				"bson": "^4.0.4"
+			},
+			"dependencies": {
+				"bson": {
+					"version": "4.0.4",
+					"resolved": "https://registry.npmjs.org/bson/-/bson-4.0.4.tgz",
+					"integrity": "sha512-Ioi3TD0/1V3aI8+hPfC56TetYmzfq2H07jJa9A1lKTxWsFtHtYdLMGMXjtGEg9v0f72NSM07diRQEUNYhLupIA==",
+					"requires": {
+						"buffer": "^5.1.0",
+						"long": "^4.0.0"
+					}
+				},
+				"buffer": {
+					"version": "5.6.0",
+					"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+					"integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+					"requires": {
+						"base64-js": "^1.0.2",
+						"ieee754": "^1.1.4"
+					}
+				}
+			}
+		},
+		"@mongosh/shell-evaluator": {
+			"version": "0.0.1-alpha.14",
+			"resolved": "https://registry.npmjs.org/@mongosh/shell-evaluator/-/shell-evaluator-0.0.1-alpha.14.tgz",
+			"integrity": "sha512-W75yM3NU/ymHLLjNC8lJugVdRli6L9rfDFKaiB3pRfLhcameXrLIcWfwqwAbqFf1B4dcVzsHp2luOgazsvkWPA==",
+			"requires": {
+				"@mongosh/async-rewriter": "^0.0.1-alpha.14",
+				"@mongosh/mapper": "^0.0.1-alpha.14",
+				"@mongosh/service-provider-core": "^0.0.1-alpha.14",
+				"@mongosh/shell-api": "^0.0.1-alpha.14"
+			}
 		},
 		"@nodelib/fs.scandir": {
 			"version": "2.1.3",
@@ -1196,6 +1637,20 @@
 				"@nodelib/fs.scandir": "2.1.3",
 				"fastq": "^1.6.0"
 			}
+		},
+		"@segment/loosely-validate-event": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@segment/loosely-validate-event/-/loosely-validate-event-2.0.0.tgz",
+			"integrity": "sha512-ZMCSfztDBqwotkl848ODgVcAmN4OItEWDCkshcKz0/W6gGSQayuuCtWV/MlodFivAZD793d6UgANd6wCXUfrIw==",
+			"requires": {
+				"component-type": "^1.2.1",
+				"join-component": "^1.1.0"
+			}
+		},
+		"@sheerun/mutationobserver-shim": {
+			"version": "0.3.3",
+			"resolved": "https://registry.npmjs.org/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.3.tgz",
+			"integrity": "sha512-DetpxZw1fzPD5xUBrIAoplLChO2VB8DlL5Gg+I1IR9b2wPqYIca2WSUxL5g1vLeR4MsQq1NeWriXAVffV+U1Fw=="
 		},
 		"@sinonjs/commons": {
 			"version": "1.7.2",
@@ -1828,11 +2283,68 @@
 				"react-treebeard": "^2.1.0"
 			}
 		},
+		"@testing-library/dom": {
+			"version": "5.6.1",
+			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-5.6.1.tgz",
+			"integrity": "sha512-Y1T2bjtvQMewffn1CJ28kpgnuvPYKsBcZMagEH0ppfEMZPDc8AkkEnTk4smrGZKw0cblNB3lhM2FMnpfLExlHg==",
+			"requires": {
+				"@babel/runtime": "^7.5.5",
+				"@sheerun/mutationobserver-shim": "^0.3.2",
+				"aria-query": "3.0.0",
+				"pretty-format": "^24.8.0",
+				"wait-for-expect": "^1.2.0"
+			}
+		},
+		"@testing-library/react": {
+			"version": "8.0.9",
+			"resolved": "https://registry.npmjs.org/@testing-library/react/-/react-8.0.9.tgz",
+			"integrity": "sha512-I7zd+MW5wk8rQA5VopZgBfxGKUd91jgZ6Vzj2gMqFf2iGGtKwvI5SVTrIJcSFaOXK88T2EUsbsIKugDtoqOcZQ==",
+			"requires": {
+				"@babel/runtime": "^7.5.5",
+				"@testing-library/dom": "^5.6.1"
+			}
+		},
+		"@types/babel__core": {
+			"version": "7.1.7",
+			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.7.tgz",
+			"integrity": "sha512-RL62NqSFPCDK2FM1pSDH0scHpJvsXtZNiYlMB73DgPBaG1E38ZYVL+ei5EkWRbr+KC4YNiAUNBnRj+bgwpgjMw==",
+			"requires": {
+				"@babel/parser": "^7.1.0",
+				"@babel/types": "^7.0.0",
+				"@types/babel__generator": "*",
+				"@types/babel__template": "*",
+				"@types/babel__traverse": "*"
+			}
+		},
+		"@types/babel__generator": {
+			"version": "7.6.1",
+			"resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.1.tgz",
+			"integrity": "sha512-bBKm+2VPJcMRVwNhxKu8W+5/zT7pwNEqeokFOmbvVSqGzFneNxYcEBro9Ac7/N9tlsaPYnZLK8J1LWKkMsLAew==",
+			"requires": {
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@types/babel__template": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.0.2.tgz",
+			"integrity": "sha512-/K6zCpeW7Imzgab2bLkLEbz0+1JlFSrUMdw7KoIIu+IUdu51GWaBZpd3y1VXGVXzynvGa4DaIaxNZHiON3GXUg==",
+			"requires": {
+				"@babel/parser": "^7.1.0",
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@types/babel__traverse": {
+			"version": "7.0.11",
+			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.11.tgz",
+			"integrity": "sha512-ddHK5icION5U6q11+tV2f9Mo6CZVuT8GJKld2q9LqHSZbvLbH34Kcu2yFGckZut453+eQU6btIA3RihmnRgI+Q==",
+			"requires": {
+				"@babel/types": "^7.3.0"
+			}
+		},
 		"@types/color-name": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-			"integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
-			"dev": true
+			"integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
 		},
 		"@types/events": {
 			"version": "3.0.0",
@@ -1851,6 +2363,28 @@
 				"@types/node": "*"
 			}
 		},
+		"@types/istanbul-lib-coverage": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.2.tgz",
+			"integrity": "sha512-rsZg7eL+Xcxsxk2XlBt9KcG8nOp9iYdKCOikY9x2RFJCyOdNj4MKPQty0e8oZr29vVAzKXr1BmR+kZauti3o1w=="
+		},
+		"@types/istanbul-lib-report": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
+			"integrity": "sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==",
+			"requires": {
+				"@types/istanbul-lib-coverage": "*"
+			}
+		},
+		"@types/istanbul-reports": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
+			"integrity": "sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==",
+			"requires": {
+				"@types/istanbul-lib-coverage": "*",
+				"@types/istanbul-lib-report": "*"
+			}
+		},
 		"@types/minimatch": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/@types/minimatch/-/minimatch-3.0.3.tgz",
@@ -1866,8 +2400,20 @@
 		"@types/parse-json": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
-			"integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA==",
-			"dev": true
+			"integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
+		},
+		"@types/yargs": {
+			"version": "13.0.9",
+			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.9.tgz",
+			"integrity": "sha512-xrvhZ4DZewMDhoH1utLtOAwYQy60eYFoXeje30TzM3VOvQlBwQaEpKFq5m34k1wOw2AKIi2pwtiAjdmhvlBUzg==",
+			"requires": {
+				"@types/yargs-parser": "*"
+			}
+		},
+		"@types/yargs-parser": {
+			"version": "15.0.0",
+			"resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-15.0.0.tgz",
+			"integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw=="
 		},
 		"@typescript-eslint/typescript-estree": {
 			"version": "2.29.0",
@@ -2122,6 +2668,14 @@
 			"integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
 			"dev": true
 		},
+		"acorn-class-fields": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/acorn-class-fields/-/acorn-class-fields-0.3.2.tgz",
+			"integrity": "sha512-wyqXoqzXSOF42uxHo40TMuC/KfloI66AZz6S1TeK8D2HjKzI7Boq1mSH2pB5RwKEJWgHqnewGpRFRZwR0qQCyQ==",
+			"requires": {
+				"acorn-private-class-elements": "^0.2.5"
+			}
+		},
 		"acorn-dynamic-import": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz",
@@ -2186,6 +2740,32 @@
 					"integrity": "sha512-wdlPY2tm/9XBr7QkKlq0WQVgiuGTX6YWPyRyBviSoScBuLfTVQhvwg6wJ369GJ/1nPfTLMfnrFIfjqVg6d+jQQ==",
 					"dev": true
 				}
+			}
+		},
+		"acorn-numeric-separator": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/acorn-numeric-separator/-/acorn-numeric-separator-0.3.2.tgz",
+			"integrity": "sha512-ZNN1qnKvjWycDSQBfuD1TCiB81ItjjeGUPLHuqfP8X8HXwAodGTWsAaqSOQ1Nc9t+Wlb3tcEFdBrwUFUIzDiiA=="
+		},
+		"acorn-private-class-elements": {
+			"version": "0.2.5",
+			"resolved": "https://registry.npmjs.org/acorn-private-class-elements/-/acorn-private-class-elements-0.2.5.tgz",
+			"integrity": "sha512-3eApRrJmPjaxWB3XidP8YMeVq9pcswPFE0KsSWVuhceCU68ZS8fkcf0fTXGhCmnNd7n48NWWV27EKMFPeCoJLg=="
+		},
+		"acorn-private-methods": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/acorn-private-methods/-/acorn-private-methods-0.3.1.tgz",
+			"integrity": "sha512-IV5XZInFQaQK5ucjJy/HAk2UYvt+Buax00evzwo8NSuo8zhOBhW5v6VOjAljYUhAzQ/Hosi+Kaz6xJmvPiSM4Q==",
+			"requires": {
+				"acorn-private-class-elements": "^0.2.4"
+			}
+		},
+		"acorn-static-class-features": {
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/acorn-static-class-features/-/acorn-static-class-features-0.2.1.tgz",
+			"integrity": "sha512-eLIAEBFwu1bcZD+39u5PAcAargtkI5tY1uDRQV6SB3zY4JIO0vqvSdtZ8hz1GGZIVY/d3RDxkM9BLTPTNNVwGw==",
+			"requires": {
+				"acorn-private-class-elements": "^0.2.3"
 			}
 		},
 		"acorn-walk": {
@@ -2450,11 +3030,46 @@
 				}
 			}
 		},
+		"analytics-node": {
+			"version": "3.4.0-beta.1",
+			"resolved": "https://registry.npmjs.org/analytics-node/-/analytics-node-3.4.0-beta.1.tgz",
+			"integrity": "sha512-+0F/y4Asc5S2qhWcYss+iCob6TTXQktwbqlIk02gcZaRxpekCbnTbJu/rcaRooVHxqp9WSzUXiWCesJYPJETZQ==",
+			"requires": {
+				"@segment/loosely-validate-event": "^2.0.0",
+				"axios": "^0.18.1",
+				"axios-retry": "^3.0.2",
+				"lodash.isstring": "^4.0.1",
+				"md5": "^2.2.1",
+				"ms": "^2.0.0",
+				"remove-trailing-slash": "^0.1.0",
+				"uuid": "^3.2.1"
+			},
+			"dependencies": {
+				"lodash.isstring": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+					"integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+				}
+			}
+		},
+		"ansi": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
+			"integrity": "sha1-DELU+xcWDVqa8eSEus4cZpIsGyE="
+		},
 		"ansi-colors": {
 			"version": "3.2.4",
 			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz",
 			"integrity": "sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA==",
 			"dev": true
+		},
+		"ansi-escape-sequences": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-5.1.2.tgz",
+			"integrity": "sha512-JcpoVp1W1bl1Qn4cVuiXEhD6+dyXKSOgCn2zlzE8inYgCJCBy1aPnUhlz6I4DFum8D4ovb9Qi/iAjUcGvG2lqw==",
+			"requires": {
+				"array-back": "^4.0.0"
+			}
 		},
 		"ansi-escapes": {
 			"version": "3.2.0",
@@ -2478,7 +3093,6 @@
 			"version": "3.2.1",
 			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
 			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-			"dev": true,
 			"requires": {
 				"color-convert": "^1.9.0"
 			}
@@ -2520,6 +3134,11 @@
 				"readable-stream": "^2.0.6"
 			}
 		},
+		"arg": {
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
+		},
 		"argparse": {
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -2527,6 +3146,22 @@
 			"dev": true,
 			"requires": {
 				"sprintf-js": "~1.0.2"
+			}
+		},
+		"aria-query": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-3.0.0.tgz",
+			"integrity": "sha1-ZbP8wcoRVajJrmTW7uKX8V1RM8w=",
+			"requires": {
+				"ast-types-flow": "0.0.7",
+				"commander": "^2.11.0"
+			},
+			"dependencies": {
+				"commander": {
+					"version": "2.20.3",
+					"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
+					"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+				}
 			}
 		},
 		"arr-diff": {
@@ -2546,6 +3181,11 @@
 			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
 			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
 			"dev": true
+		},
+		"array-back": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.1.tgz",
+			"integrity": "sha512-Z/JnaVEXv+A9xabHzN43FiiiWEE7gPCRXMrVmRm00tWbjZRul1iHm7ECzlyNq1p4a4ATXz+G9FJ3GqGOkOV3fg=="
 		},
 		"array-equal": {
 			"version": "1.0.0",
@@ -2811,6 +3451,11 @@
 			"integrity": "sha512-2mP3TwtkY/aTv5X3ZsMpNAbOnyoC/aMJwJSoaELPkHId0nSQgFcnU4dRW3isxiz7+zBexk0ym3WNVjMiQBnJSw==",
 			"dev": true
 		},
+		"ast-types-flow": {
+			"version": "0.0.7",
+			"resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
+			"integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0="
+		},
 		"astral-regex": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/astral-regex/-/astral-regex-1.0.0.tgz",
@@ -2849,6 +3494,11 @@
 			"resolved": "https://registry.npmjs.org/atob/-/atob-2.1.2.tgz",
 			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
 			"dev": true
+		},
+		"atomic-sleep": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+			"integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="
 		},
 		"autoprefixer": {
 			"version": "9.7.6",
@@ -2910,6 +3560,46 @@
 			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
 			"integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==",
 			"dev": true
+		},
+		"axios": {
+			"version": "0.18.1",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-0.18.1.tgz",
+			"integrity": "sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==",
+			"requires": {
+				"follow-redirects": "1.5.10",
+				"is-buffer": "^2.0.2"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"follow-redirects": {
+					"version": "1.5.10",
+					"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+					"integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+					"requires": {
+						"debug": "=3.1.0"
+					}
+				},
+				"is-buffer": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+					"integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
+				}
+			}
+		},
+		"axios-retry": {
+			"version": "3.1.8",
+			"resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.1.8.tgz",
+			"integrity": "sha512-yPw5Y4Bg6Dgmhm35KaJFtlh23s1TecW0HsUerK4/IS1UKl0gtN2aJqdEKtVomiOS/bDo5w4P3sqgki/M10eF8Q==",
+			"requires": {
+				"is-retry-allowed": "^1.1.0"
+			}
 		},
 		"babel-code-frame": {
 			"version": "6.26.0",
@@ -3326,11 +4016,34 @@
 				"object.assign": "^4.1.0"
 			}
 		},
+		"babel-plugin-emotion": {
+			"version": "10.0.33",
+			"resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-10.0.33.tgz",
+			"integrity": "sha512-bxZbTTGz0AJQDHm8k6Rf3RQJ8tX2scsfsRyKVgAbiUPUNIRtlK+7JxP+TAd1kRLABFxe0CFm2VdK4ePkoA9FxQ==",
+			"requires": {
+				"@babel/helper-module-imports": "^7.0.0",
+				"@emotion/hash": "0.8.0",
+				"@emotion/memoize": "0.7.4",
+				"@emotion/serialize": "^0.11.16",
+				"babel-plugin-macros": "^2.0.0",
+				"babel-plugin-syntax-jsx": "^6.18.0",
+				"convert-source-map": "^1.5.0",
+				"escape-string-regexp": "^1.0.5",
+				"find-root": "^1.1.0",
+				"source-map": "^0.5.7"
+			},
+			"dependencies": {
+				"find-root": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/find-root/-/find-root-1.1.0.tgz",
+					"integrity": "sha512-NKfW6bec6GfKc0SGx1e07QZY9PE99u0Bft/0rzSD5k3sO/vwkVUpDUKVm5Gpp5Ue3YfShPFTX2070tDs5kB9Ng=="
+				}
+			}
+		},
 		"babel-plugin-macros": {
 			"version": "2.8.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-macros/-/babel-plugin-macros-2.8.0.tgz",
 			"integrity": "sha512-SEP5kJpfGYqYKpBrj5XU3ahw5p5GOHJ0U5ssOSQ/WBVdwkD2Dzlce95exQTs3jOVWPPKLBN2rlEWkCK7dSmLvg==",
-			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.7.2",
 				"cosmiconfig": "^6.0.0",
@@ -3341,7 +4054,6 @@
 					"version": "6.0.0",
 					"resolved": "https://registry.npmjs.org/cosmiconfig/-/cosmiconfig-6.0.0.tgz",
 					"integrity": "sha512-xb3ZL6+L8b9JLLCx3ZdoZy4+2ECphCMo2PwqgP1tlfVq6M6YReyzBJtvWWtbDSpNr9hn96pkCiZqUcFEc+54Qg==",
-					"dev": true,
 					"requires": {
 						"@types/parse-json": "^4.0.0",
 						"import-fresh": "^3.1.0",
@@ -3354,7 +4066,6 @@
 					"version": "3.2.1",
 					"resolved": "https://registry.npmjs.org/import-fresh/-/import-fresh-3.2.1.tgz",
 					"integrity": "sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==",
-					"dev": true,
 					"requires": {
 						"parent-module": "^1.0.0",
 						"resolve-from": "^4.0.0"
@@ -3364,7 +4075,6 @@
 					"version": "5.0.0",
 					"resolved": "https://registry.npmjs.org/parse-json/-/parse-json-5.0.0.tgz",
 					"integrity": "sha512-OOY5b7PAEFV0E2Fir1KOkxchnZNCdowAJgQ5NuxjpBKTRP3pQhwkrkxqQjeoKJ+fO7bCpmIZaogI4eZGDMEGOw==",
-					"dev": true,
 					"requires": {
 						"@babel/code-frame": "^7.0.0",
 						"error-ex": "^1.3.1",
@@ -3375,14 +4085,12 @@
 				"path-type": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/path-type/-/path-type-4.0.0.tgz",
-					"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw==",
-					"dev": true
+					"integrity": "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="
 				},
 				"resolve-from": {
 					"version": "4.0.0",
 					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-4.0.0.tgz",
-					"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g==",
-					"dev": true
+					"integrity": "sha512-pb/MYmXstAkysRFx8piNI1tGFNQIFA3vkE3Gq4EuA1dF6gHp/+vgZqsCGJapvy8N3Q+4o7FwvquPJcnZ7RYy4g=="
 				}
 			}
 		},
@@ -3561,8 +4269,7 @@
 		"babel-plugin-syntax-jsx": {
 			"version": "6.18.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-			"integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=",
-			"dev": true
+			"integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
 		},
 		"babel-plugin-syntax-object-rest-spread": {
 			"version": "6.13.0",
@@ -4460,8 +5167,7 @@
 		"base64-js": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
-			"dev": true
+			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
 		},
 		"base64id": {
 			"version": "1.0.0",
@@ -4541,7 +5247,6 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/bl/-/bl-2.2.0.tgz",
 			"integrity": "sha512-wbgvOpqopSr7uq6fJrLH8EsvYMJf9gzfo2jCsL2eTy75qXPukA4pCgHamOQkZtY5vmfVtjB+P3LNlMHW5CEZXA==",
-			"dev": true,
 			"requires": {
 				"readable-stream": "^2.3.5",
 				"safe-buffer": "^5.1.1"
@@ -4804,8 +5509,7 @@
 		"bson": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/bson/-/bson-1.1.4.tgz",
-			"integrity": "sha512-S/yKGU1syOMzO86+dGpg2qGoDL0zvzcb262G+gqEy6TgP6rt6z6qxSFX/8X6vLC91P7G7C3nLs0+bvDzmvBA3Q==",
-			"dev": true
+			"integrity": "sha512-S/yKGU1syOMzO86+dGpg2qGoDL0zvzcb262G+gqEy6TgP6rt6z6qxSFX/8X6vLC91P7G7C3nLs0+bvDzmvBA3Q=="
 		},
 		"buffer": {
 			"version": "4.9.2",
@@ -4849,8 +5553,7 @@
 		"buffer-from": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-			"dev": true
+			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
 		},
 		"buffer-indexof": {
 			"version": "1.1.1",
@@ -5086,7 +5789,6 @@
 			"version": "2.4.2",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
 			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-			"dev": true,
 			"requires": {
 				"ansi-styles": "^3.2.1",
 				"escape-string-regexp": "^1.0.5",
@@ -5098,6 +5800,11 @@
 			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
 			"integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
 			"dev": true
+		},
+		"charenc": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+			"integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
 		},
 		"check-error": {
 			"version": "1.0.2",
@@ -5371,7 +6078,6 @@
 			"version": "1.9.3",
 			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
 			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-			"dev": true,
 			"requires": {
 				"color-name": "1.1.3"
 			}
@@ -5379,8 +6085,7 @@
 		"color-name": {
 			"version": "1.1.3",
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
-			"dev": true
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 		},
 		"color-string": {
 			"version": "0.3.0",
@@ -5484,6 +6189,11 @@
 			"resolved": "https://registry.npmjs.org/component-inherit/-/component-inherit-0.0.3.tgz",
 			"integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM=",
 			"dev": true
+		},
+		"component-type": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/component-type/-/component-type-1.2.1.tgz",
+			"integrity": "sha1-ikeQFwAjjk/DIml3EjAibyS0Fak="
 		},
 		"compressible": {
 			"version": "2.0.18",
@@ -5610,7 +6320,6 @@
 			"version": "1.7.0",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
 			"integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
-			"dev": true,
 			"requires": {
 				"safe-buffer": "~5.1.1"
 			}
@@ -5680,8 +6389,7 @@
 		"core-util-is": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
-			"dev": true
+			"integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac="
 		},
 		"cosmiconfig": {
 			"version": "5.2.1",
@@ -5721,6 +6429,28 @@
 			"requires": {
 				"bn.js": "^4.1.0",
 				"elliptic": "^6.0.0"
+			}
+		},
+		"create-emotion": {
+			"version": "10.0.27",
+			"resolved": "https://registry.npmjs.org/create-emotion/-/create-emotion-10.0.27.tgz",
+			"integrity": "sha512-fIK73w82HPPn/RsAij7+Zt8eCE8SptcJ3WoRMfxMtjteYxud8GDTKKld7MYwAX2TVhrw29uR1N/bVGxeStHILg==",
+			"requires": {
+				"@emotion/cache": "^10.0.27",
+				"@emotion/serialize": "^0.11.15",
+				"@emotion/sheet": "0.9.4",
+				"@emotion/utils": "0.11.3"
+			}
+		},
+		"create-emotion-server": {
+			"version": "10.0.27",
+			"resolved": "https://registry.npmjs.org/create-emotion-server/-/create-emotion-server-10.0.27.tgz",
+			"integrity": "sha512-1EbZgdjiho9ue1BSTpAez8SIdfbTXomtz0bg+LPOEvf/5OV7xqCGJaoSCDCB+y7kZ73hwoEhLsoPmqKSGIQMXg==",
+			"requires": {
+				"@emotion/utils": "0.11.3",
+				"html-tokenize": "^2.0.0",
+				"multipipe": "^1.0.2",
+				"through": "^2.3.8"
 			}
 		},
 		"create-hash": {
@@ -5795,6 +6525,11 @@
 				"shebang-command": "^1.2.0",
 				"which": "^1.2.9"
 			}
+		},
+		"crypt": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+			"integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
 		},
 		"cryptiles": {
 			"version": "2.0.5",
@@ -6102,8 +6837,7 @@
 		"csstype": {
 			"version": "2.6.10",
 			"resolved": "https://registry.npmjs.org/csstype/-/csstype-2.6.10.tgz",
-			"integrity": "sha512-D34BqZU4cIlMCY93rZHbrq9pjTAQJ3U8S8rfBqjwHxkGPThWFjzZDQpgMJY0QViLxth6ZKYiwFBo14RdN44U/w==",
-			"dev": true
+			"integrity": "sha512-D34BqZU4cIlMCY93rZHbrq9pjTAQJ3U8S8rfBqjwHxkGPThWFjzZDQpgMJY0QViLxth6ZKYiwFBo14RdN44U/w=="
 		},
 		"cuint": {
 			"version": "0.2.2",
@@ -6472,8 +7206,7 @@
 		"denque": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/denque/-/denque-1.4.1.tgz",
-			"integrity": "sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ==",
-			"dev": true
+			"integrity": "sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ=="
 		},
 		"depd": {
 			"version": "1.1.2",
@@ -7149,6 +7882,14 @@
 			"integrity": "sha1-rOb/gIwc5mtX0ev5eXessCM0z8E=",
 			"dev": true
 		},
+		"duplexer2": {
+			"version": "0.1.4",
+			"resolved": "https://registry.npmjs.org/duplexer2/-/duplexer2-0.1.4.tgz",
+			"integrity": "sha1-ixLauHjA1p4+eJEFFmKjL8a93ME=",
+			"requires": {
+				"readable-stream": "^2.0.2"
+			}
+		},
 		"duplexify": {
 			"version": "3.7.1",
 			"resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
@@ -7534,6 +8275,76 @@
 			"integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
 			"dev": true
 		},
+		"emotion": {
+			"version": "10.0.27",
+			"resolved": "https://registry.npmjs.org/emotion/-/emotion-10.0.27.tgz",
+			"integrity": "sha512-2xdDzdWWzue8R8lu4G76uWX5WhyQuzATon9LmNeCy/2BHVC6dsEpfhN1a0qhELgtDVdjyEA6J8Y/VlI5ZnaH0g==",
+			"requires": {
+				"babel-plugin-emotion": "^10.0.27",
+				"create-emotion": "^10.0.27"
+			}
+		},
+		"emphasize": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/emphasize/-/emphasize-3.0.0.tgz",
+			"integrity": "sha512-xhtAWvxdkxsQbcCLGVjlfB7cQ4bWSPYXeaGDwK5Bl7n2y/9R+MVK5UNBTmZ9N8m/YShsiyGgQBgFGcjOWCWXHQ==",
+			"requires": {
+				"chalk": "^3.0.0",
+				"highlight.js": "~9.12.0",
+				"lowlight": "~1.9.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+				},
+				"highlight.js": {
+					"version": "9.12.0",
+					"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.12.0.tgz",
+					"integrity": "sha1-5tnb5Xy+/mB1HwKvM2GVhwyQwB4="
+				},
+				"supports-color": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
+		},
 		"encodeurl": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -7774,7 +8585,6 @@
 			"version": "1.3.2",
 			"resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.2.tgz",
 			"integrity": "sha512-7dFHNmqeFSEt2ZBsCriorKnn3Z2pj+fd9kmI6QoWw4//DL+icEBfc0U7qJCisqrTsKTjw4fNFy2pW9OqStD84g==",
-			"dev": true,
 			"requires": {
 				"is-arrayish": "^0.2.1"
 			}
@@ -7978,8 +8788,7 @@
 		"escape-string-regexp": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-			"dev": true
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 		},
 		"escodegen": {
 			"version": "1.14.1",
@@ -8702,6 +9511,11 @@
 			"integrity": "sha1-lpGEQOMEGnpBT4xS48V06zw+HgU=",
 			"dev": true
 		},
+		"facepaint": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/facepaint/-/facepaint-1.2.1.tgz",
+			"integrity": "sha512-oNvBekbhsm/0PNSOWca5raHNAi6dG960Bx6LJgxDPNF59WpuspgQ17bN5MKwOr7JcFdQYc7StW3VZ28DBZLavQ=="
+		},
 		"fast-deep-equal": {
 			"version": "3.1.1",
 			"resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.1.tgz",
@@ -8794,6 +9608,16 @@
 			"integrity": "sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw==",
 			"dev": true
 		},
+		"fast-redact": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-2.0.0.tgz",
+			"integrity": "sha512-zxpkULI9W9MNTK2sJ3BpPQrTEXFNESd2X6O1tXMFpK/XM0G5c5Rll2EVYZH2TqI3xRGK/VaJ+eEOt7pnENJpeA=="
+		},
+		"fast-safe-stringify": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+			"integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
+		},
 		"fastparse": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.2.tgz",
@@ -8807,6 +9631,14 @@
 			"dev": true,
 			"requires": {
 				"reusify": "^1.0.4"
+			}
+		},
+		"fault": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/fault/-/fault-1.0.4.tgz",
+			"integrity": "sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==",
+			"requires": {
+				"format": "^0.2.0"
 			}
 		},
 		"faye-websocket": {
@@ -9036,6 +9868,11 @@
 				}
 			}
 		},
+		"flatstr": {
+			"version": "1.0.12",
+			"resolved": "https://registry.npmjs.org/flatstr/-/flatstr-1.0.12.tgz",
+			"integrity": "sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw=="
+		},
 		"flatted": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
@@ -9095,6 +9932,11 @@
 				"combined-stream": "^1.0.6",
 				"mime-types": "^2.1.12"
 			}
+		},
+		"format": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
+			"integrity": "sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs="
 		},
 		"forwarded": {
 			"version": "0.1.2",
@@ -9788,8 +10630,7 @@
 		"gensync": {
 			"version": "1.0.0-beta.1",
 			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
-			"integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==",
-			"dev": true
+			"integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg=="
 		},
 		"get-amd-module-type": {
 			"version": "3.0.0",
@@ -9970,8 +10811,7 @@
 		"globals": {
 			"version": "11.12.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-			"dev": true
+			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
 		},
 		"globalthis": {
 			"version": "1.0.1",
@@ -10176,8 +11016,7 @@
 		"has-flag": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
-			"dev": true
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
 		},
 		"has-symbols": {
 			"version": "1.0.1",
@@ -10261,6 +11100,16 @@
 			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
 			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
 			"dev": true
+		},
+		"highlight.js": {
+			"version": "9.18.1",
+			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.18.1.tgz",
+			"integrity": "sha512-OrVKYz70LHsnCgmbXctv/bfuvntIKDz177h0Co37DQ5jamGZLVmoCVMtjMtNZY3X9DrCcKfklHPNeA0uPZhSJg=="
+		},
+		"highlightjs-graphql": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/highlightjs-graphql/-/highlightjs-graphql-1.0.1.tgz",
+			"integrity": "sha512-g5kt/orsUJTjIt5pgs/uvi78kXndpCtYwzE7H3D0d07r3ETs9oHSZHD0EGaRPndiQ/4EYXt12rnsDkljn3ilAA=="
 		},
 		"hmac-drbg": {
 			"version": "1.0.1",
@@ -10447,6 +11296,68 @@
 			"resolved": "https://registry.npmjs.org/html-tag-names/-/html-tag-names-1.1.5.tgz",
 			"integrity": "sha512-aI5tKwNTBzOZApHIynaAwecLBv8TlZTEy/P4Sj2SzzAhBrGuI8yGZ0UIXVPQzOHGS+to2mjb04iy6VWt/8+d8A==",
 			"dev": true
+		},
+		"html-tokenize": {
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/html-tokenize/-/html-tokenize-2.0.1.tgz",
+			"integrity": "sha512-QY6S+hZ0f5m1WT8WffYN+Hg+xm/w5I8XeUcAq/ZYP5wVC8xbKi4Whhru3FtrAebD5EhBW8rmFzkDI6eCAuFe2w==",
+			"requires": {
+				"buffer-from": "~0.1.1",
+				"inherits": "~2.0.1",
+				"minimist": "~1.2.5",
+				"readable-stream": "~1.0.27-1",
+				"through2": "~0.4.1"
+			},
+			"dependencies": {
+				"buffer-from": {
+					"version": "0.1.2",
+					"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-0.1.2.tgz",
+					"integrity": "sha512-RiWIenusJsmI2KcvqQABB83tLxCByE3upSP8QU3rJDMVFGPWLvPQJt/O1Su9moRWeH7d+Q2HYb68f6+v+tw2vg=="
+				},
+				"isarray": {
+					"version": "0.0.1",
+					"resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
+					"integrity": "sha1-ihis/Kmo9Bd+Cav8YDiTmwXR7t8="
+				},
+				"object-keys": {
+					"version": "0.4.0",
+					"resolved": "https://registry.npmjs.org/object-keys/-/object-keys-0.4.0.tgz",
+					"integrity": "sha1-KKaq50KN0sOpLz2V8hM13SBOAzY="
+				},
+				"readable-stream": {
+					"version": "1.0.34",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
+					"integrity": "sha1-Elgg40vIQtLyqq+v5MKRbuMsFXw=",
+					"requires": {
+						"core-util-is": "~1.0.0",
+						"inherits": "~2.0.1",
+						"isarray": "0.0.1",
+						"string_decoder": "~0.10.x"
+					}
+				},
+				"string_decoder": {
+					"version": "0.10.31",
+					"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
+					"integrity": "sha1-YuIDvEF2bGwoyfyEMB2rHFMQ+pQ="
+				},
+				"through2": {
+					"version": "0.4.2",
+					"resolved": "https://registry.npmjs.org/through2/-/through2-0.4.2.tgz",
+					"integrity": "sha1-2/WGYDEVHsg1K7bE22SiKSqEC5s=",
+					"requires": {
+						"readable-stream": "~1.0.17",
+						"xtend": "~2.1.1"
+					}
+				},
+				"xtend": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/xtend/-/xtend-2.1.2.tgz",
+					"integrity": "sha1-bv7MKk2tjmlixJAbM3znuoe10os=",
+					"requires": {
+						"object-keys": "~0.4.0"
+					}
+				}
+			}
 		},
 		"html-webpack-plugin": {
 			"version": "3.2.0",
@@ -10658,8 +11569,7 @@
 		"ieee754": {
 			"version": "1.1.13",
 			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-			"integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
-			"dev": true
+			"integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
 		},
 		"iferr": {
 			"version": "0.1.5",
@@ -10782,8 +11692,7 @@
 		"inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
-			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-			"dev": true
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ=="
 		},
 		"ini": {
 			"version": "1.3.5",
@@ -10960,8 +11869,7 @@
 		"is-arrayish": {
 			"version": "0.2.1",
 			"resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.2.1.tgz",
-			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0=",
-			"dev": true
+			"integrity": "sha1-d8mYQFJ6qOyxqLppe4BkWnqSap0="
 		},
 		"is-binary-path": {
 			"version": "1.0.1",
@@ -10981,8 +11889,7 @@
 		"is-buffer": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-			"dev": true
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
 		},
 		"is-callable": {
 			"version": "1.1.5",
@@ -11182,6 +12089,25 @@
 			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
 			"dev": true
 		},
+		"is-recoverable-error": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-recoverable-error/-/is-recoverable-error-1.0.1.tgz",
+			"integrity": "sha512-1v/3hIRd0hHzkmq9TU+otd8SlUJjr60KyX6RfgwJ6NVbeQafc3POajWZ/BcusPxhdX0ScN3xE9tTnn6xGpC3LA==",
+			"requires": {
+				"acorn": "^7.1.1",
+				"acorn-class-fields": "^0.3.2",
+				"acorn-numeric-separator": "^0.3.1",
+				"acorn-private-methods": "^0.3.1",
+				"acorn-static-class-features": "^0.2.1"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.2.0.tgz",
+					"integrity": "sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ=="
+				}
+			}
+		},
 		"is-regex": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
@@ -11199,6 +12125,11 @@
 			"requires": {
 				"is-unc-path": "^1.0.0"
 			}
+		},
+		"is-retry-allowed": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
+			"integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg=="
 		},
 		"is-root": {
 			"version": "1.0.0",
@@ -11296,8 +12227,7 @@
 		"isarray": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
-			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
-			"dev": true
+			"integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE="
 		},
 		"isbinaryfile": {
 			"version": "3.0.3",
@@ -11420,6 +12350,11 @@
 				"iterate-iterator": "^1.0.1"
 			}
 		},
+		"join-component": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/join-component/-/join-component-1.1.0.tgz",
+			"integrity": "sha1-uEF7dQZho5K+4sJTfGiyqdSXfNU="
+		},
 		"js-base64": {
 			"version": "2.5.2",
 			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.2.tgz",
@@ -11435,8 +12370,7 @@
 		"js-tokens": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-			"dev": true
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
 		},
 		"js-yaml": {
 			"version": "3.7.0",
@@ -11505,8 +12439,7 @@
 		"jsesc": {
 			"version": "2.5.2",
 			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-			"dev": true
+			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
 		},
 		"json-loader": {
 			"version": "0.5.7",
@@ -11517,8 +12450,7 @@
 		"json-parse-better-errors": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/json-parse-better-errors/-/json-parse-better-errors-1.0.2.tgz",
-			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw==",
-			"dev": true
+			"integrity": "sha512-mrqyZKfX5EhL7hvqcV6WG1yYjnjeuYDzDhhcAAUrq8Po85NBQBJP+ZDUT75qZQ98IkUoBqdkExkukOU7Ts2wrw=="
 		},
 		"json-schema": {
 			"version": "0.2.3",
@@ -11564,7 +12496,6 @@
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
 			"integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
-			"dev": true,
 			"requires": {
 				"minimist": "^1.2.5"
 			}
@@ -12215,8 +13146,7 @@
 		"lines-and-columns": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-1.1.6.tgz",
-			"integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=",
-			"dev": true
+			"integrity": "sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA="
 		},
 		"load-json-file": {
 			"version": "2.0.0",
@@ -12297,8 +13227,7 @@
 		"lodash": {
 			"version": "4.17.15",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
-			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A==",
-			"dev": true
+			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
 		},
 		"lodash-es": {
 			"version": "4.17.15",
@@ -12808,6 +13737,11 @@
 				"lodash.isfunction": "^3.0.0"
 			}
 		},
+		"lodash.set": {
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+			"integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
+		},
 		"lodash.some": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
@@ -12906,8 +13840,7 @@
 		"long": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-			"integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
-			"dev": true
+			"integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
 		},
 		"longest": {
 			"version": "1.0.1",
@@ -12940,6 +13873,22 @@
 			"integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
 			"dev": true
 		},
+		"lowlight": {
+			"version": "1.9.2",
+			"resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.9.2.tgz",
+			"integrity": "sha512-Ek18ElVCf/wF/jEm1b92gTnigh94CtBNWiZ2ad+vTgW7cTmQxUY3I98BjHK68gZAJEWmybGBZgx9qv3QxLQB/Q==",
+			"requires": {
+				"fault": "^1.0.2",
+				"highlight.js": "~9.12.0"
+			},
+			"dependencies": {
+				"highlight.js": {
+					"version": "9.12.0",
+					"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.12.0.tgz",
+					"integrity": "sha1-5tnb5Xy+/mB1HwKvM2GVhwyQwB4="
+				}
+			}
+		},
 		"lru-cache": {
 			"version": "4.1.5",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
@@ -12963,8 +13912,7 @@
 		"make-error": {
 			"version": "1.3.6",
 			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-			"dev": true
+			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
 		},
 		"map-age-cleaner": {
 			"version": "0.1.3",
@@ -13034,6 +13982,16 @@
 			"integrity": "sha512-L0j0tFVZBQQLeEjmWOvDLoRciIY8gQGWahvkztXUal8jH8R5Rlqo9GCvgqvXcy9LQhEWdQCVvzqAbxgYNt4blQ==",
 			"dev": true
 		},
+		"md5": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
+			"integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
+			"requires": {
+				"charenc": "~0.0.1",
+				"crypt": "~0.0.1",
+				"is-buffer": "~1.1.1"
+			}
+		},
 		"md5.js": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -13080,7 +14038,6 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
 			"integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
-			"dev": true,
 			"optional": true
 		},
 		"meow": {
@@ -13347,8 +14304,7 @@
 		"minimist": {
 			"version": "1.2.5",
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
-			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
-			"dev": true
+			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
 		},
 		"minipass": {
 			"version": "2.9.0",
@@ -13951,7 +14907,6 @@
 			"version": "3.5.6",
 			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.5.6.tgz",
 			"integrity": "sha512-sh3q3GLDLT4QmoDLamxtAECwC3RGjq+oNuK1ENV8+tnipIavss6sMYt77hpygqlMOCt0Sla5cl7H4SKCVBCGEg==",
-			"dev": true,
 			"requires": {
 				"bl": "^2.2.0",
 				"bson": "^1.1.4",
@@ -13960,6 +14915,26 @@
 				"safe-buffer": "^5.1.2",
 				"saslprep": "^1.0.0"
 			}
+		},
+		"mongodb-ace-autocompleter": {
+			"version": "0.4.8",
+			"resolved": "https://registry.npmjs.org/mongodb-ace-autocompleter/-/mongodb-ace-autocompleter-0.4.8.tgz",
+			"integrity": "sha512-OMDiHtrMt5z7RxQKZKl4kLJqUDbe0xTUSBQT0r+DNHKzsQoyk5RlUK6jsMWmFYn1ADFGGAejVJWbcnlG4WGH8w==",
+			"requires": {
+				"semver": "^7.1.1"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "7.3.2",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
+				}
+			}
+		},
+		"mongodb-build-info": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/mongodb-build-info/-/mongodb-build-info-1.1.0.tgz",
+			"integrity": "sha512-ZlbQlpXv8DCvYK2I6UmyRO4z9zb4fyoph+RhEN/MSSsigaqcfl6dePkbgavemquvuKVEq0BbIiVkHw1DKwChxA=="
 		},
 		"mongodb-collection-sample": {
 			"version": "4.5.1",
@@ -14672,6 +15647,14 @@
 			"integrity": "sha512-sch/9jd74VjRCmB5U+Fj4WJnkmAtDQgxqJkBInO7zEknXE+lnDEuNBT5/Wp59HMrWUabssGGq08r6Y6F7pkvVA==",
 			"dev": true
 		},
+		"mongodb-redact": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/mongodb-redact/-/mongodb-redact-0.2.0.tgz",
+			"integrity": "sha512-kGoR02HsTzNYHFXLklvbEg7mSJZu5+L1JdaYUuSlmVUAXxzhxUBvoFoYulfqqvokE+ilAXGYywdMJStB0lPhCw==",
+			"requires": {
+				"lodash": "^4.17.15"
+			}
+		},
 		"mongodb-reflux-store": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/mongodb-reflux-store/-/mongodb-reflux-store-0.0.1.tgz",
@@ -14756,8 +15739,7 @@
 		"ms": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-			"dev": true
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 		},
 		"multicast-dns": {
 			"version": "6.2.3",
@@ -14775,11 +15757,24 @@
 			"integrity": "sha1-iZ8R2WhuXgXLkbNdXw5jt3PPyQE=",
 			"dev": true
 		},
+		"multipipe": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/multipipe/-/multipipe-1.0.2.tgz",
+			"integrity": "sha1-zBPv2DPJzamfIk+GhGG44aP9k50=",
+			"requires": {
+				"duplexer2": "^0.1.2",
+				"object-assign": "^4.1.0"
+			}
+		},
+		"mustache": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/mustache/-/mustache-4.0.1.tgz",
+			"integrity": "sha512-yL5VE97+OXn4+Er3THSmTdCFCtx5hHWzrolvH+JObZnUYwuaG7XV+Ch4fR2cIrcYI0tFHxS7iyFYl14bW8y2sA=="
+		},
 		"mute-stream": {
 			"version": "0.0.7",
 			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
-			"dev": true
+			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
 		},
 		"nan": {
 			"version": "2.14.1",
@@ -14787,6 +15782,21 @@
 			"integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
 			"dev": true,
 			"optional": true
+		},
+		"nanoassert": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/nanoassert/-/nanoassert-1.1.0.tgz",
+			"integrity": "sha1-TzFS4JVA/eKMdvRLGbvNHVpCR40="
+		},
+		"nanobus": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/nanobus/-/nanobus-4.4.0.tgz",
+			"integrity": "sha512-Hv9USGyH8EsPy0o8pPWE7x3YRIfuZDgMBirzjU6XLebhiSK2g53JlfqgolD0c39ne6wXAfaBNcIAvYe22Bav+Q==",
+			"requires": {
+				"nanoassert": "^1.1.0",
+				"nanotiming": "^7.2.0",
+				"remove-array-items": "^1.0.0"
+			}
 		},
 		"nanomatch": {
 			"version": "1.2.13",
@@ -14805,6 +15815,23 @@
 				"regex-not": "^1.0.0",
 				"snapdragon": "^0.8.1",
 				"to-regex": "^3.0.1"
+			}
+		},
+		"nanoscheduler": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/nanoscheduler/-/nanoscheduler-1.0.3.tgz",
+			"integrity": "sha512-jBbrF3qdU9321r8n9X7yu18DjP31Do2ItJm3mWrt90wJTrnDO+HXpoV7ftaUglAtjgj9s+OaCxGufbvx6pvbEQ==",
+			"requires": {
+				"nanoassert": "^1.1.0"
+			}
+		},
+		"nanotiming": {
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/nanotiming/-/nanotiming-7.3.1.tgz",
+			"integrity": "sha512-l3lC7v/PfOuRWQa8vV29Jo6TG10wHtnthLElFXs4Te4Aas57Fo4n1Q8LH9n+NDh9riOzTVvb2QNBhTS4JUKNjw==",
+			"requires": {
+				"nanoassert": "^1.1.0",
+				"nanoscheduler": "^1.0.2"
 			}
 		},
 		"napi-build-utils": {
@@ -16274,8 +17301,7 @@
 		"object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
-			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
-			"dev": true
+			"integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM="
 		},
 		"object-component": {
 			"version": "0.0.3",
@@ -16670,7 +17696,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/parent-module/-/parent-module-1.0.1.tgz",
 			"integrity": "sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==",
-			"dev": true,
 			"requires": {
 				"callsites": "^3.0.0"
 			},
@@ -16678,8 +17703,7 @@
 				"callsites": {
 					"version": "3.1.0",
 					"resolved": "https://registry.npmjs.org/callsites/-/callsites-3.1.0.tgz",
-					"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==",
-					"dev": true
+					"integrity": "sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ=="
 				}
 			}
 		},
@@ -16797,8 +17821,7 @@
 		"path-parse": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
-			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
-			"dev": true
+			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
 		},
 		"path-to-regexp": {
 			"version": "0.1.7",
@@ -16895,6 +17918,24 @@
 			"requires": {
 				"pinkie": "^2.0.0"
 			}
+		},
+		"pino": {
+			"version": "5.17.0",
+			"resolved": "https://registry.npmjs.org/pino/-/pino-5.17.0.tgz",
+			"integrity": "sha512-LqrqmRcJz8etUjyV0ddqB6OTUutCgQULPFg2b4dtijRHUsucaAdBgSUW58vY6RFSX+NT8963F+q0tM6lNwGShA==",
+			"requires": {
+				"fast-redact": "^2.0.0",
+				"fast-safe-stringify": "^2.0.7",
+				"flatstr": "^1.0.12",
+				"pino-std-serializers": "^2.4.2",
+				"quick-format-unescaped": "^3.0.3",
+				"sonic-boom": "^0.7.5"
+			}
+		},
+		"pino-std-serializers": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-2.4.2.tgz",
+			"integrity": "sha512-WaL504dO8eGs+vrK+j4BuQQq6GLKeCCcHaMB2ItygzVURcL1CycwNEUHTD/lHFHs/NL5qAz2UKrjYWXKSf4aMQ=="
 		},
 		"pirates": {
 			"version": "4.0.1",
@@ -16998,6 +18039,14 @@
 			"resolved": "https://registry.npmjs.org/pn/-/pn-1.1.0.tgz",
 			"integrity": "sha512-2qHaIQr2VLRFoxe2nASzsV6ef4yOOH+Fi9FBOVH6cqeSgUnoyySPZkxzLuzd+RYOQTRpROA0ztTMqxROKSb/nA==",
 			"dev": true
+		},
+		"polished": {
+			"version": "2.3.3",
+			"resolved": "https://registry.npmjs.org/polished/-/polished-2.3.3.tgz",
+			"integrity": "sha512-59V4fDbdxtH4I1m9TWxFsoGJbC8nnOpUYo5uFmvMfKp9Qh+6suo4VMUle1TGIIUZIGxfkW+Rs485zPk0wcwR2Q==",
+			"requires": {
+				"@babel/runtime": "^7.2.0"
+			}
 		},
 		"portfinder": {
 			"version": "1.0.25",
@@ -18942,6 +19991,86 @@
 				"utila": "~0.4"
 			}
 		},
+		"pretty-format": {
+			"version": "24.9.0",
+			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",
+			"integrity": "sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==",
+			"requires": {
+				"@jest/types": "^24.9.0",
+				"ansi-regex": "^4.0.0",
+				"ansi-styles": "^3.2.0",
+				"react-is": "^16.8.4"
+			},
+			"dependencies": {
+				"ansi-regex": {
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
+					"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+				}
+			}
+		},
+		"pretty-repl": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/pretty-repl/-/pretty-repl-2.3.0.tgz",
+			"integrity": "sha512-h7iNPLXpJPnbZZS0YIp1+EGD+oY9STelL70X8nwzrbglqP5nOUi0YxK+OJ8n6xopVHoLNQZrytYTmHrWcB1O/w==",
+			"requires": {
+				"ansi": "^0.3.1",
+				"chalk": "^4.0.0",
+				"emphasize": "^3.0.0",
+				"semver": "^7.2.2"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.0.0.tgz",
+					"integrity": "sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==",
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+				},
+				"semver": {
+					"version": "7.3.2",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
+				},
+				"supports-color": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
+		},
 		"private": {
 			"version": "0.1.8",
 			"resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
@@ -18957,8 +20086,7 @@
 		"process-nextick-args": {
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
-			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-			"dev": true
+			"integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag=="
 		},
 		"progress": {
 			"version": "2.0.3",
@@ -19212,6 +20340,11 @@
 			"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
 			"integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==",
 			"dev": true
+		},
+		"quick-format-unescaped": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-3.0.3.tgz",
+			"integrity": "sha512-dy1yjycmn9blucmJLXOfZDx1ikZJUi6E8bBZLnhPG5gBrVhHXx2xVyqqgKBubVNEXmx51dBACMHpoMQK/N/AXQ=="
 		},
 		"radium": {
 			"version": "0.19.6",
@@ -19561,8 +20694,7 @@
 		"react-is": {
 			"version": "16.13.1",
 			"resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
-			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
-			"dev": true
+			"integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ=="
 		},
 		"react-lifecycles-compat": {
 			"version": "3.0.4",
@@ -19741,6 +20873,14 @@
 				}
 			}
 		},
+		"read": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+			"integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
+			"requires": {
+				"mute-stream": "~0.0.4"
+			}
+		},
 		"read-package-json": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.1.1.tgz",
@@ -19779,7 +20919,6 @@
 			"version": "2.3.7",
 			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
 			"integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
-			"dev": true,
 			"requires": {
 				"core-util-is": "~1.0.0",
 				"inherits": "~2.0.3",
@@ -19963,8 +21102,7 @@
 		"regenerator-runtime": {
 			"version": "0.13.5",
 			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.5.tgz",
-			"integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA==",
-			"dev": true
+			"integrity": "sha512-ZS5w8CpKFinUzOwW3c83oPeVXoNsrLsaCoLtJvAClH135j/R77RuymhiSErhm2lKcwSCIpmvIWSbDkIfAqKQlA=="
 		},
 		"regenerator-transform": {
 			"version": "0.14.4",
@@ -20045,11 +21183,21 @@
 			"integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
 			"dev": true
 		},
+		"remove-array-items": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/remove-array-items/-/remove-array-items-1.1.1.tgz",
+			"integrity": "sha512-MXW/jtHyl5F1PZI7NbpS8SOtympdLuF20aoWJT5lELR1p/HJDd5nqW8Eu9uLh/hCRY3FgvrIT5AwDCgBODklcA=="
+		},
 		"remove-trailing-separator": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
 			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
 			"dev": true
+		},
+		"remove-trailing-slash": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/remove-trailing-slash/-/remove-trailing-slash-0.1.0.tgz",
+			"integrity": "sha1-FJjl3wmEwn5Jt26/Boh8otARUNI="
 		},
 		"renderkid": {
 			"version": "2.0.3",
@@ -20157,7 +21305,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
 			"integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
-			"dev": true,
 			"requires": {
 				"resolve-from": "^2.0.0",
 				"semver": "^5.1.0"
@@ -20166,8 +21313,7 @@
 				"resolve-from": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-					"integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
-					"dev": true
+					"integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
 				}
 			}
 		},
@@ -20187,7 +21333,6 @@
 			"version": "1.17.0",
 			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
 			"integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
-			"dev": true,
 			"requires": {
 				"path-parse": "^1.0.6"
 			}
@@ -20352,8 +21497,7 @@
 		"safe-buffer": {
 			"version": "5.1.2",
 			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
-			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-			"dev": true
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
 		},
 		"safe-regex": {
 			"version": "1.1.0",
@@ -20383,7 +21527,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
 			"integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
-			"dev": true,
 			"optional": true,
 			"requires": {
 				"sparse-bitfield": "^3.0.3"
@@ -20433,8 +21576,7 @@
 		"semver": {
 			"version": "5.7.1",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-			"dev": true
+			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
 		},
 		"send": {
 			"version": "0.17.1",
@@ -21051,6 +22193,15 @@
 				}
 			}
 		},
+		"sonic-boom": {
+			"version": "0.7.7",
+			"resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-0.7.7.tgz",
+			"integrity": "sha512-Ei5YOo5J64GKClHIL/5evJPgASXFVpfVYbJV9PILZQytTK6/LCwHvsZJW2Ig4p9FMC2OrBrMnXKgRN/OEoAWfg==",
+			"requires": {
+				"atomic-sleep": "^1.0.0",
+				"flatstr": "^1.0.12"
+			}
+		},
 		"sort-keys": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
@@ -21069,8 +22220,7 @@
 		"source-map": {
 			"version": "0.5.7",
 			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
-			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w=",
-			"dev": true
+			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
 		},
 		"source-map-resolve": {
 			"version": "0.5.3",
@@ -21089,7 +22239,6 @@
 			"version": "0.5.18",
 			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.18.tgz",
 			"integrity": "sha512-9luZr/BZ2QeU6tO2uG8N2aZpVSli4TSAOAqFOyTO51AJcD9P99c0K1h6dD6r6qo5dyT44BR5exweOaLLeldTkQ==",
-			"dev": true,
 			"requires": {
 				"buffer-from": "^1.0.0",
 				"source-map": "^0.6.0"
@@ -21098,8 +22247,7 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
@@ -21113,7 +22261,6 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
 			"integrity": "sha1-/0rm5oZWBWuks+eSqzM004JzyhE=",
-			"dev": true,
 			"optional": true,
 			"requires": {
 				"memory-pager": "^1.0.2"
@@ -21605,7 +22752,6 @@
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
 			"integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
-			"dev": true,
 			"requires": {
 				"safe-buffer": "~5.1.0"
 			}
@@ -21722,7 +22868,6 @@
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
 			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-			"dev": true,
 			"requires": {
 				"has-flag": "^3.0.0"
 			}
@@ -22077,8 +23222,7 @@
 		"text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
-			"dev": true
+			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
 		},
 		"throttleit": {
 			"version": "0.0.2",
@@ -22089,8 +23233,7 @@
 		"through": {
 			"version": "2.3.8",
 			"resolved": "https://registry.npmjs.org/through/-/through-2.3.8.tgz",
-			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=",
-			"dev": true
+			"integrity": "sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU="
 		},
 		"through2": {
 			"version": "2.0.5",
@@ -22147,8 +23290,7 @@
 		"to-fast-properties": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4=",
-			"dev": true
+			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
 		},
 		"to-object-path": {
 			"version": "0.3.0",
@@ -22276,6 +23418,25 @@
 			"integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==",
 			"dev": true
 		},
+		"ts-node": {
+			"version": "8.10.1",
+			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.10.1.tgz",
+			"integrity": "sha512-bdNz1L4ekHiJul6SHtZWs1ujEKERJnHs4HxN7rjTyyVOFf3HaJ6sLqe6aPG62XTzAB/63pKRh5jTSWL0D7bsvw==",
+			"requires": {
+				"arg": "^4.1.0",
+				"diff": "^4.0.1",
+				"make-error": "^1.1.1",
+				"source-map-support": "^0.5.17",
+				"yn": "3.1.1"
+			},
+			"dependencies": {
+				"diff": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+					"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
+				}
+			}
+		},
 		"tslib": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
@@ -22361,8 +23522,7 @@
 		"typescript": {
 			"version": "3.8.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
-			"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
-			"dev": true
+			"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w=="
 		},
 		"ua-parser-js": {
 			"version": "0.7.21",
@@ -22757,8 +23917,7 @@
 		"util-deprecate": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
-			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
-			"dev": true
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8="
 		},
 		"util.promisify": {
 			"version": "1.0.1",
@@ -22787,8 +23946,7 @@
 		"uuid": {
 			"version": "3.4.0",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-			"dev": true
+			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
 		},
 		"v8-compile-cache": {
 			"version": "2.0.3",
@@ -22867,6 +24025,11 @@
 			"requires": {
 				"browser-process-hrtime": "^1.0.0"
 			}
+		},
+		"wait-for-expect": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/wait-for-expect/-/wait-for-expect-1.3.0.tgz",
+			"integrity": "sha512-8fJU7jiA96HfGPt+P/UilelSAZfhMBJ52YhKzlmZQvKEZU2EcD1GQ0yqGB6liLdHjYtYAoGVigYwdxr5rktvzA=="
 		},
 		"warning": {
 			"version": "4.0.3",
@@ -24102,7 +25265,6 @@
 			"version": "1.9.2",
 			"resolved": "https://registry.npmjs.org/yaml/-/yaml-1.9.2.tgz",
 			"integrity": "sha512-HPT7cGGI0DuRcsO51qC1j9O16Dh1mZ2bnXwsi0jrSpsLz0WxOLSLXfkABVl6bZO629py3CU+OMJtpNHDLB97kg==",
-			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.9.2"
 			}
@@ -24387,6 +25549,11 @@
 			"resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
 			"integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk=",
 			"dev": true
+		},
+		"yn": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="
 		}
 	}
 }

--- a/packages/compass-shell/package.json
+++ b/packages/compass-shell/package.json
@@ -71,6 +71,7 @@
   "@babel/plugin-proposal-object-rest-spread": "^7.0.0",
   "@babel/plugin-syntax-dynamic-import": "^7.0.0",
   "@babel/plugin-syntax-object-rest-spread": "^7.0.0",
+  "@babel/plugin-transform-runtime": "^7.9.6",
   "@babel/preset-env": "^7.0.0",
   "@babel/preset-react": "^7.0.0",
   "@babel/register": "^7.0.0",


### PR DESCRIPTION
Fixes `ReferenceError: regeneratorRuntime is not defined` error when running `compass-shell` tests.
