### PR TITLE
[WIP] Printable bson with metadata

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4795,14 +4795,10 @@
       }
     },
     "bson": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-4.0.4.tgz",
-      "integrity": "sha512-Ioi3TD0/1V3aI8+hPfC56TetYmzfq2H07jJa9A1lKTxWsFtHtYdLMGMXjtGEg9v0f72NSM07diRQEUNYhLupIA==",
-      "dev": true,
-      "requires": {
-        "buffer": "^5.1.0",
-        "long": "^4.0.0"
-      }
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-1.1.4.tgz",
+      "integrity": "sha512-S/yKGU1syOMzO86+dGpg2qGoDL0zvzcb262G+gqEy6TgP6rt6z6qxSFX/8X6vLC91P7G7C3nLs0+bvDzmvBA3Q==",
+      "dev": true
     },
     "btoa-lite": {
       "version": "1.0.0",
@@ -12301,12 +12297,6 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/lolex/-/lolex-4.2.0.tgz",
       "integrity": "sha512-gKO5uExCXvSm6zbF562EvM+rd1kQDnB9AZBbiQVzf1ZmdDpxUSvpnAaVOP83N/31mRK8Ml8/VE8DMvsAZQ+7wg==",
-      "dev": true
-    },
-    "long": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-      "integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA==",
       "dev": true
     },
     "loose-envify": {

--- a/package.json
+++ b/package.json
@@ -64,7 +64,7 @@
     "aws-sdk": "^2.674.0",
     "axios": "^0.19.2",
     "browserify": "^16.5.0",
-    "bson": "^4.0.4",
+    "bson": "^1.1.4",
     "chai": "^4.2.0",
     "cross-env": "^6.0.3",
     "electron-notarize": "mongodb-js/electron-notarize",

--- a/packages/browser-repl/package.json
+++ b/packages/browser-repl/package.json
@@ -61,7 +61,6 @@
     "@types/sinon": "^7.5.1",
     "@types/sinon-chai": "^3.2.3",
     "babel-loader": "^8.1.0",
-    "bson": "^4.0.3",
     "css-loader": "^3.4.1",
     "enzyme": "^3.11.0",
     "enzyme-adapter-react-16": "^1.15.2",

--- a/packages/cli-repl/package-lock.json
+++ b/packages/cli-repl/package-lock.json
@@ -190,28 +190,10 @@
 				"is-retry-allowed": "^1.1.0"
 			}
 		},
-		"base64-js": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
-		},
 		"bson": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/bson/-/bson-4.0.4.tgz",
-			"integrity": "sha512-Ioi3TD0/1V3aI8+hPfC56TetYmzfq2H07jJa9A1lKTxWsFtHtYdLMGMXjtGEg9v0f72NSM07diRQEUNYhLupIA==",
-			"requires": {
-				"buffer": "^5.1.0",
-				"long": "^4.0.0"
-			}
-		},
-		"buffer": {
-			"version": "5.6.0",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
-			"integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
-			"requires": {
-				"base64-js": "^1.0.2",
-				"ieee754": "^1.1.4"
-			}
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/bson/-/bson-1.1.4.tgz",
+			"integrity": "sha512-S/yKGU1syOMzO86+dGpg2qGoDL0zvzcb262G+gqEy6TgP6rt6z6qxSFX/8X6vLC91P7G7C3nLs0+bvDzmvBA3Q=="
 		},
 		"camelcase": {
 			"version": "5.0.0",
@@ -360,11 +342,6 @@
 			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.12.0.tgz",
 			"integrity": "sha1-5tnb5Xy+/mB1HwKvM2GVhwyQwB4="
 		},
-		"ieee754": {
-			"version": "1.1.13",
-			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-			"integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
-		},
 		"inherits": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
@@ -433,11 +410,6 @@
 			"version": "4.3.2",
 			"resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
 			"integrity": "sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM="
-		},
-		"long": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-			"integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
 		},
 		"lowlight": {
 			"version": "1.9.2",

--- a/packages/cli-repl/package.json
+++ b/packages/cli-repl/package.json
@@ -48,7 +48,7 @@
     "acorn-static-class-features": "^0.2.1",
     "analytics-node": "^3.4.0-beta.1",
     "ansi-escape-sequences": "^5.1.2",
-    "bson": "^4.0.4",
+    "bson": "^1.1.4",
     "fast-json-parse": "^1.0.3",
     "is-recoverable-error": "^1.0.0",
     "lodash.set": "^4.3.2",

--- a/packages/service-provider-server/package.json
+++ b/packages/service-provider-server/package.json
@@ -40,6 +40,7 @@
   "dependencies": {
     "@mongosh/errors": "^0.0.8",
     "@mongosh/service-provider-core": "^0.0.8",
+    "@mongosh/shell-api": "^0.0.8",
     "@types/sinon": "^7.5.1",
     "@types/sinon-chai": "^3.2.3",
     "mongodb": "3.5.3 || ^3.5.5"

--- a/packages/service-provider-server/src/cli-service-provider.ts
+++ b/packages/service-provider-server/src/cli-service-provider.ts
@@ -1,4 +1,4 @@
-import {
+import mongodb, {
   MongoClient,
   Db
 } from 'mongodb';
@@ -16,6 +16,7 @@ import {
   ReplPlatform,
   DEFAULT_DB
 } from '@mongosh/service-provider-core';
+import { modifyBson } from '@mongosh/shell-api';
 
 import NodeOptions from './node/node-options';
 
@@ -81,6 +82,7 @@ class CliServiceProvider implements ServiceProvider {
     this.mongoClient = mongoClient;
     this.uri = uri;
     this.platform = ReplPlatform.CLI;
+    modifyBson(mongodb, this.platform);
     try {
       this.initialDb = mongoClient.s.options.dbName || DEFAULT_DB;
     } catch (err) {

--- a/packages/service-provider-server/src/compass/compass-service-provider.ts
+++ b/packages/service-provider-server/src/compass/compass-service-provider.ts
@@ -1,6 +1,8 @@
 import CliServiceProvider from '../cli-service-provider';
 import { MongoClient } from 'mongodb';
 import { DEFAULT_DB, ReplPlatform } from '@mongosh/service-provider-core';
+import { modifyBson } from '@mongosh/shell-api';
+import mongodb from 'mongodb';
 
 interface DataService {
   client: {
@@ -24,6 +26,7 @@ class CompassServiceProvider extends CliServiceProvider {
   constructor(mongoClient: MongoClient, uri?: string) {
     super(mongoClient, uri);
     this.platform = ReplPlatform.Compass;
+    modifyBson(mongodb, this.platform);
     try {
       this.initialDb = mongoClient.s.options.dbName || DEFAULT_DB;
     } catch (err) {

--- a/packages/shell-api/package-lock.json
+++ b/packages/shell-api/package-lock.json
@@ -4,38 +4,10 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
-		"base64-js": {
-			"version": "1.3.1",
-			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.3.1.tgz",
-			"integrity": "sha512-mLQ4i2QO1ytvGWFWmcngKO//JXAQueZvwEKtjgQFM4jIK0kU+ytMfplL8j+n5mspOfjHwoAg+9yhb7BwAHm36g=="
-		},
 		"bson": {
-			"version": "4.0.4",
-			"resolved": "https://registry.npmjs.org/bson/-/bson-4.0.4.tgz",
-			"integrity": "sha512-Ioi3TD0/1V3aI8+hPfC56TetYmzfq2H07jJa9A1lKTxWsFtHtYdLMGMXjtGEg9v0f72NSM07diRQEUNYhLupIA==",
-			"requires": {
-				"buffer": "^5.1.0",
-				"long": "^4.0.0"
-			}
-		},
-		"buffer": {
-			"version": "5.6.0",
-			"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.6.0.tgz",
-			"integrity": "sha512-/gDYp/UtU0eA1ys8bOs9J6a+E/KWIY+DZ+Q2WESNUA0jFRsJOc0SNUO6xJ5SGA1xueg3NL65W6s+NY5l9cunuw==",
-			"requires": {
-				"base64-js": "^1.0.2",
-				"ieee754": "^1.1.4"
-			}
-		},
-		"ieee754": {
-			"version": "1.1.13",
-			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.1.13.tgz",
-			"integrity": "sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg=="
-		},
-		"long": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/long/-/long-4.0.0.tgz",
-			"integrity": "sha512-XsP+KhQif4bjX1kbuSiySJFNAehNxgLb6hPRGJ9QsUr8ajHkuXGdrHmFUTUUXhDwVX2R5bY4JNZEwbUiMhV+MA=="
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/bson/-/bson-1.1.4.tgz",
+			"integrity": "sha512-S/yKGU1syOMzO86+dGpg2qGoDL0zvzcb262G+gqEy6TgP6rt6z6qxSFX/8X6vLC91P7G7C3nLs0+bvDzmvBA3Q=="
 		}
 	}
 }

--- a/packages/shell-api/package.json
+++ b/packages/shell-api/package.json
@@ -38,9 +38,6 @@
     "@mongosh/history": "^0.0.8",
     "@mongosh/i18n": "^0.0.8",
     "@mongosh/service-provider-core": "^0.0.8",
-    "bson": "^4.0.4"
-  },
-  "devDependencies": {
-    "@mongosh/service-provider-server": "^0.0.8"
+    "bson": "^1.1.4"
   }
 }

--- a/packages/shell-api/src/enums.ts
+++ b/packages/shell-api/src/enums.ts
@@ -15,6 +15,11 @@ export const ALL_SERVER_VERSIONS = [ ServerVersions.earliest, ServerVersions.lat
 export const ALL_TOPOLOGIES = [ Topologies.ReplSet, Topologies.Sharded, Topologies.Standalone ];
 export const ALL_PLATFORMS = [ ReplPlatform.Compass, ReplPlatform.Browser, ReplPlatform.CLI ];
 
+export const toStringMethods = {};
+toStringMethods[ReplPlatform.Compass] = 'TODO';
+toStringMethods[ReplPlatform.Browser] = 'TODO';
+toStringMethods[ReplPlatform.CLI] = Symbol.for('nodejs.util.inspect.custom');
+
 export enum ReadPreference {
   PRIMARY = 0,
   PRIMARY_PREFERRED = 1,

--- a/packages/shell-api/src/index.ts
+++ b/packages/shell-api/src/index.ts
@@ -10,6 +10,7 @@ import toIterator from './toIterator';
 import Shard from './shard';
 import ReplicaSet from './replica-set';
 import ShellApi from './shell-api';
+import modifyBson from './modify-bson';
 import {
   BulkWriteResult,
   CommandResult,
@@ -63,5 +64,6 @@ export {
   Topologies,
   shellApiType,
   asShellResult,
-  ShellResult
+  ShellResult,
+  modifyBson
 };

--- a/packages/shell-api/src/integration.spec.ts
+++ b/packages/shell-api/src/integration.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { CliServiceProvider } from '@mongosh/service-provider-server';
+import { CliServiceProvider } from '../../service-provider-server'; // avoid cyclic dep just for test
 import { Cursor, Explainable, AggregationCursor, ShellInternalState, Mongo, ShellApi, asShellResult } from './index';
 import { startTestServer } from '../../../testing/integration-testing-hooks';
 

--- a/packages/shell-api/src/modify-bson.ts
+++ b/packages/shell-api/src/modify-bson.ts
@@ -1,0 +1,57 @@
+import { toStringMethods } from './enums';
+/**
+ * This method modifies the BSON class passed in as argument. This is required so that
+ * we can have the driver return our BSON classes without having to write our own serializer.
+ * @param {Object} bson
+ */
+export default function(bson, platform): void {
+  const toString = toStringMethods[platform];
+  bson.Binary.prototype[toString] = function(): string {
+    return `BinData(${this.value()})`;
+  };
+
+  bson.Code.prototype[toString] = function(): string {
+    return this.toJSON();
+  };
+
+  bson.DBRef.prototype[toString] = function(): string {
+    return `DBRef(${this.toJSON()})`;
+  };
+
+  bson.Decimal128.prototype[toString] = function(): string {
+    return `NumberDecimal('${this.toString()}')`;
+  };
+
+  bson.Double.prototype[toString] = function(): string {
+    return this.valueOf();
+  };
+
+  bson.Int32.prototype[toString] = function(): string {
+    return this.valueOf();
+  };
+
+  bson.Long.prototype[toString] = function(): string {
+    return `NumberLong(${this.toNumber()})`;
+  };
+
+  bson.MaxKey.prototype[toString] = function(): string {
+    return '{ "$maxKey" : 1 }';
+  };
+
+  bson.MinKey.prototype[toString] = function(): string {
+    return '{ "$minKey" : 1 }';
+  };
+
+  bson.ObjectId.prototype[toString] = function(): string {
+    return `ObjectID('${this.toHexString()}')`;
+  };
+
+  bson.Symbol.prototype[toString] = function(): string {
+    return `'${this.valueOf()}'`;
+  };
+
+  bson.Timestamp.prototype[toString] = function(): string {
+    // TODO: use this.high and this.low to display timestamp instead of toString()
+    return `Timestamp(${this.toString()})`;
+  };
+}

--- a/packages/shell-api/src/shell-internal-state.ts
+++ b/packages/shell-api/src/shell-internal-state.ts
@@ -17,6 +17,8 @@ import { MongoshInvalidInputError } from '@mongosh/errors';
 import AsyncWriter from '@mongosh/async-rewriter';
 import { toIgnore } from './decorators';
 import NoDatabase from './no-db';
+import modifyBson from './modify-bson';
+import bson from 'bson';
 
 /**
  * Anything to do with the internal shell state is stored here.
@@ -34,6 +36,7 @@ export default class ShellInternalState {
   public shellApi: ShellApi;
   public cliOptions: any;
   constructor(initialServiceProvider: ServiceProvider, messageBus: any = new EventEmitter(), cliOptions: any = {}) {
+    modifyBson(bson, initialServiceProvider.platform);
     this.initialServiceProvider = initialServiceProvider;
     this.messageBus = messageBus;
     this.asyncWriter = new AsyncWriter(signatures);


### PR DESCRIPTION
I think it would be clearest to read the code then read these questions:

The goal of this PR is to get the bson classes to print in a custom way, both when the user creates new BSON and when it is returned from the driver. Because we don't want to write our own serializer for raw BSON, we've decided to extend the BSON package with a platform-specific method that functions as a `toString` method, via modifying the prototype in memory (I don't love it but I think any other option would be a LOT more work and more error-prone).

The problem is that the Node driver requires a really old version of the 'bson' package, so we need to pin our use of the 'bson' package to 1.1.4. This is annoying because we can't use the built-in extjson and in order to do that will need to import `mongodb-extjson' if we want to use that. I can't find any consistent/documented methods on shell BSON objects that convert to/from extjson but I may be missing something. So my first question is: what do we need to do to support extjson?

The second issue is because of the monorepo and the node driver using a different version of bson, we have to add the print/help methods to the bson package in at least two places (one for BSON classes created by the user [shell-api], the other for BSON classes returned from the driver[service-provider-server]). Right now it's happening in shell-api `setCtx` and in the ServiceProvider package constructors. I would really like it if we could move the ServiceProvider call to the cli-repl instead, but I haven't gotten it to work (although it seems to work in #204 , not sure why it won't work for me). Even better would be to only modify it in one place, but I can't figure out why there are two `bson` packages - the one used by the driver, and the one we import directly from 'bson'. And we cannot always use the driver bson because we need it in the shell-api, which has to be web friendly. The driver will eventually update to using the 4.x bson but not in the time frame this ticket needs to be done. So the questions are (1) can we figure out how to have the driver use the same 'bson' package as we use in 'shell-api' without requiring the driver from 'shell-api'? And the second is (2) if not, can we move it from `service-provider-server` to `cli-repl`?

The last question is that I'm not sure what string we actually want for Compass/Browser. The CLI uses `Symbol.for('nodejs.util.inspect.custom')` but what should the Browser/Compass use for that symbol?



