### PR TITLE
Allow `require` in vscode and compass shell

### DIFF
--- a/packages/browser-runtime-electron/src/electron-runtime.spec.ts
+++ b/packages/browser-runtime-electron/src/electron-runtime.spec.ts
@@ -52,6 +52,11 @@ describe('Electron runtime', function() {
     expect(result.shellApiType).to.equal('ShowDatabasesResult');
   });
 
+  it('allows to use require', async() => {
+    const result = await electronRuntime.evaluate('require("util").types.isDate(new Date())');
+    expect(result.value).to.equal(true);
+  });
+
   it('can switch database', async() => {
     expect(
       (await electronRuntime.evaluate('db')).value

--- a/packages/browser-runtime-electron/src/electron-runtime.ts
+++ b/packages/browser-runtime-electron/src/electron-runtime.ts
@@ -1,3 +1,4 @@
+/* eslint-disable @typescript-eslint/camelcase */
 import {
   ElectronInterpreterEnvironment
 } from './electron-interpreter-environment';
@@ -11,15 +12,33 @@ import {
 
 import { ServiceProvider } from '@mongosh/service-provider-core';
 
+declare const __webpack_require__: any;
+declare const __non_webpack_require__: any;
+
 export class ElectronRuntime implements Runtime {
   private openContextRuntime: OpenContextRuntime;
 
   constructor(serviceProvider: ServiceProvider, messageBus?: {
     emit: (eventName: string, ...args: any[]) => void;
   }) {
+    // NOTE:
+    //
+    // This is necessary for client code bundling this library with
+    // webpack.
+    //
+    // Webpack will replace require with its own implementation, and that would
+    // not necessarily have access to the node modules available in node
+    // (depends on the target configuration).
+    //
+    // IMPORTANT: as it cannot be easily tested be aware of this bug before
+    // changing this line: https://github.com/webpack/webpack/issues/5939 (it
+    // seems that checking for `typeof __non_webpack_require__` does not work).
+    //
+    const requireFunc = typeof __webpack_require__ === 'function' ? __non_webpack_require__ : require;
+
     this.openContextRuntime = new OpenContextRuntime(
       serviceProvider,
-      new ElectronInterpreterEnvironment({ require }),
+      new ElectronInterpreterEnvironment({ require: requireFunc }),
       messageBus
     );
   }

--- a/packages/browser-runtime-electron/src/electron-runtime.ts
+++ b/packages/browser-runtime-electron/src/electron-runtime.ts
@@ -19,7 +19,7 @@ export class ElectronRuntime implements Runtime {
   }) {
     this.openContextRuntime = new OpenContextRuntime(
       serviceProvider,
-      new ElectronInterpreterEnvironment({}),
+      new ElectronInterpreterEnvironment({ require }),
       messageBus
     );
   }


### PR DESCRIPTION
A fix that allows to use `require` in playgrounds and compass.

**NOTE:** 

Webpack will replace `require` with its own implementation, and that would not necessarily have access to the node modules available in node (depends on the target configuration).

As a workaround we alias `require` to [`__non_webpack_require__`](https://webpack.js.org/api/module-variables/#__non_webpack_require__-webpack-specific) when available.
