### PR TITLE
COMPASS-4351: Add compass shell telemetry

### DIFF
--- a/packages/compass-shell/package-lock.json
+++ b/packages/compass-shell/package-lock.json
@@ -14710,6 +14710,11 @@
 			"integrity": "sha512-sch/9jd74VjRCmB5U+Fj4WJnkmAtDQgxqJkBInO7zEknXE+lnDEuNBT5/Wp59HMrWUabssGGq08r6Y6F7pkvVA==",
 			"dev": true
 		},
+		"mongodb-redux-common": {
+			"version": "0.0.2",
+			"resolved": "https://registry.npmjs.org/mongodb-redux-common/-/mongodb-redux-common-0.0.2.tgz",
+			"integrity": "sha512-gM0YByWsqU0ID01GX0rOee9vH/RiLapF9M+Jg1S8ApBZHfN3353tLQfc7Azh8pg8gwSDvVLGOohqH94GXW3XDg=="
+		},
 		"mongodb-reflux-store": {
 			"version": "0.0.1",
 			"resolved": "https://registry.npmjs.org/mongodb-reflux-store/-/mongodb-reflux-store-0.0.1.tgz",

--- a/packages/compass-shell/package.json
+++ b/packages/compass-shell/package.json
@@ -55,7 +55,8 @@
   "@mongosh/browser-repl": "^0.0.8",
   "@mongosh/browser-runtime-electron": "^0.0.8",
   "@mongosh/service-provider-server": "^0.0.8",
-  "hadron-react-buttons": "^4.0.4"
+  "hadron-react-buttons": "^4.0.4",
+  "mongodb-redux-common": "0.0.2"
  },
  "peerDependencies": {
   "hadron-ipc": "^1.1.0",

--- a/packages/compass-shell/package.json
+++ b/packages/compass-shell/package.json
@@ -94,7 +94,7 @@
   "electron": "^3.1.13",
   "electron-packager": "^8.7.0",
   "electron-rebuild": "^1.10.0",
-  "enzyme": "^3.7.0",
+  "enzyme": "^3.11.0",
   "enzyme-adapter-react-16": "^1.6.0",
   "eslint-config-mongodb-js": "^5.0.3",
   "file-loader": "^3.0.1",

--- a/packages/compass-shell/src/components/compass-shell/compass-shell.jsx
+++ b/packages/compass-shell/src/components/compass-shell/compass-shell.jsx
@@ -4,6 +4,7 @@ import styles from './compass-shell.less';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Resizable } from 're-resizable';
+import { globalAppRegistryEmit } from 'mongodb-redux-common/app-registry';
 
 import { Shell } from '@mongosh/browser-repl';
 
@@ -30,11 +31,13 @@ export class CompassShell extends Component {
     isExpanded: PropTypes.bool,
     runtime: PropTypes.object,
     shellOutput: PropTypes.array,
-    historyStorage: PropTypes.object
+    historyStorage: PropTypes.object,
+    onOpenShellPlugin: PropTypes.func
   };
 
   static defaultProps = {
-    runtime: null
+    runtime: null,
+    onOpenShellPlugin: () => {}
   };
   constructor(props) {
     super(props);
@@ -99,6 +102,8 @@ export class CompassShell extends Component {
         height: defaultShellHeightClosed
       });
     } else {
+      this.props.onOpenShellPlugin();
+
       this.resizableRef.updateSize({
         width: '100%',
         height: this.lastOpenHeight
@@ -172,5 +177,9 @@ export default connect(
   (state) => ({
     runtime: state.runtime ? state.runtime.runtime : null
   }),
-  {}
+  (dispatch) => ({
+    onOpenShellPlugin: () => dispatch(
+      globalAppRegistryEmit('compass:compass-shell:opened')
+    )
+  })
 )(CompassShell);

--- a/packages/compass-shell/src/components/compass-shell/compass-shell.jsx
+++ b/packages/compass-shell/src/components/compass-shell/compass-shell.jsx
@@ -4,7 +4,6 @@ import styles from './compass-shell.less';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { Resizable } from 're-resizable';
-import { globalAppRegistryEmit } from 'mongodb-redux-common/app-registry';
 
 import { Shell } from '@mongosh/browser-repl';
 
@@ -28,16 +27,16 @@ const defaultShellHeightOpened = 240;
 
 export class CompassShell extends Component {
   static propTypes = {
+    emitShellPluginOpened: PropTypes.func,
     isExpanded: PropTypes.bool,
     runtime: PropTypes.object,
     shellOutput: PropTypes.array,
-    historyStorage: PropTypes.object,
-    onOpenShellPlugin: PropTypes.func
+    historyStorage: PropTypes.object
   };
 
   static defaultProps = {
-    runtime: null,
-    onOpenShellPlugin: () => {}
+    emitShellPluginOpened: () => {},
+    runtime: null
   };
   constructor(props) {
     super(props);
@@ -102,7 +101,7 @@ export class CompassShell extends Component {
         height: defaultShellHeightClosed
       });
     } else {
-      this.props.onOpenShellPlugin();
+      this.props.emitShellPluginOpened();
 
       this.resizableRef.updateSize({
         width: '100%',
@@ -175,11 +174,11 @@ export class CompassShell extends Component {
 
 export default connect(
   (state) => ({
+    emitShellPluginOpened: () => {
+      if (state.appRegistry && state.appRegistry.globalAppRegistry) {
+        state.appRegistry.globalAppRegistry.emit('compass:compass-shell:opened');
+      }
+    },
     runtime: state.runtime ? state.runtime.runtime : null
-  }),
-  (dispatch) => ({
-    onOpenShellPlugin: () => dispatch(
-      globalAppRegistryEmit('compass:compass-shell:opened')
-    )
   })
 )(CompassShell);

--- a/packages/compass-shell/src/components/compass-shell/compass-shell.spec.js
+++ b/packages/compass-shell/src/components/compass-shell/compass-shell.spec.js
@@ -19,11 +19,11 @@ describe('CompassShell', () => {
     it('does not render a shell', () => {
       const fakeRuntime = {};
       const wrapper = shallow(<CompassShell runtime={fakeRuntime} isExpanded={false} />);
-      expect(wrapper.find(Shell)).to.have.lengthOf(0);
+      expect(wrapper.find(Shell).exists()).to.equal(false);
     });
 
     context('when is it expanded', () => {
-      it('calls the function prop onOpenShellPlugin', () => {
+      it('calls the function prop emitShellPluginOpened', () => {
         let calledFunc = false;
         const mockOnOpenShellPlugin = () => {
           calledFunc = true;
@@ -31,7 +31,7 @@ describe('CompassShell', () => {
 
         const shell = new CompassShell({
           isExpanded: false,
-          onOpenShellPlugin: mockOnOpenShellPlugin
+          emitShellPluginOpened: mockOnOpenShellPlugin
         });
         shell.resizableRef = {
           sizeStyle: {
@@ -50,7 +50,7 @@ describe('CompassShell', () => {
     context('when runtime property is not present', () => {
       it('does not render a shell if runtime is null', () => {
         const wrapper = shallow(<CompassShell runtime={null} isExpanded />);
-        expect(wrapper.find(Shell)).to.have.lengthOf(0);
+        expect(wrapper.find(Shell).exists()).to.equal(false);
       });
     });
 
@@ -163,7 +163,7 @@ describe('CompassShell', () => {
         it('resumes its previous height', () => {
           const shell = new CompassShell({
             isExpanded: true,
-            onOpenShellPlugin: () => {}
+            emitShellPluginOpened: () => {}
           });
           shell.setState = stateUpdate => {
             shell.state = {

--- a/packages/compass-shell/src/components/compass-shell/compass-shell.spec.js
+++ b/packages/compass-shell/src/components/compass-shell/compass-shell.spec.js
@@ -21,6 +21,29 @@ describe('CompassShell', () => {
       const wrapper = shallow(<CompassShell runtime={fakeRuntime} isExpanded={false} />);
       expect(wrapper.find(Shell)).to.have.lengthOf(0);
     });
+
+    context('when is it expanded', () => {
+      it('calls the function prop onOpenShellPlugin', () => {
+        let calledFunc = false;
+        const mockOnOpenShellPlugin = () => {
+          calledFunc = true;
+        };
+
+        const shell = new CompassShell({
+          isExpanded: false,
+          onOpenShellPlugin: mockOnOpenShellPlugin
+        });
+        shell.resizableRef = {
+          sizeStyle: {
+            height: 100
+          },
+          updateSize: () => {}
+        };
+        shell.shellToggleClicked();
+
+        expect(calledFunc).to.equal(true);
+      });
+    });
   });
 
   context('when the prop isExpanded is true', () => {
@@ -138,7 +161,10 @@ describe('CompassShell', () => {
 
       context('when it is expanded again', () => {
         it('resumes its previous height', () => {
-          const shell = new CompassShell({ isExpanded: true });
+          const shell = new CompassShell({
+            isExpanded: true,
+            onOpenShellPlugin: () => {}
+          });
           shell.setState = stateUpdate => {
             shell.state = {
               ...shell.state,

--- a/packages/compass-shell/src/components/shell-header/shell-header.spec.js
+++ b/packages/compass-shell/src/components/shell-header/shell-header.spec.js
@@ -37,7 +37,7 @@ describe('ShellHeader', () => {
         showInfoModal={() => {}}
       />);
 
-      expect(wrapper.find(`.${styles['compass-shell-header-right-actions']}`)).to.be.present();
+      expect(wrapper.find(`.${styles['compass-shell-header-right-actions']}`).exists()).to.equal(true);
     });
   });
 

--- a/packages/compass-shell/src/modules/index.js
+++ b/packages/compass-shell/src/modules/index.js
@@ -1,12 +1,11 @@
 import { combineReducers } from 'redux';
+import appRegistry from 'mongodb-redux-common/app-registry';
 
 import infoModal from './info-modal';
 import runtime from './runtime';
 
-/**
- * The reducer.
- */
 const reducer = combineReducers({
+  appRegistry,
   infoModal,
   runtime
 });

--- a/packages/compass-shell/src/modules/runtime.js
+++ b/packages/compass-shell/src/modules/runtime.js
@@ -46,7 +46,8 @@ function reduceSetupRuntime(state, action) {
   }
 
   const runtime = new ElectronRuntime(
-    CompassServiceProvider.fromDataService(action.dataService)
+    CompassServiceProvider.fromDataService(action.dataService),
+    action.appRegistry
   );
 
   return {
@@ -61,11 +62,13 @@ function reduceSetupRuntime(state, action) {
  *
  * @param {Error} error - The connection error.
  * @param {DataService} dataService - The data service.
+ * @param {EventEmitter} appRegistry - A message bus for runtime events.
  *
  * @returns {Object} The data service connected action.
  */
-export const setupRuntime = (error, dataService) => ({
+export const setupRuntime = (error, dataService, appRegistry) => ({
   type: SETUP_RUNTIME,
-  error: error,
-  dataService: dataService
+  error,
+  dataService,
+  appRegistry
 });

--- a/packages/compass-shell/src/plugin.spec.js
+++ b/packages/compass-shell/src/plugin.spec.js
@@ -1,0 +1,44 @@
+import React from 'react';
+import { mount } from 'enzyme';
+import { EventEmitter } from 'events';
+
+import { CompassShell } from './components/compass-shell';
+import createPlugin from './plugin';
+import CompassShellStore from 'stores';
+
+describe('CompassShellPlugin', () => {
+  it('returns a render-able plugin', () => {
+    const { Plugin } = createPlugin();
+
+    const wrapper = mount(<Plugin />);
+    expect(wrapper.find(CompassShell).exists()).to.equal(true);
+  });
+
+  it('returns a CompassShellStore store', () => {
+    const { store } = createPlugin();
+    const appRegistry = new EventEmitter();
+    store.onActivated(appRegistry);
+    expect(store).to.be.instanceOf(CompassShellStore);
+  });
+
+  it('emits an event on the app registry when it is expanded', () => {
+    const { store, Plugin } = createPlugin();
+
+    const appRegistry = new EventEmitter();
+    let eventOccured = false;
+    appRegistry.on('compass:compass-shell:opened', () => {
+      eventOccured = true;
+    });
+
+    store.onActivated(appRegistry);
+
+    const wrapper = mount(<Plugin />);
+    const shellComponentWrapper = wrapper.find(CompassShell);
+
+    const { emitShellPluginOpened } = shellComponentWrapper.props();
+    emitShellPluginOpened();
+
+    expect(eventOccured).to.equal(true);
+  });
+});
+

--- a/packages/compass-shell/src/stores/store.js
+++ b/packages/compass-shell/src/stores/store.js
@@ -1,6 +1,9 @@
 import { createStore } from 'redux';
 import reducer from 'modules';
 import { setupRuntime } from 'modules/runtime';
+import {
+  globalAppRegistryActivated
+} from 'mongodb-redux-common/app-registry';
 
 const debug = require('debug')('mongodb-compass-shell:store');
 
@@ -8,6 +11,8 @@ export default class CompassShellStore {
   constructor() {
     this.reduxStore = createStore(reducer);
   }
+
+  globalAppRegistry = null;
 
   onActivated(appRegistry) {
     debug('activated');
@@ -21,6 +26,9 @@ export default class CompassShellStore {
       'data-service-disconnected',
       this.onDataServiceDisconnected
     );
+
+    // Set the global app registry in the store.
+    this.reduxStore.dispatch(globalAppRegistryActivated(appRegistry));
   }
 
   onDataServiceConnected = (error, dataService) => {

--- a/packages/compass-shell/src/stores/store.js
+++ b/packages/compass-shell/src/stores/store.js
@@ -17,6 +17,8 @@ export default class CompassShellStore {
   onActivated(appRegistry) {
     debug('activated');
 
+    this.globalAppRegistry = appRegistry;
+
     appRegistry.on(
       'data-service-connected',
       this.onDataServiceConnected
@@ -34,12 +36,14 @@ export default class CompassShellStore {
   onDataServiceConnected = (error, dataService) => {
     this.reduxStore.dispatch(setupRuntime(
       error,
-      dataService
+      dataService,
+      this.globalAppRegistry
     ));
   }
 
   onDataServiceDisconnected = () => {
     this.reduxStore.dispatch(setupRuntime(
+      null,
       null,
       null
     ));

--- a/packages/compass-shell/src/stores/store.spec.js
+++ b/packages/compass-shell/src/stores/store.spec.js
@@ -12,6 +12,13 @@ describe('CompassShellStore [Store]', () => {
     store.onActivated(appRegistry);
   });
 
+  describe('appRegistry', () => {
+    it('sets the global appregistry', () => {
+      expect(store.reduxStore.getState().appRegistry).to.not.equal(null);
+      expect(store.reduxStore.getState().appRegistry.globalAppRegistry).to.not.equal(null);
+    });
+  });
+
   describe('runtime', () => {
     const getRuntimeState = () => store.reduxStore.getState().runtime;
 

--- a/packages/compass-shell/src/stores/store.spec.js
+++ b/packages/compass-shell/src/stores/store.spec.js
@@ -59,7 +59,6 @@ describe('CompassShellStore [Store]', () => {
 
       const runtimeState = getRuntimeState();
 
-      
       runtimeState.runtime.evaluate('show dbs;');
 
       expect(eventRecieved).to.equal(true);

--- a/packages/shell-api/src/integration.spec.ts
+++ b/packages/shell-api/src/integration.spec.ts
@@ -347,6 +347,7 @@ describe('Shell API (integration)', function() {
               _id: 1
             },
             name: '_id_',
+            ns: `${dbName}.${collectionName}`,
             v: 2
           });
         expect(result[1]).to.deep.include(
@@ -355,6 +356,7 @@ describe('Shell API (integration)', function() {
               x: 1
             },
             name: 'x_1',
+            ns: `${dbName}.${collectionName}`,
             v: 2
           });
       });

--- a/packages/shell-api/src/integration.spec.ts
+++ b/packages/shell-api/src/integration.spec.ts
@@ -347,7 +347,6 @@ describe('Shell API (integration)', function() {
               _id: 1
             },
             name: '_id_',
-            ns: `${dbName}.${collectionName}`,
             v: 2
           });
         expect(result[1]).to.deep.include(
@@ -356,7 +355,6 @@ describe('Shell API (integration)', function() {
               x: 1
             },
             name: 'x_1',
-            ns: `${dbName}.${collectionName}`,
             v: 2
           });
       });


### PR DESCRIPTION
COMPASS-4351

This PR adds telemetry events for the compass shell plugin. When the plugin is expanded it emits a `compass:compass-shell:opened`. The global appRegistry is passed as a message bus option to mongosh so that mongosh log events are emitted in compass land and can be consumed by the metrics (or possibly elsewhere later).

Here's the PR in `compass-metrics` where the events are being passed to the telemetry:  https://github.com/mongodb-js/compass-metrics/pull/147

![app registry mongosh](https://user-images.githubusercontent.com/1791149/88775524-1916c680-d185-11ea-8d93-0d4e1ba5b573.gif)

After this is merged we'll want to do a release, we can see with the team if there's anything to be merged soon or if it can happen sooner. Then we can update the version in compass as well. 