### PR TITLE
apply licence to MongoDB Inc.

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -176,18 +176,7 @@
 
    END OF TERMS AND CONDITIONS
 
-   APPENDIX: How to apply the Apache License to your work.
-
-      To apply the Apache License to your work, attach the following
-      boilerplate notice, with the fields enclosed by brackets "[]"
-      replaced with your own identifying information. (Don't include
-      the brackets!)  The text should be enclosed in the appropriate
-      comment syntax for the file format. We also recommend that a
-      file or class name and description of purpose be included on the
-      same "printed page" as the copyright notice for easier
-      identification within third-party archives.
-
-   Copyright [yyyy] [name of copyright owner]
+   Copyright 2020 MongoDB Inc.
 
    Licensed under the Apache License, Version 2.0 (the "License");
    you may not use this file except in compliance with the License.
@@ -200,3 +189,4 @@
    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
    See the License for the specific language governing permissions and
    limitations under the License.
+


### PR DESCRIPTION
According to the previous version of this file, this is how to apply Apache 2.0 to a project:

   APPENDIX: How to apply the Apache License to your work.	

      To apply the Apache License to your work, attach the following	
      boilerplate notice, with the fields enclosed by brackets "[]"	
      replaced with your own identifying information. (Don't include	
      the brackets!)  The text should be enclosed in the appropriate	
      comment syntax for the file format. We also recommend that a	
      file or class name and description of purpose be included on the	
      same "printed page" as the copyright notice for easier	
      identification within third-party archives.