### PR TITLE
fix duplicated symbol in compiled binary

### DIFF
--- a/packages/shell-api/src/enums.ts
+++ b/packages/shell-api/src/enums.ts
@@ -37,7 +37,7 @@ export const DBQuery = {
   Option: DBQueryOption
 };
 
-export const shellApiType = Symbol('shellApiType');
+export const shellApiType = Symbol.for('@@mongosh.shellApiType');
 // TODO: Would require changes to java-shell
 // export const asPrintable = Symbol('asPrintable');
-export const asShellResult = Symbol('asShellResult');
+export const asShellResult = Symbol.for('@@mongosh.asShellResult');


### PR DESCRIPTION
`export const shellApiType = Symbol('...')` is working fine in node js with `npm run start` but in the binary we get actually 2 distinct unique symbols: one used in the class definition and one used in the shell evaluator.

To fix this we use `Symbol.for('...')` with a unique name.