### PR TITLE
MONGOSH-240: log out mongosh_version to log file

### DIFF
--- a/packages/service-provider-browser/src/stitch-service-provider-browser.ts
+++ b/packages/service-provider-browser/src/stitch-service-provider-browser.ts
@@ -71,6 +71,7 @@ class StitchServiceProviderBrowser implements ServiceProvider {
   async getConnectionInfo(): Promise<any> {
     const buildInfo = await this.buildInfo();
     const topology = await this.getTopology();
+    const { version } = require('../package.json');
     let cmdLineOpts = null;
     try {
       cmdLineOpts = await this.getCmdLineOpts();
@@ -79,6 +80,7 @@ class StitchServiceProviderBrowser implements ServiceProvider {
     }
     const connectInfo = getConnectInfo(
       '', // TODO: something more useful?
+      version,
       buildInfo,
       cmdLineOpts,
       topology

--- a/packages/service-provider-core/src/connect-info.spec.ts
+++ b/packages/service-provider-core/src/connect-info.spec.ts
@@ -78,6 +78,7 @@ describe('getConnectInfo', function() {
       is_atlas: true,
       is_localhost: false,
       server_version: '3.2.0-rc2',
+      mongosh_version: '0.0.6',
       is_enterprise: true,
       auth_type: 'LDAP',
       is_data_lake: false,
@@ -91,6 +92,7 @@ describe('getConnectInfo', function() {
     };
     expect(getConnectInfo(
       ATLAS_URI,
+      '0.0.6',
       BUILD_INFO,
       CMD_LINE_OPTS,
       TOPOLOGY_WITH_CREDENTIALS)).to.deep.equal(output);
@@ -101,6 +103,7 @@ describe('getConnectInfo', function() {
       is_atlas: true,
       is_localhost: false,
       server_version: '3.2.0-rc2',
+      mongosh_version: '0.0.6',
       is_enterprise: true,
       auth_type: null,
       is_data_lake: false,
@@ -114,6 +117,7 @@ describe('getConnectInfo', function() {
     };
     expect(getConnectInfo(
       ATLAS_URI,
+      '0.0.6',
       BUILD_INFO,
       CMD_LINE_OPTS,
       TOPOLOGY_NO_CREDENTIALS)).to.deep.equal(output);

--- a/packages/service-provider-core/src/connect-info.ts
+++ b/packages/service-provider-core/src/connect-info.ts
@@ -7,6 +7,7 @@ interface ConnectInfo {
   is_atlas: boolean;
   is_localhost: boolean;
   server_version: string;
+  mongosh_version: string;
   server_os?: string;
   server_arch?: string;
   is_enterprise: boolean;
@@ -19,7 +20,7 @@ interface ConnectInfo {
   uri: string;
 }
 
-export default function getConnectInfo(uri: string, buildInfo: any, cmdLineOpts: any, topology: any): ConnectInfo {
+export default function getConnectInfo(uri: string, mongoshVersion: string, buildInfo: any, cmdLineOpts: any, topology: any): ConnectInfo {
   const { isGenuine: is_genuine, serverName: non_genuine_server_name } =
     getBuildInfo.getGenuineMongoDB(buildInfo, cmdLineOpts);
   const { isDataLake: is_data_lake, dlVersion: dl_version }
@@ -36,6 +37,8 @@ export default function getConnectInfo(uri: string, buildInfo: any, cmdLineOpts:
     is_atlas: getBuildInfo.isAtlas(uri),
     is_localhost: getBuildInfo.isLocalhost(uri),
     server_version: buildInfo.version,
+    node_version: process.version,
+    mongosh_version: mongoshVersion,
     server_os,
     uri,
     server_arch,
@@ -43,7 +46,6 @@ export default function getConnectInfo(uri: string, buildInfo: any, cmdLineOpts:
     auth_type,
     is_data_lake,
     dl_version,
-    node_version: process.version,
     is_genuine,
     non_genuine_server_name
   };

--- a/packages/service-provider-server/src/cli-service-provider.ts
+++ b/packages/service-provider-server/src/cli-service-provider.ts
@@ -105,6 +105,7 @@ class CliServiceProvider implements ServiceProvider {
   async getConnectionInfo(): Promise<any> {
     const buildInfo = await this.buildInfo();
     const topology = await this.getTopology();
+    const { version } = require('../package.json');
     let cmdLineOpts = null;
     try {
       cmdLineOpts = await this.getCmdLineOpts();
@@ -113,6 +114,7 @@ class CliServiceProvider implements ServiceProvider {
     }
     const connectInfo = getConnectInfo(
       this.uri,
+      version,
       buildInfo,
       cmdLineOpts,
       topology


### PR DESCRIPTION
## Description
- adds `mongosh_version` (from package.json) to `getConnectInfo` function return.
- `mongosh_version` is then sent to analytics and gets logged to logger