### PR TITLE
MONGOSH-259: process.exit when connection fails

### DIFF
--- a/packages/cli-repl/src/cli-repl.ts
+++ b/packages/cli-repl/src/cli-repl.ts
@@ -68,7 +68,7 @@ class CliRepl {
       this.setupRepl(driverUri, driverOptions).catch((error) => {
         this.bus.emit('mongosh:error', error);
         console.log(formatError(error));
-        return;
+        return process.exit();
       });
     }
   }
@@ -362,7 +362,7 @@ class CliRepl {
       this.setupRepl(driverUri, driverOptions).catch((e) => {
         this.bus.emit('mongosh:error', e);
         console.log(formatError(e));
-        return;
+        return process.exit();
       });
     });
   }


### PR DESCRIPTION
## Description

`process.exit` if connection does not succeed or connection with username/password does not succeed. 