### PR TITLE
MONGOSH-305 - Support database and collection helper methods

### DIFF
--- a/packages/cli-repl/src/completer.spec.ts
+++ b/packages/cli-repl/src/completer.spec.ts
@@ -26,6 +26,7 @@ describe('completer.completer', () => {
       const i = 'db.';
       expect(completer(undefined, i)).to.deep.equal([[
         'db.getMongo',
+        'db.getName',
         'db.getCollectionNames',
         'db.getCollectionInfos',
         'db.runCommand',

--- a/packages/i18n/src/locales/en_US.js
+++ b/packages/i18n/src/locales/en_US.js
@@ -1185,6 +1185,11 @@ const translations = {
                 }
               },
               returns: ''
+            },
+            getMongo: {
+              description: 'Returns the Mongo object.',
+              example: 'db.collection.getMongo()',
+              parameters: {}
             }
           }
         }
@@ -1507,6 +1512,12 @@ const translations = {
               link: 'https://docs.mongodb.com/manual/reference/method/db.getMongo/',
               description: 'Returns the current database connection',
               example: 'connection = db.getMongo()',
+              parameters: {}
+            },
+            getName: {
+              link: 'https://docs.mongodb.com/manual/reference/method/db.getName',
+              description: 'Returns the name of the DB',
+              example: 'db.getName()',
               parameters: {}
             }
           }

--- a/packages/shell-api/src/collection.ts
+++ b/packages/shell-api/src/collection.ts
@@ -1112,6 +1112,17 @@ export default class Collection extends ShellApiClass {
   }
 
   /**
+   * Returns the collection mongo
+   *
+   * @return {Mongo}
+   */
+  @returnType('Mongo')
+  getMongo(): Mongo {
+    this._emitCollectionApiCall('getMongo');
+    return this._mongo;
+  }
+
+  /**
    * Get all the collection statistics.
    *
    * @param {Object} options - The stats options.

--- a/packages/shell-api/src/database.spec.ts
+++ b/packages/shell-api/src/database.spec.ts
@@ -145,6 +145,12 @@ describe('Database', () => {
       });
     });
 
+    describe('getName', () => {
+      it('returns the name of the DB', async() => {
+        expect(database.getName()).to.equal('db1');
+      });
+    });
+
     describe('runCommand', () => {
       it('calls serviceProvider.runCommand on the database', async() => {
         await database.runCommand({ someCommand: 'someCollection' });

--- a/packages/shell-api/src/database.spec.ts
+++ b/packages/shell-api/src/database.spec.ts
@@ -151,6 +151,12 @@ describe('Database', () => {
       });
     });
 
+    describe('getMongo', () => {
+      it('returns the name of the DB', async() => {
+        expect(database.getMongo()).to.equal(mongo);
+      });
+    });
+
     describe('runCommand', () => {
       it('calls serviceProvider.runCommand on the database', async() => {
         await database.runCommand({ someCommand: 'someCollection' });

--- a/packages/shell-api/src/database.ts
+++ b/packages/shell-api/src/database.ts
@@ -89,6 +89,10 @@ export default class Database extends ShellApiClass {
     return this._mongo;
   }
 
+  getName(): string {
+    return this._name;
+  }
+
   /**
    * Returns an array of collection names
    *


### PR DESCRIPTION
Not implementing Database.getSisterDB , see https://jira.mongodb.org/browse/SERVER-46231
Collection.getCollection is not mentioned in docs, plus the behavior in the old shell is weird: db.abc.getCollection('def') --> Collection("abc.def")