### PR TITLE
fixes to telemetry, objectid, and local config file

### DIFF
--- a/packages/cli-repl/package-lock.json
+++ b/packages/cli-repl/package-lock.json
@@ -309,6 +309,11 @@
 			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
 			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 		},
+		"fast-json-parse": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/fast-json-parse/-/fast-json-parse-1.0.3.tgz",
+			"integrity": "sha512-FRWsaZRWEJ1ESVNbDWmsAlqDk96gPQezzLghafp5J4GUKjbCz3OkAHuZs5TuPEtkbVQERysLp9xv6c24fBm8Aw=="
+		},
 		"fast-redact": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-2.0.0.tgz",

--- a/packages/cli-repl/package.json
+++ b/packages/cli-repl/package.json
@@ -49,6 +49,7 @@
     "analytics-node": "^3.4.0-beta.1",
     "ansi-escape-sequences": "^5.1.2",
     "bson": "^4.0.4",
+    "fast-json-parse": "^1.0.3",
     "is-recoverable-error": "^1.0.0",
     "lodash.set": "^4.3.2",
     "minimist": "^1.2.5",

--- a/packages/cli-repl/src/cli-repl.ts
+++ b/packages/cli-repl/src/cli-repl.ts
@@ -251,6 +251,8 @@ class CliRepl {
       this.writeConfigFileSync(configPath);
     } catch (err) {
       if (err.code === 'EEXIST') {
+        // make sure we catch errors for json parse and always have err and
+        // value on config result
         const config = jsonParse(fs.readFileSync(configPath, 'utf8'));
 
         if (config.err) {

--- a/packages/cli-repl/src/cli-repl.ts
+++ b/packages/cli-repl/src/cli-repl.ts
@@ -256,7 +256,7 @@ class CliRepl {
         const config = jsonParse(fs.readFileSync(configPath, 'utf8'));
 
         if (config.err) {
-          this.bus.emit('mongosh:error', 'Unable to parse user config', err)
+          this.bus.emit('mongosh:error', 'Unable to parse user config', err);
           return;
         }
 

--- a/packages/cli-repl/src/connect-info.spec.ts
+++ b/packages/cli-repl/src/connect-info.spec.ts
@@ -85,6 +85,7 @@ describe('getConnectInfo', function() {
       is_genuine: true,
       non_genuine_server_name: 'mongodb',
       server_arch: 'x86_64',
+      node_version: process.version,
       server_os: 'osx',
       uri: ATLAS_URI
     };
@@ -107,6 +108,7 @@ describe('getConnectInfo', function() {
       is_genuine: true,
       non_genuine_server_name: 'mongodb',
       server_arch: 'x86_64',
+      node_version: process.version,
       server_os: 'osx',
       uri: ATLAS_URI
     };

--- a/packages/cli-repl/src/connect-info.ts
+++ b/packages/cli-repl/src/connect-info.ts
@@ -43,7 +43,7 @@ export default function getConnectInfo(uri: string, buildInfo: any, cmdLineOpts:
     auth_type,
     is_data_lake,
     dl_version,
-    node_version: process.version;
+    node_version: process.version,
     is_genuine,
     non_genuine_server_name
   };

--- a/packages/cli-repl/src/connect-info.ts
+++ b/packages/cli-repl/src/connect-info.ts
@@ -15,6 +15,7 @@ interface ConnectInfo {
   dl_version?: string;
   is_genuine: boolean;
   non_genuine_server_name: string;
+  node_version: string;
   uri: string;
 }
 
@@ -42,6 +43,7 @@ export default function getConnectInfo(uri: string, buildInfo: any, cmdLineOpts:
     auth_type,
     is_data_lake,
     dl_version,
+    node_version: process.version;
     is_genuine,
     non_genuine_server_name
   };

--- a/packages/cli-repl/src/logger.ts
+++ b/packages/cli-repl/src/logger.ts
@@ -67,7 +67,6 @@ export default function logger(bus: any, logDir: string): void {
   let analytics = new NoopAnalytics();
   try {
     // this file gets written as a part of a release
-    log.warn(require('./analytics-config.js').SEGMENT_API_KEY);
     analytics = new Analytics(require('./analytics-config.js').SEGMENT_API_KEY);
   } catch (e) {
     bus.emit('mongosh:error', e);

--- a/packages/cli-repl/src/logger.ts
+++ b/packages/cli-repl/src/logger.ts
@@ -57,7 +57,7 @@ NoopAnalytics.prototype.identify = function(): void {};
 NoopAnalytics.prototype.track = function(): void {};
 
 export default function logger(bus: any, logDir: string): void {
-  const session_id = new ObjectId(Date.now());
+  const session_id = new ObjectId(Date.now()).toString();
   const logDest = path.join(logDir, `${session_id}_log`);
   const log = pino({ name: 'monogsh' }, pino.destination(logDest));
   console.log(`Current sessionID: ${session_id}`);

--- a/packages/cli-repl/src/logger.ts
+++ b/packages/cli-repl/src/logger.ts
@@ -47,6 +47,7 @@ interface ConnectEvent {
   dl_version?: string;
   is_genuine: boolean;
   non_genuine_server_name: string;
+  node_version: string;
   uri: string;
 }
 

--- a/packages/cli-repl/src/logger.ts
+++ b/packages/cli-repl/src/logger.ts
@@ -97,6 +97,7 @@ export default function logger(bus: any, logDir: string): void {
   bus.on('mongosh:update-user', function(id, enableTelemetry) {
     userId = id;
     telemetry = enableTelemetry;
+    if (telemetry) analytics.identify({ userId });
     log.info('mongosh:update-user', { enableTelemetry });
   });
 

--- a/packages/java-shell/package-lock.json
+++ b/packages/java-shell/package-lock.json
@@ -940,9 +940,9 @@
 			"dev": true
 		},
 		"pbkdf2": {
-			"version": "3.0.17",
-			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.17.tgz",
-			"integrity": "sha512-U/il5MsrZp7mGg3mSQfn742na2T+1/vHDCG5/iTI3X9MKUuYUZVLQhyRsg06mCgDBTd57TxzgZt7P+fYfjRLtA==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.1.0.tgz",
+			"integrity": "sha512-wHMFZ6HTLGlB9f/WsQBs5OwMQJoLXYuJUzbA+j+hRBf7+Y8KcXpatzIviIcTy1OAyhWQp08nyiPO8Dnv0z4Sww==",
 			"dev": true,
 			"requires": {
 				"create-hash": "^1.1.2",


### PR DESCRIPTION
## Description

Updates a few things in regards to telemetry:
- always call `toString()` when initially creating ObjectIds for sessions and
  userID
- Use `fast-json-parse` when parsing config file. Return and log if an error is
  present.
- run analytics.identify when updating user data if telemetry is present.
- remove warn log for analytics key
- log out node version as part of connection log event