### PR TITLE
MONGOSH-268: Fix autocompletion in compass-shell

### DIFF
--- a/packages/service-provider-core/package.json
+++ b/packages/service-provider-core/package.json
@@ -14,6 +14,8 @@
   "scripts": {
     "compile-ts": "tsc -p tsconfig.json",
     "prepublish": "npm run compile-ts",
+    "test": "mocha -r \"../../scripts/import-expansions.js\" --timeout 60000 --colors -r ts-node/register \"./src/**/*.spec.ts\"",
+    "test-ci": "mocha -r \"../../scripts/import-expansions.js\" --timeout 60000 -r ts-node/register \"./src/**/*.spec.ts\"",
     "lint": "eslint \"**/*.{js,ts,tsx}\"",
     "check": "npm run lint"
   },

--- a/packages/service-provider-core/src/connect-info.spec.ts
+++ b/packages/service-provider-core/src/connect-info.spec.ts
@@ -122,4 +122,29 @@ describe('getConnectInfo', function() {
       CMD_LINE_OPTS,
       TOPOLOGY_NO_CREDENTIALS)).to.deep.equal(output);
   });
+
+  it('reports correct information when an empty uri is passed', function() {
+    const output = {
+      is_atlas: false,
+      is_localhost: false,
+      server_version: '3.2.0-rc2',
+      mongosh_version: '0.0.6',
+      is_enterprise: true,
+      auth_type: 'LDAP',
+      is_data_lake: false,
+      dl_version: null,
+      is_genuine: true,
+      non_genuine_server_name: 'mongodb',
+      server_arch: 'x86_64',
+      node_version: process.version,
+      server_os: 'osx',
+      uri: ''
+    };
+    expect(getConnectInfo(
+      '',
+      '0.0.6',
+      BUILD_INFO,
+      CMD_LINE_OPTS,
+      TOPOLOGY_WITH_CREDENTIALS)).to.deep.equal(output);
+  });
 });

--- a/packages/service-provider-server/src/cli-service-provider.integration.spec.ts
+++ b/packages/service-provider-server/src/cli-service-provider.integration.spec.ts
@@ -45,6 +45,36 @@ describe('CliServiceProvider [integration]', function() {
     });
   });
 
+  describe('.getConnectionInfo', () => {
+    context('when a uri has been passed', () => {
+      it('returns the connection\'s info', async() => {
+        const instance = new CliServiceProvider(client, connectionString);
+        const connectionInfo = await instance.getConnectionInfo();
+
+        expect(Object.keys(connectionInfo)).to.deep.equal([
+          'buildInfo',
+          'topology',
+          'extraInfo'
+        ]);
+        expect(connectionInfo.buildInfo.version.length > 1);
+      });
+    });
+
+    context('when the optional uri has not been passed', () => {
+      it('returns the connection\'s info', async() => {
+        const instance = new CliServiceProvider(client);
+        const connectionInfo = await instance.getConnectionInfo();
+
+        expect(Object.keys(connectionInfo)).to.deep.equal([
+          'buildInfo',
+          'topology',
+          'extraInfo'
+        ]);
+        expect(connectionInfo.buildInfo.version.length > 1);
+      });
+    });
+  });
+
   describe('#aggregate', () => {
     context('when running against a collection', () => {
       let result;

--- a/packages/service-provider-server/src/cli-service-provider.ts
+++ b/packages/service-provider-server/src/cli-service-provider.ts
@@ -69,7 +69,7 @@ class CliServiceProvider implements ServiceProvider {
   }
 
   private readonly mongoClient: MongoClient;
-  private readonly uri: string;
+  private readonly uri: string | undefined;
 
   /**
    * Instantiate a new CliServiceProvider with the Node driver's connected
@@ -78,7 +78,7 @@ class CliServiceProvider implements ServiceProvider {
    * @param {MongoClient} mongoClient - The Node drivers' MongoClient instance.
    * @param {string} uri - optional URI for telemetry.
    */
-  constructor(mongoClient: MongoClient, uri?: string) {
+  constructor(mongoClient: MongoClient, uri: string | undefined) {
     this.mongoClient = mongoClient;
     this.uri = uri;
     this.platform = ReplPlatform.CLI;
@@ -112,13 +112,15 @@ class CliServiceProvider implements ServiceProvider {
       // eslint-disable-next-line no-empty
     } catch (e) {
     }
+
     const connectInfo = getConnectInfo(
-      this.uri,
+      this.uri ? this.uri : '',
       version,
       buildInfo,
       cmdLineOpts,
       topology
     );
+
     return {
       buildInfo: buildInfo,
       topology: topology,

--- a/packages/service-provider-server/src/cli-service-provider.ts
+++ b/packages/service-provider-server/src/cli-service-provider.ts
@@ -69,7 +69,7 @@ class CliServiceProvider implements ServiceProvider {
   }
 
   private readonly mongoClient: MongoClient;
-  private readonly uri: string | undefined;
+  private readonly uri?: string;
 
   /**
    * Instantiate a new CliServiceProvider with the Node driver's connected
@@ -78,7 +78,7 @@ class CliServiceProvider implements ServiceProvider {
    * @param {MongoClient} mongoClient - The Node drivers' MongoClient instance.
    * @param {string} uri - optional URI for telemetry.
    */
-  constructor(mongoClient: MongoClient, uri: string | undefined) {
+  constructor(mongoClient: MongoClient, uri?: string) {
     this.mongoClient = mongoClient;
     this.uri = uri;
     this.platform = ReplPlatform.CLI;


### PR DESCRIPTION
https://jira.mongodb.org/browse/MONGOSH-268

Small fix: the uri passed to the service provider is optional, however when we were fetching connection info to have the mongo version for autocomplete we were running string operations on the uri, which were erroring out. Added a small test to catch in future. Was cool to learn more of the inner workings of mongosh.

I think in future we could make this a bit more streamlined by passing the connection information in from compass into the browser repl/shell api internal state, so we can avoid the extra fetching of connection info inside of mongosh. 

Auto completion working in compass-shell:
![Jul-15-2020 14-08-15](https://user-images.githubusercontent.com/1791149/87543895-d2fe3500-c6a5-11ea-9c07-729ffcd1d68c.gif)

Was thinking about pulling telemetry into this ticket, but since it involves changes in compass metrics also I opened a new ticket and can work on that: https://jira.mongodb.org/browse/COMPASS-4351

Once we merge this we can have a release of mongosh and pull in the new compass-shell version in compass to pull it into the next compass beta release for 1.22.0