### PR TITLE
COMPASS-4292: Shell plugin info modal

### DIFF
--- a/packages/compass-shell/package-lock.json
+++ b/packages/compass-shell/package-lock.json
@@ -10364,8 +10364,7 @@
 		"hadron-react-buttons": {
 			"version": "4.0.4",
 			"resolved": "https://registry.npmjs.org/hadron-react-buttons/-/hadron-react-buttons-4.0.4.tgz",
-			"integrity": "sha512-TLTtgayqBxitGEEMc04Ori1mF0fsFnFkAweAgSnZOkX7apAl1bS6l6eSPR4M/0vsIIkBIIh7ZDcUbdeSe40BiA==",
-			"dev": true
+			"integrity": "sha512-TLTtgayqBxitGEEMc04Ori1mF0fsFnFkAweAgSnZOkX7apAl1bS6l6eSPR4M/0vsIIkBIIh7ZDcUbdeSe40BiA=="
 		},
 		"handle-thing": {
 			"version": "2.0.1",

--- a/packages/compass-shell/package-lock.json
+++ b/packages/compass-shell/package-lock.json
@@ -44,6 +44,7 @@
 			"version": "7.9.0",
 			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.9.0.tgz",
 			"integrity": "sha512-kWc7L0fw1xwvI0zi8OKVBuxRVefwGOrKSQMvrQ3dW+bIIavBY3/NpXmpjMy7bQnLgwgzWQZ8TlM57YHpHNHz4w==",
+			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.8.3",
 				"@babel/generator": "^7.9.0",
@@ -67,6 +68,7 @@
 					"version": "4.1.1",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
 					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
 					"requires": {
 						"ms": "^2.1.1"
 					}
@@ -74,7 +76,8 @@
 				"ms": {
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
 				}
 			}
 		},
@@ -82,6 +85,7 @@
 			"version": "7.9.5",
 			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.5.tgz",
 			"integrity": "sha512-GbNIxVB3ZJe3tLeDm1HSn2AhuD/mVcyLDpgtLXa5tplmWrJdF/elxB56XNqCuD6szyNkDi6wuoKXln3QeBmCHQ==",
+			"dev": true,
 			"requires": {
 				"@babel/types": "^7.9.5",
 				"jsesc": "^2.5.1",
@@ -192,6 +196,7 @@
 			"version": "7.9.5",
 			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.9.5.tgz",
 			"integrity": "sha512-JVcQZeXM59Cd1qanDUxv9fgJpt3NeKUaqBqUEvfmQ+BCOKq2xUgaWZW2hr0dkbyJgezYuplEoh5knmrnS68efw==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-get-function-arity": "^7.8.3",
 				"@babel/template": "^7.8.3",
@@ -202,6 +207,7 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
 			"integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
+			"dev": true,
 			"requires": {
 				"@babel/types": "^7.8.3"
 			}
@@ -219,6 +225,7 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.8.3.tgz",
 			"integrity": "sha512-fO4Egq88utkQFjbPrSHGmGLFqmrshs11d46WI+WZDESt7Wu7wN2G2Iu+NMMZJFDOVRHAMIkB5SNh30NtwCA7RA==",
+			"dev": true,
 			"requires": {
 				"@babel/types": "^7.8.3"
 			}
@@ -235,6 +242,7 @@
 			"version": "7.9.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.9.0.tgz",
 			"integrity": "sha512-0FvKyu0gpPfIQ8EkxlrAydOWROdHpBmiCiRwLkUiBGhCUPRRbVD2/tm3sFr/c/GWFrQ/ffutGUAnx7V0FzT2wA==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-module-imports": "^7.8.3",
 				"@babel/helper-replace-supers": "^7.8.6",
@@ -249,6 +257,7 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.8.3.tgz",
 			"integrity": "sha512-Kag20n86cbO2AvHca6EJsvqAd82gc6VMGule4HwebwMlwkpXuVqrNRj6CkCV2sKxgi9MyAUnZVnZ6lJ1/vKhHQ==",
+			"dev": true,
 			"requires": {
 				"@babel/types": "^7.8.3"
 			}
@@ -285,6 +294,7 @@
 			"version": "7.8.6",
 			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.8.6.tgz",
 			"integrity": "sha512-PeMArdA4Sv/Wf4zXwBKPqVj7n9UF/xg6slNRtZW84FM7JpE1CbG8B612FyM4cxrf4fMAMGO0kR7voy1ForHHFA==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-member-expression-to-functions": "^7.8.3",
 				"@babel/helper-optimise-call-expression": "^7.8.3",
@@ -296,6 +306,7 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.8.3.tgz",
 			"integrity": "sha512-VNGUDjx5cCWg4vvCTR8qQ7YJYZ+HBjxOgXEl7ounz+4Sn7+LMD3CFrCTEU6/qXKbA2nKg21CwhhBzO0RpRbdCw==",
+			"dev": true,
 			"requires": {
 				"@babel/template": "^7.8.3",
 				"@babel/types": "^7.8.3"
@@ -305,6 +316,7 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
 			"integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
+			"dev": true,
 			"requires": {
 				"@babel/types": "^7.8.3"
 			}
@@ -330,6 +342,7 @@
 			"version": "7.9.2",
 			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.9.2.tgz",
 			"integrity": "sha512-JwLvzlXVPjO8eU9c/wF9/zOIN7X6h8DYf7mG4CiFRZRvZNKEF5dQ3H3V+ASkHoIB3mWhatgl5ONhyqHRI6MppA==",
+			"dev": true,
 			"requires": {
 				"@babel/template": "^7.8.3",
 				"@babel/traverse": "^7.9.0",
@@ -349,7 +362,8 @@
 		"@babel/parser": {
 			"version": "7.9.4",
 			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.4.tgz",
-			"integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA=="
+			"integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA==",
+			"dev": true
 		},
 		"@babel/plugin-proposal-async-generator-functions": {
 			"version": "7.8.3",
@@ -561,21 +575,6 @@
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.8.3"
-			}
-		},
-		"@babel/plugin-syntax-typescript": {
-			"version": "7.10.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.10.1.tgz",
-			"integrity": "sha512-X/d8glkrAtra7CaQGMiGs/OGa6XgUzqPcBXCIGFCpCqnfGlT0Wfbzo/B89xHhnInTaItPK8LALblVXcUOEh95Q==",
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.10.1"
-			},
-			"dependencies": {
-				"@babel/helper-plugin-utils": {
-					"version": "7.10.1",
-					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
-					"integrity": "sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA=="
-				}
 			}
 		},
 		"@babel/plugin-transform-arrow-functions": {
@@ -938,177 +937,6 @@
 				"@babel/helper-plugin-utils": "^7.8.3"
 			}
 		},
-		"@babel/plugin-transform-typescript": {
-			"version": "7.10.1",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.10.1.tgz",
-			"integrity": "sha512-v+QWKlmCnsaimLeqq9vyCsVRMViZG1k2SZTlcZvB+TqyH570Zsij8nvVUZzOASCRiQFUxkLrn9Wg/kH0zgy5OQ==",
-			"requires": {
-				"@babel/helper-create-class-features-plugin": "^7.10.1",
-				"@babel/helper-plugin-utils": "^7.10.1",
-				"@babel/plugin-syntax-typescript": "^7.10.1"
-			},
-			"dependencies": {
-				"@babel/code-frame": {
-					"version": "7.10.1",
-					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.1.tgz",
-					"integrity": "sha512-IGhtTmpjGbYzcEDOw7DcQtbQSXcG9ftmAXtWTu9V936vDye4xjjekktFAtgZsWpzTj/X01jocB46mTywm/4SZw==",
-					"requires": {
-						"@babel/highlight": "^7.10.1"
-					}
-				},
-				"@babel/generator": {
-					"version": "7.10.2",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.2.tgz",
-					"integrity": "sha512-AxfBNHNu99DTMvlUPlt1h2+Hn7knPpH5ayJ8OqDWSeLld+Fi2AYBTC/IejWDM9Edcii4UzZRCsbUt0WlSDsDsA==",
-					"requires": {
-						"@babel/types": "^7.10.2",
-						"jsesc": "^2.5.1",
-						"lodash": "^4.17.13",
-						"source-map": "^0.5.0"
-					}
-				},
-				"@babel/helper-create-class-features-plugin": {
-					"version": "7.10.2",
-					"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.10.2.tgz",
-					"integrity": "sha512-5C/QhkGFh1vqcziq1vAL6SI9ymzUp8BCYjFpvYVhWP4DlATIb3u5q3iUd35mvlyGs8fO7hckkW7i0tmH+5+bvQ==",
-					"requires": {
-						"@babel/helper-function-name": "^7.10.1",
-						"@babel/helper-member-expression-to-functions": "^7.10.1",
-						"@babel/helper-optimise-call-expression": "^7.10.1",
-						"@babel/helper-plugin-utils": "^7.10.1",
-						"@babel/helper-replace-supers": "^7.10.1",
-						"@babel/helper-split-export-declaration": "^7.10.1"
-					}
-				},
-				"@babel/helper-function-name": {
-					"version": "7.10.1",
-					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.1.tgz",
-					"integrity": "sha512-fcpumwhs3YyZ/ttd5Rz0xn0TpIwVkN7X0V38B9TWNfVF42KEkhkAAuPCQ3oXmtTRtiPJrmZ0TrfS0GKF0eMaRQ==",
-					"requires": {
-						"@babel/helper-get-function-arity": "^7.10.1",
-						"@babel/template": "^7.10.1",
-						"@babel/types": "^7.10.1"
-					}
-				},
-				"@babel/helper-get-function-arity": {
-					"version": "7.10.1",
-					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.1.tgz",
-					"integrity": "sha512-F5qdXkYGOQUb0hpRaPoetF9AnsXknKjWMZ+wmsIRsp5ge5sFh4c3h1eH2pRTTuy9KKAA2+TTYomGXAtEL2fQEw==",
-					"requires": {
-						"@babel/types": "^7.10.1"
-					}
-				},
-				"@babel/helper-member-expression-to-functions": {
-					"version": "7.10.1",
-					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.1.tgz",
-					"integrity": "sha512-u7XLXeM2n50gb6PWJ9hoO5oO7JFPaZtrh35t8RqKLT1jFKj9IWeD1zrcrYp1q1qiZTdEarfDWfTIP8nGsu0h5g==",
-					"requires": {
-						"@babel/types": "^7.10.1"
-					}
-				},
-				"@babel/helper-optimise-call-expression": {
-					"version": "7.10.1",
-					"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.1.tgz",
-					"integrity": "sha512-a0DjNS1prnBsoKx83dP2falChcs7p3i8VMzdrSbfLhuQra/2ENC4sbri34dz/rWmDADsmF1q5GbfaXydh0Jbjg==",
-					"requires": {
-						"@babel/types": "^7.10.1"
-					}
-				},
-				"@babel/helper-plugin-utils": {
-					"version": "7.10.1",
-					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
-					"integrity": "sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA=="
-				},
-				"@babel/helper-replace-supers": {
-					"version": "7.10.1",
-					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.1.tgz",
-					"integrity": "sha512-SOwJzEfpuQwInzzQJGjGaiG578UYmyi2Xw668klPWV5n07B73S0a9btjLk/52Mlcxa+5AdIYqws1KyXRfMoB7A==",
-					"requires": {
-						"@babel/helper-member-expression-to-functions": "^7.10.1",
-						"@babel/helper-optimise-call-expression": "^7.10.1",
-						"@babel/traverse": "^7.10.1",
-						"@babel/types": "^7.10.1"
-					}
-				},
-				"@babel/helper-split-export-declaration": {
-					"version": "7.10.1",
-					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.1.tgz",
-					"integrity": "sha512-UQ1LVBPrYdbchNhLwj6fetj46BcFwfS4NllJo/1aJsT+1dLTEnXJL0qHqtY7gPzF8S2fXBJamf1biAXV3X077g==",
-					"requires": {
-						"@babel/types": "^7.10.1"
-					}
-				},
-				"@babel/helper-validator-identifier": {
-					"version": "7.10.1",
-					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.1.tgz",
-					"integrity": "sha512-5vW/JXLALhczRCWP0PnFDMCJAchlBvM7f4uk/jXritBnIa6E1KmqmtrS3yn1LAnxFBypQ3eneLuXjsnfQsgILw=="
-				},
-				"@babel/highlight": {
-					"version": "7.10.1",
-					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.1.tgz",
-					"integrity": "sha512-8rMof+gVP8mxYZApLF/JgNDAkdKa+aJt3ZYxF8z6+j/hpeXL7iMsKCPHa2jNMHu/qqBwzQF4OHNoYi8dMA/rYg==",
-					"requires": {
-						"@babel/helper-validator-identifier": "^7.10.1",
-						"chalk": "^2.0.0",
-						"js-tokens": "^4.0.0"
-					}
-				},
-				"@babel/parser": {
-					"version": "7.10.2",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.2.tgz",
-					"integrity": "sha512-PApSXlNMJyB4JiGVhCOlzKIif+TKFTvu0aQAhnTvfP/z3vVSN6ZypH5bfUNwFXXjRQtUEBNFd2PtmCmG2Py3qQ=="
-				},
-				"@babel/template": {
-					"version": "7.10.1",
-					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.1.tgz",
-					"integrity": "sha512-OQDg6SqvFSsc9A0ej6SKINWrpJiNonRIniYondK2ViKhB06i3c0s+76XUft71iqBEe9S1OKsHwPAjfHnuvnCig==",
-					"requires": {
-						"@babel/code-frame": "^7.10.1",
-						"@babel/parser": "^7.10.1",
-						"@babel/types": "^7.10.1"
-					}
-				},
-				"@babel/traverse": {
-					"version": "7.10.1",
-					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.1.tgz",
-					"integrity": "sha512-C/cTuXeKt85K+p08jN6vMDz8vSV0vZcI0wmQ36o6mjbuo++kPMdpOYw23W2XH04dbRt9/nMEfA4W3eR21CD+TQ==",
-					"requires": {
-						"@babel/code-frame": "^7.10.1",
-						"@babel/generator": "^7.10.1",
-						"@babel/helper-function-name": "^7.10.1",
-						"@babel/helper-split-export-declaration": "^7.10.1",
-						"@babel/parser": "^7.10.1",
-						"@babel/types": "^7.10.1",
-						"debug": "^4.1.0",
-						"globals": "^11.1.0",
-						"lodash": "^4.17.13"
-					}
-				},
-				"@babel/types": {
-					"version": "7.10.2",
-					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.2.tgz",
-					"integrity": "sha512-AD3AwWBSz0AWF0AkCN9VPiWrvldXq+/e3cHa4J89vo4ymjz1XwrBFFVZmkJTsQIPNk+ZVomPSXUJqq8yyjZsng==",
-					"requires": {
-						"@babel/helper-validator-identifier": "^7.10.1",
-						"lodash": "^4.17.13",
-						"to-fast-properties": "^2.0.0"
-					}
-				},
-				"debug": {
-					"version": "4.1.1",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
-					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-					"requires": {
-						"ms": "^2.1.1"
-					}
-				},
-				"ms": {
-					"version": "2.1.2",
-					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-				}
-			}
-		},
 		"@babel/plugin-transform-unicode-regex": {
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.8.3.tgz",
@@ -1224,22 +1052,6 @@
 				"@babel/plugin-transform-react-jsx-source": "^7.9.0"
 			}
 		},
-		"@babel/preset-typescript": {
-			"version": "7.10.1",
-			"resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.10.1.tgz",
-			"integrity": "sha512-m6GV3y1ShiqxnyQj10600ZVOFrSSAa8HQ3qIUk2r+gcGtHTIRw0dJnFLt1WNXpKjtVw7yw1DAPU/6ma2ZvgJuA==",
-			"requires": {
-				"@babel/helper-plugin-utils": "^7.10.1",
-				"@babel/plugin-transform-typescript": "^7.10.1"
-			},
-			"dependencies": {
-				"@babel/helper-plugin-utils": {
-					"version": "7.10.1",
-					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
-					"integrity": "sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA=="
-				}
-			}
-		},
 		"@babel/register": {
 			"version": "7.9.0",
 			"resolved": "https://registry.npmjs.org/@babel/register/-/register-7.9.0.tgz",
@@ -1285,6 +1097,7 @@
 			"version": "7.8.6",
 			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
 			"integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
+			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.8.3",
 				"@babel/parser": "^7.8.6",
@@ -1295,6 +1108,7 @@
 			"version": "7.9.5",
 			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.9.5.tgz",
 			"integrity": "sha512-c4gH3jsvSuGUezlP6rzSJ6jf8fYjLj3hsMZRx/nX0h+fmHN0w+ekubRrHPqnMec0meycA2nwCsJ7dC8IPem2FQ==",
+			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.8.3",
 				"@babel/generator": "^7.9.5",
@@ -1311,6 +1125,7 @@
 					"version": "4.1.1",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
 					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"dev": true,
 					"requires": {
 						"ms": "^2.1.1"
 					}
@@ -1318,7 +1133,8 @@
 				"ms": {
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
+					"dev": true
 				}
 			}
 		},
@@ -1389,11 +1205,6 @@
 			"version": "0.2.5",
 			"resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
 			"integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
-		},
-		"@hapi/bourne": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.0.0.tgz",
-			"integrity": "sha512-WEezM1FWztfbzqIUbsDzFRVMxSoLy3HugVcux6KDDtTqzPsLE8NDRHfXvev66aH1i2oOKKar3/XDjbvh/OUBdg=="
 		},
 		"@hot-loader/react-dom": {
 			"version": "16.13.0",
@@ -1472,291 +1283,11 @@
 			"resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-2.0.1.tgz",
 			"integrity": "sha512-xwD6kOokWvaygxF0T2gnf77HEu68G7EXr1ZrNiNtZzg80Y1V2hikhUNoESWij6g/A6qJZvAiwpseflVo3PnlHQ=="
 		},
-		"@leafygreen-ui/syntax": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/@leafygreen-ui/syntax/-/syntax-2.7.0.tgz",
-			"integrity": "sha512-bQRIFKPUwZsne39R49eQN5qEl556w88N/FjJfzAU/LjR2OVp+W5sWhx1PiacwCq+J1r/7wu/PKUh5rV/dpSgmQ==",
-			"requires": {
-				"@leafygreen-ui/lib": "^4.3.0",
-				"@leafygreen-ui/palette": "^2.0.1",
-				"highlight.js": "^9.15.6",
-				"highlightjs-graphql": "^1.0.1"
-			}
-		},
 		"@mongodb-js/triejs": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/@mongodb-js/triejs/-/triejs-0.1.5.tgz",
 			"integrity": "sha512-elh8S1OxmEGe8/wbr6ky//dHhV2ld6oZV8/M9lgozJsL/6Aqm8j5+ElquzoX9k9l3Q+dohuX/SIGR/kTRZHS4g==",
 			"dev": true
-		},
-		"@mongosh/async-rewriter": {
-			"version": "0.0.2-alpha.0",
-			"resolved": "https://registry.npmjs.org/@mongosh/async-rewriter/-/async-rewriter-0.0.2-alpha.0.tgz",
-			"integrity": "sha512-36I7mx5MLeFMMw09/vMGbXowDpKO6TpOmu7sj0BLUpG6AnPhsAyFJLAyQteeZwWSgvtp2nl1Z9qr60Zj8LSBBg==",
-			"requires": {
-				"@babel/core": "^7.9.0",
-				"@babel/parser": "^7.9.4",
-				"@babel/preset-typescript": "^7.9.0",
-				"@babel/template": "^7.8.6",
-				"@babel/traverse": "^7.9.0",
-				"@babel/types": "^7.9.0",
-				"@mongosh/errors": "^0.0.2-alpha.0",
-				"@types/babel__core": "^7.1.6",
-				"@types/babel__traverse": "^7.0.9",
-				"acorn": "^7.2.0",
-				"acorn-class-fields": "^0.3.2",
-				"acorn-numeric-separator": "^0.3.2",
-				"acorn-private-methods": "^0.3.1",
-				"acorn-static-class-features": "^0.2.1",
-				"acorn-walk": "^7.1.1",
-				"ts-node": "^8.8.1",
-				"typescript": "^3.8.3"
-			},
-			"dependencies": {
-				"acorn": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.2.0.tgz",
-					"integrity": "sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ=="
-				},
-				"acorn-walk": {
-					"version": "7.1.1",
-					"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.1.1.tgz",
-					"integrity": "sha512-wdlPY2tm/9XBr7QkKlq0WQVgiuGTX6YWPyRyBviSoScBuLfTVQhvwg6wJ369GJ/1nPfTLMfnrFIfjqVg6d+jQQ=="
-				}
-			}
-		},
-		"@mongosh/browser-repl": {
-			"version": "0.0.2-alpha.0",
-			"resolved": "https://registry.npmjs.org/@mongosh/browser-repl/-/browser-repl-0.0.2-alpha.0.tgz",
-			"integrity": "sha512-LFrV/cPh443eBFfHHkx9/TVmUf+0m7j+2h5GMF4eYTtSju+HptK7xjDaaikCq9pMDS2ZGjuS+LRHOyS+VlTWpA==",
-			"requires": {
-				"@babel/generator": "^7.8.3",
-				"@babel/parser": "^7.8.3",
-				"@babel/runtime": "^7.8.3",
-				"@babel/template": "^7.8.3",
-				"@leafygreen-ui/icon": "^4.0.0",
-				"@leafygreen-ui/palette": "^2.0.0",
-				"@leafygreen-ui/syntax": "^2.2.0",
-				"@mongosh/browser-runtime-core": "^0.0.2-alpha.0",
-				"@mongosh/history": "^0.0.2-alpha.0",
-				"@mongosh/i18n": "^0.0.2-alpha.0",
-				"@mongosh/service-provider-core": "^0.0.2-alpha.0",
-				"pretty-bytes": "^5.3.0",
-				"text-table": "^0.2.0"
-			},
-			"dependencies": {
-				"@leafygreen-ui/icon": {
-					"version": "4.3.0",
-					"resolved": "https://registry.npmjs.org/@leafygreen-ui/icon/-/icon-4.3.0.tgz",
-					"integrity": "sha512-6DOFKxj3U0hp2yQEq/Yq19qIiIIUXwRj2fH1ddOJFYLtAoeFOCSeuF6rE2dqXrXW/puQdjgpXV60w9J8gyXGog=="
-				},
-				"pretty-bytes": {
-					"version": "5.3.0",
-					"resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.3.0.tgz",
-					"integrity": "sha512-hjGrh+P926p4R4WbaB6OckyRtO0F0/lQBiT+0gnxjV+5kjPBrfVBFCsCLbMqVQeydvIoouYTCmmEURiH3R1Bdg=="
-				}
-			}
-		},
-		"@mongosh/browser-runtime-core": {
-			"version": "0.0.2-alpha.0",
-			"resolved": "https://registry.npmjs.org/@mongosh/browser-runtime-core/-/browser-runtime-core-0.0.2-alpha.0.tgz",
-			"integrity": "sha512-NHeinaJU22M3PU8QoZZHh91ylXJFAt2oEe9GxYq3/Es/ZtcsEG/Cr93l4BOJVlOEtOWe/shj6ZCU1D8sScbmVA==",
-			"requires": {
-				"@babel/generator": "^7.9.4",
-				"@babel/parser": "^7.9.4",
-				"@mongosh/cli-repl": "^0.0.2-alpha.0",
-				"@mongosh/service-provider-core": "^0.0.2-alpha.0",
-				"@mongosh/shell-evaluator": "^0.0.2-alpha.0"
-			}
-		},
-		"@mongosh/browser-runtime-electron": {
-			"version": "0.0.2-alpha.0",
-			"resolved": "https://registry.npmjs.org/@mongosh/browser-runtime-electron/-/browser-runtime-electron-0.0.2-alpha.0.tgz",
-			"integrity": "sha512-BmE01Gt43iDJEXe5HXlegY1eiiFfExNig/oj2MPge2r+XGyYR2xVSw+4F9qlgXQsbU+mTtRk9NKqmA7jQFDAIw==",
-			"requires": {
-				"@mongosh/browser-runtime-core": "^0.0.2-alpha.0",
-				"@mongosh/service-provider-core": "^0.0.2-alpha.0"
-			}
-		},
-		"@mongosh/build": {
-			"version": "0.0.2-alpha.0",
-			"resolved": "https://registry.npmjs.org/@mongosh/build/-/build-0.0.2-alpha.0.tgz",
-			"integrity": "sha512-XH8KNxHDQhNNS2nAkDTNNdAP+DReEU8uX3Cks5iZgPdZPub8YM1sfM4piOJL2KSCXdBRDFNuO6enFu5ToNVvSw=="
-		},
-		"@mongosh/cli-repl": {
-			"version": "0.0.2-alpha.0",
-			"resolved": "https://registry.npmjs.org/@mongosh/cli-repl/-/cli-repl-0.0.2-alpha.0.tgz",
-			"integrity": "sha512-nAJCcrROO4lT6iSY3H13TA0s6srb+OJgo+VtuU6PhukOXPJ7QEjXmeaKRGE/eafddHpsg2XDtosDd2/8nO1jJg==",
-			"requires": {
-				"@mongosh/build": "^0.0.2-alpha.0",
-				"@mongosh/errors": "^0.0.2-alpha.0",
-				"@mongosh/history": "^0.0.2-alpha.0",
-				"@mongosh/i18n": "^0.0.2-alpha.0",
-				"@mongosh/service-provider-server": "^0.0.2-alpha.0",
-				"@mongosh/shell-api": "^0.0.2-alpha.0",
-				"@mongosh/shell-evaluator": "^0.0.2-alpha.0",
-				"acorn": "^7.1.1",
-				"acorn-class-fields": "^0.3.2",
-				"acorn-numeric-separator": "^0.3.0",
-				"acorn-private-methods": "^0.3.1",
-				"acorn-static-class-features": "^0.2.1",
-				"analytics-node": "^3.4.0-beta.1",
-				"ansi-escape-sequences": "^5.1.2",
-				"bson": "^4.0.4",
-				"is-recoverable-error": "^1.0.0",
-				"lodash.set": "^4.3.2",
-				"minimist": "^1.2.5",
-				"mkdirp": "^1.0.3",
-				"mongodb-ace-autocompleter": "^0.4.1",
-				"mongodb-build-info": "^1.1.0",
-				"mongodb-redact": "^0.2.0",
-				"nanobus": "^4.4.0",
-				"pino": "^5.16.0",
-				"pino-pretty": "^4.0.0",
-				"pretty-bytes": "^5.3.0",
-				"pretty-repl": "^2.3.0",
-				"read": "^1.0.7",
-				"semver": "^7.1.2",
-				"text-table": "^0.2.0"
-			},
-			"dependencies": {
-				"acorn": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.2.0.tgz",
-					"integrity": "sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ=="
-				},
-				"bson": {
-					"version": "4.0.4",
-					"resolved": "https://registry.npmjs.org/bson/-/bson-4.0.4.tgz",
-					"integrity": "sha512-Ioi3TD0/1V3aI8+hPfC56TetYmzfq2H07jJa9A1lKTxWsFtHtYdLMGMXjtGEg9v0f72NSM07diRQEUNYhLupIA==",
-					"requires": {
-						"buffer": "^5.1.0",
-						"long": "^4.0.0"
-					}
-				},
-				"buffer": {
-					"version": "5.6.0",
-					"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
-					"integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
-					"requires": {
-						"base64-js": "^1.0.2",
-						"ieee754": "^1.1.4"
-					}
-				},
-				"mkdirp": {
-					"version": "1.0.4",
-					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-					"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
-				},
-				"pretty-bytes": {
-					"version": "5.3.0",
-					"resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.3.0.tgz",
-					"integrity": "sha512-hjGrh+P926p4R4WbaB6OckyRtO0F0/lQBiT+0gnxjV+5kjPBrfVBFCsCLbMqVQeydvIoouYTCmmEURiH3R1Bdg=="
-				},
-				"semver": {
-					"version": "7.3.2",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
-				}
-			}
-		},
-		"@mongosh/errors": {
-			"version": "0.0.2-alpha.0",
-			"resolved": "https://registry.npmjs.org/@mongosh/errors/-/errors-0.0.2-alpha.0.tgz",
-			"integrity": "sha512-nvCFRwAxVk/4lfarrcDyOnwbL6zi5659TbQi4LCDXMAhuDd0C1RqauhdX38hrR6N1twQ9VynmsZ53Dfb2O7l0A=="
-		},
-		"@mongosh/history": {
-			"version": "0.0.2-alpha.0",
-			"resolved": "https://registry.npmjs.org/@mongosh/history/-/history-0.0.2-alpha.0.tgz",
-			"integrity": "sha512-wGwJz6cqeZokLkZ7ukB5zrIxBrq7UIdhToF9qtV1Z9GZotZL7QIOsBXfREObb7XAQDOnQaXVyA5pLXO30FWYvg==",
-			"requires": {
-				"mongodb-redact": "^0.2.0"
-			}
-		},
-		"@mongosh/i18n": {
-			"version": "0.0.2-alpha.0",
-			"resolved": "https://registry.npmjs.org/@mongosh/i18n/-/i18n-0.0.2-alpha.0.tgz",
-			"integrity": "sha512-0bbI+ZK7ghWGixDeylNIG+GDuhydeK6YR3A/P2opGbGAeHFye53l7Bb8lWVFArcZQjCiRMdXqoqpbkKgC7tL4g==",
-			"requires": {
-				"mustache": "^4.0.0"
-			}
-		},
-		"@mongosh/mapper": {
-			"version": "0.0.2-alpha.0",
-			"resolved": "https://registry.npmjs.org/@mongosh/mapper/-/mapper-0.0.2-alpha.0.tgz",
-			"integrity": "sha512-QfdoumZnkqsb6M1F4ok3BwYc7R0tWyu/RzXXtvB34AwfY2aiZAYOtVtK7JMdHOCnqxjPKxByxq4DCwLJ7KpWDQ==",
-			"requires": {
-				"@mongosh/errors": "^0.0.2-alpha.0",
-				"@mongosh/service-provider-core": "^0.0.2-alpha.0",
-				"@mongosh/shell-api": "^0.0.2-alpha.0",
-				"pretty-bytes": "^5.3.0",
-				"text-table": "^0.2.0"
-			},
-			"dependencies": {
-				"pretty-bytes": {
-					"version": "5.3.0",
-					"resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.3.0.tgz",
-					"integrity": "sha512-hjGrh+P926p4R4WbaB6OckyRtO0F0/lQBiT+0gnxjV+5kjPBrfVBFCsCLbMqVQeydvIoouYTCmmEURiH3R1Bdg=="
-				}
-			}
-		},
-		"@mongosh/service-provider-core": {
-			"version": "0.0.2-alpha.0",
-			"resolved": "https://registry.npmjs.org/@mongosh/service-provider-core/-/service-provider-core-0.0.2-alpha.0.tgz",
-			"integrity": "sha512-MLWDNIMoZPvzpTQbufR0E2EBZm1x6YGpwcxeVgQc26KqlVpItz1uh3oZX0U7lVTIm1KF2MmCZkzlqEdT5PI8OA=="
-		},
-		"@mongosh/service-provider-server": {
-			"version": "0.0.2-alpha.0",
-			"resolved": "https://registry.npmjs.org/@mongosh/service-provider-server/-/service-provider-server-0.0.2-alpha.0.tgz",
-			"integrity": "sha512-7y+/uchFPK8Qfmk8a8sIbjukHj1kW5k3WfmxwlSY2cRM/YtRzkreFZPzcfFjqhyRFhrFDcz1jxmY24PlODRN0w==",
-			"requires": {
-				"@mongosh/errors": "^0.0.2-alpha.0",
-				"@mongosh/service-provider-core": "^0.0.2-alpha.0",
-				"@types/sinon": "^7.5.1",
-				"@types/sinon-chai": "^3.2.3",
-				"mongodb": "3.5.3 || ^3.5.5"
-			}
-		},
-		"@mongosh/shell-api": {
-			"version": "0.0.2-alpha.0",
-			"resolved": "https://registry.npmjs.org/@mongosh/shell-api/-/shell-api-0.0.2-alpha.0.tgz",
-			"integrity": "sha512-c3M7n6hFwX4pIr/LJOSgMoxsmi/mlLj44el55EaE9WKhhYsrUKRw0FFYKpISTfYpCdy84uayvlnsvw2fIi5dkg==",
-			"requires": {
-				"@mongosh/errors": "^0.0.2-alpha.0",
-				"@mongosh/i18n": "^0.0.2-alpha.0",
-				"bson": "^4.0.4"
-			},
-			"dependencies": {
-				"bson": {
-					"version": "4.0.4",
-					"resolved": "https://registry.npmjs.org/bson/-/bson-4.0.4.tgz",
-					"integrity": "sha512-Ioi3TD0/1V3aI8+hPfC56TetYmzfq2H07jJa9A1lKTxWsFtHtYdLMGMXjtGEg9v0f72NSM07diRQEUNYhLupIA==",
-					"requires": {
-						"buffer": "^5.1.0",
-						"long": "^4.0.0"
-					}
-				},
-				"buffer": {
-					"version": "5.6.0",
-					"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
-					"integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
-					"requires": {
-						"base64-js": "^1.0.2",
-						"ieee754": "^1.1.4"
-					}
-				}
-			}
-		},
-		"@mongosh/shell-evaluator": {
-			"version": "0.0.2-alpha.0",
-			"resolved": "https://registry.npmjs.org/@mongosh/shell-evaluator/-/shell-evaluator-0.0.2-alpha.0.tgz",
-			"integrity": "sha512-c5U4aNiLpGLTtE2oRe98MDLZ6ljiNA+vIYAdO/u7K3IIcUf7okiWBWiuKhZA6yptP7bxJHCV9E7na75nPu6nvQ==",
-			"requires": {
-				"@mongosh/async-rewriter": "^0.0.2-alpha.0",
-				"@mongosh/mapper": "^0.0.2-alpha.0",
-				"@mongosh/service-provider-core": "^0.0.2-alpha.0",
-				"@mongosh/shell-api": "^0.0.2-alpha.0"
-			}
 		},
 		"@nodelib/fs.scandir": {
 			"version": "2.1.3",
@@ -1782,15 +1313,6 @@
 			"requires": {
 				"@nodelib/fs.scandir": "2.1.3",
 				"fastq": "^1.6.0"
-			}
-		},
-		"@segment/loosely-validate-event": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@segment/loosely-validate-event/-/loosely-validate-event-2.0.0.tgz",
-			"integrity": "sha512-ZMCSfztDBqwotkl848ODgVcAmN4OItEWDCkshcKz0/W6gGSQayuuCtWV/MlodFivAZD793d6UgANd6wCXUfrIw==",
-			"requires": {
-				"component-type": "^1.2.1",
-				"join-component": "^1.1.0"
 			}
 		},
 		"@sheerun/mutationobserver-shim": {
@@ -2450,52 +1972,11 @@
 				"@testing-library/dom": "^5.6.1"
 			}
 		},
-		"@types/babel__core": {
-			"version": "7.1.8",
-			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.8.tgz",
-			"integrity": "sha512-KXBiQG2OXvaPWFPDS1rD8yV9vO0OuWIqAEqLsbfX0oU2REN5KuoMnZ1gClWcBhO5I3n6oTVAmrMufOvRqdmFTQ==",
-			"requires": {
-				"@babel/parser": "^7.1.0",
-				"@babel/types": "^7.0.0",
-				"@types/babel__generator": "*",
-				"@types/babel__template": "*",
-				"@types/babel__traverse": "*"
-			}
-		},
-		"@types/babel__generator": {
-			"version": "7.6.1",
-			"resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.1.tgz",
-			"integrity": "sha512-bBKm+2VPJcMRVwNhxKu8W+5/zT7pwNEqeokFOmbvVSqGzFneNxYcEBro9Ac7/N9tlsaPYnZLK8J1LWKkMsLAew==",
-			"requires": {
-				"@babel/types": "^7.0.0"
-			}
-		},
-		"@types/babel__template": {
-			"version": "7.0.2",
-			"resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.0.2.tgz",
-			"integrity": "sha512-/K6zCpeW7Imzgab2bLkLEbz0+1JlFSrUMdw7KoIIu+IUdu51GWaBZpd3y1VXGVXzynvGa4DaIaxNZHiON3GXUg==",
-			"requires": {
-				"@babel/parser": "^7.1.0",
-				"@babel/types": "^7.0.0"
-			}
-		},
-		"@types/babel__traverse": {
-			"version": "7.0.12",
-			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.12.tgz",
-			"integrity": "sha512-t4CoEokHTfcyfb4hUaF9oOHu9RmmNWnm1CP0YmMqOOfClKascOmvlEM736vlqeScuGvBDsHkf8R2INd4DWreQA==",
-			"requires": {
-				"@babel/types": "^7.3.0"
-			}
-		},
-		"@types/chai": {
-			"version": "4.2.11",
-			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.11.tgz",
-			"integrity": "sha512-t7uW6eFafjO+qJ3BIV2gGUyZs27egcNRkUdalkud+Qa3+kg//f129iuOFivHDXQ+vnU3fDXuwgv0cqMCbcE8sw=="
-		},
 		"@types/color-name": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-			"integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
+			"integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
+			"dev": true
 		},
 		"@types/events": {
 			"version": "3.0.0",
@@ -2552,20 +2033,6 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
 			"integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
-		},
-		"@types/sinon": {
-			"version": "7.5.2",
-			"resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-7.5.2.tgz",
-			"integrity": "sha512-T+m89VdXj/eidZyejvmoP9jivXgBDdkOSBVQjU9kF349NEx10QdPNGxHeZUaj1IlJ32/ewdyXJjnJxyxJroYwg=="
-		},
-		"@types/sinon-chai": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/@types/sinon-chai/-/sinon-chai-3.2.4.tgz",
-			"integrity": "sha512-xq5KOWNg70PRC7dnR2VOxgYQ6paumW+4pTZP+6uTSdhpYsAUEeeT5bw6rRHHQrZ4KyR+M5ojOR+lje6TGSpUxA==",
-			"requires": {
-				"@types/chai": "*",
-				"@types/sinon": "*"
-			}
 		},
 		"@types/yargs": {
 			"version": "13.0.9",
@@ -2833,14 +2300,6 @@
 			"integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
 			"dev": true
 		},
-		"acorn-class-fields": {
-			"version": "0.3.4",
-			"resolved": "https://registry.npmjs.org/acorn-class-fields/-/acorn-class-fields-0.3.4.tgz",
-			"integrity": "sha512-yqUCIu0UJHFmCVhH3Cq29UR+3OJo1CtNWf1ncxTf3KfdEDt7aD0iVYmX7UN+RvIHyOsgukzplQhNkgePtASLUw==",
-			"requires": {
-				"acorn-private-class-elements": "^0.2.5"
-			}
-		},
 		"acorn-dynamic-import": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz",
@@ -2905,32 +2364,6 @@
 					"integrity": "sha512-wdlPY2tm/9XBr7QkKlq0WQVgiuGTX6YWPyRyBviSoScBuLfTVQhvwg6wJ369GJ/1nPfTLMfnrFIfjqVg6d+jQQ==",
 					"dev": true
 				}
-			}
-		},
-		"acorn-numeric-separator": {
-			"version": "0.3.2",
-			"resolved": "https://registry.npmjs.org/acorn-numeric-separator/-/acorn-numeric-separator-0.3.2.tgz",
-			"integrity": "sha512-ZNN1qnKvjWycDSQBfuD1TCiB81ItjjeGUPLHuqfP8X8HXwAodGTWsAaqSOQ1Nc9t+Wlb3tcEFdBrwUFUIzDiiA=="
-		},
-		"acorn-private-class-elements": {
-			"version": "0.2.5",
-			"resolved": "https://registry.npmjs.org/acorn-private-class-elements/-/acorn-private-class-elements-0.2.5.tgz",
-			"integrity": "sha512-3eApRrJmPjaxWB3XidP8YMeVq9pcswPFE0KsSWVuhceCU68ZS8fkcf0fTXGhCmnNd7n48NWWV27EKMFPeCoJLg=="
-		},
-		"acorn-private-methods": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/acorn-private-methods/-/acorn-private-methods-0.3.1.tgz",
-			"integrity": "sha512-IV5XZInFQaQK5ucjJy/HAk2UYvt+Buax00evzwo8NSuo8zhOBhW5v6VOjAljYUhAzQ/Hosi+Kaz6xJmvPiSM4Q==",
-			"requires": {
-				"acorn-private-class-elements": "^0.2.4"
-			}
-		},
-		"acorn-static-class-features": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/acorn-static-class-features/-/acorn-static-class-features-0.2.2.tgz",
-			"integrity": "sha512-B7aWeS7MXqdgP3RnettN/CFz7HevAlQWfh5zkc3LJzeCQoF1InTzYBCfkkbmit1p0pmCEB8IG05gB62pOm5lvA==",
-			"requires": {
-				"acorn-private-class-elements": "^0.2.3"
 			}
 		},
 		"acorn-walk": {
@@ -3195,46 +2628,11 @@
 				}
 			}
 		},
-		"analytics-node": {
-			"version": "3.4.0-beta.1",
-			"resolved": "https://registry.npmjs.org/analytics-node/-/analytics-node-3.4.0-beta.1.tgz",
-			"integrity": "sha512-+0F/y4Asc5S2qhWcYss+iCob6TTXQktwbqlIk02gcZaRxpekCbnTbJu/rcaRooVHxqp9WSzUXiWCesJYPJETZQ==",
-			"requires": {
-				"@segment/loosely-validate-event": "^2.0.0",
-				"axios": "^0.18.1",
-				"axios-retry": "^3.0.2",
-				"lodash.isstring": "^4.0.1",
-				"md5": "^2.2.1",
-				"ms": "^2.0.0",
-				"remove-trailing-slash": "^0.1.0",
-				"uuid": "^3.2.1"
-			},
-			"dependencies": {
-				"lodash.isstring": {
-					"version": "4.0.1",
-					"resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
-					"integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
-				}
-			}
-		},
-		"ansi": {
-			"version": "0.3.1",
-			"resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
-			"integrity": "sha1-DELU+xcWDVqa8eSEus4cZpIsGyE="
-		},
 		"ansi-colors": {
 			"version": "3.2.4",
 			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz",
 			"integrity": "sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA==",
 			"dev": true
-		},
-		"ansi-escape-sequences": {
-			"version": "5.1.2",
-			"resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-5.1.2.tgz",
-			"integrity": "sha512-JcpoVp1W1bl1Qn4cVuiXEhD6+dyXKSOgCn2zlzE8inYgCJCBy1aPnUhlz6I4DFum8D4ovb9Qi/iAjUcGvG2lqw==",
-			"requires": {
-				"array-back": "^4.0.0"
-			}
 		},
 		"ansi-escapes": {
 			"version": "3.2.0",
@@ -3299,11 +2697,6 @@
 				"readable-stream": "^2.0.6"
 			}
 		},
-		"arg": {
-			"version": "4.1.3",
-			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
-			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
-		},
 		"argparse": {
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -3311,29 +2704,6 @@
 			"dev": true,
 			"requires": {
 				"sprintf-js": "~1.0.2"
-			}
-		},
-		"args": {
-			"version": "5.0.1",
-			"resolved": "https://registry.npmjs.org/args/-/args-5.0.1.tgz",
-			"integrity": "sha512-1kqmFCFsPffavQFGt8OxJdIcETti99kySRUPMpOhaGjL6mRJn8HFU1OxKY5bMqfZKUwTQc1mZkAjmGYaVOHFtQ==",
-			"requires": {
-				"camelcase": "5.0.0",
-				"chalk": "2.4.2",
-				"leven": "2.1.0",
-				"mri": "1.1.4"
-			},
-			"dependencies": {
-				"camelcase": {
-					"version": "5.0.0",
-					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
-					"integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA=="
-				},
-				"leven": {
-					"version": "2.1.0",
-					"resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
-					"integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA="
-				}
 			}
 		},
 		"aria-query": {
@@ -3369,11 +2739,6 @@
 			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
 			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
 			"dev": true
-		},
-		"array-back": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.1.tgz",
-			"integrity": "sha512-Z/JnaVEXv+A9xabHzN43FiiiWEE7gPCRXMrVmRm00tWbjZRul1iHm7ECzlyNq1p4a4ATXz+G9FJ3GqGOkOV3fg=="
 		},
 		"array-equal": {
 			"version": "1.0.0",
@@ -3683,11 +3048,6 @@
 			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
 			"dev": true
 		},
-		"atomic-sleep": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
-			"integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="
-		},
 		"autoprefixer": {
 			"version": "9.7.6",
 			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.7.6.tgz",
@@ -3748,46 +3108,6 @@
 			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
 			"integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==",
 			"dev": true
-		},
-		"axios": {
-			"version": "0.18.1",
-			"resolved": "https://registry.npmjs.org/axios/-/axios-0.18.1.tgz",
-			"integrity": "sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==",
-			"requires": {
-				"follow-redirects": "1.5.10",
-				"is-buffer": "^2.0.2"
-			},
-			"dependencies": {
-				"debug": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
-					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-					"requires": {
-						"ms": "2.0.0"
-					}
-				},
-				"follow-redirects": {
-					"version": "1.5.10",
-					"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
-					"integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
-					"requires": {
-						"debug": "=3.1.0"
-					}
-				},
-				"is-buffer": {
-					"version": "2.0.4",
-					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
-					"integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
-				}
-			}
-		},
-		"axios-retry": {
-			"version": "3.1.8",
-			"resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.1.8.tgz",
-			"integrity": "sha512-yPw5Y4Bg6Dgmhm35KaJFtlh23s1TecW0HsUerK4/IS1UKl0gtN2aJqdEKtVomiOS/bDo5w4P3sqgki/M10eF8Q==",
-			"requires": {
-				"is-retry-allowed": "^1.1.0"
-			}
 		},
 		"babel-code-frame": {
 			"version": "6.26.0",
@@ -5355,7 +4675,8 @@
 		"base64-js": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
+			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
+			"dev": true
 		},
 		"base64id": {
 			"version": "1.0.0",
@@ -5435,6 +4756,7 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/bl/-/bl-2.2.0.tgz",
 			"integrity": "sha512-wbgvOpqopSr7uq6fJrLH8EsvYMJf9gzfo2jCsL2eTy75qXPukA4pCgHamOQkZtY5vmfVtjB+P3LNlMHW5CEZXA==",
+			"dev": true,
 			"requires": {
 				"readable-stream": "^2.3.5",
 				"safe-buffer": "^5.1.1"
@@ -5697,7 +5019,8 @@
 		"bson": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/bson/-/bson-1.1.4.tgz",
-			"integrity": "sha512-S/yKGU1syOMzO86+dGpg2qGoDL0zvzcb262G+gqEy6TgP6rt6z6qxSFX/8X6vLC91P7G7C3nLs0+bvDzmvBA3Q=="
+			"integrity": "sha512-S/yKGU1syOMzO86+dGpg2qGoDL0zvzcb262G+gqEy6TgP6rt6z6qxSFX/8X6vLC91P7G7C3nLs0+bvDzmvBA3Q==",
+			"dev": true
 		},
 		"buffer": {
 			"version": "4.9.2",
@@ -5741,7 +5064,8 @@
 		"buffer-from": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
+			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
+			"dev": true
 		},
 		"buffer-indexof": {
 			"version": "1.1.1",
@@ -5988,11 +5312,6 @@
 			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
 			"integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
 			"dev": true
-		},
-		"charenc": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
-			"integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
 		},
 		"check-error": {
 			"version": "1.0.2",
@@ -6378,11 +5697,6 @@
 			"integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM=",
 			"dev": true
 		},
-		"component-type": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/component-type/-/component-type-1.2.1.tgz",
-			"integrity": "sha1-ikeQFwAjjk/DIml3EjAibyS0Fak="
-		},
 		"compressible": {
 			"version": "2.0.18",
 			"resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
@@ -6713,11 +6027,6 @@
 				"shebang-command": "^1.2.0",
 				"which": "^1.2.9"
 			}
-		},
-		"crypt": {
-			"version": "0.0.2",
-			"resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
-			"integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
 		},
 		"cryptiles": {
 			"version": "2.0.5",
@@ -7103,11 +6412,6 @@
 			"integrity": "sha512-bYQuGLeFxhkxNOF3rcMtiZxvCBAquGzZm6oWA1oZ0g2THUzivaRhv8uOhdr19LmoobSOLoIAxeUK2RdbM8IFTA==",
 			"dev": true
 		},
-		"dateformat": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
-			"integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q=="
-		},
 		"debug": {
 			"version": "3.2.6",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
@@ -7399,7 +6703,8 @@
 		"denque": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/denque/-/denque-1.4.1.tgz",
-			"integrity": "sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ=="
+			"integrity": "sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ==",
+			"dev": true
 		},
 		"depd": {
 			"version": "1.1.2",
@@ -8477,67 +7782,6 @@
 				"create-emotion": "^10.0.27"
 			}
 		},
-		"emphasize": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/emphasize/-/emphasize-3.0.0.tgz",
-			"integrity": "sha512-xhtAWvxdkxsQbcCLGVjlfB7cQ4bWSPYXeaGDwK5Bl7n2y/9R+MVK5UNBTmZ9N8m/YShsiyGgQBgFGcjOWCWXHQ==",
-			"requires": {
-				"chalk": "^3.0.0",
-				"highlight.js": "~9.12.0",
-				"lowlight": "~1.9.0"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-				},
-				"highlight.js": {
-					"version": "9.12.0",
-					"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.12.0.tgz",
-					"integrity": "sha1-5tnb5Xy+/mB1HwKvM2GVhwyQwB4="
-				},
-				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
-			}
-		},
 		"encodeurl": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -8557,6 +7801,7 @@
 			"version": "1.4.4",
 			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
 			"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+			"dev": true,
 			"requires": {
 				"once": "^1.4.0"
 			}
@@ -9800,16 +9045,6 @@
 			"integrity": "sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw==",
 			"dev": true
 		},
-		"fast-redact": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-2.0.0.tgz",
-			"integrity": "sha512-zxpkULI9W9MNTK2sJ3BpPQrTEXFNESd2X6O1tXMFpK/XM0G5c5Rll2EVYZH2TqI3xRGK/VaJ+eEOt7pnENJpeA=="
-		},
-		"fast-safe-stringify": {
-			"version": "2.0.7",
-			"resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
-			"integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
-		},
 		"fastparse": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.2.tgz",
@@ -9823,14 +9058,6 @@
 			"dev": true,
 			"requires": {
 				"reusify": "^1.0.4"
-			}
-		},
-		"fault": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/fault/-/fault-1.0.4.tgz",
-			"integrity": "sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==",
-			"requires": {
-				"format": "^0.2.0"
 			}
 		},
 		"faye-websocket": {
@@ -10060,11 +9287,6 @@
 				}
 			}
 		},
-		"flatstr": {
-			"version": "1.0.12",
-			"resolved": "https://registry.npmjs.org/flatstr/-/flatstr-1.0.12.tgz",
-			"integrity": "sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw=="
-		},
 		"flatted": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
@@ -10124,11 +9346,6 @@
 				"combined-stream": "^1.0.6",
 				"mime-types": "^2.1.12"
 			}
-		},
-		"format": {
-			"version": "0.2.2",
-			"resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
-			"integrity": "sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs="
 		},
 		"forwarded": {
 			"version": "0.1.2",
@@ -10822,7 +10039,8 @@
 		"gensync": {
 			"version": "1.0.0-beta.1",
 			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
-			"integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg=="
+			"integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==",
+			"dev": true
 		},
 		"get-amd-module-type": {
 			"version": "3.0.0",
@@ -11003,7 +10221,8 @@
 		"globals": {
 			"version": "11.12.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
+			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
+			"dev": true
 		},
 		"globalthis": {
 			"version": "1.0.1",
@@ -11298,16 +10517,6 @@
 			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
 			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
 			"dev": true
-		},
-		"highlight.js": {
-			"version": "9.18.1",
-			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.18.1.tgz",
-			"integrity": "sha512-OrVKYz70LHsnCgmbXctv/bfuvntIKDz177h0Co37DQ5jamGZLVmoCVMtjMtNZY3X9DrCcKfklHPNeA0uPZhSJg=="
-		},
-		"highlightjs-graphql": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/highlightjs-graphql/-/highlightjs-graphql-1.0.1.tgz",
-			"integrity": "sha512-g5kt/orsUJTjIt5pgs/uvi78kXndpCtYwzE7H3D0d07r3ETs9oHSZHD0EGaRPndiQ/4EYXt12rnsDkljn3ilAA=="
 		},
 		"hmac-drbg": {
 			"version": "1.0.1",
@@ -11767,7 +10976,8 @@
 		"ieee754": {
 			"version": "1.1.13",
 			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-			"integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
+			"integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
+			"dev": true
 		},
 		"iferr": {
 			"version": "0.1.5",
@@ -12087,7 +11297,8 @@
 		"is-buffer": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
+			"dev": true
 		},
 		"is-callable": {
 			"version": "1.1.5",
@@ -12287,25 +11498,6 @@
 			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
 			"dev": true
 		},
-		"is-recoverable-error": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/is-recoverable-error/-/is-recoverable-error-1.0.1.tgz",
-			"integrity": "sha512-1v/3hIRd0hHzkmq9TU+otd8SlUJjr60KyX6RfgwJ6NVbeQafc3POajWZ/BcusPxhdX0ScN3xE9tTnn6xGpC3LA==",
-			"requires": {
-				"acorn": "^7.1.1",
-				"acorn-class-fields": "^0.3.2",
-				"acorn-numeric-separator": "^0.3.1",
-				"acorn-private-methods": "^0.3.1",
-				"acorn-static-class-features": "^0.2.1"
-			},
-			"dependencies": {
-				"acorn": {
-					"version": "7.2.0",
-					"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.2.0.tgz",
-					"integrity": "sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ=="
-				}
-			}
-		},
 		"is-regex": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
@@ -12323,11 +11515,6 @@
 			"requires": {
 				"is-unc-path": "^1.0.0"
 			}
-		},
-		"is-retry-allowed": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
-			"integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg=="
 		},
 		"is-root": {
 			"version": "1.0.0",
@@ -12548,21 +11735,6 @@
 				"iterate-iterator": "^1.0.1"
 			}
 		},
-		"jmespath": {
-			"version": "0.15.0",
-			"resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
-			"integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
-		},
-		"join-component": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/join-component/-/join-component-1.1.0.tgz",
-			"integrity": "sha1-uEF7dQZho5K+4sJTfGiyqdSXfNU="
-		},
-		"joycon": {
-			"version": "2.2.5",
-			"resolved": "https://registry.npmjs.org/joycon/-/joycon-2.2.5.tgz",
-			"integrity": "sha512-YqvUxoOcVPnCp0VU1/56f+iKSdvIRJYPznH22BdXV3xMk75SFXhWeJkZ8C9XxUWt1b5x2X1SxuFygW1U0FmkEQ=="
-		},
 		"js-base64": {
 			"version": "2.5.2",
 			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.2.tgz",
@@ -12647,7 +11819,8 @@
 		"jsesc": {
 			"version": "2.5.2",
 			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
+			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
+			"dev": true
 		},
 		"json-loader": {
 			"version": "0.5.7",
@@ -12704,6 +11877,7 @@
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
 			"integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+			"dev": true,
 			"requires": {
 				"minimist": "^1.2.5"
 			}
@@ -13945,11 +13119,6 @@
 				"lodash.isfunction": "^3.0.0"
 			}
 		},
-		"lodash.set": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
-			"integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
-		},
 		"lodash.some": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
@@ -14048,7 +13217,8 @@
 		"long": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-			"integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+			"integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
+			"dev": true
 		},
 		"longest": {
 			"version": "1.0.1",
@@ -14081,22 +13251,6 @@
 			"integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
 			"dev": true
 		},
-		"lowlight": {
-			"version": "1.9.2",
-			"resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.9.2.tgz",
-			"integrity": "sha512-Ek18ElVCf/wF/jEm1b92gTnigh94CtBNWiZ2ad+vTgW7cTmQxUY3I98BjHK68gZAJEWmybGBZgx9qv3QxLQB/Q==",
-			"requires": {
-				"fault": "^1.0.2",
-				"highlight.js": "~9.12.0"
-			},
-			"dependencies": {
-				"highlight.js": {
-					"version": "9.12.0",
-					"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.12.0.tgz",
-					"integrity": "sha1-5tnb5Xy+/mB1HwKvM2GVhwyQwB4="
-				}
-			}
-		},
 		"lru-cache": {
 			"version": "4.1.5",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
@@ -14120,7 +13274,8 @@
 		"make-error": {
 			"version": "1.3.6",
 			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
+			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
+			"dev": true
 		},
 		"map-age-cleaner": {
 			"version": "0.1.3",
@@ -14190,16 +13345,6 @@
 			"integrity": "sha512-L0j0tFVZBQQLeEjmWOvDLoRciIY8gQGWahvkztXUal8jH8R5Rlqo9GCvgqvXcy9LQhEWdQCVvzqAbxgYNt4blQ==",
 			"dev": true
 		},
-		"md5": {
-			"version": "2.2.1",
-			"resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
-			"integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
-			"requires": {
-				"charenc": "~0.0.1",
-				"crypt": "~0.0.1",
-				"is-buffer": "~1.1.1"
-			}
-		},
 		"md5.js": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -14246,6 +13391,7 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
 			"integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+			"dev": true,
 			"optional": true
 		},
 		"meow": {
@@ -15115,6 +14261,7 @@
 			"version": "3.5.6",
 			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.5.6.tgz",
 			"integrity": "sha512-sh3q3GLDLT4QmoDLamxtAECwC3RGjq+oNuK1ENV8+tnipIavss6sMYt77hpygqlMOCt0Sla5cl7H4SKCVBCGEg==",
+			"dev": true,
 			"requires": {
 				"bl": "^2.2.0",
 				"bson": "^1.1.4",
@@ -15123,26 +14270,6 @@
 				"safe-buffer": "^5.1.2",
 				"saslprep": "^1.0.0"
 			}
-		},
-		"mongodb-ace-autocompleter": {
-			"version": "0.4.9",
-			"resolved": "https://registry.npmjs.org/mongodb-ace-autocompleter/-/mongodb-ace-autocompleter-0.4.9.tgz",
-			"integrity": "sha512-N920FVjKXTWHhZIUcG230AL2ZCEr4yYWguI3+qrDBs2FCPMIKX7ARm9MSZjnzaIxpvaAuv4K2RhgFQQ9XIVCmw==",
-			"requires": {
-				"semver": "^7.1.1"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "7.3.2",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
-				}
-			}
-		},
-		"mongodb-build-info": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/mongodb-build-info/-/mongodb-build-info-1.1.0.tgz",
-			"integrity": "sha512-ZlbQlpXv8DCvYK2I6UmyRO4z9zb4fyoph+RhEN/MSSsigaqcfl6dePkbgavemquvuKVEq0BbIiVkHw1DKwChxA=="
 		},
 		"mongodb-collection-sample": {
 			"version": "4.5.1",
@@ -15855,14 +14982,6 @@
 			"integrity": "sha512-sch/9jd74VjRCmB5U+Fj4WJnkmAtDQgxqJkBInO7zEknXE+lnDEuNBT5/Wp59HMrWUabssGGq08r6Y6F7pkvVA==",
 			"dev": true
 		},
-		"mongodb-redact": {
-			"version": "0.2.0",
-			"resolved": "https://registry.npmjs.org/mongodb-redact/-/mongodb-redact-0.2.0.tgz",
-			"integrity": "sha512-kGoR02HsTzNYHFXLklvbEg7mSJZu5+L1JdaYUuSlmVUAXxzhxUBvoFoYulfqqvokE+ilAXGYywdMJStB0lPhCw==",
-			"requires": {
-				"lodash": "^4.17.15"
-			}
-		},
 		"mongodb-reflux-store": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/mongodb-reflux-store/-/mongodb-reflux-store-0.0.1.tgz",
@@ -15944,15 +15063,11 @@
 				"run-queue": "^1.0.3"
 			}
 		},
-		"mri": {
-			"version": "1.1.4",
-			"resolved": "https://registry.npmjs.org/mri/-/mri-1.1.4.tgz",
-			"integrity": "sha512-6y7IjGPm8AzlvoUrwAaw1tLnUBudaS3752vcd8JtrpGGQn+rXIe63LFVHm/YMwtqAuh+LJPCFdlLYPWM1nYn6w=="
-		},
 		"ms": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+			"dev": true
 		},
 		"multicast-dns": {
 			"version": "6.2.3",
@@ -15979,15 +15094,11 @@
 				"object-assign": "^4.1.0"
 			}
 		},
-		"mustache": {
-			"version": "4.0.1",
-			"resolved": "https://registry.npmjs.org/mustache/-/mustache-4.0.1.tgz",
-			"integrity": "sha512-yL5VE97+OXn4+Er3THSmTdCFCtx5hHWzrolvH+JObZnUYwuaG7XV+Ch4fR2cIrcYI0tFHxS7iyFYl14bW8y2sA=="
-		},
 		"mute-stream": {
 			"version": "0.0.7",
 			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
+			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
+			"dev": true
 		},
 		"nan": {
 			"version": "2.14.1",
@@ -15995,21 +15106,6 @@
 			"integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
 			"dev": true,
 			"optional": true
-		},
-		"nanoassert": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/nanoassert/-/nanoassert-1.1.0.tgz",
-			"integrity": "sha1-TzFS4JVA/eKMdvRLGbvNHVpCR40="
-		},
-		"nanobus": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/nanobus/-/nanobus-4.4.0.tgz",
-			"integrity": "sha512-Hv9USGyH8EsPy0o8pPWE7x3YRIfuZDgMBirzjU6XLebhiSK2g53JlfqgolD0c39ne6wXAfaBNcIAvYe22Bav+Q==",
-			"requires": {
-				"nanoassert": "^1.1.0",
-				"nanotiming": "^7.2.0",
-				"remove-array-items": "^1.0.0"
-			}
 		},
 		"nanomatch": {
 			"version": "1.2.13",
@@ -16028,23 +15124,6 @@
 				"regex-not": "^1.0.0",
 				"snapdragon": "^0.8.1",
 				"to-regex": "^3.0.1"
-			}
-		},
-		"nanoscheduler": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/nanoscheduler/-/nanoscheduler-1.0.3.tgz",
-			"integrity": "sha512-jBbrF3qdU9321r8n9X7yu18DjP31Do2ItJm3mWrt90wJTrnDO+HXpoV7ftaUglAtjgj9s+OaCxGufbvx6pvbEQ==",
-			"requires": {
-				"nanoassert": "^1.1.0"
-			}
-		},
-		"nanotiming": {
-			"version": "7.3.1",
-			"resolved": "https://registry.npmjs.org/nanotiming/-/nanotiming-7.3.1.tgz",
-			"integrity": "sha512-l3lC7v/PfOuRWQa8vV29Jo6TG10wHtnthLElFXs4Te4Aas57Fo4n1Q8LH9n+NDh9riOzTVvb2QNBhTS4JUKNjw==",
-			"requires": {
-				"nanoassert": "^1.1.0",
-				"nanoscheduler": "^1.0.2"
 			}
 		},
 		"napi-build-utils": {
@@ -17676,6 +16755,7 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"dev": true,
 			"requires": {
 				"wrappy": "1"
 			}
@@ -18130,112 +17210,6 @@
 			"requires": {
 				"pinkie": "^2.0.0"
 			}
-		},
-		"pino": {
-			"version": "5.17.0",
-			"resolved": "https://registry.npmjs.org/pino/-/pino-5.17.0.tgz",
-			"integrity": "sha512-LqrqmRcJz8etUjyV0ddqB6OTUutCgQULPFg2b4dtijRHUsucaAdBgSUW58vY6RFSX+NT8963F+q0tM6lNwGShA==",
-			"requires": {
-				"fast-redact": "^2.0.0",
-				"fast-safe-stringify": "^2.0.7",
-				"flatstr": "^1.0.12",
-				"pino-std-serializers": "^2.4.2",
-				"quick-format-unescaped": "^3.0.3",
-				"sonic-boom": "^0.7.5"
-			}
-		},
-		"pino-pretty": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-4.0.0.tgz",
-			"integrity": "sha512-YLy/n3dMXYWOodSm530gelkSAJGmEp29L9pqiycInlIae5FEJPWAkMRO3JFMbIFtjD2Ve4SH2aBcz2aRreGpBQ==",
-			"requires": {
-				"@hapi/bourne": "^2.0.0",
-				"args": "^5.0.1",
-				"chalk": "^3.0.0",
-				"dateformat": "^3.0.3",
-				"fast-safe-stringify": "^2.0.7",
-				"jmespath": "^0.15.0",
-				"joycon": "^2.2.5",
-				"pump": "^3.0.0",
-				"readable-stream": "^3.6.0",
-				"split2": "^3.1.1",
-				"strip-json-comments": "^3.0.1"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
-					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-				},
-				"pump": {
-					"version": "3.0.0",
-					"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
-					"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
-					"requires": {
-						"end-of-stream": "^1.1.0",
-						"once": "^1.3.1"
-					}
-				},
-				"readable-stream": {
-					"version": "3.6.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-					"requires": {
-						"inherits": "^2.0.3",
-						"string_decoder": "^1.1.1",
-						"util-deprecate": "^1.0.1"
-					}
-				},
-				"strip-json-comments": {
-					"version": "3.1.0",
-					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.0.tgz",
-					"integrity": "sha512-e6/d0eBu7gHtdCqFt0xJr642LdToM5/cN4Qb9DbHjVx1CP5RyeM+zH7pbecEmDv/lBqb0QH+6Uqq75rxFPkM0w=="
-				},
-				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
-			}
-		},
-		"pino-std-serializers": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-2.4.2.tgz",
-			"integrity": "sha512-WaL504dO8eGs+vrK+j4BuQQq6GLKeCCcHaMB2ItygzVURcL1CycwNEUHTD/lHFHs/NL5qAz2UKrjYWXKSf4aMQ=="
 		},
 		"pirates": {
 			"version": "4.0.1",
@@ -20309,68 +19283,6 @@
 				}
 			}
 		},
-		"pretty-repl": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/pretty-repl/-/pretty-repl-2.3.0.tgz",
-			"integrity": "sha512-h7iNPLXpJPnbZZS0YIp1+EGD+oY9STelL70X8nwzrbglqP5nOUi0YxK+OJ8n6xopVHoLNQZrytYTmHrWcB1O/w==",
-			"requires": {
-				"ansi": "^0.3.1",
-				"chalk": "^4.0.0",
-				"emphasize": "^3.0.0",
-				"semver": "^7.2.2"
-			},
-			"dependencies": {
-				"ansi-styles": {
-					"version": "4.2.1",
-					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
-					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
-					"requires": {
-						"@types/color-name": "^1.1.1",
-						"color-convert": "^2.0.1"
-					}
-				},
-				"chalk": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.0.0.tgz",
-					"integrity": "sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==",
-					"requires": {
-						"ansi-styles": "^4.1.0",
-						"supports-color": "^7.1.0"
-					}
-				},
-				"color-convert": {
-					"version": "2.0.1",
-					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-					"requires": {
-						"color-name": "~1.1.4"
-					}
-				},
-				"color-name": {
-					"version": "1.1.4",
-					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
-				},
-				"has-flag": {
-					"version": "4.0.0",
-					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
-				},
-				"semver": {
-					"version": "7.3.2",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
-					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
-				},
-				"supports-color": {
-					"version": "7.1.0",
-					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
-					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
-					"requires": {
-						"has-flag": "^4.0.0"
-					}
-				}
-			}
-		},
 		"private": {
 			"version": "0.1.8",
 			"resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
@@ -20640,11 +19552,6 @@
 			"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
 			"integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==",
 			"dev": true
-		},
-		"quick-format-unescaped": {
-			"version": "3.0.3",
-			"resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-3.0.3.tgz",
-			"integrity": "sha512-dy1yjycmn9blucmJLXOfZDx1ikZJUi6E8bBZLnhPG5gBrVhHXx2xVyqqgKBubVNEXmx51dBACMHpoMQK/N/AXQ=="
 		},
 		"radium": {
 			"version": "0.19.6",
@@ -21182,14 +20089,6 @@
 				}
 			}
 		},
-		"read": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
-			"integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
-			"requires": {
-				"mute-stream": "~0.0.4"
-			}
-		},
 		"read-package-json": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.1.1.tgz",
@@ -21492,21 +20391,11 @@
 			"integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
 			"dev": true
 		},
-		"remove-array-items": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/remove-array-items/-/remove-array-items-1.1.1.tgz",
-			"integrity": "sha512-MXW/jtHyl5F1PZI7NbpS8SOtympdLuF20aoWJT5lELR1p/HJDd5nqW8Eu9uLh/hCRY3FgvrIT5AwDCgBODklcA=="
-		},
 		"remove-trailing-separator": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
 			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
 			"dev": true
-		},
-		"remove-trailing-slash": {
-			"version": "0.1.0",
-			"resolved": "https://registry.npmjs.org/remove-trailing-slash/-/remove-trailing-slash-0.1.0.tgz",
-			"integrity": "sha1-FJjl3wmEwn5Jt26/Boh8otARUNI="
 		},
 		"renderkid": {
 			"version": "2.0.3",
@@ -21614,6 +20503,7 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
 			"integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
+			"dev": true,
 			"requires": {
 				"resolve-from": "^2.0.0",
 				"semver": "^5.1.0"
@@ -21622,7 +20512,8 @@
 				"resolve-from": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-					"integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
+					"integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
+					"dev": true
 				}
 			}
 		},
@@ -21836,6 +20727,7 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
 			"integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"sparse-bitfield": "^3.0.3"
@@ -21885,7 +20777,8 @@
 		"semver": {
 			"version": "5.7.1",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+			"dev": true
 		},
 		"send": {
 			"version": "0.17.1",
@@ -22502,15 +21395,6 @@
 				}
 			}
 		},
-		"sonic-boom": {
-			"version": "0.7.7",
-			"resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-0.7.7.tgz",
-			"integrity": "sha512-Ei5YOo5J64GKClHIL/5evJPgASXFVpfVYbJV9PILZQytTK6/LCwHvsZJW2Ig4p9FMC2OrBrMnXKgRN/OEoAWfg==",
-			"requires": {
-				"atomic-sleep": "^1.0.0",
-				"flatstr": "^1.0.12"
-			}
-		},
 		"sort-keys": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
@@ -22548,6 +21432,7 @@
 			"version": "0.5.18",
 			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.18.tgz",
 			"integrity": "sha512-9luZr/BZ2QeU6tO2uG8N2aZpVSli4TSAOAqFOyTO51AJcD9P99c0K1h6dD6r6qo5dyT44BR5exweOaLLeldTkQ==",
+			"dev": true,
 			"requires": {
 				"buffer-from": "^1.0.0",
 				"source-map": "^0.6.0"
@@ -22556,7 +21441,8 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
+					"dev": true
 				}
 			}
 		},
@@ -22570,6 +21456,7 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
 			"integrity": "sha1-/0rm5oZWBWuks+eSqzM004JzyhE=",
+			"dev": true,
 			"optional": true,
 			"requires": {
 				"memory-pager": "^1.0.2"
@@ -22733,26 +21620,6 @@
 			"dev": true,
 			"requires": {
 				"extend-shallow": "^3.0.0"
-			}
-		},
-		"split2": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/split2/-/split2-3.1.1.tgz",
-			"integrity": "sha512-emNzr1s7ruq4N+1993yht631/JH+jaj0NYBosuKmLcq+JkGQ9MmTw1RB1fGaTCzUuseRIClrlSLHRNYGwWQ58Q==",
-			"requires": {
-				"readable-stream": "^3.0.0"
-			},
-			"dependencies": {
-				"readable-stream": {
-					"version": "3.6.0",
-					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
-					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
-					"requires": {
-						"inherits": "^2.0.3",
-						"string_decoder": "^1.1.1",
-						"util-deprecate": "^1.0.1"
-					}
-				}
 			}
 		},
 		"sprintf-js": {
@@ -23551,7 +22418,8 @@
 		"text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
+			"dev": true
 		},
 		"throttleit": {
 			"version": "0.0.2",
@@ -23747,25 +22615,6 @@
 			"integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==",
 			"dev": true
 		},
-		"ts-node": {
-			"version": "8.10.2",
-			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.10.2.tgz",
-			"integrity": "sha512-ISJJGgkIpDdBhWVu3jufsWpK3Rzo7bdiIXJjQc0ynKxVOVcg2oIrf2H2cejminGrptVc6q6/uynAHNCuWGbpVA==",
-			"requires": {
-				"arg": "^4.1.0",
-				"diff": "^4.0.1",
-				"make-error": "^1.1.1",
-				"source-map-support": "^0.5.17",
-				"yn": "3.1.1"
-			},
-			"dependencies": {
-				"diff": {
-					"version": "4.0.2",
-					"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
-					"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
-				}
-			}
-		},
 		"tslib": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
@@ -23851,7 +22700,8 @@
 		"typescript": {
 			"version": "3.8.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
-			"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w=="
+			"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
+			"dev": true
 		},
 		"ua-parser-js": {
 			"version": "0.7.21",
@@ -24275,7 +23125,8 @@
 		"uuid": {
 			"version": "3.4.0",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+			"dev": true
 		},
 		"v8-compile-cache": {
 			"version": "2.0.3",
@@ -25476,7 +24327,8 @@
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"dev": true
 		},
 		"write": {
 			"version": "1.0.3",
@@ -25877,11 +24729,6 @@
 			"resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
 			"integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk=",
 			"dev": true
-		},
-		"yn": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
-			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="
 		}
 	}
 }

--- a/packages/compass-shell/package-lock.json
+++ b/packages/compass-shell/package-lock.json
@@ -44,7 +44,6 @@
 			"version": "7.9.0",
 			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.9.0.tgz",
 			"integrity": "sha512-kWc7L0fw1xwvI0zi8OKVBuxRVefwGOrKSQMvrQ3dW+bIIavBY3/NpXmpjMy7bQnLgwgzWQZ8TlM57YHpHNHz4w==",
-			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.8.3",
 				"@babel/generator": "^7.9.0",
@@ -68,7 +67,6 @@
 					"version": "4.1.1",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
 					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-					"dev": true,
 					"requires": {
 						"ms": "^2.1.1"
 					}
@@ -76,8 +74,7 @@
 				"ms": {
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-					"dev": true
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 				}
 			}
 		},
@@ -85,7 +82,6 @@
 			"version": "7.9.5",
 			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.5.tgz",
 			"integrity": "sha512-GbNIxVB3ZJe3tLeDm1HSn2AhuD/mVcyLDpgtLXa5tplmWrJdF/elxB56XNqCuD6szyNkDi6wuoKXln3QeBmCHQ==",
-			"dev": true,
 			"requires": {
 				"@babel/types": "^7.9.5",
 				"jsesc": "^2.5.1",
@@ -196,7 +192,6 @@
 			"version": "7.9.5",
 			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.9.5.tgz",
 			"integrity": "sha512-JVcQZeXM59Cd1qanDUxv9fgJpt3NeKUaqBqUEvfmQ+BCOKq2xUgaWZW2hr0dkbyJgezYuplEoh5knmrnS68efw==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-get-function-arity": "^7.8.3",
 				"@babel/template": "^7.8.3",
@@ -207,7 +202,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
 			"integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
-			"dev": true,
 			"requires": {
 				"@babel/types": "^7.8.3"
 			}
@@ -225,7 +219,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.8.3.tgz",
 			"integrity": "sha512-fO4Egq88utkQFjbPrSHGmGLFqmrshs11d46WI+WZDESt7Wu7wN2G2Iu+NMMZJFDOVRHAMIkB5SNh30NtwCA7RA==",
-			"dev": true,
 			"requires": {
 				"@babel/types": "^7.8.3"
 			}
@@ -242,7 +235,6 @@
 			"version": "7.9.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.9.0.tgz",
 			"integrity": "sha512-0FvKyu0gpPfIQ8EkxlrAydOWROdHpBmiCiRwLkUiBGhCUPRRbVD2/tm3sFr/c/GWFrQ/ffutGUAnx7V0FzT2wA==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-module-imports": "^7.8.3",
 				"@babel/helper-replace-supers": "^7.8.6",
@@ -257,7 +249,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.8.3.tgz",
 			"integrity": "sha512-Kag20n86cbO2AvHca6EJsvqAd82gc6VMGule4HwebwMlwkpXuVqrNRj6CkCV2sKxgi9MyAUnZVnZ6lJ1/vKhHQ==",
-			"dev": true,
 			"requires": {
 				"@babel/types": "^7.8.3"
 			}
@@ -294,7 +285,6 @@
 			"version": "7.8.6",
 			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.8.6.tgz",
 			"integrity": "sha512-PeMArdA4Sv/Wf4zXwBKPqVj7n9UF/xg6slNRtZW84FM7JpE1CbG8B612FyM4cxrf4fMAMGO0kR7voy1ForHHFA==",
-			"dev": true,
 			"requires": {
 				"@babel/helper-member-expression-to-functions": "^7.8.3",
 				"@babel/helper-optimise-call-expression": "^7.8.3",
@@ -306,7 +296,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.8.3.tgz",
 			"integrity": "sha512-VNGUDjx5cCWg4vvCTR8qQ7YJYZ+HBjxOgXEl7ounz+4Sn7+LMD3CFrCTEU6/qXKbA2nKg21CwhhBzO0RpRbdCw==",
-			"dev": true,
 			"requires": {
 				"@babel/template": "^7.8.3",
 				"@babel/types": "^7.8.3"
@@ -316,7 +305,6 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
 			"integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
-			"dev": true,
 			"requires": {
 				"@babel/types": "^7.8.3"
 			}
@@ -342,7 +330,6 @@
 			"version": "7.9.2",
 			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.9.2.tgz",
 			"integrity": "sha512-JwLvzlXVPjO8eU9c/wF9/zOIN7X6h8DYf7mG4CiFRZRvZNKEF5dQ3H3V+ASkHoIB3mWhatgl5ONhyqHRI6MppA==",
-			"dev": true,
 			"requires": {
 				"@babel/template": "^7.8.3",
 				"@babel/traverse": "^7.9.0",
@@ -362,8 +349,7 @@
 		"@babel/parser": {
 			"version": "7.9.4",
 			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.4.tgz",
-			"integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA==",
-			"dev": true
+			"integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA=="
 		},
 		"@babel/plugin-proposal-async-generator-functions": {
 			"version": "7.8.3",
@@ -575,6 +561,21 @@
 			"dev": true,
 			"requires": {
 				"@babel/helper-plugin-utils": "^7.8.3"
+			}
+		},
+		"@babel/plugin-syntax-typescript": {
+			"version": "7.10.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.10.1.tgz",
+			"integrity": "sha512-X/d8glkrAtra7CaQGMiGs/OGa6XgUzqPcBXCIGFCpCqnfGlT0Wfbzo/B89xHhnInTaItPK8LALblVXcUOEh95Q==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.1"
+			},
+			"dependencies": {
+				"@babel/helper-plugin-utils": {
+					"version": "7.10.1",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
+					"integrity": "sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA=="
+				}
 			}
 		},
 		"@babel/plugin-transform-arrow-functions": {
@@ -937,6 +938,177 @@
 				"@babel/helper-plugin-utils": "^7.8.3"
 			}
 		},
+		"@babel/plugin-transform-typescript": {
+			"version": "7.10.1",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.10.1.tgz",
+			"integrity": "sha512-v+QWKlmCnsaimLeqq9vyCsVRMViZG1k2SZTlcZvB+TqyH570Zsij8nvVUZzOASCRiQFUxkLrn9Wg/kH0zgy5OQ==",
+			"requires": {
+				"@babel/helper-create-class-features-plugin": "^7.10.1",
+				"@babel/helper-plugin-utils": "^7.10.1",
+				"@babel/plugin-syntax-typescript": "^7.10.1"
+			},
+			"dependencies": {
+				"@babel/code-frame": {
+					"version": "7.10.1",
+					"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.10.1.tgz",
+					"integrity": "sha512-IGhtTmpjGbYzcEDOw7DcQtbQSXcG9ftmAXtWTu9V936vDye4xjjekktFAtgZsWpzTj/X01jocB46mTywm/4SZw==",
+					"requires": {
+						"@babel/highlight": "^7.10.1"
+					}
+				},
+				"@babel/generator": {
+					"version": "7.10.2",
+					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.10.2.tgz",
+					"integrity": "sha512-AxfBNHNu99DTMvlUPlt1h2+Hn7knPpH5ayJ8OqDWSeLld+Fi2AYBTC/IejWDM9Edcii4UzZRCsbUt0WlSDsDsA==",
+					"requires": {
+						"@babel/types": "^7.10.2",
+						"jsesc": "^2.5.1",
+						"lodash": "^4.17.13",
+						"source-map": "^0.5.0"
+					}
+				},
+				"@babel/helper-create-class-features-plugin": {
+					"version": "7.10.2",
+					"resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.10.2.tgz",
+					"integrity": "sha512-5C/QhkGFh1vqcziq1vAL6SI9ymzUp8BCYjFpvYVhWP4DlATIb3u5q3iUd35mvlyGs8fO7hckkW7i0tmH+5+bvQ==",
+					"requires": {
+						"@babel/helper-function-name": "^7.10.1",
+						"@babel/helper-member-expression-to-functions": "^7.10.1",
+						"@babel/helper-optimise-call-expression": "^7.10.1",
+						"@babel/helper-plugin-utils": "^7.10.1",
+						"@babel/helper-replace-supers": "^7.10.1",
+						"@babel/helper-split-export-declaration": "^7.10.1"
+					}
+				},
+				"@babel/helper-function-name": {
+					"version": "7.10.1",
+					"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.10.1.tgz",
+					"integrity": "sha512-fcpumwhs3YyZ/ttd5Rz0xn0TpIwVkN7X0V38B9TWNfVF42KEkhkAAuPCQ3oXmtTRtiPJrmZ0TrfS0GKF0eMaRQ==",
+					"requires": {
+						"@babel/helper-get-function-arity": "^7.10.1",
+						"@babel/template": "^7.10.1",
+						"@babel/types": "^7.10.1"
+					}
+				},
+				"@babel/helper-get-function-arity": {
+					"version": "7.10.1",
+					"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.10.1.tgz",
+					"integrity": "sha512-F5qdXkYGOQUb0hpRaPoetF9AnsXknKjWMZ+wmsIRsp5ge5sFh4c3h1eH2pRTTuy9KKAA2+TTYomGXAtEL2fQEw==",
+					"requires": {
+						"@babel/types": "^7.10.1"
+					}
+				},
+				"@babel/helper-member-expression-to-functions": {
+					"version": "7.10.1",
+					"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.10.1.tgz",
+					"integrity": "sha512-u7XLXeM2n50gb6PWJ9hoO5oO7JFPaZtrh35t8RqKLT1jFKj9IWeD1zrcrYp1q1qiZTdEarfDWfTIP8nGsu0h5g==",
+					"requires": {
+						"@babel/types": "^7.10.1"
+					}
+				},
+				"@babel/helper-optimise-call-expression": {
+					"version": "7.10.1",
+					"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.10.1.tgz",
+					"integrity": "sha512-a0DjNS1prnBsoKx83dP2falChcs7p3i8VMzdrSbfLhuQra/2ENC4sbri34dz/rWmDADsmF1q5GbfaXydh0Jbjg==",
+					"requires": {
+						"@babel/types": "^7.10.1"
+					}
+				},
+				"@babel/helper-plugin-utils": {
+					"version": "7.10.1",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
+					"integrity": "sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA=="
+				},
+				"@babel/helper-replace-supers": {
+					"version": "7.10.1",
+					"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.10.1.tgz",
+					"integrity": "sha512-SOwJzEfpuQwInzzQJGjGaiG578UYmyi2Xw668klPWV5n07B73S0a9btjLk/52Mlcxa+5AdIYqws1KyXRfMoB7A==",
+					"requires": {
+						"@babel/helper-member-expression-to-functions": "^7.10.1",
+						"@babel/helper-optimise-call-expression": "^7.10.1",
+						"@babel/traverse": "^7.10.1",
+						"@babel/types": "^7.10.1"
+					}
+				},
+				"@babel/helper-split-export-declaration": {
+					"version": "7.10.1",
+					"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.10.1.tgz",
+					"integrity": "sha512-UQ1LVBPrYdbchNhLwj6fetj46BcFwfS4NllJo/1aJsT+1dLTEnXJL0qHqtY7gPzF8S2fXBJamf1biAXV3X077g==",
+					"requires": {
+						"@babel/types": "^7.10.1"
+					}
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.10.1",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.10.1.tgz",
+					"integrity": "sha512-5vW/JXLALhczRCWP0PnFDMCJAchlBvM7f4uk/jXritBnIa6E1KmqmtrS3yn1LAnxFBypQ3eneLuXjsnfQsgILw=="
+				},
+				"@babel/highlight": {
+					"version": "7.10.1",
+					"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.10.1.tgz",
+					"integrity": "sha512-8rMof+gVP8mxYZApLF/JgNDAkdKa+aJt3ZYxF8z6+j/hpeXL7iMsKCPHa2jNMHu/qqBwzQF4OHNoYi8dMA/rYg==",
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.10.1",
+						"chalk": "^2.0.0",
+						"js-tokens": "^4.0.0"
+					}
+				},
+				"@babel/parser": {
+					"version": "7.10.2",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.10.2.tgz",
+					"integrity": "sha512-PApSXlNMJyB4JiGVhCOlzKIif+TKFTvu0aQAhnTvfP/z3vVSN6ZypH5bfUNwFXXjRQtUEBNFd2PtmCmG2Py3qQ=="
+				},
+				"@babel/template": {
+					"version": "7.10.1",
+					"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.10.1.tgz",
+					"integrity": "sha512-OQDg6SqvFSsc9A0ej6SKINWrpJiNonRIniYondK2ViKhB06i3c0s+76XUft71iqBEe9S1OKsHwPAjfHnuvnCig==",
+					"requires": {
+						"@babel/code-frame": "^7.10.1",
+						"@babel/parser": "^7.10.1",
+						"@babel/types": "^7.10.1"
+					}
+				},
+				"@babel/traverse": {
+					"version": "7.10.1",
+					"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.10.1.tgz",
+					"integrity": "sha512-C/cTuXeKt85K+p08jN6vMDz8vSV0vZcI0wmQ36o6mjbuo++kPMdpOYw23W2XH04dbRt9/nMEfA4W3eR21CD+TQ==",
+					"requires": {
+						"@babel/code-frame": "^7.10.1",
+						"@babel/generator": "^7.10.1",
+						"@babel/helper-function-name": "^7.10.1",
+						"@babel/helper-split-export-declaration": "^7.10.1",
+						"@babel/parser": "^7.10.1",
+						"@babel/types": "^7.10.1",
+						"debug": "^4.1.0",
+						"globals": "^11.1.0",
+						"lodash": "^4.17.13"
+					}
+				},
+				"@babel/types": {
+					"version": "7.10.2",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.10.2.tgz",
+					"integrity": "sha512-AD3AwWBSz0AWF0AkCN9VPiWrvldXq+/e3cHa4J89vo4ymjz1XwrBFFVZmkJTsQIPNk+ZVomPSXUJqq8yyjZsng==",
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.10.1",
+						"lodash": "^4.17.13",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"debug": {
+					"version": "4.1.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+					"requires": {
+						"ms": "^2.1.1"
+					}
+				},
+				"ms": {
+					"version": "2.1.2",
+					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+				}
+			}
+		},
 		"@babel/plugin-transform-unicode-regex": {
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-unicode-regex/-/plugin-transform-unicode-regex-7.8.3.tgz",
@@ -1052,6 +1224,22 @@
 				"@babel/plugin-transform-react-jsx-source": "^7.9.0"
 			}
 		},
+		"@babel/preset-typescript": {
+			"version": "7.10.1",
+			"resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.10.1.tgz",
+			"integrity": "sha512-m6GV3y1ShiqxnyQj10600ZVOFrSSAa8HQ3qIUk2r+gcGtHTIRw0dJnFLt1WNXpKjtVw7yw1DAPU/6ma2ZvgJuA==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.10.1",
+				"@babel/plugin-transform-typescript": "^7.10.1"
+			},
+			"dependencies": {
+				"@babel/helper-plugin-utils": {
+					"version": "7.10.1",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.10.1.tgz",
+					"integrity": "sha512-fvoGeXt0bJc7VMWZGCAEBEMo/HAjW2mP8apF5eXK0wSqwLAVHAISCWRoLMBMUs2kqeaG77jltVqu4Hn8Egl3nA=="
+				}
+			}
+		},
 		"@babel/register": {
 			"version": "7.9.0",
 			"resolved": "https://registry.npmjs.org/@babel/register/-/register-7.9.0.tgz",
@@ -1097,7 +1285,6 @@
 			"version": "7.8.6",
 			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
 			"integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
-			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.8.3",
 				"@babel/parser": "^7.8.6",
@@ -1108,7 +1295,6 @@
 			"version": "7.9.5",
 			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.9.5.tgz",
 			"integrity": "sha512-c4gH3jsvSuGUezlP6rzSJ6jf8fYjLj3hsMZRx/nX0h+fmHN0w+ekubRrHPqnMec0meycA2nwCsJ7dC8IPem2FQ==",
-			"dev": true,
 			"requires": {
 				"@babel/code-frame": "^7.8.3",
 				"@babel/generator": "^7.9.5",
@@ -1125,7 +1311,6 @@
 					"version": "4.1.1",
 					"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
 					"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
-					"dev": true,
 					"requires": {
 						"ms": "^2.1.1"
 					}
@@ -1133,8 +1318,7 @@
 				"ms": {
 					"version": "2.1.2",
 					"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
-					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
-					"dev": true
+					"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 				}
 			}
 		},
@@ -1205,6 +1389,11 @@
 			"version": "0.2.5",
 			"resolved": "https://registry.npmjs.org/@emotion/weak-memoize/-/weak-memoize-0.2.5.tgz",
 			"integrity": "sha512-6U71C2Wp7r5XtFtQzYrW5iKFT67OixrSxjI4MptCHzdSVlgabczzqLe0ZSgnub/5Kp4hSbpDB1tMytZY9pwxxA=="
+		},
+		"@hapi/bourne": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.0.0.tgz",
+			"integrity": "sha512-WEezM1FWztfbzqIUbsDzFRVMxSoLy3HugVcux6KDDtTqzPsLE8NDRHfXvev66aH1i2oOKKar3/XDjbvh/OUBdg=="
 		},
 		"@hot-loader/react-dom": {
 			"version": "16.13.0",
@@ -1283,11 +1472,291 @@
 			"resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-2.0.1.tgz",
 			"integrity": "sha512-xwD6kOokWvaygxF0T2gnf77HEu68G7EXr1ZrNiNtZzg80Y1V2hikhUNoESWij6g/A6qJZvAiwpseflVo3PnlHQ=="
 		},
+		"@leafygreen-ui/syntax": {
+			"version": "2.7.0",
+			"resolved": "https://registry.npmjs.org/@leafygreen-ui/syntax/-/syntax-2.7.0.tgz",
+			"integrity": "sha512-bQRIFKPUwZsne39R49eQN5qEl556w88N/FjJfzAU/LjR2OVp+W5sWhx1PiacwCq+J1r/7wu/PKUh5rV/dpSgmQ==",
+			"requires": {
+				"@leafygreen-ui/lib": "^4.3.0",
+				"@leafygreen-ui/palette": "^2.0.1",
+				"highlight.js": "^9.15.6",
+				"highlightjs-graphql": "^1.0.1"
+			}
+		},
 		"@mongodb-js/triejs": {
 			"version": "0.1.5",
 			"resolved": "https://registry.npmjs.org/@mongodb-js/triejs/-/triejs-0.1.5.tgz",
 			"integrity": "sha512-elh8S1OxmEGe8/wbr6ky//dHhV2ld6oZV8/M9lgozJsL/6Aqm8j5+ElquzoX9k9l3Q+dohuX/SIGR/kTRZHS4g==",
 			"dev": true
+		},
+		"@mongosh/async-rewriter": {
+			"version": "0.0.2-alpha.0",
+			"resolved": "https://registry.npmjs.org/@mongosh/async-rewriter/-/async-rewriter-0.0.2-alpha.0.tgz",
+			"integrity": "sha512-36I7mx5MLeFMMw09/vMGbXowDpKO6TpOmu7sj0BLUpG6AnPhsAyFJLAyQteeZwWSgvtp2nl1Z9qr60Zj8LSBBg==",
+			"requires": {
+				"@babel/core": "^7.9.0",
+				"@babel/parser": "^7.9.4",
+				"@babel/preset-typescript": "^7.9.0",
+				"@babel/template": "^7.8.6",
+				"@babel/traverse": "^7.9.0",
+				"@babel/types": "^7.9.0",
+				"@mongosh/errors": "^0.0.2-alpha.0",
+				"@types/babel__core": "^7.1.6",
+				"@types/babel__traverse": "^7.0.9",
+				"acorn": "^7.2.0",
+				"acorn-class-fields": "^0.3.2",
+				"acorn-numeric-separator": "^0.3.2",
+				"acorn-private-methods": "^0.3.1",
+				"acorn-static-class-features": "^0.2.1",
+				"acorn-walk": "^7.1.1",
+				"ts-node": "^8.8.1",
+				"typescript": "^3.8.3"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.2.0.tgz",
+					"integrity": "sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ=="
+				},
+				"acorn-walk": {
+					"version": "7.1.1",
+					"resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-7.1.1.tgz",
+					"integrity": "sha512-wdlPY2tm/9XBr7QkKlq0WQVgiuGTX6YWPyRyBviSoScBuLfTVQhvwg6wJ369GJ/1nPfTLMfnrFIfjqVg6d+jQQ=="
+				}
+			}
+		},
+		"@mongosh/browser-repl": {
+			"version": "0.0.2-alpha.0",
+			"resolved": "https://registry.npmjs.org/@mongosh/browser-repl/-/browser-repl-0.0.2-alpha.0.tgz",
+			"integrity": "sha512-LFrV/cPh443eBFfHHkx9/TVmUf+0m7j+2h5GMF4eYTtSju+HptK7xjDaaikCq9pMDS2ZGjuS+LRHOyS+VlTWpA==",
+			"requires": {
+				"@babel/generator": "^7.8.3",
+				"@babel/parser": "^7.8.3",
+				"@babel/runtime": "^7.8.3",
+				"@babel/template": "^7.8.3",
+				"@leafygreen-ui/icon": "^4.0.0",
+				"@leafygreen-ui/palette": "^2.0.0",
+				"@leafygreen-ui/syntax": "^2.2.0",
+				"@mongosh/browser-runtime-core": "^0.0.2-alpha.0",
+				"@mongosh/history": "^0.0.2-alpha.0",
+				"@mongosh/i18n": "^0.0.2-alpha.0",
+				"@mongosh/service-provider-core": "^0.0.2-alpha.0",
+				"pretty-bytes": "^5.3.0",
+				"text-table": "^0.2.0"
+			},
+			"dependencies": {
+				"@leafygreen-ui/icon": {
+					"version": "4.3.0",
+					"resolved": "https://registry.npmjs.org/@leafygreen-ui/icon/-/icon-4.3.0.tgz",
+					"integrity": "sha512-6DOFKxj3U0hp2yQEq/Yq19qIiIIUXwRj2fH1ddOJFYLtAoeFOCSeuF6rE2dqXrXW/puQdjgpXV60w9J8gyXGog=="
+				},
+				"pretty-bytes": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.3.0.tgz",
+					"integrity": "sha512-hjGrh+P926p4R4WbaB6OckyRtO0F0/lQBiT+0gnxjV+5kjPBrfVBFCsCLbMqVQeydvIoouYTCmmEURiH3R1Bdg=="
+				}
+			}
+		},
+		"@mongosh/browser-runtime-core": {
+			"version": "0.0.2-alpha.0",
+			"resolved": "https://registry.npmjs.org/@mongosh/browser-runtime-core/-/browser-runtime-core-0.0.2-alpha.0.tgz",
+			"integrity": "sha512-NHeinaJU22M3PU8QoZZHh91ylXJFAt2oEe9GxYq3/Es/ZtcsEG/Cr93l4BOJVlOEtOWe/shj6ZCU1D8sScbmVA==",
+			"requires": {
+				"@babel/generator": "^7.9.4",
+				"@babel/parser": "^7.9.4",
+				"@mongosh/cli-repl": "^0.0.2-alpha.0",
+				"@mongosh/service-provider-core": "^0.0.2-alpha.0",
+				"@mongosh/shell-evaluator": "^0.0.2-alpha.0"
+			}
+		},
+		"@mongosh/browser-runtime-electron": {
+			"version": "0.0.2-alpha.0",
+			"resolved": "https://registry.npmjs.org/@mongosh/browser-runtime-electron/-/browser-runtime-electron-0.0.2-alpha.0.tgz",
+			"integrity": "sha512-BmE01Gt43iDJEXe5HXlegY1eiiFfExNig/oj2MPge2r+XGyYR2xVSw+4F9qlgXQsbU+mTtRk9NKqmA7jQFDAIw==",
+			"requires": {
+				"@mongosh/browser-runtime-core": "^0.0.2-alpha.0",
+				"@mongosh/service-provider-core": "^0.0.2-alpha.0"
+			}
+		},
+		"@mongosh/build": {
+			"version": "0.0.2-alpha.0",
+			"resolved": "https://registry.npmjs.org/@mongosh/build/-/build-0.0.2-alpha.0.tgz",
+			"integrity": "sha512-XH8KNxHDQhNNS2nAkDTNNdAP+DReEU8uX3Cks5iZgPdZPub8YM1sfM4piOJL2KSCXdBRDFNuO6enFu5ToNVvSw=="
+		},
+		"@mongosh/cli-repl": {
+			"version": "0.0.2-alpha.0",
+			"resolved": "https://registry.npmjs.org/@mongosh/cli-repl/-/cli-repl-0.0.2-alpha.0.tgz",
+			"integrity": "sha512-nAJCcrROO4lT6iSY3H13TA0s6srb+OJgo+VtuU6PhukOXPJ7QEjXmeaKRGE/eafddHpsg2XDtosDd2/8nO1jJg==",
+			"requires": {
+				"@mongosh/build": "^0.0.2-alpha.0",
+				"@mongosh/errors": "^0.0.2-alpha.0",
+				"@mongosh/history": "^0.0.2-alpha.0",
+				"@mongosh/i18n": "^0.0.2-alpha.0",
+				"@mongosh/service-provider-server": "^0.0.2-alpha.0",
+				"@mongosh/shell-api": "^0.0.2-alpha.0",
+				"@mongosh/shell-evaluator": "^0.0.2-alpha.0",
+				"acorn": "^7.1.1",
+				"acorn-class-fields": "^0.3.2",
+				"acorn-numeric-separator": "^0.3.0",
+				"acorn-private-methods": "^0.3.1",
+				"acorn-static-class-features": "^0.2.1",
+				"analytics-node": "^3.4.0-beta.1",
+				"ansi-escape-sequences": "^5.1.2",
+				"bson": "^4.0.4",
+				"is-recoverable-error": "^1.0.0",
+				"lodash.set": "^4.3.2",
+				"minimist": "^1.2.5",
+				"mkdirp": "^1.0.3",
+				"mongodb-ace-autocompleter": "^0.4.1",
+				"mongodb-build-info": "^1.1.0",
+				"mongodb-redact": "^0.2.0",
+				"nanobus": "^4.4.0",
+				"pino": "^5.16.0",
+				"pino-pretty": "^4.0.0",
+				"pretty-bytes": "^5.3.0",
+				"pretty-repl": "^2.3.0",
+				"read": "^1.0.7",
+				"semver": "^7.1.2",
+				"text-table": "^0.2.0"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.2.0.tgz",
+					"integrity": "sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ=="
+				},
+				"bson": {
+					"version": "4.0.4",
+					"resolved": "https://registry.npmjs.org/bson/-/bson-4.0.4.tgz",
+					"integrity": "sha512-Ioi3TD0/1V3aI8+hPfC56TetYmzfq2H07jJa9A1lKTxWsFtHtYdLMGMXjtGEg9v0f72NSM07diRQEUNYhLupIA==",
+					"requires": {
+						"buffer": "^5.1.0",
+						"long": "^4.0.0"
+					}
+				},
+				"buffer": {
+					"version": "5.6.0",
+					"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+					"integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+					"requires": {
+						"base64-js": "^1.0.2",
+						"ieee754": "^1.1.4"
+					}
+				},
+				"mkdirp": {
+					"version": "1.0.4",
+					"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
+					"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
+				},
+				"pretty-bytes": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.3.0.tgz",
+					"integrity": "sha512-hjGrh+P926p4R4WbaB6OckyRtO0F0/lQBiT+0gnxjV+5kjPBrfVBFCsCLbMqVQeydvIoouYTCmmEURiH3R1Bdg=="
+				},
+				"semver": {
+					"version": "7.3.2",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
+				}
+			}
+		},
+		"@mongosh/errors": {
+			"version": "0.0.2-alpha.0",
+			"resolved": "https://registry.npmjs.org/@mongosh/errors/-/errors-0.0.2-alpha.0.tgz",
+			"integrity": "sha512-nvCFRwAxVk/4lfarrcDyOnwbL6zi5659TbQi4LCDXMAhuDd0C1RqauhdX38hrR6N1twQ9VynmsZ53Dfb2O7l0A=="
+		},
+		"@mongosh/history": {
+			"version": "0.0.2-alpha.0",
+			"resolved": "https://registry.npmjs.org/@mongosh/history/-/history-0.0.2-alpha.0.tgz",
+			"integrity": "sha512-wGwJz6cqeZokLkZ7ukB5zrIxBrq7UIdhToF9qtV1Z9GZotZL7QIOsBXfREObb7XAQDOnQaXVyA5pLXO30FWYvg==",
+			"requires": {
+				"mongodb-redact": "^0.2.0"
+			}
+		},
+		"@mongosh/i18n": {
+			"version": "0.0.2-alpha.0",
+			"resolved": "https://registry.npmjs.org/@mongosh/i18n/-/i18n-0.0.2-alpha.0.tgz",
+			"integrity": "sha512-0bbI+ZK7ghWGixDeylNIG+GDuhydeK6YR3A/P2opGbGAeHFye53l7Bb8lWVFArcZQjCiRMdXqoqpbkKgC7tL4g==",
+			"requires": {
+				"mustache": "^4.0.0"
+			}
+		},
+		"@mongosh/mapper": {
+			"version": "0.0.2-alpha.0",
+			"resolved": "https://registry.npmjs.org/@mongosh/mapper/-/mapper-0.0.2-alpha.0.tgz",
+			"integrity": "sha512-QfdoumZnkqsb6M1F4ok3BwYc7R0tWyu/RzXXtvB34AwfY2aiZAYOtVtK7JMdHOCnqxjPKxByxq4DCwLJ7KpWDQ==",
+			"requires": {
+				"@mongosh/errors": "^0.0.2-alpha.0",
+				"@mongosh/service-provider-core": "^0.0.2-alpha.0",
+				"@mongosh/shell-api": "^0.0.2-alpha.0",
+				"pretty-bytes": "^5.3.0",
+				"text-table": "^0.2.0"
+			},
+			"dependencies": {
+				"pretty-bytes": {
+					"version": "5.3.0",
+					"resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.3.0.tgz",
+					"integrity": "sha512-hjGrh+P926p4R4WbaB6OckyRtO0F0/lQBiT+0gnxjV+5kjPBrfVBFCsCLbMqVQeydvIoouYTCmmEURiH3R1Bdg=="
+				}
+			}
+		},
+		"@mongosh/service-provider-core": {
+			"version": "0.0.2-alpha.0",
+			"resolved": "https://registry.npmjs.org/@mongosh/service-provider-core/-/service-provider-core-0.0.2-alpha.0.tgz",
+			"integrity": "sha512-MLWDNIMoZPvzpTQbufR0E2EBZm1x6YGpwcxeVgQc26KqlVpItz1uh3oZX0U7lVTIm1KF2MmCZkzlqEdT5PI8OA=="
+		},
+		"@mongosh/service-provider-server": {
+			"version": "0.0.2-alpha.0",
+			"resolved": "https://registry.npmjs.org/@mongosh/service-provider-server/-/service-provider-server-0.0.2-alpha.0.tgz",
+			"integrity": "sha512-7y+/uchFPK8Qfmk8a8sIbjukHj1kW5k3WfmxwlSY2cRM/YtRzkreFZPzcfFjqhyRFhrFDcz1jxmY24PlODRN0w==",
+			"requires": {
+				"@mongosh/errors": "^0.0.2-alpha.0",
+				"@mongosh/service-provider-core": "^0.0.2-alpha.0",
+				"@types/sinon": "^7.5.1",
+				"@types/sinon-chai": "^3.2.3",
+				"mongodb": "3.5.3 || ^3.5.5"
+			}
+		},
+		"@mongosh/shell-api": {
+			"version": "0.0.2-alpha.0",
+			"resolved": "https://registry.npmjs.org/@mongosh/shell-api/-/shell-api-0.0.2-alpha.0.tgz",
+			"integrity": "sha512-c3M7n6hFwX4pIr/LJOSgMoxsmi/mlLj44el55EaE9WKhhYsrUKRw0FFYKpISTfYpCdy84uayvlnsvw2fIi5dkg==",
+			"requires": {
+				"@mongosh/errors": "^0.0.2-alpha.0",
+				"@mongosh/i18n": "^0.0.2-alpha.0",
+				"bson": "^4.0.4"
+			},
+			"dependencies": {
+				"bson": {
+					"version": "4.0.4",
+					"resolved": "https://registry.npmjs.org/bson/-/bson-4.0.4.tgz",
+					"integrity": "sha512-Ioi3TD0/1V3aI8+hPfC56TetYmzfq2H07jJa9A1lKTxWsFtHtYdLMGMXjtGEg9v0f72NSM07diRQEUNYhLupIA==",
+					"requires": {
+						"buffer": "^5.1.0",
+						"long": "^4.0.0"
+					}
+				},
+				"buffer": {
+					"version": "5.6.0",
+					"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
+					"integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
+					"requires": {
+						"base64-js": "^1.0.2",
+						"ieee754": "^1.1.4"
+					}
+				}
+			}
+		},
+		"@mongosh/shell-evaluator": {
+			"version": "0.0.2-alpha.0",
+			"resolved": "https://registry.npmjs.org/@mongosh/shell-evaluator/-/shell-evaluator-0.0.2-alpha.0.tgz",
+			"integrity": "sha512-c5U4aNiLpGLTtE2oRe98MDLZ6ljiNA+vIYAdO/u7K3IIcUf7okiWBWiuKhZA6yptP7bxJHCV9E7na75nPu6nvQ==",
+			"requires": {
+				"@mongosh/async-rewriter": "^0.0.2-alpha.0",
+				"@mongosh/mapper": "^0.0.2-alpha.0",
+				"@mongosh/service-provider-core": "^0.0.2-alpha.0",
+				"@mongosh/shell-api": "^0.0.2-alpha.0"
+			}
 		},
 		"@nodelib/fs.scandir": {
 			"version": "2.1.3",
@@ -1313,6 +1782,15 @@
 			"requires": {
 				"@nodelib/fs.scandir": "2.1.3",
 				"fastq": "^1.6.0"
+			}
+		},
+		"@segment/loosely-validate-event": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@segment/loosely-validate-event/-/loosely-validate-event-2.0.0.tgz",
+			"integrity": "sha512-ZMCSfztDBqwotkl848ODgVcAmN4OItEWDCkshcKz0/W6gGSQayuuCtWV/MlodFivAZD793d6UgANd6wCXUfrIw==",
+			"requires": {
+				"component-type": "^1.2.1",
+				"join-component": "^1.1.0"
 			}
 		},
 		"@sheerun/mutationobserver-shim": {
@@ -1972,11 +2450,52 @@
 				"@testing-library/dom": "^5.6.1"
 			}
 		},
+		"@types/babel__core": {
+			"version": "7.1.8",
+			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.8.tgz",
+			"integrity": "sha512-KXBiQG2OXvaPWFPDS1rD8yV9vO0OuWIqAEqLsbfX0oU2REN5KuoMnZ1gClWcBhO5I3n6oTVAmrMufOvRqdmFTQ==",
+			"requires": {
+				"@babel/parser": "^7.1.0",
+				"@babel/types": "^7.0.0",
+				"@types/babel__generator": "*",
+				"@types/babel__template": "*",
+				"@types/babel__traverse": "*"
+			}
+		},
+		"@types/babel__generator": {
+			"version": "7.6.1",
+			"resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.1.tgz",
+			"integrity": "sha512-bBKm+2VPJcMRVwNhxKu8W+5/zT7pwNEqeokFOmbvVSqGzFneNxYcEBro9Ac7/N9tlsaPYnZLK8J1LWKkMsLAew==",
+			"requires": {
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@types/babel__template": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.0.2.tgz",
+			"integrity": "sha512-/K6zCpeW7Imzgab2bLkLEbz0+1JlFSrUMdw7KoIIu+IUdu51GWaBZpd3y1VXGVXzynvGa4DaIaxNZHiON3GXUg==",
+			"requires": {
+				"@babel/parser": "^7.1.0",
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@types/babel__traverse": {
+			"version": "7.0.12",
+			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.12.tgz",
+			"integrity": "sha512-t4CoEokHTfcyfb4hUaF9oOHu9RmmNWnm1CP0YmMqOOfClKascOmvlEM736vlqeScuGvBDsHkf8R2INd4DWreQA==",
+			"requires": {
+				"@babel/types": "^7.3.0"
+			}
+		},
+		"@types/chai": {
+			"version": "4.2.11",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.11.tgz",
+			"integrity": "sha512-t7uW6eFafjO+qJ3BIV2gGUyZs27egcNRkUdalkud+Qa3+kg//f129iuOFivHDXQ+vnU3fDXuwgv0cqMCbcE8sw=="
+		},
 		"@types/color-name": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/@types/color-name/-/color-name-1.1.1.tgz",
-			"integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ==",
-			"dev": true
+			"integrity": "sha512-rr+OQyAjxze7GgWrSaJwydHStIhHq2lvY3BOC2Mj7KnzI7XK0Uw1TOOdI9lDoajEbSWLiYgoo4f1R51erQfhPQ=="
 		},
 		"@types/events": {
 			"version": "3.0.0",
@@ -2033,6 +2552,20 @@
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/@types/parse-json/-/parse-json-4.0.0.tgz",
 			"integrity": "sha512-//oorEZjL6sbPcKUaCdIGlIUeH26mgzimjBB77G6XRgnDl/L5wOnpyBGRe/Mmf5CVW3PwEBE1NjiMZ/ssFh4wA=="
+		},
+		"@types/sinon": {
+			"version": "7.5.2",
+			"resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-7.5.2.tgz",
+			"integrity": "sha512-T+m89VdXj/eidZyejvmoP9jivXgBDdkOSBVQjU9kF349NEx10QdPNGxHeZUaj1IlJ32/ewdyXJjnJxyxJroYwg=="
+		},
+		"@types/sinon-chai": {
+			"version": "3.2.4",
+			"resolved": "https://registry.npmjs.org/@types/sinon-chai/-/sinon-chai-3.2.4.tgz",
+			"integrity": "sha512-xq5KOWNg70PRC7dnR2VOxgYQ6paumW+4pTZP+6uTSdhpYsAUEeeT5bw6rRHHQrZ4KyR+M5ojOR+lje6TGSpUxA==",
+			"requires": {
+				"@types/chai": "*",
+				"@types/sinon": "*"
+			}
 		},
 		"@types/yargs": {
 			"version": "13.0.9",
@@ -2300,6 +2833,14 @@
 			"integrity": "sha512-1D++VG7BhrtvQpNbBzovKNc1FLGGEE/oGe7b9xJm/RFHMBeUaUGpluV9RLjZa47YFdPcDAenEYuq9pQPcMdLJg==",
 			"dev": true
 		},
+		"acorn-class-fields": {
+			"version": "0.3.4",
+			"resolved": "https://registry.npmjs.org/acorn-class-fields/-/acorn-class-fields-0.3.4.tgz",
+			"integrity": "sha512-yqUCIu0UJHFmCVhH3Cq29UR+3OJo1CtNWf1ncxTf3KfdEDt7aD0iVYmX7UN+RvIHyOsgukzplQhNkgePtASLUw==",
+			"requires": {
+				"acorn-private-class-elements": "^0.2.5"
+			}
+		},
 		"acorn-dynamic-import": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz",
@@ -2364,6 +2905,32 @@
 					"integrity": "sha512-wdlPY2tm/9XBr7QkKlq0WQVgiuGTX6YWPyRyBviSoScBuLfTVQhvwg6wJ369GJ/1nPfTLMfnrFIfjqVg6d+jQQ==",
 					"dev": true
 				}
+			}
+		},
+		"acorn-numeric-separator": {
+			"version": "0.3.2",
+			"resolved": "https://registry.npmjs.org/acorn-numeric-separator/-/acorn-numeric-separator-0.3.2.tgz",
+			"integrity": "sha512-ZNN1qnKvjWycDSQBfuD1TCiB81ItjjeGUPLHuqfP8X8HXwAodGTWsAaqSOQ1Nc9t+Wlb3tcEFdBrwUFUIzDiiA=="
+		},
+		"acorn-private-class-elements": {
+			"version": "0.2.5",
+			"resolved": "https://registry.npmjs.org/acorn-private-class-elements/-/acorn-private-class-elements-0.2.5.tgz",
+			"integrity": "sha512-3eApRrJmPjaxWB3XidP8YMeVq9pcswPFE0KsSWVuhceCU68ZS8fkcf0fTXGhCmnNd7n48NWWV27EKMFPeCoJLg=="
+		},
+		"acorn-private-methods": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/acorn-private-methods/-/acorn-private-methods-0.3.1.tgz",
+			"integrity": "sha512-IV5XZInFQaQK5ucjJy/HAk2UYvt+Buax00evzwo8NSuo8zhOBhW5v6VOjAljYUhAzQ/Hosi+Kaz6xJmvPiSM4Q==",
+			"requires": {
+				"acorn-private-class-elements": "^0.2.4"
+			}
+		},
+		"acorn-static-class-features": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/acorn-static-class-features/-/acorn-static-class-features-0.2.2.tgz",
+			"integrity": "sha512-B7aWeS7MXqdgP3RnettN/CFz7HevAlQWfh5zkc3LJzeCQoF1InTzYBCfkkbmit1p0pmCEB8IG05gB62pOm5lvA==",
+			"requires": {
+				"acorn-private-class-elements": "^0.2.3"
 			}
 		},
 		"acorn-walk": {
@@ -2628,11 +3195,46 @@
 				}
 			}
 		},
+		"analytics-node": {
+			"version": "3.4.0-beta.1",
+			"resolved": "https://registry.npmjs.org/analytics-node/-/analytics-node-3.4.0-beta.1.tgz",
+			"integrity": "sha512-+0F/y4Asc5S2qhWcYss+iCob6TTXQktwbqlIk02gcZaRxpekCbnTbJu/rcaRooVHxqp9WSzUXiWCesJYPJETZQ==",
+			"requires": {
+				"@segment/loosely-validate-event": "^2.0.0",
+				"axios": "^0.18.1",
+				"axios-retry": "^3.0.2",
+				"lodash.isstring": "^4.0.1",
+				"md5": "^2.2.1",
+				"ms": "^2.0.0",
+				"remove-trailing-slash": "^0.1.0",
+				"uuid": "^3.2.1"
+			},
+			"dependencies": {
+				"lodash.isstring": {
+					"version": "4.0.1",
+					"resolved": "https://registry.npmjs.org/lodash.isstring/-/lodash.isstring-4.0.1.tgz",
+					"integrity": "sha1-1SfftUVuynzJu5XV2ur4i6VKVFE="
+				}
+			}
+		},
+		"ansi": {
+			"version": "0.3.1",
+			"resolved": "https://registry.npmjs.org/ansi/-/ansi-0.3.1.tgz",
+			"integrity": "sha1-DELU+xcWDVqa8eSEus4cZpIsGyE="
+		},
 		"ansi-colors": {
 			"version": "3.2.4",
 			"resolved": "https://registry.npmjs.org/ansi-colors/-/ansi-colors-3.2.4.tgz",
 			"integrity": "sha512-hHUXGagefjN2iRrID63xckIvotOXOojhQKWIPUZ4mNUZ9nLZW+7FMNoE1lOkEhNWYsx/7ysGIuJYCiMAA9FnrA==",
 			"dev": true
+		},
+		"ansi-escape-sequences": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/ansi-escape-sequences/-/ansi-escape-sequences-5.1.2.tgz",
+			"integrity": "sha512-JcpoVp1W1bl1Qn4cVuiXEhD6+dyXKSOgCn2zlzE8inYgCJCBy1aPnUhlz6I4DFum8D4ovb9Qi/iAjUcGvG2lqw==",
+			"requires": {
+				"array-back": "^4.0.0"
+			}
 		},
 		"ansi-escapes": {
 			"version": "3.2.0",
@@ -2697,6 +3299,11 @@
 				"readable-stream": "^2.0.6"
 			}
 		},
+		"arg": {
+			"version": "4.1.3",
+			"resolved": "https://registry.npmjs.org/arg/-/arg-4.1.3.tgz",
+			"integrity": "sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA=="
+		},
 		"argparse": {
 			"version": "1.0.10",
 			"resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
@@ -2704,6 +3311,29 @@
 			"dev": true,
 			"requires": {
 				"sprintf-js": "~1.0.2"
+			}
+		},
+		"args": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/args/-/args-5.0.1.tgz",
+			"integrity": "sha512-1kqmFCFsPffavQFGt8OxJdIcETti99kySRUPMpOhaGjL6mRJn8HFU1OxKY5bMqfZKUwTQc1mZkAjmGYaVOHFtQ==",
+			"requires": {
+				"camelcase": "5.0.0",
+				"chalk": "2.4.2",
+				"leven": "2.1.0",
+				"mri": "1.1.4"
+			},
+			"dependencies": {
+				"camelcase": {
+					"version": "5.0.0",
+					"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
+					"integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA=="
+				},
+				"leven": {
+					"version": "2.1.0",
+					"resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+					"integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA="
+				}
 			}
 		},
 		"aria-query": {
@@ -2739,6 +3369,11 @@
 			"resolved": "https://registry.npmjs.org/arr-union/-/arr-union-3.1.0.tgz",
 			"integrity": "sha1-45sJrqne+Gao8gbiiK9jkZuuOcQ=",
 			"dev": true
+		},
+		"array-back": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.1.tgz",
+			"integrity": "sha512-Z/JnaVEXv+A9xabHzN43FiiiWEE7gPCRXMrVmRm00tWbjZRul1iHm7ECzlyNq1p4a4ATXz+G9FJ3GqGOkOV3fg=="
 		},
 		"array-equal": {
 			"version": "1.0.0",
@@ -3048,6 +3683,11 @@
 			"integrity": "sha512-Wm6ukoaOGJi/73p/cl2GvLjTI5JM1k/O14isD73YML8StrH/7/lRFgmg8nICZgD3bZZvjwCGxtMOD3wWNAu8cg==",
 			"dev": true
 		},
+		"atomic-sleep": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",
+			"integrity": "sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ=="
+		},
 		"autoprefixer": {
 			"version": "9.7.6",
 			"resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-9.7.6.tgz",
@@ -3108,6 +3748,46 @@
 			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
 			"integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug==",
 			"dev": true
+		},
+		"axios": {
+			"version": "0.18.1",
+			"resolved": "https://registry.npmjs.org/axios/-/axios-0.18.1.tgz",
+			"integrity": "sha512-0BfJq4NSfQXd+SkFdrvFbG7addhYSBA2mQwISr46pD6E5iqkWg02RAs8vyTT/j0RTnoYmeXauBuSv1qKwR179g==",
+			"requires": {
+				"follow-redirects": "1.5.10",
+				"is-buffer": "^2.0.2"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+					"integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+					"requires": {
+						"ms": "2.0.0"
+					}
+				},
+				"follow-redirects": {
+					"version": "1.5.10",
+					"resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+					"integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+					"requires": {
+						"debug": "=3.1.0"
+					}
+				},
+				"is-buffer": {
+					"version": "2.0.4",
+					"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
+					"integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
+				}
+			}
+		},
+		"axios-retry": {
+			"version": "3.1.8",
+			"resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.1.8.tgz",
+			"integrity": "sha512-yPw5Y4Bg6Dgmhm35KaJFtlh23s1TecW0HsUerK4/IS1UKl0gtN2aJqdEKtVomiOS/bDo5w4P3sqgki/M10eF8Q==",
+			"requires": {
+				"is-retry-allowed": "^1.1.0"
+			}
 		},
 		"babel-code-frame": {
 			"version": "6.26.0",
@@ -4675,8 +5355,7 @@
 		"base64-js": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g==",
-			"dev": true
+			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
 		},
 		"base64id": {
 			"version": "1.0.0",
@@ -4756,7 +5435,6 @@
 			"version": "2.2.0",
 			"resolved": "https://registry.npmjs.org/bl/-/bl-2.2.0.tgz",
 			"integrity": "sha512-wbgvOpqopSr7uq6fJrLH8EsvYMJf9gzfo2jCsL2eTy75qXPukA4pCgHamOQkZtY5vmfVtjB+P3LNlMHW5CEZXA==",
-			"dev": true,
 			"requires": {
 				"readable-stream": "^2.3.5",
 				"safe-buffer": "^5.1.1"
@@ -5019,8 +5697,7 @@
 		"bson": {
 			"version": "1.1.4",
 			"resolved": "https://registry.npmjs.org/bson/-/bson-1.1.4.tgz",
-			"integrity": "sha512-S/yKGU1syOMzO86+dGpg2qGoDL0zvzcb262G+gqEy6TgP6rt6z6qxSFX/8X6vLC91P7G7C3nLs0+bvDzmvBA3Q==",
-			"dev": true
+			"integrity": "sha512-S/yKGU1syOMzO86+dGpg2qGoDL0zvzcb262G+gqEy6TgP6rt6z6qxSFX/8X6vLC91P7G7C3nLs0+bvDzmvBA3Q=="
 		},
 		"buffer": {
 			"version": "4.9.2",
@@ -5064,8 +5741,7 @@
 		"buffer-from": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.1.tgz",
-			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A==",
-			"dev": true
+			"integrity": "sha512-MQcXEUbCKtEo7bhqEs6560Hyd4XaovZlO/k9V3hjVUF/zwW7KBVdSK4gIt/bzwS9MbR5qob+F5jusZsb0YQK2A=="
 		},
 		"buffer-indexof": {
 			"version": "1.1.1",
@@ -5312,6 +5988,11 @@
 			"resolved": "https://registry.npmjs.org/chardet/-/chardet-0.4.2.tgz",
 			"integrity": "sha1-tUc7M9yXxCTl2Y3IfVXU2KKci/I=",
 			"dev": true
+		},
+		"charenc": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+			"integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
 		},
 		"check-error": {
 			"version": "1.0.2",
@@ -5697,6 +6378,11 @@
 			"integrity": "sha1-ZF/ErfWLcrZJ1crmUTVhnbJv8UM=",
 			"dev": true
 		},
+		"component-type": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/component-type/-/component-type-1.2.1.tgz",
+			"integrity": "sha1-ikeQFwAjjk/DIml3EjAibyS0Fak="
+		},
 		"compressible": {
 			"version": "2.0.18",
 			"resolved": "https://registry.npmjs.org/compressible/-/compressible-2.0.18.tgz",
@@ -6027,6 +6713,11 @@
 				"shebang-command": "^1.2.0",
 				"which": "^1.2.9"
 			}
+		},
+		"crypt": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+			"integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
 		},
 		"cryptiles": {
 			"version": "2.0.5",
@@ -6412,6 +7103,11 @@
 			"integrity": "sha512-bYQuGLeFxhkxNOF3rcMtiZxvCBAquGzZm6oWA1oZ0g2THUzivaRhv8uOhdr19LmoobSOLoIAxeUK2RdbM8IFTA==",
 			"dev": true
 		},
+		"dateformat": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
+			"integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q=="
+		},
 		"debug": {
 			"version": "3.2.6",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-3.2.6.tgz",
@@ -6703,8 +7399,7 @@
 		"denque": {
 			"version": "1.4.1",
 			"resolved": "https://registry.npmjs.org/denque/-/denque-1.4.1.tgz",
-			"integrity": "sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ==",
-			"dev": true
+			"integrity": "sha512-OfzPuSZKGcgr96rf1oODnfjqBFmr1DVoc/TrItj3Ohe0Ah1C5WX5Baquw/9U9KovnQ88EqmJbD66rKYUQYN1tQ=="
 		},
 		"depd": {
 			"version": "1.1.2",
@@ -7782,6 +8477,67 @@
 				"create-emotion": "^10.0.27"
 			}
 		},
+		"emphasize": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/emphasize/-/emphasize-3.0.0.tgz",
+			"integrity": "sha512-xhtAWvxdkxsQbcCLGVjlfB7cQ4bWSPYXeaGDwK5Bl7n2y/9R+MVK5UNBTmZ9N8m/YShsiyGgQBgFGcjOWCWXHQ==",
+			"requires": {
+				"chalk": "^3.0.0",
+				"highlight.js": "~9.12.0",
+				"lowlight": "~1.9.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+				},
+				"highlight.js": {
+					"version": "9.12.0",
+					"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.12.0.tgz",
+					"integrity": "sha1-5tnb5Xy+/mB1HwKvM2GVhwyQwB4="
+				},
+				"supports-color": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
+		},
 		"encodeurl": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/encodeurl/-/encodeurl-1.0.2.tgz",
@@ -7801,7 +8557,6 @@
 			"version": "1.4.4",
 			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
 			"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
-			"dev": true,
 			"requires": {
 				"once": "^1.4.0"
 			}
@@ -9045,6 +9800,16 @@
 			"integrity": "sha512-Ue0LwpDYErFbmNnZSF0UH6eImUwDmogUO1jyE+JbN2gsQz/jICm1Ve7t9QT0rNSsfJt+Hs4/S3GnsDVjL4HVrw==",
 			"dev": true
 		},
+		"fast-redact": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/fast-redact/-/fast-redact-2.0.0.tgz",
+			"integrity": "sha512-zxpkULI9W9MNTK2sJ3BpPQrTEXFNESd2X6O1tXMFpK/XM0G5c5Rll2EVYZH2TqI3xRGK/VaJ+eEOt7pnENJpeA=="
+		},
+		"fast-safe-stringify": {
+			"version": "2.0.7",
+			"resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.0.7.tgz",
+			"integrity": "sha512-Utm6CdzT+6xsDk2m8S6uL8VHxNwI6Jub+e9NYTcAms28T84pTa25GJQV9j0CY0N1rM8hK4x6grpF2BQf+2qwVA=="
+		},
 		"fastparse": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/fastparse/-/fastparse-1.1.2.tgz",
@@ -9058,6 +9823,14 @@
 			"dev": true,
 			"requires": {
 				"reusify": "^1.0.4"
+			}
+		},
+		"fault": {
+			"version": "1.0.4",
+			"resolved": "https://registry.npmjs.org/fault/-/fault-1.0.4.tgz",
+			"integrity": "sha512-CJ0HCB5tL5fYTEA7ToAq5+kTwd++Borf1/bifxd9iT70QcXr4MRrO3Llf8Ifs70q+SJcGHFtnIE/Nw6giCtECA==",
+			"requires": {
+				"format": "^0.2.0"
 			}
 		},
 		"faye-websocket": {
@@ -9287,6 +10060,11 @@
 				}
 			}
 		},
+		"flatstr": {
+			"version": "1.0.12",
+			"resolved": "https://registry.npmjs.org/flatstr/-/flatstr-1.0.12.tgz",
+			"integrity": "sha512-4zPxDyhCyiN2wIAtSLI6gc82/EjqZc1onI4Mz/l0pWrAlsSfYH/2ZIcU+e3oA2wDwbzIWNKwa23F8rh6+DRWkw=="
+		},
 		"flatted": {
 			"version": "2.0.2",
 			"resolved": "https://registry.npmjs.org/flatted/-/flatted-2.0.2.tgz",
@@ -9346,6 +10124,11 @@
 				"combined-stream": "^1.0.6",
 				"mime-types": "^2.1.12"
 			}
+		},
+		"format": {
+			"version": "0.2.2",
+			"resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
+			"integrity": "sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs="
 		},
 		"forwarded": {
 			"version": "0.1.2",
@@ -10039,8 +10822,7 @@
 		"gensync": {
 			"version": "1.0.0-beta.1",
 			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
-			"integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg==",
-			"dev": true
+			"integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg=="
 		},
 		"get-amd-module-type": {
 			"version": "3.0.0",
@@ -10221,8 +11003,7 @@
 		"globals": {
 			"version": "11.12.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-			"dev": true
+			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
 		},
 		"globalthis": {
 			"version": "1.0.1",
@@ -10360,6 +11141,12 @@
 					"dev": true
 				}
 			}
+		},
+		"hadron-react-buttons": {
+			"version": "4.0.4",
+			"resolved": "https://registry.npmjs.org/hadron-react-buttons/-/hadron-react-buttons-4.0.4.tgz",
+			"integrity": "sha512-TLTtgayqBxitGEEMc04Ori1mF0fsFnFkAweAgSnZOkX7apAl1bS6l6eSPR4M/0vsIIkBIIh7ZDcUbdeSe40BiA==",
+			"dev": true
 		},
 		"handle-thing": {
 			"version": "2.0.1",
@@ -10511,6 +11298,16 @@
 			"resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
 			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
 			"dev": true
+		},
+		"highlight.js": {
+			"version": "9.18.1",
+			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.18.1.tgz",
+			"integrity": "sha512-OrVKYz70LHsnCgmbXctv/bfuvntIKDz177h0Co37DQ5jamGZLVmoCVMtjMtNZY3X9DrCcKfklHPNeA0uPZhSJg=="
+		},
+		"highlightjs-graphql": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/highlightjs-graphql/-/highlightjs-graphql-1.0.1.tgz",
+			"integrity": "sha512-g5kt/orsUJTjIt5pgs/uvi78kXndpCtYwzE7H3D0d07r3ETs9oHSZHD0EGaRPndiQ/4EYXt12rnsDkljn3ilAA=="
 		},
 		"hmac-drbg": {
 			"version": "1.0.1",
@@ -10970,8 +11767,7 @@
 		"ieee754": {
 			"version": "1.1.13",
 			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-			"integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==",
-			"dev": true
+			"integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
 		},
 		"iferr": {
 			"version": "0.1.5",
@@ -11291,8 +12087,7 @@
 		"is-buffer": {
 			"version": "1.1.6",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
-			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==",
-			"dev": true
+			"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
 		},
 		"is-callable": {
 			"version": "1.1.5",
@@ -11492,6 +12287,25 @@
 			"integrity": "sha1-eaKp7OfwlugPNtKy87wWwf9L8/o=",
 			"dev": true
 		},
+		"is-recoverable-error": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/is-recoverable-error/-/is-recoverable-error-1.0.1.tgz",
+			"integrity": "sha512-1v/3hIRd0hHzkmq9TU+otd8SlUJjr60KyX6RfgwJ6NVbeQafc3POajWZ/BcusPxhdX0ScN3xE9tTnn6xGpC3LA==",
+			"requires": {
+				"acorn": "^7.1.1",
+				"acorn-class-fields": "^0.3.2",
+				"acorn-numeric-separator": "^0.3.1",
+				"acorn-private-methods": "^0.3.1",
+				"acorn-static-class-features": "^0.2.1"
+			},
+			"dependencies": {
+				"acorn": {
+					"version": "7.2.0",
+					"resolved": "https://registry.npmjs.org/acorn/-/acorn-7.2.0.tgz",
+					"integrity": "sha512-apwXVmYVpQ34m/i71vrApRrRKCWQnZZF1+npOD0WV5xZFfwWOmKGQ2RWlfdy9vWITsenisM8M0Qeq8agcFHNiQ=="
+				}
+			}
+		},
 		"is-regex": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.5.tgz",
@@ -11509,6 +12323,11 @@
 			"requires": {
 				"is-unc-path": "^1.0.0"
 			}
+		},
+		"is-retry-allowed": {
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
+			"integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg=="
 		},
 		"is-root": {
 			"version": "1.0.0",
@@ -11729,6 +12548,21 @@
 				"iterate-iterator": "^1.0.1"
 			}
 		},
+		"jmespath": {
+			"version": "0.15.0",
+			"resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+			"integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc="
+		},
+		"join-component": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/join-component/-/join-component-1.1.0.tgz",
+			"integrity": "sha1-uEF7dQZho5K+4sJTfGiyqdSXfNU="
+		},
+		"joycon": {
+			"version": "2.2.5",
+			"resolved": "https://registry.npmjs.org/joycon/-/joycon-2.2.5.tgz",
+			"integrity": "sha512-YqvUxoOcVPnCp0VU1/56f+iKSdvIRJYPznH22BdXV3xMk75SFXhWeJkZ8C9XxUWt1b5x2X1SxuFygW1U0FmkEQ=="
+		},
 		"js-base64": {
 			"version": "2.5.2",
 			"resolved": "https://registry.npmjs.org/js-base64/-/js-base64-2.5.2.tgz",
@@ -11813,8 +12647,7 @@
 		"jsesc": {
 			"version": "2.5.2",
 			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-			"dev": true
+			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
 		},
 		"json-loader": {
 			"version": "0.5.7",
@@ -11871,7 +12704,6 @@
 			"version": "2.1.3",
 			"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
 			"integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
-			"dev": true,
 			"requires": {
 				"minimist": "^1.2.5"
 			}
@@ -13113,6 +13945,11 @@
 				"lodash.isfunction": "^3.0.0"
 			}
 		},
+		"lodash.set": {
+			"version": "4.3.2",
+			"resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
+			"integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
+		},
 		"lodash.some": {
 			"version": "4.6.0",
 			"resolved": "https://registry.npmjs.org/lodash.some/-/lodash.some-4.6.0.tgz",
@@ -13211,8 +14048,7 @@
 		"long": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-			"integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
-			"dev": true
+			"integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
 		},
 		"longest": {
 			"version": "1.0.1",
@@ -13245,6 +14081,22 @@
 			"integrity": "sha1-miyr0bno4K6ZOkv31YdcOcQujqw=",
 			"dev": true
 		},
+		"lowlight": {
+			"version": "1.9.2",
+			"resolved": "https://registry.npmjs.org/lowlight/-/lowlight-1.9.2.tgz",
+			"integrity": "sha512-Ek18ElVCf/wF/jEm1b92gTnigh94CtBNWiZ2ad+vTgW7cTmQxUY3I98BjHK68gZAJEWmybGBZgx9qv3QxLQB/Q==",
+			"requires": {
+				"fault": "^1.0.2",
+				"highlight.js": "~9.12.0"
+			},
+			"dependencies": {
+				"highlight.js": {
+					"version": "9.12.0",
+					"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.12.0.tgz",
+					"integrity": "sha1-5tnb5Xy+/mB1HwKvM2GVhwyQwB4="
+				}
+			}
+		},
 		"lru-cache": {
 			"version": "4.1.5",
 			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.5.tgz",
@@ -13268,8 +14120,7 @@
 		"make-error": {
 			"version": "1.3.6",
 			"resolved": "https://registry.npmjs.org/make-error/-/make-error-1.3.6.tgz",
-			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==",
-			"dev": true
+			"integrity": "sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw=="
 		},
 		"map-age-cleaner": {
 			"version": "0.1.3",
@@ -13339,6 +14190,16 @@
 			"integrity": "sha512-L0j0tFVZBQQLeEjmWOvDLoRciIY8gQGWahvkztXUal8jH8R5Rlqo9GCvgqvXcy9LQhEWdQCVvzqAbxgYNt4blQ==",
 			"dev": true
 		},
+		"md5": {
+			"version": "2.2.1",
+			"resolved": "https://registry.npmjs.org/md5/-/md5-2.2.1.tgz",
+			"integrity": "sha1-U6s41f48iJG6RlMp6iP6wFQBJvk=",
+			"requires": {
+				"charenc": "~0.0.1",
+				"crypt": "~0.0.1",
+				"is-buffer": "~1.1.1"
+			}
+		},
 		"md5.js": {
 			"version": "1.3.5",
 			"resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.5.tgz",
@@ -13385,7 +14246,6 @@
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
 			"integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
-			"dev": true,
 			"optional": true
 		},
 		"meow": {
@@ -14255,7 +15115,6 @@
 			"version": "3.5.6",
 			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-3.5.6.tgz",
 			"integrity": "sha512-sh3q3GLDLT4QmoDLamxtAECwC3RGjq+oNuK1ENV8+tnipIavss6sMYt77hpygqlMOCt0Sla5cl7H4SKCVBCGEg==",
-			"dev": true,
 			"requires": {
 				"bl": "^2.2.0",
 				"bson": "^1.1.4",
@@ -14264,6 +15123,26 @@
 				"safe-buffer": "^5.1.2",
 				"saslprep": "^1.0.0"
 			}
+		},
+		"mongodb-ace-autocompleter": {
+			"version": "0.4.9",
+			"resolved": "https://registry.npmjs.org/mongodb-ace-autocompleter/-/mongodb-ace-autocompleter-0.4.9.tgz",
+			"integrity": "sha512-N920FVjKXTWHhZIUcG230AL2ZCEr4yYWguI3+qrDBs2FCPMIKX7ARm9MSZjnzaIxpvaAuv4K2RhgFQQ9XIVCmw==",
+			"requires": {
+				"semver": "^7.1.1"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "7.3.2",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
+				}
+			}
+		},
+		"mongodb-build-info": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/mongodb-build-info/-/mongodb-build-info-1.1.0.tgz",
+			"integrity": "sha512-ZlbQlpXv8DCvYK2I6UmyRO4z9zb4fyoph+RhEN/MSSsigaqcfl6dePkbgavemquvuKVEq0BbIiVkHw1DKwChxA=="
 		},
 		"mongodb-collection-sample": {
 			"version": "4.5.1",
@@ -14976,6 +15855,14 @@
 			"integrity": "sha512-sch/9jd74VjRCmB5U+Fj4WJnkmAtDQgxqJkBInO7zEknXE+lnDEuNBT5/Wp59HMrWUabssGGq08r6Y6F7pkvVA==",
 			"dev": true
 		},
+		"mongodb-redact": {
+			"version": "0.2.0",
+			"resolved": "https://registry.npmjs.org/mongodb-redact/-/mongodb-redact-0.2.0.tgz",
+			"integrity": "sha512-kGoR02HsTzNYHFXLklvbEg7mSJZu5+L1JdaYUuSlmVUAXxzhxUBvoFoYulfqqvokE+ilAXGYywdMJStB0lPhCw==",
+			"requires": {
+				"lodash": "^4.17.15"
+			}
+		},
 		"mongodb-reflux-store": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/mongodb-reflux-store/-/mongodb-reflux-store-0.0.1.tgz",
@@ -15057,11 +15944,15 @@
 				"run-queue": "^1.0.3"
 			}
 		},
+		"mri": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/mri/-/mri-1.1.4.tgz",
+			"integrity": "sha512-6y7IjGPm8AzlvoUrwAaw1tLnUBudaS3752vcd8JtrpGGQn+rXIe63LFVHm/YMwtqAuh+LJPCFdlLYPWM1nYn6w=="
+		},
 		"ms": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-			"dev": true
+			"integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
 		},
 		"multicast-dns": {
 			"version": "6.2.3",
@@ -15088,11 +15979,15 @@
 				"object-assign": "^4.1.0"
 			}
 		},
+		"mustache": {
+			"version": "4.0.1",
+			"resolved": "https://registry.npmjs.org/mustache/-/mustache-4.0.1.tgz",
+			"integrity": "sha512-yL5VE97+OXn4+Er3THSmTdCFCtx5hHWzrolvH+JObZnUYwuaG7XV+Ch4fR2cIrcYI0tFHxS7iyFYl14bW8y2sA=="
+		},
 		"mute-stream": {
 			"version": "0.0.7",
 			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz",
-			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s=",
-			"dev": true
+			"integrity": "sha1-MHXOk7whuPq0PhvE2n6BFe0ee6s="
 		},
 		"nan": {
 			"version": "2.14.1",
@@ -15100,6 +15995,21 @@
 			"integrity": "sha512-isWHgVjnFjh2x2yuJ/tj3JbwoHu3UC2dX5G/88Cm24yB6YopVgxvBObDY7n5xW6ExmFhJpSEQqFPvq9zaXc8Jw==",
 			"dev": true,
 			"optional": true
+		},
+		"nanoassert": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/nanoassert/-/nanoassert-1.1.0.tgz",
+			"integrity": "sha1-TzFS4JVA/eKMdvRLGbvNHVpCR40="
+		},
+		"nanobus": {
+			"version": "4.4.0",
+			"resolved": "https://registry.npmjs.org/nanobus/-/nanobus-4.4.0.tgz",
+			"integrity": "sha512-Hv9USGyH8EsPy0o8pPWE7x3YRIfuZDgMBirzjU6XLebhiSK2g53JlfqgolD0c39ne6wXAfaBNcIAvYe22Bav+Q==",
+			"requires": {
+				"nanoassert": "^1.1.0",
+				"nanotiming": "^7.2.0",
+				"remove-array-items": "^1.0.0"
+			}
 		},
 		"nanomatch": {
 			"version": "1.2.13",
@@ -15118,6 +16028,23 @@
 				"regex-not": "^1.0.0",
 				"snapdragon": "^0.8.1",
 				"to-regex": "^3.0.1"
+			}
+		},
+		"nanoscheduler": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/nanoscheduler/-/nanoscheduler-1.0.3.tgz",
+			"integrity": "sha512-jBbrF3qdU9321r8n9X7yu18DjP31Do2ItJm3mWrt90wJTrnDO+HXpoV7ftaUglAtjgj9s+OaCxGufbvx6pvbEQ==",
+			"requires": {
+				"nanoassert": "^1.1.0"
+			}
+		},
+		"nanotiming": {
+			"version": "7.3.1",
+			"resolved": "https://registry.npmjs.org/nanotiming/-/nanotiming-7.3.1.tgz",
+			"integrity": "sha512-l3lC7v/PfOuRWQa8vV29Jo6TG10wHtnthLElFXs4Te4Aas57Fo4n1Q8LH9n+NDh9riOzTVvb2QNBhTS4JUKNjw==",
+			"requires": {
+				"nanoassert": "^1.1.0",
+				"nanoscheduler": "^1.0.2"
 			}
 		},
 		"napi-build-utils": {
@@ -16749,7 +17676,6 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
 			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-			"dev": true,
 			"requires": {
 				"wrappy": "1"
 			}
@@ -17204,6 +18130,112 @@
 			"requires": {
 				"pinkie": "^2.0.0"
 			}
+		},
+		"pino": {
+			"version": "5.17.0",
+			"resolved": "https://registry.npmjs.org/pino/-/pino-5.17.0.tgz",
+			"integrity": "sha512-LqrqmRcJz8etUjyV0ddqB6OTUutCgQULPFg2b4dtijRHUsucaAdBgSUW58vY6RFSX+NT8963F+q0tM6lNwGShA==",
+			"requires": {
+				"fast-redact": "^2.0.0",
+				"fast-safe-stringify": "^2.0.7",
+				"flatstr": "^1.0.12",
+				"pino-std-serializers": "^2.4.2",
+				"quick-format-unescaped": "^3.0.3",
+				"sonic-boom": "^0.7.5"
+			}
+		},
+		"pino-pretty": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-4.0.0.tgz",
+			"integrity": "sha512-YLy/n3dMXYWOodSm530gelkSAJGmEp29L9pqiycInlIae5FEJPWAkMRO3JFMbIFtjD2Ve4SH2aBcz2aRreGpBQ==",
+			"requires": {
+				"@hapi/bourne": "^2.0.0",
+				"args": "^5.0.1",
+				"chalk": "^3.0.0",
+				"dateformat": "^3.0.3",
+				"fast-safe-stringify": "^2.0.7",
+				"jmespath": "^0.15.0",
+				"joycon": "^2.2.5",
+				"pump": "^3.0.0",
+				"readable-stream": "^3.6.0",
+				"split2": "^3.1.1",
+				"strip-json-comments": "^3.0.1"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-3.0.0.tgz",
+					"integrity": "sha512-4D3B6Wf41KOYRFdszmDqMCGq5VV/uMAB273JILmO+3jAlh8X4qDtdtgCR3fxtbLEMzSx22QdhnDcJvu2u1fVwg==",
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+				},
+				"pump": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+					"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+					"requires": {
+						"end-of-stream": "^1.1.0",
+						"once": "^1.3.1"
+					}
+				},
+				"readable-stream": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				},
+				"strip-json-comments": {
+					"version": "3.1.0",
+					"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.0.tgz",
+					"integrity": "sha512-e6/d0eBu7gHtdCqFt0xJr642LdToM5/cN4Qb9DbHjVx1CP5RyeM+zH7pbecEmDv/lBqb0QH+6Uqq75rxFPkM0w=="
+				},
+				"supports-color": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
+		},
+		"pino-std-serializers": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/pino-std-serializers/-/pino-std-serializers-2.4.2.tgz",
+			"integrity": "sha512-WaL504dO8eGs+vrK+j4BuQQq6GLKeCCcHaMB2ItygzVURcL1CycwNEUHTD/lHFHs/NL5qAz2UKrjYWXKSf4aMQ=="
 		},
 		"pirates": {
 			"version": "4.0.1",
@@ -19277,6 +20309,68 @@
 				}
 			}
 		},
+		"pretty-repl": {
+			"version": "2.3.0",
+			"resolved": "https://registry.npmjs.org/pretty-repl/-/pretty-repl-2.3.0.tgz",
+			"integrity": "sha512-h7iNPLXpJPnbZZS0YIp1+EGD+oY9STelL70X8nwzrbglqP5nOUi0YxK+OJ8n6xopVHoLNQZrytYTmHrWcB1O/w==",
+			"requires": {
+				"ansi": "^0.3.1",
+				"chalk": "^4.0.0",
+				"emphasize": "^3.0.0",
+				"semver": "^7.2.2"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "4.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.2.1.tgz",
+					"integrity": "sha512-9VGjrMsG1vePxcSweQsN20KY/c4zN0h9fLjqAbwbPfahM3t+NL+M9HC8xeXG2I8pX5NoamTGNuomEUFI7fcUjA==",
+					"requires": {
+						"@types/color-name": "^1.1.1",
+						"color-convert": "^2.0.1"
+					}
+				},
+				"chalk": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.0.0.tgz",
+					"integrity": "sha512-N9oWFcegS0sFr9oh1oz2d7Npos6vNoWW9HvtCg5N1KRFpUhaAhvTv5Y58g880fZaEYSNm3qDz8SU1UrGvp+n7A==",
+					"requires": {
+						"ansi-styles": "^4.1.0",
+						"supports-color": "^7.1.0"
+					}
+				},
+				"color-convert": {
+					"version": "2.0.1",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+					"integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+					"requires": {
+						"color-name": "~1.1.4"
+					}
+				},
+				"color-name": {
+					"version": "1.1.4",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+					"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
+				},
+				"has-flag": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+					"integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ=="
+				},
+				"semver": {
+					"version": "7.3.2",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
+					"integrity": "sha512-OrOb32TeeambH6UrhtShmF7CRDqhL6/5XpPNp2DuRH6+9QLw/orhp72j87v8Qa1ScDkvrrBNpZcDejAirJmfXQ=="
+				},
+				"supports-color": {
+					"version": "7.1.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.1.0.tgz",
+					"integrity": "sha512-oRSIpR8pxT1Wr2FquTNnGet79b3BWljqOuoW/h4oBhxJ/HUbX5nX6JSruTkvXDCFMwDPvsaTTbvMLKZWSy0R5g==",
+					"requires": {
+						"has-flag": "^4.0.0"
+					}
+				}
+			}
+		},
 		"private": {
 			"version": "0.1.8",
 			"resolved": "https://registry.npmjs.org/private/-/private-0.1.8.tgz",
@@ -19546,6 +20640,11 @@
 			"resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.1.1.tgz",
 			"integrity": "sha512-w7fLxIRCRT7U8Qu53jQnJyPkYZIaR4n5151KMfcJlO/A9397Wxb1amJvROTK6TOnp7PfoAmg/qXiNHI+08jRfA==",
 			"dev": true
+		},
+		"quick-format-unescaped": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-3.0.3.tgz",
+			"integrity": "sha512-dy1yjycmn9blucmJLXOfZDx1ikZJUi6E8bBZLnhPG5gBrVhHXx2xVyqqgKBubVNEXmx51dBACMHpoMQK/N/AXQ=="
 		},
 		"radium": {
 			"version": "0.19.6",
@@ -20083,6 +21182,14 @@
 				}
 			}
 		},
+		"read": {
+			"version": "1.0.7",
+			"resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
+			"integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
+			"requires": {
+				"mute-stream": "~0.0.4"
+			}
+		},
 		"read-package-json": {
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/read-package-json/-/read-package-json-2.1.1.tgz",
@@ -20385,11 +21492,21 @@
 			"integrity": "sha1-VNvzd+UUQKypCkzSdGANP/LYiKk=",
 			"dev": true
 		},
+		"remove-array-items": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/remove-array-items/-/remove-array-items-1.1.1.tgz",
+			"integrity": "sha512-MXW/jtHyl5F1PZI7NbpS8SOtympdLuF20aoWJT5lELR1p/HJDd5nqW8Eu9uLh/hCRY3FgvrIT5AwDCgBODklcA=="
+		},
 		"remove-trailing-separator": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/remove-trailing-separator/-/remove-trailing-separator-1.1.0.tgz",
 			"integrity": "sha1-wkvOKig62tW8P1jg1IJJuSN52O8=",
 			"dev": true
+		},
+		"remove-trailing-slash": {
+			"version": "0.1.0",
+			"resolved": "https://registry.npmjs.org/remove-trailing-slash/-/remove-trailing-slash-0.1.0.tgz",
+			"integrity": "sha1-FJjl3wmEwn5Jt26/Boh8otARUNI="
 		},
 		"renderkid": {
 			"version": "2.0.3",
@@ -20497,7 +21614,6 @@
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/require_optional/-/require_optional-1.0.1.tgz",
 			"integrity": "sha512-qhM/y57enGWHAe3v/NcwML6a3/vfESLe/sGM2dII+gEO0BpKRUkWZow/tyloNqJyN6kXSl3RyyM8Ll5D/sJP8g==",
-			"dev": true,
 			"requires": {
 				"resolve-from": "^2.0.0",
 				"semver": "^5.1.0"
@@ -20506,8 +21622,7 @@
 				"resolve-from": {
 					"version": "2.0.0",
 					"resolved": "https://registry.npmjs.org/resolve-from/-/resolve-from-2.0.0.tgz",
-					"integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c=",
-					"dev": true
+					"integrity": "sha1-lICrIOlP+h2egKgEx+oUdhGWa1c="
 				}
 			}
 		},
@@ -20721,7 +21836,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
 			"integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
-			"dev": true,
 			"optional": true,
 			"requires": {
 				"sparse-bitfield": "^3.0.3"
@@ -20771,8 +21885,7 @@
 		"semver": {
 			"version": "5.7.1",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
-			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
-			"dev": true
+			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
 		},
 		"send": {
 			"version": "0.17.1",
@@ -21389,6 +22502,15 @@
 				}
 			}
 		},
+		"sonic-boom": {
+			"version": "0.7.7",
+			"resolved": "https://registry.npmjs.org/sonic-boom/-/sonic-boom-0.7.7.tgz",
+			"integrity": "sha512-Ei5YOo5J64GKClHIL/5evJPgASXFVpfVYbJV9PILZQytTK6/LCwHvsZJW2Ig4p9FMC2OrBrMnXKgRN/OEoAWfg==",
+			"requires": {
+				"atomic-sleep": "^1.0.0",
+				"flatstr": "^1.0.12"
+			}
+		},
 		"sort-keys": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/sort-keys/-/sort-keys-1.1.2.tgz",
@@ -21426,7 +22548,6 @@
 			"version": "0.5.18",
 			"resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.5.18.tgz",
 			"integrity": "sha512-9luZr/BZ2QeU6tO2uG8N2aZpVSli4TSAOAqFOyTO51AJcD9P99c0K1h6dD6r6qo5dyT44BR5exweOaLLeldTkQ==",
-			"dev": true,
 			"requires": {
 				"buffer-from": "^1.0.0",
 				"source-map": "^0.6.0"
@@ -21435,8 +22556,7 @@
 				"source-map": {
 					"version": "0.6.1",
 					"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-					"dev": true
+					"integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g=="
 				}
 			}
 		},
@@ -21450,7 +22570,6 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
 			"integrity": "sha1-/0rm5oZWBWuks+eSqzM004JzyhE=",
-			"dev": true,
 			"optional": true,
 			"requires": {
 				"memory-pager": "^1.0.2"
@@ -21614,6 +22733,26 @@
 			"dev": true,
 			"requires": {
 				"extend-shallow": "^3.0.0"
+			}
+		},
+		"split2": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/split2/-/split2-3.1.1.tgz",
+			"integrity": "sha512-emNzr1s7ruq4N+1993yht631/JH+jaj0NYBosuKmLcq+JkGQ9MmTw1RB1fGaTCzUuseRIClrlSLHRNYGwWQ58Q==",
+			"requires": {
+				"readable-stream": "^3.0.0"
+			},
+			"dependencies": {
+				"readable-stream": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
+					}
+				}
 			}
 		},
 		"sprintf-js": {
@@ -22412,8 +23551,7 @@
 		"text-table": {
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
-			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ=",
-			"dev": true
+			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
 		},
 		"throttleit": {
 			"version": "0.0.2",
@@ -22609,6 +23747,25 @@
 			"integrity": "sha512-c3zayb8/kWWpycWYg87P71E1S1ZL6b6IJxfb5fvsUgsf0S2MVGaDhDXXjDMpdCpfWXqptc+4mXwmiy1ypXqRAA==",
 			"dev": true
 		},
+		"ts-node": {
+			"version": "8.10.2",
+			"resolved": "https://registry.npmjs.org/ts-node/-/ts-node-8.10.2.tgz",
+			"integrity": "sha512-ISJJGgkIpDdBhWVu3jufsWpK3Rzo7bdiIXJjQc0ynKxVOVcg2oIrf2H2cejminGrptVc6q6/uynAHNCuWGbpVA==",
+			"requires": {
+				"arg": "^4.1.0",
+				"diff": "^4.0.1",
+				"make-error": "^1.1.1",
+				"source-map-support": "^0.5.17",
+				"yn": "3.1.1"
+			},
+			"dependencies": {
+				"diff": {
+					"version": "4.0.2",
+					"resolved": "https://registry.npmjs.org/diff/-/diff-4.0.2.tgz",
+					"integrity": "sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A=="
+				}
+			}
+		},
 		"tslib": {
 			"version": "1.11.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.11.1.tgz",
@@ -22694,8 +23851,7 @@
 		"typescript": {
 			"version": "3.8.3",
 			"resolved": "https://registry.npmjs.org/typescript/-/typescript-3.8.3.tgz",
-			"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w==",
-			"dev": true
+			"integrity": "sha512-MYlEfn5VrLNsgudQTVJeNaQFUAI7DkhnOjdpAp4T+ku1TfQClewlbSuTVHiA+8skNBgaf02TL/kLOvig4y3G8w=="
 		},
 		"ua-parser-js": {
 			"version": "0.7.21",
@@ -23119,8 +24275,7 @@
 		"uuid": {
 			"version": "3.4.0",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-			"dev": true
+			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
 		},
 		"v8-compile-cache": {
 			"version": "2.0.3",
@@ -24321,8 +25476,7 @@
 		"wrappy": {
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
-			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-			"dev": true
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8="
 		},
 		"write": {
 			"version": "1.0.3",
@@ -24723,6 +25877,11 @@
 			"resolved": "https://registry.npmjs.org/yeast/-/yeast-0.1.2.tgz",
 			"integrity": "sha1-AI4G2AlDIMNy28L47XagymyKxBk=",
 			"dev": true
+		},
+		"yn": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/yn/-/yn-3.1.1.tgz",
+			"integrity": "sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q=="
 		}
 	}
 }

--- a/packages/compass-shell/package.json
+++ b/packages/compass-shell/package.json
@@ -54,7 +54,8 @@
   "@leafygreen-ui/icon-button": "^5.0.2",
   "@mongosh/browser-repl": "^0.0.5",
   "@mongosh/browser-runtime-electron": "^0.0.5",
-  "@mongosh/service-provider-server": "^0.0.5"
+  "@mongosh/service-provider-server": "^0.0.5",
+  "hadron-react-buttons": "^4.0.4"
  },
  "peerDependencies": {
   "hadron-ipc": "^1.1.0",
@@ -99,7 +100,6 @@
   "font-awesome": "^4.7.0",
   "hadron-app": "^3.1.0",
   "hadron-app-registry": "^7.1.0",
-  "hadron-react-buttons": "^4.0.4",
   "html-webpack-plugin": "^3.2.0",
   "ignore-loader": "^0.1.2",
   "istanbul-instrumenter-loader": "^3.0.0",

--- a/packages/compass-shell/package.json
+++ b/packages/compass-shell/package.json
@@ -58,7 +58,6 @@
  },
  "peerDependencies": {
   "hadron-ipc": "^1.1.0",
-  "hadron-react-buttons": "^3.1.0",
   "hadron-react-components": "^3.2.1",
   "prop-types": "^15.7.2",
   "react": "^16.8.0",
@@ -100,6 +99,7 @@
   "font-awesome": "^4.7.0",
   "hadron-app": "^3.1.0",
   "hadron-app-registry": "^7.1.0",
+  "hadron-react-buttons": "^4.0.4",
   "html-webpack-plugin": "^3.2.0",
   "ignore-loader": "^0.1.2",
   "istanbul-instrumenter-loader": "^3.0.0",

--- a/packages/compass-shell/src/components/compass-shell/compass-shell.jsx
+++ b/packages/compass-shell/src/components/compass-shell/compass-shell.jsx
@@ -1,4 +1,4 @@
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import classnames from 'classnames';
 import styles from './compass-shell.less';
 import PropTypes from 'prop-types';
@@ -7,6 +7,7 @@ import { Resizable } from 're-resizable';
 
 import { Shell } from '@mongosh/browser-repl';
 
+import InfoModal from '../info-modal';
 import ResizeHandle from '../resize-handle';
 import ShellHeader from '../shell-header';
 
@@ -117,38 +118,41 @@ export class CompassShell extends Component {
     }
 
     return (
-      <Resizable
-        className={styles['compass-shell']}
-        defaultSize={{
-          width: '100%',
-          height: defaultShellHeightClosed
-        }}
-        id="content"
-        minHeight={defaultShellHeightClosed}
-        maxHeight={800}
-        enable={{
-          ...resizeableDirections,
-          top: isExpanded
-        }}
-        ref={c => { this.resizableRef = c; }}
-        handleComponent={{
-          top: <ResizeHandle />,
-        }}
-      >
-        <ShellHeader
-          isExpanded={isExpanded}
-          onShellToggleClicked={this.shellToggleClicked}
-        />
-        {isExpanded && (
-          <div className={classnames(styles['compass-shell-shell-container'])}>
-            <Shell
-              runtime={this.props.runtime}
-              initialHistory={this.state.initialHistory}
-              onHistoryChanged={this.saveHistory}
-            />
-          </div>
-        )}
-      </Resizable>
+      <Fragment>
+        <InfoModal />
+        <Resizable
+          className={styles['compass-shell']}
+          defaultSize={{
+            width: '100%',
+            height: defaultShellHeightClosed
+          }}
+          id="content"
+          minHeight={defaultShellHeightClosed}
+          maxHeight={800}
+          enable={{
+            ...resizeableDirections,
+            top: isExpanded
+          }}
+          ref={c => { this.resizableRef = c; }}
+          handleComponent={{
+            top: <ResizeHandle />,
+          }}
+        >
+          <ShellHeader
+            isExpanded={isExpanded}
+            onShellToggleClicked={this.shellToggleClicked}
+          />
+          {isExpanded && (
+            <div className={classnames(styles['compass-shell-shell-container'])}>
+              <Shell
+                runtime={this.props.runtime}
+                initialHistory={this.state.initialHistory}
+                onHistoryChanged={this.saveHistory}
+              />
+            </div>
+          )}
+        </Resizable>
+      </Fragment>
     );
   }
 }

--- a/packages/compass-shell/src/components/compass-shell/compass-shell.spec.js
+++ b/packages/compass-shell/src/components/compass-shell/compass-shell.spec.js
@@ -7,6 +7,7 @@ import { Resizable } from 're-resizable';
 import { CompassShell } from './compass-shell';
 import ResizeHandle from '../resize-handle';
 import ShellHeader from '../shell-header';
+import InfoModal from '../info-modal';
 
 function updateAndWaitAsync(wrapper) {
   wrapper.update();
@@ -47,6 +48,12 @@ describe('CompassShell', () => {
         const fakeRuntime = {};
         const wrapper = shallow(<CompassShell runtime={fakeRuntime} isExpanded />);
         expect(wrapper.find(Resizable)).to.be.present();
+      });
+
+      it('renders the info modal component', () => {
+        const fakeRuntime = {};
+        const wrapper = shallow(<CompassShell runtime={fakeRuntime} isExpanded />);
+        expect(wrapper.find(InfoModal)).to.be.present();
       });
 
       it('passes the resize handle component to the Resizable component', () => {

--- a/packages/compass-shell/src/components/info-modal/index.js
+++ b/packages/compass-shell/src/components/info-modal/index.js
@@ -1,0 +1,3 @@
+import InfoModal from './info-modal';
+
+export default InfoModal;

--- a/packages/compass-shell/src/components/info-modal/info-modal.jsx
+++ b/packages/compass-shell/src/components/info-modal/info-modal.jsx
@@ -66,7 +66,7 @@ export class InfoModal extends PureComponent {
               className={styles['info-modal-banner-link']}
               id="mongosh-info-link"
               rel="noreopener"
-              href="https://docs.mongodb.com/manual/products/mongosh"
+              href="https://docs.mongodb.com/mongodb-shell/"
               target="_blank"
             >MongoSH Beta</a>
           </div>

--- a/packages/compass-shell/src/components/info-modal/info-modal.jsx
+++ b/packages/compass-shell/src/components/info-modal/info-modal.jsx
@@ -1,0 +1,167 @@
+import { TextButton } from 'hadron-react-buttons';
+import PropTypes from 'prop-types';
+import React, { PureComponent } from 'react';
+import { Modal } from 'react-bootstrap';
+import { connect } from 'react-redux';
+
+import { SET_SHOW_INFO_MODAL } from '../../modules/info-modal';
+
+import styles from './info-modal.less';
+
+/**
+ * Show information on how to use the shell in compass.
+ */
+class InfoModal extends PureComponent {
+  static propTypes = {
+    hideInfoModal: PropTypes.func.isRequired,
+    isInfoModalVisible: PropTypes.bool.isRequired
+  };
+
+  /**
+   * Render the component.
+   *
+   * @returns {React.Component} The component.
+   */
+  render() {
+    const {
+      hideInfoModal,
+      isInfoModalVisible
+    } = this.props;
+
+    return (
+      <Modal show={isInfoModalVisible}>
+        <Modal.Header closeButton onHide={hideInfoModal}>
+          <h4>MongoSH Beta</h4>
+        </Modal.Header>
+        <Modal.Body>
+          <div className={styles['info-modal-banner']}>
+            More information on this release of&nbsp;
+            <a
+              className={styles['info-modal-banner-link']}
+              id="mongosh-info-link"
+              rel="noreopener"
+              href="https://docs.mongodb.com/manual/reference/mongo-shell/#command-helpers"
+              target="_blank"
+            >MongoSH Beta</a>
+          </div>
+          <div className={styles['info-modal-shortcuts-title']}>
+            Keyboard Shortcuts
+          </div>
+          <div className={styles['info-modal-shortcuts']}>
+            <div className={styles['info-modal-shortcuts-hotkey']}>
+              <span
+                className={styles['info-modal-shortcuts-hotkey-key']}
+              >Ctrl+A</span>Moves the cursor to the begining of the line.
+            </div>
+            <div className={styles['info-modal-shortcuts-hotkey']}>
+              <span
+                className={styles['info-modal-shortcuts-hotkey-key']}
+              >Ctrl+B</span>Moves the cursor backwards one character.
+            </div>
+            <div className={styles['info-modal-shortcuts-hotkey']}>
+              <span
+                className={styles['info-modal-shortcuts-hotkey-key']}
+              >Ctrl+C</span>Cancels the current running command.
+            </div>
+            <div className={styles['info-modal-shortcuts-hotkey']}>
+              <span
+                className={styles['info-modal-shortcuts-hotkey-key']}
+              >Ctrl+D</span>Logs out of the current session.
+            </div>
+            <div className={styles['info-modal-shortcuts-hotkey']}>
+              <span
+                className={styles['info-modal-shortcuts-hotkey-key']}
+              >Ctrl+E</span>Moves the cursor to the end of the line.
+            </div>
+            <div className={styles['info-modal-shortcuts-hotkey']}>
+              <span
+                className={styles['info-modal-shortcuts-hotkey-key']}
+              >Ctrl+F</span>Moves the cursor forwards one character.
+            </div>
+            <div className={styles['info-modal-shortcuts-hotkey']}>
+              <span
+                className={styles['info-modal-shortcuts-hotkey-key']}
+              >Ctrl+H</span>Erase one character. Similair to hitting backspace.
+            </div>
+            <div className={styles['info-modal-shortcuts-hotkey']}>
+              <span
+                className={styles['info-modal-shortcuts-hotkey-key']}
+              >Ctrl+L</span>Clear the line after the cursor.
+            </div>
+            <div className={styles['info-modal-shortcuts-hotkey']}>
+              <span
+                className={styles['info-modal-shortcuts-hotkey-key']}
+              >Ctrl+P</span>Paste the previous line(s).
+            </div>
+            <div className={styles['info-modal-shortcuts-hotkey']}>
+              <span
+                className={styles['info-modal-shortcuts-hotkey-key']}
+              >Ctrl+Q</span>Turns all output stopped on-screen back on (XON).
+            </div>
+            <div className={styles['info-modal-shortcuts-hotkey']}>
+              <span
+                className={styles['info-modal-shortcuts-hotkey-key']}
+              >Ctrl+R</span>Allows you to search for previously used commands.
+            </div>
+            <div className={styles['info-modal-shortcuts-hotkey']}>
+              <span
+                className={styles['info-modal-shortcuts-hotkey-key']}
+              >Ctrl+S</span>Stops all output on-screen (XOFF).
+            </div>
+            <div className={styles['info-modal-shortcuts-hotkey']}>
+              <span
+                className={styles['info-modal-shortcuts-hotkey-key']}
+              >Ctrl+T</span>Swap the last two characters before the cursor.
+            </div>
+            <div className={styles['info-modal-shortcuts-hotkey']}>
+              <span
+                className={styles['info-modal-shortcuts-hotkey-key']}
+              >Ctrl+U</span>Clears the line before the cursor position. If you are at the end of the line, clears the entire line.
+            </div>
+            <div className={styles['info-modal-shortcuts-hotkey']}>
+              <span
+                className={styles['info-modal-shortcuts-hotkey-key']}
+              >Ctrl+W</span>Delete the word before the cursor.
+            </div>
+            <div className={styles['info-modal-shortcuts-hotkey']}>
+              <span
+                className={styles['info-modal-shortcuts-hotkey-key']}
+              >Ctrl+Z</span>Puts whatever you are running into a suspended background process. fg restores it.
+            </div>
+
+            <div className={styles['info-modal-shortcuts-hotkey']}>
+              <span
+                className={styles['info-modal-shortcuts-hotkey-key']}
+              >&uarr;</span>Cycle backwards through command history.
+            </div>
+            <div className={styles['info-modal-shortcuts-hotkey']}>
+              <span
+                className={styles['info-modal-shortcuts-hotkey-key']}
+              >&darr;</span>Cycle forwards through command history.
+            </div>
+          </div>
+        </Modal.Body>
+        <Modal.Footer>
+          <TextButton
+            id="close-info-modal"
+            className="btn btn-default btn-sm"
+            text="Close"
+            clickHandler={hideInfoModal}
+          />
+        </Modal.Footer>
+      </Modal>
+    );
+  }
+}
+
+export default connect(
+  (state) => ({
+    isInfoModalVisible: state.infoModal.isInfoModalVisible
+  }),
+  (dispatch) => ({
+    hideInfoModal: () => dispatch({
+      type: SET_SHOW_INFO_MODAL,
+      isInfoModalVisible: false
+    })
+  })
+)(InfoModal);

--- a/packages/compass-shell/src/components/info-modal/info-modal.jsx
+++ b/packages/compass-shell/src/components/info-modal/info-modal.jsx
@@ -8,10 +8,36 @@ import { SET_SHOW_INFO_MODAL } from '../../modules/info-modal';
 
 import styles from './info-modal.less';
 
+const hotkeys = [{
+  key: 'Ctrl+A',
+  description: 'Moves the cursor to the begining of the line.'
+}, {
+  key: 'Ctrl+B',
+  description: 'Moves the cursor backwards one character.'
+}, {
+  key: 'Ctrl+D',
+  description: 'Erases the next character.'
+}, {
+  key: 'Ctrl+E',
+  description: 'Moves the cursor to the end of the line.'
+}, {
+  key: 'Ctrl+F',
+  description: 'Moves the cursor forwards one character.'
+}, {
+  key: 'Ctrl+H',
+  description: 'Erases one character. Similar to hitting backspace.'
+}, {
+  key: 'Ctrl+T',
+  description: 'Swap the last two characters before the cursor.'
+}, {
+  key: 'Ctrl+U',
+  description: 'Changes the line to uppercase.'
+}];
+
 /**
  * Show information on how to use the shell in compass.
  */
-class InfoModal extends PureComponent {
+export class InfoModal extends PureComponent {
   static propTypes = {
     hideInfoModal: PropTypes.func.isRequired,
     isInfoModalVisible: PropTypes.bool.isRequired
@@ -40,7 +66,7 @@ class InfoModal extends PureComponent {
               className={styles['info-modal-banner-link']}
               id="mongosh-info-link"
               rel="noreopener"
-              href="https://docs.mongodb.com/manual/reference/mongo-shell/#command-helpers"
+              href="https://docs.mongodb.com/manual/products/mongosh"
               target="_blank"
             >MongoSH Beta</a>
           </div>
@@ -48,87 +74,13 @@ class InfoModal extends PureComponent {
             Keyboard Shortcuts
           </div>
           <div className={styles['info-modal-shortcuts']}>
-            <div className={styles['info-modal-shortcuts-hotkey']}>
-              <span
-                className={styles['info-modal-shortcuts-hotkey-key']}
-              >Ctrl+A</span>Moves the cursor to the begining of the line.
-            </div>
-            <div className={styles['info-modal-shortcuts-hotkey']}>
-              <span
-                className={styles['info-modal-shortcuts-hotkey-key']}
-              >Ctrl+B</span>Moves the cursor backwards one character.
-            </div>
-            <div className={styles['info-modal-shortcuts-hotkey']}>
-              <span
-                className={styles['info-modal-shortcuts-hotkey-key']}
-              >Ctrl+C</span>Cancels the current running command.
-            </div>
-            <div className={styles['info-modal-shortcuts-hotkey']}>
-              <span
-                className={styles['info-modal-shortcuts-hotkey-key']}
-              >Ctrl+D</span>Logs out of the current session.
-            </div>
-            <div className={styles['info-modal-shortcuts-hotkey']}>
-              <span
-                className={styles['info-modal-shortcuts-hotkey-key']}
-              >Ctrl+E</span>Moves the cursor to the end of the line.
-            </div>
-            <div className={styles['info-modal-shortcuts-hotkey']}>
-              <span
-                className={styles['info-modal-shortcuts-hotkey-key']}
-              >Ctrl+F</span>Moves the cursor forwards one character.
-            </div>
-            <div className={styles['info-modal-shortcuts-hotkey']}>
-              <span
-                className={styles['info-modal-shortcuts-hotkey-key']}
-              >Ctrl+H</span>Erase one character. Similair to hitting backspace.
-            </div>
-            <div className={styles['info-modal-shortcuts-hotkey']}>
-              <span
-                className={styles['info-modal-shortcuts-hotkey-key']}
-              >Ctrl+L</span>Clear the line after the cursor.
-            </div>
-            <div className={styles['info-modal-shortcuts-hotkey']}>
-              <span
-                className={styles['info-modal-shortcuts-hotkey-key']}
-              >Ctrl+P</span>Paste the previous line(s).
-            </div>
-            <div className={styles['info-modal-shortcuts-hotkey']}>
-              <span
-                className={styles['info-modal-shortcuts-hotkey-key']}
-              >Ctrl+Q</span>Turns all output stopped on-screen back on (XON).
-            </div>
-            <div className={styles['info-modal-shortcuts-hotkey']}>
-              <span
-                className={styles['info-modal-shortcuts-hotkey-key']}
-              >Ctrl+R</span>Allows you to search for previously used commands.
-            </div>
-            <div className={styles['info-modal-shortcuts-hotkey']}>
-              <span
-                className={styles['info-modal-shortcuts-hotkey-key']}
-              >Ctrl+S</span>Stops all output on-screen (XOFF).
-            </div>
-            <div className={styles['info-modal-shortcuts-hotkey']}>
-              <span
-                className={styles['info-modal-shortcuts-hotkey-key']}
-              >Ctrl+T</span>Swap the last two characters before the cursor.
-            </div>
-            <div className={styles['info-modal-shortcuts-hotkey']}>
-              <span
-                className={styles['info-modal-shortcuts-hotkey-key']}
-              >Ctrl+U</span>Clears the line before the cursor position. If you are at the end of the line, clears the entire line.
-            </div>
-            <div className={styles['info-modal-shortcuts-hotkey']}>
-              <span
-                className={styles['info-modal-shortcuts-hotkey-key']}
-              >Ctrl+W</span>Delete the word before the cursor.
-            </div>
-            <div className={styles['info-modal-shortcuts-hotkey']}>
-              <span
-                className={styles['info-modal-shortcuts-hotkey-key']}
-              >Ctrl+Z</span>Puts whatever you are running into a suspended background process. fg restores it.
-            </div>
-
+            {hotkeys.map(shortcut => (
+              <div className={styles['info-modal-shortcuts-hotkey']}>
+                <span
+                  className={styles['info-modal-shortcuts-hotkey-key']}
+                >{shortcut.key}</span>{shortcut.description}
+              </div>
+            ))}
             <div className={styles['info-modal-shortcuts-hotkey']}>
               <span
                 className={styles['info-modal-shortcuts-hotkey-key']}

--- a/packages/compass-shell/src/components/info-modal/info-modal.less
+++ b/packages/compass-shell/src/components/info-modal/info-modal.less
@@ -1,0 +1,39 @@
+@import '~@leafygreen-ui/palette/dist/ui-colors.less';
+
+.info-modal-banner {
+  color: @leafygreen__blue--dark-2;
+  border-color: @leafygreen__blue--light-2;
+  background-color: @leafygreen__blue--light-3;
+
+  padding: 9px 12px 9px 20px;
+  border-width: 1px;
+  border-style: solid;
+  border-radius: 6px;
+  font-size: 14px;
+
+  &-link {
+    font-weight: bold;
+    text-decoration: underline;
+  }
+}
+
+.info-modal-shortcuts-title {
+  font-weight: bold;
+  padding: 14px 0;
+}
+
+.info-modal-shortcuts {
+  .info-modal-shortcuts-hotkey {
+    padding: 3px 0;
+  }
+
+  .info-modal-shortcuts-hotkey:nth-child(odd) {
+    background-color: @leafygreen__gray--light-2;
+  }
+
+  .info-modal-shortcuts-hotkey-key {
+    font-weight: bold;
+    padding-left: 14px;
+    padding-right: 10px;
+  }
+}

--- a/packages/compass-shell/src/components/info-modal/info-model.spec.js
+++ b/packages/compass-shell/src/components/info-modal/info-model.spec.js
@@ -1,0 +1,40 @@
+import React from 'react';
+import { mount } from 'enzyme';
+
+import { InfoModal } from './info-modal';
+import styles from './info-modal.less';
+
+describe('InfoModal [Component]', () => {
+  let component;
+
+  beforeEach(() => {
+    component = mount(
+      <InfoModal
+        isInfoModalVisible
+        hideInfoModal={() => {}}
+      />
+    );
+  });
+
+  afterEach(() => {
+    component = null;
+  });
+
+  it('renders the title text', () => {
+    expect(component.find('h4')).to.have.text(
+      'MongoSH Beta'
+    );
+  });
+
+  it('renders the hotkeys key', () => {
+    expect(component.find(`.${styles['info-modal-shortcuts-hotkey-key']}`).at(5)).to.have.text(
+      'Ctrl+H'
+    );
+  });
+
+  it('renders the hotkeys description', () => {
+    expect(component.find(`.${styles['info-modal-shortcuts-hotkey']}`).at(5)).to.have.text(
+      'Ctrl+HErases one character. Similar to hitting backspace.'
+    );
+  });
+});

--- a/packages/compass-shell/src/components/shell-header/shell-header.jsx
+++ b/packages/compass-shell/src/components/shell-header/shell-header.jsx
@@ -1,18 +1,19 @@
-import React, { Component, Fragment } from 'react';
-import styles from './shell-header.less';
-import PropTypes from 'prop-types';
 import IconButton from '@leafygreen-ui/icon-button';
 import Icon from '@leafygreen-ui/icon';
+import PropTypes from 'prop-types';
+import React, { Component, Fragment } from 'react';
+import { connect } from 'react-redux';
 
-export default class ShellHeader extends Component {
+import { SET_SHOW_INFO_MODAL } from '../../modules/info-modal';
+
+import styles from './shell-header.less';
+
+export class ShellHeader extends Component {
   static propTypes = {
     isExpanded: PropTypes.bool.isRequired,
-    onShellToggleClicked: PropTypes.func.isRequired
+    onShellToggleClicked: PropTypes.func.isRequired,
+    showInfoModal: PropTypes.func.isRequired
   };
-
-  onInfoClicked = () => {
-    // TODO: Open modal.
-  }
 
   /**
    * Render ShellHeader component.
@@ -22,7 +23,8 @@ export default class ShellHeader extends Component {
   render() {
     const {
       isExpanded,
-      onShellToggleClicked
+      onShellToggleClicked,
+      showInfoModal
     } = this.props;
 
     return (
@@ -40,7 +42,7 @@ export default class ShellHeader extends Component {
                 className={styles['compass-shell-header-info-btn']}
                 variant="dark"
                 aria-label="Shell Info"
-                onClick={this.onInfoClicked}
+                onClick={showInfoModal}
               >
                 <Icon glyph="InfoWithCircle" />
               </IconButton>
@@ -69,3 +71,13 @@ export default class ShellHeader extends Component {
     );
   }
 }
+
+export default connect(
+  null,
+  (dispatch) => ({
+    showInfoModal: () => dispatch({
+      type: SET_SHOW_INFO_MODAL,
+      isInfoModalVisible: true
+    })
+  })
+)(ShellHeader);

--- a/packages/compass-shell/src/components/shell-header/shell-header.jsx
+++ b/packages/compass-shell/src/components/shell-header/shell-header.jsx
@@ -1,14 +1,19 @@
-import React, { Component } from 'react';
+import React, { Component, Fragment } from 'react';
 import styles from './shell-header.less';
 import PropTypes from 'prop-types';
 import IconButton from '@leafygreen-ui/icon-button';
 import Icon from '@leafygreen-ui/icon';
 
-export default class CompassShell extends Component {
+export default class ShellHeader extends Component {
   static propTypes = {
     isExpanded: PropTypes.bool.isRequired,
     onShellToggleClicked: PropTypes.func.isRequired
   };
+
+  onInfoClicked = () => {
+    // TODO: Open modal.
+  }
+
   /**
    * Render ShellHeader component.
    *
@@ -30,14 +35,24 @@ export default class CompassShell extends Component {
         </button>
         <div className={styles['compass-shell-header-right-actions']}>
           {isExpanded && (
-            <IconButton
-              className={styles['compass-shell-header-close-btn']}
-              variant="dark"
-              aria-label="Close Shell"
-              onClick={onShellToggleClicked}
-            >
-              <Icon glyph="ChevronDown" />
-            </IconButton>
+            <Fragment>
+              <IconButton
+                className={styles['compass-shell-header-info-btn']}
+                variant="dark"
+                aria-label="Shell Info"
+                onClick={this.onInfoClicked}
+              >
+                <Icon glyph="InfoWithCircle" />
+              </IconButton>
+              <IconButton
+                className={styles['compass-shell-header-close-btn']}
+                variant="dark"
+                aria-label="Close Shell"
+                onClick={onShellToggleClicked}
+              >
+                <Icon glyph="ChevronDown" />
+              </IconButton>
+            </Fragment>
           )}
           {!isExpanded && (
             <IconButton

--- a/packages/compass-shell/src/components/shell-header/shell-header.less
+++ b/packages/compass-shell/src/components/shell-header/shell-header.less
@@ -26,4 +26,8 @@
       color: @leafygreen__gray--light-3;
     }  
   }
+
+  &-info-btn {
+    margin-right: 8px;
+  }
 }

--- a/packages/compass-shell/src/components/shell-header/shell-header.spec.js
+++ b/packages/compass-shell/src/components/shell-header/shell-header.spec.js
@@ -3,7 +3,7 @@ import { mount, shallow } from 'enzyme';
 import Icon from '@leafygreen-ui/icon';
 import IconButton from '@leafygreen-ui/icon-button';
 
-import ShellHeader from './shell-header';
+import { ShellHeader } from './shell-header';
 import styles from './shell-header.less';
 
 describe('ShellHeader', () => {
@@ -12,16 +12,29 @@ describe('ShellHeader', () => {
       const wrapper = mount(<ShellHeader
         isExpanded
         onShellToggleClicked={() => {}}
+        showInfoModal={() => {}}
       />);
 
       expect(wrapper.find(IconButton).exists()).to.equal(true);
-      expect(wrapper.find(Icon).prop('glyph')).to.equal('ChevronDown');
+      expect(wrapper.find(Icon).at(1).prop('glyph')).to.equal('ChevronDown');
+    });
+
+    it('renders an info button', () => {
+      const wrapper = mount(<ShellHeader
+        isExpanded
+        onShellToggleClicked={() => {}}
+        showInfoModal={() => {}}
+      />);
+
+      expect(wrapper.find(IconButton).exists()).to.equal(true);
+      expect(wrapper.find(Icon).at(0).prop('glyph')).to.equal('InfoWithCircle');
     });
 
     it('renders an actions area', () => {
       const wrapper = mount(<ShellHeader
         isExpanded
         onShellToggleClicked={() => {}}
+        showInfoModal={() => {}}
       />);
 
       expect(wrapper.find(`.${styles['compass-shell-header-right-actions']}`)).to.be.present();
@@ -33,6 +46,7 @@ describe('ShellHeader', () => {
       const wrapper = mount(<ShellHeader
         isExpanded={false}
         onShellToggleClicked={() => {}}
+        showInfoModal={() => {}}
       />);
 
       expect(wrapper.find(IconButton).exists()).to.equal(true);
@@ -45,6 +59,7 @@ describe('ShellHeader', () => {
       const wrapper = shallow(<ShellHeader
         isExpanded={false}
         onShellToggleClicked={() => {}}
+        showInfoModal={() => {}}
       />);
 
       expect(wrapper.find('button').exists()).to.equal(true);

--- a/packages/compass-shell/src/modules/index.js
+++ b/packages/compass-shell/src/modules/index.js
@@ -1,10 +1,13 @@
 import { combineReducers } from 'redux';
+
+import infoModal from './info-modal';
 import runtime from './runtime';
 
 /**
  * The reducer.
  */
 const reducer = combineReducers({
+  infoModal,
   runtime
 });
 

--- a/packages/compass-shell/src/modules/info-modal.js
+++ b/packages/compass-shell/src/modules/info-modal.js
@@ -1,19 +1,16 @@
 export const SET_SHOW_INFO_MODAL = 'SHELL/INFO_MODAL/SET_SHOW_INFO_MODAL';
 
-/**
- * The initial state.
- */
 export const INITIAL_STATE = {
   isInfoModalVisible: false
 };
 
 /**
- * Reducer function for handling data service connected actions.
+ * Reducer function for handling actions with the info modal.
  *
- * @param {Object} state - The data service state.
+ * @param {Object} state - The info modal state.
  * @param {Object} action - The action.
  *
- * @returns {String} The new state.
+ * @returns {Object} The new state.
  */
 export default function reducer(state = INITIAL_STATE, action) {
   if (action.type === SET_SHOW_INFO_MODAL) {

--- a/packages/compass-shell/src/modules/info-modal.js
+++ b/packages/compass-shell/src/modules/info-modal.js
@@ -1,0 +1,27 @@
+export const SET_SHOW_INFO_MODAL = 'SHELL/INFO_MODAL/SET_SHOW_INFO_MODAL';
+
+/**
+ * The initial state.
+ */
+export const INITIAL_STATE = {
+  isInfoModalVisible: false
+};
+
+/**
+ * Reducer function for handling data service connected actions.
+ *
+ * @param {Object} state - The data service state.
+ * @param {Object} action - The action.
+ *
+ * @returns {String} The new state.
+ */
+export default function reducer(state = INITIAL_STATE, action) {
+  if (action.type === SET_SHOW_INFO_MODAL) {
+    return {
+      ...state,
+      isInfoModalVisible: action.isInfoModalVisible
+    };
+  }
+
+  return state;
+}


### PR DESCRIPTION
https://jira.mongodb.org/browse/COMPASS-4292

This PR adds an info modal with existing ace editor hotkeys listed. I'd like to add ctrl+r search functionality but we can do that in another PR. 

The mocks had some other hotkeys listed, some of which we can't support now (background processing): https://mongodb.invisionapp.com/share/RZVV94NAY6B#/screens/403867891

Here's where we're linking to: https://docs.mongodb.com/manual/products/mongosh
I'm going to check that's the right place.

Currently the behavior is that the info button does not show unless the shell is expanded. Is this expected?

![Jun-08-2020 07-36-34](https://user-images.githubusercontent.com/1791149/83996132-a561f580-a95b-11ea-953f-3d5214ae4d2c.gif)
