### PR TITLE
MONGOSH-180 - Support user management commands

### DIFF
--- a/packages/cli-repl/src/completer.spec.ts
+++ b/packages/cli-repl/src/completer.spec.ts
@@ -34,6 +34,17 @@ describe('completer.completer', () => {
         'db.getSiblingDB',
         'db.getCollection',
         'db.dropDatabase',
+        'db.createUser',
+        'db.updateUser',
+        'db.changeUserPassword',
+        'db.logout',
+        'db.dropUser',
+        'db.dropAllUsers',
+        'db.auth',
+        'db.grantRolesToUser',
+        'db.revokeRolesFromUser',
+        'db.getUser',
+        'db.getUsers'
       ], i]);
     });
 

--- a/packages/cli-repl/test/e2e-auth.spec.ts
+++ b/packages/cli-repl/test/e2e-auth.spec.ts
@@ -1,0 +1,576 @@
+import { expect } from 'chai';
+import {
+  MongoClient
+} from 'mongodb';
+import { eventually } from './helpers';
+import { TestShell } from './test-shell';
+import {
+  startTestServer
+} from '../../../testing/integration-testing-hooks';
+
+function createAssertUserExists(db, dbName): Function {
+  return async(opts = {}, username = 'anna'): Promise<void> => {
+    const result = await db.command({ usersInfo: 1 });
+    expect(result.users.length).to.equal(1);
+    const user = result.users[0];
+    expect(user.db).to.equal(dbName);
+    expect(user.user).to.equal(username);
+    Object.keys(opts).forEach((k) => {
+      expect(user[k]).to.deep.equal(opts[k]);
+    });
+  };
+}
+
+function createAssertUserAuth(db, connectionString, dbName): Function {
+  return async(pwd = 'pwd', username = 'anna', keepClient = false): Promise<any> => {
+    try {
+      const c = await MongoClient.connect(
+        connectionString,
+        {
+          useNewUrlParser: true,
+          useUnifiedTopology: true,
+          auth: { user: username, password: pwd, authSource: dbName },
+          connectTimeoutMS: 1000
+        }
+      );
+      if (keepClient) {
+        return c;
+      }
+      await c.close();
+    } catch (e) {
+      expect.fail(`Could not authenticate user to initialize test: ${e.message}`);
+    }
+  };
+}
+
+describe('Auth e2e', function() {
+  const connectionString = startTestServer();
+  let assertUserExists;
+  let assertUserAuth;
+
+  let db;
+  let client;
+  let shell: TestShell;
+  let dbName;
+
+  describe('with regular URI', () => {
+    beforeEach(async() => {
+      dbName = `test-${Date.now()}`;
+      shell = TestShell.start({ args: [connectionString] });
+
+      client = await (MongoClient as any).connect(
+        connectionString,
+        { useNewUrlParser: true, useUnifiedTopology: true }
+      );
+
+      db = client.db(dbName);
+      assertUserExists = createAssertUserExists(db, dbName);
+      assertUserAuth = createAssertUserAuth(db, connectionString, dbName);
+
+      await shell.waitForPrompt();
+      shell.assertNoErrors();
+    });
+
+    afterEach(async() => {
+      await db.dropDatabase();
+      await db.command({ dropAllUsersFromDatabase: 1 });
+
+      client.close();
+      TestShell.killall();
+    });
+
+    describe('user management', () => {
+      describe('createUser', async() => {
+        afterEach(async() => {
+          await assertUserAuth();
+        });
+        it('all arguments', async() => {
+          await shell.writeInputLine(`use ${dbName}`);
+          await shell.writeInputLine(
+            'db.createUser({ user: "anna", pwd: "pwd", customData: { extra: 1 }, roles: ["dbAdmin"], mechanisms: ["SCRAM-SHA-256"], passwordDigestor: "server"})'
+          );
+          await eventually(async() => {
+            shell.assertContainsOutput('{ ok: 1 }');
+          });
+          await assertUserExists({
+            customData: { extra: 1 },
+            roles: [{ role: 'dbAdmin', db: dbName }],
+            mechanisms: ['SCRAM-SHA-256']
+          });
+          shell.assertNoErrors();
+        });
+        it('default arguments', async() => {
+          await shell.writeInputLine(`use ${dbName}`);
+          await shell.writeInputLine(
+            'db.createUser({ user: "anna", pwd: "pwd", roles: []})'
+          );
+          await eventually(async() => {
+            shell.assertContainsOutput('{ ok: 1 }');
+          });
+          await assertUserExists({
+            roles: [],
+            mechanisms: ['SCRAM-SHA-1', 'SCRAM-SHA-256']
+          });
+          shell.assertNoErrors();
+        });
+        it('digestPassword', async() => {
+          await shell.writeInputLine(`use ${dbName}`);
+          await shell.writeInputLine(
+            'db.createUser({ user: "anna", pwd: "pwd", roles: [], mechanisms: ["SCRAM-SHA-1"], passwordDigestor: "client"})'
+          );
+          await eventually(async() => {
+            shell.assertContainsOutput('{ ok: 1 }');
+          });
+          await assertUserExists({
+            roles: [],
+            mechanisms: ['SCRAM-SHA-1']
+          });
+          shell.assertNoErrors();
+        });
+      });
+      describe('updateUser', async() => {
+        beforeEach(async() => {
+          const r = await db.command({
+            createUser: 'anna',
+            pwd: 'pwd',
+            roles: []
+          });
+          expect(r.ok).to.equal(1, 'Unable to create user to initialize test');
+          await assertUserExists({
+            roles: []
+          });
+          await assertUserAuth();
+        });
+        afterEach(async() => {
+          await db.command({ dropAllUsersFromDatabase: 1 });
+        });
+        it('all arguments', async() => {
+          await shell.writeInputLine(`use ${dbName}`);
+          await shell.writeInputLine(
+            'db.updateUser("anna", { pwd: "pwd2", customData: { extra: 1 }, roles: ["dbAdmin"], mechanisms: ["SCRAM-SHA-256"], passwordDigestor: "server"})'
+          );
+          await eventually(async() => {
+            shell.assertContainsOutput('{ ok: 1 }');
+          });
+          await assertUserExists({
+            customData: { extra: 1 },
+            roles: [{ role: 'dbAdmin', db: dbName }],
+            mechanisms: ['SCRAM-SHA-256']
+          });
+          await assertUserAuth('pwd2');
+          shell.assertNoErrors();
+        });
+        it('just customData', async() => {
+          await shell.writeInputLine(`use ${dbName}`);
+          await shell.writeInputLine(
+            'db.updateUser("anna", { customData: { extra: 1 } })'
+          );
+          await eventually(async() => {
+            shell.assertContainsOutput('{ ok: 1 }');
+          });
+          await assertUserExists({
+            roles: [],
+            customData: { extra: 1 },
+            mechanisms: ['SCRAM-SHA-1', 'SCRAM-SHA-256' ]
+          });
+          shell.assertNoErrors();
+        });
+        it('digestPassword', async() => {
+          await shell.writeInputLine(`use ${dbName}`);
+          await shell.writeInputLine(
+            'db.updateUser("anna", { pwd: "pwd3", passwordDigestor: "client", mechanisms: ["SCRAM-SHA-1"]})'
+          );
+          await eventually(async() => {
+            shell.assertContainsOutput('{ ok: 1 }');
+          });
+          await assertUserExists({
+            roles: [],
+            mechanisms: ['SCRAM-SHA-1']
+          });
+          await assertUserAuth('pwd3');
+          shell.assertNoErrors();
+        });
+        it('changeUserPassword', async() => {
+          await shell.writeInputLine(`use ${dbName}`);
+          await shell.writeInputLine(
+            'db.changeUserPassword("anna", "pwd4")'
+          );
+          await eventually(async() => {
+            shell.assertContainsOutput('{ ok: 1 }');
+          });
+          await assertUserExists({
+            roles: [],
+            mechanisms: ['SCRAM-SHA-1', 'SCRAM-SHA-256']
+          });
+          await assertUserAuth('pwd4');
+        });
+      });
+      describe('delete users', async() => {
+        beforeEach(async() => {
+          const r = await db.command({
+            createUser: 'anna',
+            pwd: 'pwd',
+            roles: []
+          });
+          expect(r.ok).to.equal(1, 'Unable to create user to initialize test');
+          const r2 = await db.command({
+            createUser: 'anna2',
+            pwd: 'pwd2',
+            roles: []
+          });
+          expect(r2.ok).to.equal(1, 'Unable to create user to initialize test');
+          const result = await db.command({ usersInfo: 1 });
+          expect(result.users.length).to.equal(2);
+        });
+        afterEach(async() => {
+          await db.command({ dropAllUsersFromDatabase: 1 });
+        });
+        it('dropUser', async() => {
+          await shell.writeInputLine(`use ${dbName}`);
+          await shell.writeInputLine(
+            'db.dropUser("anna2")'
+          );
+          await eventually(async() => {
+            shell.assertContainsOutput('{ ok: 1 }');
+          });
+          await assertUserExists();
+          shell.assertNoErrors();
+        });
+        it('dropAllUsers', async() => {
+          await shell.writeInputLine(`use ${dbName}`);
+          await shell.writeInputLine(
+            'db.dropAllUsers()'
+          );
+          await eventually(async() => {
+            shell.assertContainsOutput('{ n: 2, ok: 1 }');
+          });
+          const result = await db.command({ usersInfo: 1 });
+          expect(result.users.length).to.equal(0);
+          shell.assertNoErrors();
+        });
+      });
+      describe('add/remove roles', async() => {
+        beforeEach(async() => {
+          const r = await db.command({
+            createUser: 'anna',
+            pwd: 'pwd',
+            roles: [ { role: 'dbAdmin', db: dbName }]
+          });
+          expect(r.ok).to.equal(1, 'Unable to create user to initialize test');
+          await assertUserExists({
+            roles: [ { role: 'dbAdmin', db: dbName }]
+          });
+          await assertUserAuth();
+        });
+        afterEach(async() => {
+          await db.command({ dropAllUsersFromDatabase: 1 });
+        });
+        it('grantRolesToUser', async() => {
+          await shell.writeInputLine(`use ${dbName}`);
+          await shell.writeInputLine(
+            'db.grantRolesToUser("anna", [ "userAdmin", "dbOwner" ])'
+          );
+          await eventually(async() => {
+            shell.assertContainsOutput('{ ok: 1 }');
+          });
+          const result = await db.command({ usersInfo: 1 });
+          expect(result.users.length).to.equal(1);
+          const user = result.users[0];
+          expect(user.roles.map(k => k.role)).to.have.members([
+            'dbOwner', 'dbAdmin', 'userAdmin'
+          ]);
+          shell.assertNoErrors();
+        });
+        it('revokeRolesFrom', async() => {
+          await shell.writeInputLine(`use ${dbName}`);
+          await shell.writeInputLine(
+            'db.revokeRolesFromUser("anna", [ "dbAdmin" ])'
+          );
+          await eventually(async() => {
+            shell.assertContainsOutput('{ ok: 1 }');
+          });
+          await assertUserExists({
+            roles: [],
+          });
+          shell.assertNoErrors();
+        });
+      });
+      describe('get user info', () => {
+        beforeEach(async() => {
+          const r = await db.command({
+            createUser: 'anna',
+            pwd: 'pwd',
+            roles: []
+          });
+          expect(r.ok).to.equal(1, 'Unable to create user to initialize test');
+          const r2 = await db.command({
+            createUser: 'anna2',
+            pwd: 'pwd2',
+            roles: []
+          });
+          expect(r2.ok).to.equal(1, 'Unable to create user to initialize test');
+          const result = await db.command({ usersInfo: 1 });
+          expect(result.users.length).to.equal(2);
+        });
+        afterEach(async() => {
+          await db.command({ dropAllUsersFromDatabase: 1 });
+        });
+        it('getUser when user exists', async() => {
+          await shell.writeInputLine(`use ${dbName}`);
+          await shell.writeInputLine(
+            'db.getUser("anna2")'
+          );
+          await eventually(async() => {
+            shell.assertContainsOutput('user: \'anna2\'');
+          });
+          shell.assertNoErrors();
+        });
+        it('getUser when user does not exist', async() => {
+          await shell.writeInputLine(`use ${dbName}`);
+          await shell.writeInputLine(
+            'db.getUser("anna3")'
+          );
+          await eventually(async() => {
+            shell.assertContainsOutput('null');
+          });
+          shell.assertNoErrors();
+        });
+        it('getUsers without filter', async() => {
+          await shell.writeInputLine(`use ${dbName}`);
+          await shell.writeInputLine(
+            'db.getUsers()'
+          );
+          await eventually(async() => {
+            shell.assertContainsOutput('users: [');
+            shell.assertContainsOutput('user: \'anna\'');
+            shell.assertContainsOutput('user: \'anna2\'');
+          });
+          shell.assertNoErrors();
+        });
+        it('getUsers with filter', async() => {
+          await shell.writeInputLine(`use ${dbName}`);
+          await shell.writeInputLine(
+            'db.getUsers({ filter: { user: "anna" } })'
+          );
+          await eventually(async() => {
+            shell.assertContainsOutput('user: \'anna\'');
+          });
+          shell.assertNoErrors();
+        });
+      });
+    });
+    describe('authentication', () => {
+      beforeEach(async() => {
+        const r = await db.command({
+          createUser: 'anna',
+          pwd: 'pwd',
+          roles: []
+        });
+        expect(r.ok).to.equal(1, 'Unable to create user to initialize test');
+        await assertUserExists({
+          roles: []
+        });
+      });
+      afterEach(async() => {
+        db.command({ dropAllUsersFromDatabase: 1 });
+      });
+      describe('auth', async() => {
+        it('logs in with simple user/pwd', async() => {
+          await shell.writeInputLine(`use ${dbName}`);
+          await shell.writeInputLine(
+            'db.auth("anna", "pwd")'
+          );
+          await eventually(async() => {
+            shell.assertContainsOutput('{ ok: 1 }');
+          });
+          await shell.writeInputLine(
+            'db.runCommand({connectionStatus: 1})'
+          );
+          await eventually(async() => {
+            shell.assertContainsOutput('user: \'anna\'');
+          });
+          shell.assertNoErrors();
+        });
+        it('logs in with user doc', async() => {
+          await shell.writeInputLine(`use ${dbName}`);
+          await shell.writeInputLine(
+            'db.auth({user: "anna", pwd: "pwd"})'
+          );
+          await eventually(async() => {
+            shell.assertContainsOutput('{ ok: 1 }');
+          });
+          await shell.writeInputLine(
+            'db.runCommand({connectionStatus: 1})'
+          );
+          await eventually(async() => {
+            shell.assertContainsOutput('user: \'anna\'');
+          });
+          shell.assertNoErrors();
+        });
+        it('digestPassword errors with message', async() => {
+          await shell.writeInputLine(`use ${dbName}`);
+          await shell.writeInputLine(
+            'db.auth({user: "anna", pwd: "pwd", digestPassword: true})'
+          );
+          await eventually(async() => {
+            shell.assertContainsError('MongoshUnimplementedError: digestPassword is not supported for authentication');
+          });
+          await shell.writeInputLine(
+            'db.runCommand({connectionStatus: 1})'
+          );
+          await eventually(async() => {
+            shell.assertContainsOutput('authenticatedUsers: []');
+          });
+        });
+        it('throws if pwd is wrong', async() => {
+          await shell.writeInputLine(`use ${dbName}`);
+          await shell.writeInputLine(
+            'db.auth("anna", "pwd2")'
+          );
+          await eventually(async() => {
+            shell.assertContainsError('MongoServerSelectionError: Authentication failed');
+          }, { timeout: 40000 });
+          await shell.writeInputLine(
+            'db.runCommand({connectionStatus: 1})'
+          );
+          await eventually(async() => {
+            shell.assertContainsOutput('authenticatedUsers: []');
+          });
+        });
+        it('throws if mech is not recognized', async() => {
+          await shell.writeInputLine(`use ${dbName}`);
+          await shell.writeInputLine(
+            'db.auth({ user: "anna", pwd: "pwd2", mechanism: "not a mechanism"})'
+          );
+          await eventually(async() => {
+            shell.assertContainsError('MongoError: authentication mechanism not a mechanism not supported\', options.authMechanism');
+          }, { timeout: 40000 });
+          await shell.writeInputLine(
+            'db.runCommand({connectionStatus: 1})'
+          );
+          await eventually(async() => {
+            shell.assertContainsOutput('authenticatedUsers: []');
+          });
+        });
+      });
+      describe('logout', async() => {
+        it('logs out after authenticating', async() => {
+          await shell.writeInputLine(`use ${dbName}`);
+          await shell.writeInputLine(
+            'db.auth("anna", "pwd")'
+          );
+          await eventually(async() => {
+            shell.assertContainsOutput('{ ok: 1 }');
+          });
+          await shell.writeInputLine(
+            'db.runCommand({connectionStatus: 1})'
+          );
+          await eventually(async() => {
+            shell.assertContainsOutput('user: \'anna\'');
+          });
+          await shell.writeInputLine(
+            'db.logout()'
+          );
+          await eventually(async() => {
+            shell.assertContainsOutput('{ ok: 1 }');
+          });
+          await shell.writeInputLine(
+            'db.runCommand({connectionStatus: 1})'
+          );
+          await eventually(async() => {
+            shell.assertContainsOutput('authenticatedUsers: []');
+          });
+          shell.assertNoErrors();
+        });
+      });
+    });
+  });
+  describe('with options in URI', () => {
+    beforeEach(async() => {
+      dbName = `test-${Date.now()}`;
+
+      client = await (MongoClient as any).connect(
+        connectionString,
+        { useNewUrlParser: true, useUnifiedTopology: true }
+      );
+
+      db = client.db(dbName);
+      expect((await db.command({
+        createUser: 'anna', pwd: 'pwd', roles: []
+      })).ok).to.equal(1);
+      expect((await db.command({
+        createUser: 'anna2', pwd: 'pwd2', roles: []
+      })).ok).to.equal(1);
+
+      assertUserExists = createAssertUserExists(db, dbName);
+      assertUserAuth = createAssertUserAuth(db, connectionString, dbName);
+      await assertUserAuth('pwd2', 'anna2');
+    });
+    it('can auth when there is login in URI', async() => {
+      const split = connectionString.split('//');
+      const authConnectionString = `${split[0]}//anna2:pwd2@${split[1]}/${dbName}`;
+      shell = TestShell.start({ args: [authConnectionString] });
+      await shell.waitForPrompt();
+      shell.assertNoErrors();
+      await shell.writeInputLine(`use ${dbName}`);
+      await shell.writeInputLine(
+        'db.runCommand({connectionStatus: 1})'
+      );
+      await eventually(async() => {
+        shell.assertContainsOutput('user: \'anna2\'');
+      });
+      await shell.writeInputLine(
+        'db.auth({user: "anna", pwd: "pwd"})'
+      );
+      await eventually(async() => {
+        shell.assertContainsOutput('{ ok: 1 }');
+      });
+      await shell.writeInputLine(
+        'db.runCommand({connectionStatus: 1})'
+      );
+      await eventually(async() => {
+        shell.assertContainsOutput('user: \'anna\'');
+      });
+      shell.assertNoErrors();
+    });
+    it('can auth when there is -u and -p', async() => {
+      shell = TestShell.start({ args: [
+        connectionString,
+        ' -u "anna2"',
+        ' -p "pwd2"',
+        ` --authenticationDatabase "${dbName}"`
+      ] });
+      await shell.waitForPrompt();
+      shell.assertNoErrors();
+      await shell.writeInputLine('db');
+      await shell.writeInputLine(`use ${dbName}`);
+      await shell.writeInputLine('db.getUsers()');
+      await shell.writeInputLine(
+        'db.runCommand({connectionStatus: 1})'
+      );
+      await eventually(async() => {
+        shell.assertContainsOutput('user: \'anna2\'');
+      });
+      await shell.writeInputLine(
+        'db.auth({user: "anna", pwd: "pwd"})'
+      );
+      await eventually(async() => {
+        shell.assertContainsOutput('{ ok: 1 }');
+      });
+      await shell.writeInputLine(
+        'db.runCommand({connectionStatus: 1})'
+      );
+      await eventually(async() => {
+        shell.assertContainsOutput('user: \'anna\'');
+      });
+      shell.assertNoErrors();
+    });
+    afterEach(async() => {
+      await db.dropDatabase();
+      await db.command({ dropAllUsersFromDatabase: 1 });
+
+      client.close();
+      TestShell.killall();
+    });
+  });
+});

--- a/packages/cli-repl/test/e2e.spec.ts
+++ b/packages/cli-repl/test/e2e.spec.ts
@@ -131,12 +131,42 @@ describe('e2e', function() {
       shell.assertContainsError('SyntaxError: Unterminated string constant');
     });
 
-    it('does not throw for valid input', async() => {
-      await shell.executeLine('1');
-      shell.assertNoErrors();
+    describe('literals', async() => {
+      it('number', async() => {
+        await shell.executeLine('1');
+        shell.assertNoErrors();
 
-      await eventually(() => {
-        shell.assertContainsOutput('1');
+        await eventually(() => {
+          shell.assertContainsOutput('1');
+        });
+        it('string', async() => {
+          await shell.executeLine('"string"');
+          shell.assertNoErrors();
+
+          await eventually(() => {
+            shell.assertContainsOutput('string');
+          });
+        });
+        it('undefined', async() => {
+          await shell.executeLine('undefined');
+          shell.assertNoErrors();
+        });
+        it('null', async() => {
+          await shell.executeLine('null');
+          shell.assertNoErrors();
+
+          await eventually(() => {
+            shell.assertContainsOutput('1');
+          });
+        });
+        it('bool', async() => {
+          await shell.executeLine('true');
+          shell.assertNoErrors();
+
+          await eventually(() => {
+            shell.assertContainsOutput('true');
+          });
+        });
       });
     });
     it('throws when a syntax error is encountered', async() => {

--- a/packages/service-provider-browser/src/stitch-service-provider-browser.ts
+++ b/packages/service-provider-browser/src/stitch-service-provider-browser.ts
@@ -11,7 +11,7 @@ import {
   getConnectInfo,
   ReplPlatform,
   DEFAULT_DB,
-  ServiceProviderCore
+  ServiceProviderCore, AuthOptions
 } from '@mongosh/service-provider-core';
 
 import StitchTransport from './stitch-transport';
@@ -474,6 +474,12 @@ class StitchServiceProviderBrowser extends ServiceProviderCore implements Servic
    */
   get userId(): string {
     return this.stitchTransport.userId;
+  }
+
+  authenticate(
+    authDoc: AuthOptions
+  ): Promise<any> {
+    throw new MongoshUnimplementedError('Authentication not supported via Browser');
   }
 }
 

--- a/packages/service-provider-core/src/admin.ts
+++ b/packages/service-provider-core/src/admin.ts
@@ -1,7 +1,23 @@
 import Result from './result';
 import { ReplPlatform } from './platform';
+import AuthOptions from './auth-options';
 
 export default interface Admin {
+  /**
+   * What platform (Compass/CLI/Browser)
+   */
+  platform: ReplPlatform;
+
+  /**
+   * The initial database
+   */
+  initialDb: string;
+
+  /**
+   * The BSON package
+   */
+  bsonLibrary: any;
+
    /**
    * Returns buildInfo.
    *
@@ -39,17 +55,7 @@ export default interface Admin {
   getConnectionInfo(): Promise<any>;
 
   /**
-   * What platform (Compass/CLI/Browser)
+   * Authenticate
    */
-  platform: ReplPlatform;
-
-  /**
-   * The initial database
-   */
-  initialDb: string;
-
-  /**
-   * The BSON package
-   */
-  bsonLibrary: any;
+  authenticate(authDoc: AuthOptions): Promise<any>;
 }

--- a/packages/service-provider-core/src/auth-options.ts
+++ b/packages/service-provider-core/src/auth-options.ts
@@ -1,0 +1,7 @@
+export default interface AuthOptions {
+  user: string;
+  pwd: string;
+  mechanism?: string;
+  digestPassword?: boolean;
+  authDb?: string;
+}

--- a/packages/service-provider-core/src/index.ts
+++ b/packages/service-provider-core/src/index.ts
@@ -8,6 +8,7 @@ import ReadConcern from './read-concern';
 import CommandOptions from './command-options';
 import BaseOptions from './base-options';
 import DatabaseOptions from './database-options';
+import AuthOptions from './auth-options';
 import getConnectInfo from './connect-info';
 import { ReplPlatform } from './platform';
 import CliOptions from './cli-options';
@@ -27,6 +28,7 @@ export {
   WriteConcern,
   CommandOptions,
   BaseOptions,
+  AuthOptions,
   DatabaseOptions,
   getConnectInfo,
   ReplPlatform,

--- a/packages/shell-evaluator/src/shell-evaluator.ts
+++ b/packages/shell-evaluator/src/shell-evaluator.ts
@@ -94,7 +94,11 @@ class ShellEvaluator {
       filename
     );
 
-    if (evaluationResult !== undefined && evaluationResult[shellApiType] !== undefined) {
+    if (
+      evaluationResult !== undefined &&
+      evaluationResult !== null &&
+      evaluationResult[shellApiType] !== undefined
+    ) {
       return await evaluationResult[asShellResult]();
     }
 


### PR DESCRIPTION
Two things I want to double check
- it won't ever be a problem that we are passing the options originally set by the user when the connect via the CLI (the auth ones are overwritten)
- command history hasn't been saving the ones with passwords, however, it's been a bit funky and has been not saving regular commands as well