### PR TITLE
Changed copy of node version mismatched message.

### DIFF
--- a/packages/cli-repl/src/cli-repl.ts
+++ b/packages/cli-repl/src/cli-repl.ts
@@ -311,7 +311,7 @@ class CliRepl {
   verifyNodeVersion(): void {
     const { engines } = require('../package.json');
     if (!semver.satisfies(process.version, engines.node)) {
-      console.log(`WARNING: mismatched node version. Minimum node version required ${engines.node}. Currently using ${process.version}. Exiting...\n\n`);
+      console.log(`WARNING: mismatched node version. Required version: ${engines.node}. Currently using: ${process.version}. Exiting...\n\n`);
       process.exit(1);
     }
   }


### PR DESCRIPTION
We are not checking for a minimum, we are checking if the version matches the one we expect but the error message was still talking about a minimum version required.