### PR TITLE
Browser repl disable input between commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "prestart-cli": "npm run compile-cli",
     "start-cli": "lerna exec npm start --scope @mongosh/cli-repl",
     "compile-browser": "lerna run build --scope @mongosh/browser-repl",
+    "prestart-browser": "npm run compile-browser",
     "start-browser": "lerna exec npm start --scope @mongosh/browser-repl",
     "compile-compass": "npm run compile-browser && lerna run compile --scope @mongodb-js/compass-shell",
     "start-compass": "lerna run start-compass --scope @mongodb-js/compass-shell",

--- a/packages/browser-repl/src/components/editor.spec.tsx
+++ b/packages/browser-repl/src/components/editor.spec.tsx
@@ -43,6 +43,20 @@ describe('<Editor />', () => {
     expect(aceEditor.getValue()).to.equal('some value');
   });
 
+  it('is not readonly by default', () => {
+    const wrapper = mount(<Editor />);
+    const aceEditor = getAceEditorInstance(wrapper);
+
+    expect(aceEditor.getOption('readOnly')).to.equal(false);
+  });
+
+  it('allows to set the editor as readonly', () => {
+    const wrapper = mount(<Editor readOnly />);
+    const aceEditor = getAceEditorInstance(wrapper);
+
+    expect(aceEditor.getOption('readOnly')).to.equal(true);
+  });
+
   it('calls onChange when the content changes', () => {
     const spy = sinon.spy();
     const wrapper = mount(<Editor onChange={spy} />);
@@ -183,3 +197,4 @@ describe('<Editor />', () => {
     expect(spy.args[0][0].editor).to.equal(aceEditor);
   });
 });
+

--- a/packages/browser-repl/src/components/editor.spec.tsx
+++ b/packages/browser-repl/src/components/editor.spec.tsx
@@ -50,8 +50,8 @@ describe('<Editor />', () => {
     expect(aceEditor.getOption('readOnly')).to.equal(false);
   });
 
-  it('allows to set the editor as readonly', () => {
-    const wrapper = mount(<Editor readOnly />);
+  it('allows to set the editor as readonly when operationInProgress is true', () => {
+    const wrapper = mount(<Editor operationInProgress />);
     const aceEditor = getAceEditorInstance(wrapper);
 
     expect(aceEditor.getOption('readOnly')).to.equal(true);

--- a/packages/browser-repl/src/components/editor.tsx
+++ b/packages/browser-repl/src/components/editor.tsx
@@ -38,9 +38,11 @@ export class Editor extends Component<EditorProps> {
   };
 
   private editor: any;
+  private visibleCursorDisplayStyle: string;
 
   private onEditorLoad = (editor: any): void => {
     this.editor = editor;
+    this.visibleCursorDisplayStyle = this.editor.renderer.$cursorLayer.element.style.display;
 
     if (this.props.autocompleter) {
       editor.commands.on('afterExec', function(e) {
@@ -54,9 +56,23 @@ export class Editor extends Component<EditorProps> {
   };
 
   componentDidUpdate(): void {
+    if (this.props.readOnly) {
+      this.hideCursor();
+    } else {
+      this.showCursor();
+    }
+
     if (this.props.moveCursorToTheEndOfInput) {
       this.moveCursorToTheEndOfInput();
     }
+  }
+
+  private hideCursor(): void {
+    this.editor.renderer.$cursorLayer.element.style.display = 'none';
+  }
+
+  private showCursor(): void {
+    this.editor.renderer.$cursorLayer.element.style.display = this.visibleCursorDisplayStyle;
   }
 
   private moveCursorToTheEndOfInput(): void {

--- a/packages/browser-repl/src/components/editor.tsx
+++ b/packages/browser-repl/src/components/editor.tsx
@@ -13,16 +13,16 @@ const tools = ace.acequire('ace/ext/language_tools');
 const noop = (): void => {};
 
 interface EditorProps {
+  autocompleter?: Autocompleter;
+  moveCursorToTheEndOfInput?: boolean;
   onEnter?(): void | Promise<void>;
   onArrowUpOnFirstLine?(): void | Promise<void>;
   onArrowDownOnLastLine?(): void | Promise<void>;
   onChange?(value: string): void | Promise<void>;
   onClearCommand?(): void | Promise<void>;
-  autocompleter?: Autocompleter;
+  operationInProgress?: boolean;
   setInputRef?(ref): void;
   value?: string;
-  readOnly?: boolean;
-  moveCursorToTheEndOfInput?: boolean;
 }
 
 export class Editor extends Component<EditorProps> {
@@ -32,8 +32,8 @@ export class Editor extends Component<EditorProps> {
     onArrowDownOnLastLine: noop,
     onChange: noop,
     onClearCommand: noop,
+    operationInProgress: false,
     value: '',
-    readOnly: false,
     moveCursorToTheEndOfInput: false
   };
 
@@ -56,7 +56,7 @@ export class Editor extends Component<EditorProps> {
   };
 
   componentDidUpdate(): void {
-    if (this.props.readOnly) {
+    if (this.props.operationInProgress) {
       this.hideCursor();
     } else {
       this.showCursor();
@@ -82,14 +82,12 @@ export class Editor extends Component<EditorProps> {
   }
 
   render(): JSX.Element {
-    const { onClearCommand } = this.props;
-
     return (<AceEditor
       showPrintMargin={false}
       showGutter={false}
       highlightActiveLine
       setOptions={{
-        readOnly: !!this.props.readOnly,
+        readOnly: !!this.props.operationInProgress,
         enableBasicAutocompletion: !!this.props.autocompleter,
         enableLiveAutocompletion: !!this.props.autocompleter,
         enableSnippets: false,
@@ -143,7 +141,7 @@ export class Editor extends Component<EditorProps> {
         {
           name: 'clearShell',
           bindKey: { win: 'Ctrl-L', mac: 'Command-L' },
-          exec: onClearCommand
+          exec: this.props.onClearCommand
         }
       ]}
       width="100%"

--- a/packages/browser-repl/src/components/editor.tsx
+++ b/packages/browser-repl/src/components/editor.tsx
@@ -22,6 +22,7 @@ interface EditorProps {
   setInputRef?(ref): void;
   value?: string;
   readOnly?: boolean;
+  moveCursorToTheEndOfInput?: boolean;
 }
 
 export class Editor extends Component<EditorProps> {
@@ -32,7 +33,8 @@ export class Editor extends Component<EditorProps> {
     onChange: noop,
     onClearCommand: noop,
     value: '',
-    readOnly: false
+    readOnly: false,
+    moveCursorToTheEndOfInput: false
   };
 
   private editor: any;
@@ -50,6 +52,18 @@ export class Editor extends Component<EditorProps> {
       tools.setCompleters([new AceAutocompleterAdapter(this.props.autocompleter)]);
     }
   };
+
+  componentDidUpdate(): void {
+    if (this.props.moveCursorToTheEndOfInput) {
+      this.moveCursorToTheEndOfInput();
+    }
+  }
+
+  private moveCursorToTheEndOfInput(): void {
+    const row = this.editor.session.getLength() - 1;
+    const column = this.editor.session.getLine(row).length;
+    this.editor.gotoLine(row + 1, column);
+  }
 
   render(): JSX.Element {
     const { onClearCommand } = this.props;

--- a/packages/browser-repl/src/components/editor.tsx
+++ b/packages/browser-repl/src/components/editor.tsx
@@ -21,6 +21,7 @@ interface EditorProps {
   autocompleter?: Autocompleter;
   setInputRef?(ref): void;
   value?: string;
+  readOnly?: boolean;
 }
 
 export class Editor extends Component<EditorProps> {
@@ -30,7 +31,8 @@ export class Editor extends Component<EditorProps> {
     onArrowDownOnLastLine: noop,
     onChange: noop,
     onClearCommand: noop,
-    value: ''
+    value: '',
+    readOnly: false
   };
 
   private editor: any;
@@ -57,6 +59,7 @@ export class Editor extends Component<EditorProps> {
       showGutter={false}
       highlightActiveLine
       setOptions={{
+        readOnly: !!this.props.readOnly,
         enableBasicAutocompletion: !!this.props.autocompleter,
         enableLiveAutocompletion: !!this.props.autocompleter,
         enableSnippets: false,

--- a/packages/browser-repl/src/components/shell-input.less
+++ b/packages/browser-repl/src/components/shell-input.less
@@ -2,6 +2,6 @@
 @import './common.less';
 
 .shell-input {
-  padding: 0 4px;
+  padding: 0 8px;
   min-height: @line-height;
 }

--- a/packages/browser-repl/src/components/shell-input.spec.tsx
+++ b/packages/browser-repl/src/components/shell-input.spec.tsx
@@ -39,13 +39,6 @@ describe('<ShellInput />', () => {
     expect(onInput).to.have.been.calledWith('value');
   });
 
-  it('does not call onInput if the input is empty', () => {
-    const onInput = sinon.spy();
-    const wrapper = shallow(<ShellInput onInput={onInput}/>);
-    enter(wrapper);
-    expect(onInput).to.not.have.been.called;
-  });
-
   it('sets the editor as readOnly while onInput is executed', async() => {
     let onInputDone;
 

--- a/packages/browser-repl/src/components/shell-input.spec.tsx
+++ b/packages/browser-repl/src/components/shell-input.spec.tsx
@@ -46,6 +46,34 @@ describe('<ShellInput />', () => {
     expect(onInput).to.not.have.been.called;
   });
 
+  it('sets the editor as readOnly while onInput is executed', async() => {
+    let onInputDone;
+
+    const onInput = (): any => {
+      return new Promise((resolve) => {
+        onInputDone = resolve;
+      });
+    };
+
+    const wrapper = shallow(<ShellInput onInput={onInput}/>);
+    changeValue(wrapper, 'value');
+    enter(wrapper);
+    wrapper.update();
+
+    expect(wrapper.find('Editor').prop('readOnly')).to.equal(true);
+    onInputDone();
+
+    await new Promise((resolve) => setTimeout(resolve));
+
+    wrapper.update();
+    expect(wrapper.find('Editor').prop('readOnly')).to.equal(false);
+  });
+
+  it('does not set the editor as readOnly by default', () => {
+    const wrapper = shallow(<ShellInput />);
+    expect(wrapper.find('Editor').prop('readOnly')).to.equal(false);
+  });
+
   describe('history', () => {
     it('navigates history backward on ArrowUp', () => {
       const wrapper = shallow(<ShellInput history={['value2', 'value1']} />);

--- a/packages/browser-repl/src/components/shell-input.spec.tsx
+++ b/packages/browser-repl/src/components/shell-input.spec.tsx
@@ -1,11 +1,11 @@
 import React from 'react';
 import sinon from 'sinon';
 import { expect } from '../../testing/chai';
-import { shallow } from '../../testing/enzyme';
+import { shallow, mount } from '../../testing/enzyme';
 
 import { ShellInput } from './shell-input';
 import { Editor } from './editor';
-import { Completion } from '../autocompleter/autocompleter';
+import Loader from './shell-loader';
 
 function changeValue(wrapper, value): void {
   wrapper.find(Editor).prop('onChange')(value);
@@ -39,32 +39,9 @@ describe('<ShellInput />', () => {
     expect(onInput).to.have.been.calledWith('value');
   });
 
-  it('sets the editor as readOnly while onInput is executed', async() => {
-    let onInputDone;
-
-    const onInput = (): any => {
-      return new Promise((resolve) => {
-        onInputDone = resolve;
-      });
-    };
-
-    const wrapper = shallow(<ShellInput onInput={onInput}/>);
-    changeValue(wrapper, 'value');
-    enter(wrapper);
-    wrapper.update();
-
-    expect(wrapper.find('Editor').prop('readOnly')).to.equal(true);
-    onInputDone();
-
-    await new Promise((resolve) => setTimeout(resolve));
-
-    wrapper.update();
-    expect(wrapper.find('Editor').prop('readOnly')).to.equal(false);
-  });
-
   it('does not set the editor as readOnly by default', () => {
     const wrapper = shallow(<ShellInput />);
-    expect(wrapper.find('Editor').prop('readOnly')).to.equal(false);
+    expect(wrapper.find('Editor').prop('operationInProgress')).to.equal(false);
   });
 
   describe('history', () => {
@@ -133,11 +110,29 @@ describe('<ShellInput />', () => {
       arrowDown(wrapper);
       expect(wrapper.state('currentValue')).to.equal('value3');
     });
+
+    it('shows a loader when operationInProgress is true ', () => {
+      const wrapper = mount(<ShellInput
+        history={['value2', 'value1']}
+        operationInProgress
+      />);
+
+      expect(wrapper.find(Loader).exists()).to.equal(true);
+    });
+
+    it('does not show a loader when operationInProgress is fase ', () => {
+      const wrapper = shallow(<ShellInput
+        history={['value2', 'value1']}
+        operationInProgress={false}
+      />);
+
+      expect(wrapper.find(Loader).exists()).to.equal(false);
+    });
   });
 
   describe('autocompletion', () => {
     it('forwards an autocompleter to the editor', () => {
-      const autocompleter = { getCompletions: (): Promise<Completion[]> => Promise.resolve([]) };
+      const autocompleter = { getCompletions: (): Promise<any[]> => Promise.resolve([]) };
       const wrapper = shallow(<ShellInput autocompleter={autocompleter} />);
       expect(wrapper.find('Editor').prop('autocompleter')).to.equal(autocompleter);
     });

--- a/packages/browser-repl/src/components/shell-input.tsx
+++ b/packages/browser-repl/src/components/shell-input.tsx
@@ -92,9 +92,6 @@ export class ShellInput extends Component<ShellInputProps, ShellInputState> {
   private onEnter = async(): Promise<void> => {
     try {
       const currentValue = this.state.currentValue;
-      if (!currentValue || currentValue.trim() === '') {
-        return;
-      }
 
       this.setState({
         readOnly: true

--- a/packages/browser-repl/src/components/shell-input.tsx
+++ b/packages/browser-repl/src/components/shell-input.tsx
@@ -17,11 +17,13 @@ interface ShellInputProps {
 
 interface ShellInputState {
   currentValue: string;
+  readOnly: boolean;
 }
 
 export class ShellInput extends Component<ShellInputProps, ShellInputState> {
   readonly state: ShellInputState = {
-    currentValue: ''
+    currentValue: '',
+    readOnly: false
   };
 
   private historyNavigationEntries: string[];
@@ -87,18 +89,23 @@ export class ShellInput extends Component<ShellInputProps, ShellInputState> {
     this.syncCurrentValueWithHistoryNavigation();
   };
 
-  private onEnter = (): void => {
+  private onEnter = async(): Promise<void> => {
     const currentValue = this.state.currentValue;
     if (!currentValue || currentValue.trim() === '') {
       return;
     }
 
+    this.setState({
+      readOnly: true
+    });
+
     if (this.props.onInput) {
-      this.props.onInput(currentValue);
+      await this.props.onInput(currentValue);
     }
 
     this.setState({
-      currentValue: ''
+      currentValue: '',
+      readOnly: false
     });
   };
 
@@ -117,6 +124,7 @@ export class ShellInput extends Component<ShellInputProps, ShellInputState> {
       onClearCommand={this.props.onClearCommand}
       setInputRef={this.props.setInputRef}
       value={this.state.currentValue}
+      readOnly={this.state.readOnly}
     />);
 
     const className = classnames(styles['shell-input']);

--- a/packages/browser-repl/src/components/shell-input.tsx
+++ b/packages/browser-repl/src/components/shell-input.tsx
@@ -18,12 +18,14 @@ interface ShellInputProps {
 interface ShellInputState {
   currentValue: string;
   readOnly: boolean;
+  didLoadHistoryItem: boolean;
 }
 
 export class ShellInput extends Component<ShellInputProps, ShellInputState> {
   readonly state: ShellInputState = {
     currentValue: '',
-    readOnly: false
+    readOnly: false,
+    didLoadHistoryItem: false
   };
 
   private historyNavigationEntries: string[];
@@ -54,7 +56,7 @@ export class ShellInput extends Component<ShellInputProps, ShellInputState> {
   }
 
   private onChange = (value: string): void => {
-    this.setState({ currentValue: value });
+    this.setState({ currentValue: value, didLoadHistoryItem: false });
   };
 
   private syncCurrentValueWithHistoryNavigation(): void {
@@ -65,7 +67,8 @@ export class ShellInput extends Component<ShellInputProps, ShellInputState> {
     }
 
     this.setState({
-      currentValue: value
+      currentValue: value,
+      didLoadHistoryItem: true
     });
   }
 
@@ -124,6 +127,7 @@ export class ShellInput extends Component<ShellInputProps, ShellInputState> {
       setInputRef={this.props.setInputRef}
       value={this.state.currentValue}
       readOnly={this.state.readOnly}
+      moveCursorToTheEndOfInput={this.state.didLoadHistoryItem}
     />);
 
     const className = classnames(styles['shell-input']);

--- a/packages/browser-repl/src/components/shell-input.tsx
+++ b/packages/browser-repl/src/components/shell-input.tsx
@@ -90,23 +90,25 @@ export class ShellInput extends Component<ShellInputProps, ShellInputState> {
   };
 
   private onEnter = async(): Promise<void> => {
-    const currentValue = this.state.currentValue;
-    if (!currentValue || currentValue.trim() === '') {
-      return;
+    try {
+      const currentValue = this.state.currentValue;
+      if (!currentValue || currentValue.trim() === '') {
+        return;
+      }
+
+      this.setState({
+        readOnly: true
+      });
+
+      if (this.props.onInput) {
+        await this.props.onInput(currentValue);
+      }
+    } finally {
+      this.setState({
+        currentValue: '',
+        readOnly: false
+      });
     }
-
-    this.setState({
-      readOnly: true
-    });
-
-    if (this.props.onInput) {
-      await this.props.onInput(currentValue);
-    }
-
-    this.setState({
-      currentValue: '',
-      readOnly: false
-    });
   };
 
   render(): JSX.Element {

--- a/packages/browser-repl/src/components/shell-input.tsx
+++ b/packages/browser-repl/src/components/shell-input.tsx
@@ -1,9 +1,11 @@
 import React, { Component } from 'react';
 import classnames from 'classnames';
-import { Editor } from './editor';
 import { Autocompleter } from '@mongosh/browser-runtime-core';
-import { LineWithIcon } from './utils/line-with-icon';
 import Icon from '@leafygreen-ui/icon';
+
+import { Editor } from './editor';
+import { LineWithIcon } from './utils/line-with-icon';
+import Loader from './shell-loader';
 
 const styles = require('./shell-input.less');
 
@@ -12,6 +14,7 @@ interface ShellInputProps {
   history?: readonly string[];
   onClearCommand?(): void | Promise<void>;
   onInput?(code: string): void | Promise<void>;
+  operationInProgress?: boolean;
   setInputRef?(ref): void;
 }
 
@@ -93,26 +96,21 @@ export class ShellInput extends Component<ShellInputProps, ShellInputState> {
   };
 
   private onEnter = async(): Promise<void> => {
-    try {
-      const currentValue = this.state.currentValue;
-
-      this.setState({
-        readOnly: true
-      });
-
-      if (this.props.onInput) {
-        await this.props.onInput(currentValue);
-      }
-    } finally {
-      this.setState({
-        currentValue: '',
-        readOnly: false
-      });
+    if (this.props.onInput) {
+      await this.props.onInput(this.state.currentValue);
     }
+
+    this.setState({
+      currentValue: ''
+    });
   };
 
   render(): JSX.Element {
-    const icon = (<Icon
+    const icon = this.props.operationInProgress ? (
+      <Loader
+        size={10}
+      />
+    ) : (<Icon
       size={12}
       glyph={'ChevronRight'}
     />);
@@ -126,7 +124,7 @@ export class ShellInput extends Component<ShellInputProps, ShellInputState> {
       onClearCommand={this.props.onClearCommand}
       setInputRef={this.props.setInputRef}
       value={this.state.currentValue}
-      readOnly={this.state.readOnly}
+      operationInProgress={this.props.operationInProgress}
       moveCursorToTheEndOfInput={this.state.didLoadHistoryItem}
     />);
 

--- a/packages/browser-repl/src/components/shell-input.tsx
+++ b/packages/browser-repl/src/components/shell-input.tsx
@@ -108,7 +108,7 @@ export class ShellInput extends Component<ShellInputProps, ShellInputState> {
   render(): JSX.Element {
     const icon = this.props.operationInProgress ? (
       <Loader
-        size={10}
+        size={12}
       />
     ) : (<Icon
       size={12}

--- a/packages/browser-repl/src/components/shell-loader.less
+++ b/packages/browser-repl/src/components/shell-loader.less
@@ -6,7 +6,8 @@
   border-radius: 50%;
   padding: 0;
   margin: 0;
-  margin-left: -2px;
+  box-sizing: border-box;
+
   animation: shell-loader-spin 500ms linear infinite;
 }
 

--- a/packages/browser-repl/src/components/shell-loader.less
+++ b/packages/browser-repl/src/components/shell-loader.less
@@ -1,0 +1,14 @@
+@import '~@leafygreen-ui/palette/dist/ui-colors.less';
+
+.shell-loader {
+  border: 4px solid @leafygreen__green--light-3;
+  border-top: 4px solid @leafygreen__green--base;
+  border-radius: 50%;
+  margin-left: -6px;
+  animation: shell-loader-spin 500ms linear infinite;
+}
+
+@keyframes shell-loader-spin {
+  0% { transform: rotate(0deg); }
+  100% { transform: rotate(360deg); }
+}

--- a/packages/browser-repl/src/components/shell-loader.less
+++ b/packages/browser-repl/src/components/shell-loader.less
@@ -1,10 +1,12 @@
 @import '~@leafygreen-ui/palette/dist/ui-colors.less';
 
 .shell-loader {
-  border: 4px solid @leafygreen__green--light-3;
-  border-top: 4px solid @leafygreen__green--base;
+  border: 2px solid @leafygreen__gray--light-3;
+  border-top: 2px solid @leafygreen__green--base;
   border-radius: 50%;
-  margin-left: -6px;
+  padding: 0;
+  margin: 0;
+  margin-left: -2px;
   animation: shell-loader-spin 500ms linear infinite;
 }
 

--- a/packages/browser-repl/src/components/shell-loader.tsx
+++ b/packages/browser-repl/src/components/shell-loader.tsx
@@ -1,0 +1,24 @@
+import React, { Component } from 'react';
+import classnames from 'classnames';
+
+const styles = require('./shell-loader.less');
+
+interface ShellLoaderProps {
+  size: number;
+}
+
+export default class ShellLoader extends Component<ShellLoaderProps> {
+  render(): JSX.Element {
+    const { size } = this.props;
+
+    return (
+      <div
+        className={classnames(styles['shell-loader'])}
+        style={{
+          height: `${size}px`,
+          width: `${size}px`
+        }}
+      />
+    );
+  }
+}

--- a/packages/browser-repl/src/components/shell-output-line.less
+++ b/packages/browser-repl/src/components/shell-output-line.less
@@ -1,7 +1,7 @@
 @import '~@leafygreen-ui/palette/dist/ui-colors.less';
 
 .shell-output-line {
-  padding: 0 4px;
+  padding: 0 8px;
 
   &-error {
     background-color: @leafygreen__red--light-2;

--- a/packages/browser-repl/src/components/shell.spec.tsx
+++ b/packages/browser-repl/src/components/shell.spec.tsx
@@ -211,6 +211,26 @@ describe('<Shell />', () => {
     });
   });
 
+  context('when empty input is entered', () => {
+    beforeEach(async() => {
+      await onInput('');
+    });
+
+    it('does not evaluate the input with runtime', () => {
+      expect(fakeRuntime.evaluate).not.to.have.been.calledWith('');
+    });
+
+    it('adds a blank line to the output', () => {
+      expect(wrapper.find(ShellOutput).prop('output')).to.deep.equal([
+        { format: 'input', value: ' ' },
+      ]);
+    });
+
+    it('does not update the history', async() => {
+      expect(wrapper.find(ShellInput).prop('history')).to.deep.equal([]);
+    });
+  });
+
   context('when an input is entered and it causes an error', () => {
     let error;
 
@@ -229,7 +249,6 @@ describe('<Shell />', () => {
         { format: 'error', value: error }
       ]);
     });
-
 
     it('calls onOutputChanged with output', () => {
       expect(onOutputChangedSpy).to.have.been.calledWith([

--- a/packages/browser-repl/src/components/shell.spec.tsx
+++ b/packages/browser-repl/src/components/shell.spec.tsx
@@ -1,7 +1,9 @@
 import React from 'react';
 import sinon from 'sinon';
+
 import { expect } from '../../testing/chai';
 import { shallow, mount, ShallowWrapper, ReactWrapper } from '../../testing/enzyme';
+
 import { Shell } from './shell';
 import { ShellInput } from './shell-input';
 import { ShellOutput } from './shell-output';
@@ -64,6 +66,10 @@ describe('<Shell />', () => {
 
   it('passes runtime as autocompleter to ShellInput', () => {
     expect(wrapper.find(ShellInput).prop('autocompleter')).to.equal(fakeRuntime);
+  });
+
+  it('does not set the editor as readOnly by default', () => {
+    expect(wrapper.find(ShellInput).prop('operationInProgress')).to.equal(false);
   });
 
   context('when initialOutput is set', () => {
@@ -231,6 +237,36 @@ describe('<Shell />', () => {
     });
   });
 
+
+  it('sets the editor as readOnly/operationInProgress true while onInput is executed', async() => {
+    let onInputDone;
+    wrapper = shallow(<Shell
+      runtime={{
+        // eslint-disable-next-line @typescript-eslint/no-unused-vars
+        evaluate: (code: string): Promise<any> => {
+          return new Promise(resolve => {
+            onInputDone = resolve;
+          });
+        }
+      } as any}
+    />);
+
+    const onInputStub = wrapper.find(ShellInput).prop('onInput');
+    onInputStub('ok');
+
+    // Check operationInProgress is true while eval is called
+    expect(wrapper.find(ShellInput).prop('operationInProgress')).to.equal(true);
+
+    // Fufill eval.
+    onInputDone();
+    await wait();
+
+    wrapper.update();
+
+    // Ensure operationInProgress is false.
+    expect(wrapper.find(ShellInput).prop('operationInProgress')).to.equal(false);
+  });
+
   context('when an input is entered and it causes an error', () => {
     let error;
 
@@ -248,6 +284,10 @@ describe('<Shell />', () => {
         { format: 'input', value: 'some code' },
         { format: 'error', value: error }
       ]);
+    });
+
+    it('sets the editor as operationInProgress false after the execution', async() => {
+      expect(wrapper.find(ShellInput).prop('operationInProgress')).to.equal(false);
     });
 
     it('calls onOutputChanged with output', () => {

--- a/packages/browser-repl/src/components/shell.tsx
+++ b/packages/browser-repl/src/components/shell.tsx
@@ -59,6 +59,7 @@ interface ShellProps {
 }
 
 interface ShellState {
+  operationInProgress: boolean;
   output: readonly ShellOutputEntry[];
   history: readonly string[];
 }
@@ -86,6 +87,7 @@ export class Shell extends Component<ShellProps, ShellState> {
   };
 
   readonly state: ShellState = {
+    operationInProgress: false,
     output: this.props.initialOutput.slice(-this.props.maxOutputLength),
     history: this.props.initialHistory.slice(0, this.props.maxHistoryLength)
   };
@@ -160,11 +162,14 @@ export class Shell extends Component<ShellProps, ShellState> {
       return;
     }
 
-
     const inputLine: ShellOutputEntry = {
       format: 'input',
       value: code
     };
+
+    this.setState({
+      operationInProgress: true
+    });
 
     const outputLine = await this.evaluate(code);
 
@@ -175,7 +180,11 @@ export class Shell extends Component<ShellProps, ShellState> {
 
     const history = this.addEntryToHistory(code);
 
-    this.setState({ output, history });
+    this.setState({
+      operationInProgress: false,
+      output,
+      history
+    });
 
     this.props.onOutputChanged(output);
     this.props.onHistoryChanged(history);
@@ -223,10 +232,11 @@ export class Shell extends Component<ShellProps, ShellState> {
         </div>
         <div ref={(el): void => { this.shellInputElement = el; }}>
           <ShellInput
+            autocompleter={this.props.runtime}
+            history={this.state.history}
             onClearCommand={this.onClearCommand}
             onInput={this.onInput}
-            history={this.state.history}
-            autocompleter={this.props.runtime}
+            operationInProgress={this.state.operationInProgress}
             setInputRef={(ref): void => { this.shellInputRef = ref;}}
           />
         </div>

--- a/packages/browser-repl/src/components/shell.tsx
+++ b/packages/browser-repl/src/components/shell.tsx
@@ -155,6 +155,12 @@ export class Shell extends Component<ShellProps, ShellState> {
   };
 
   private onInput = async(code: string): Promise<void> => {
+    if (!code || code.trim() === '') {
+      this.appendEmptyInput();
+      return;
+    }
+
+
     const inputLine: ShellOutputEntry = {
       format: 'input',
       value: code
@@ -174,6 +180,19 @@ export class Shell extends Component<ShellProps, ShellState> {
     this.props.onOutputChanged(output);
     this.props.onHistoryChanged(history);
   };
+
+  private appendEmptyInput(): void {
+    const inputLine: ShellOutputEntry = {
+      format: 'input',
+      value: ' '
+    };
+
+    const output = this.addEntriesToOutput([
+      inputLine
+    ]);
+
+    this.setState({ output });
+  }
 
   private scrollToBottom(): void {
     if (!this.shellInputElement) {

--- a/packages/browser-repl/src/index.stories.tsx
+++ b/packages/browser-repl/src/index.stories.tsx
@@ -10,12 +10,19 @@ export default {
   decorators: [withKnobs]
 };
 
+
+const delay = (msecs): any => new Promise((resolve) => {
+  setTimeout(resolve, msecs);
+});
+
 class DemoServiceProvider {
   async buildInfo(): Promise<object> {
     return { version: '4.0.0' };
   }
 
   async listDatabases(): Promise<any> {
+    await delay(1000);
+
     return {
       databases: [
         { name: 'db1', sizeOnDisk: 10000, empty: false },
@@ -48,6 +55,10 @@ export const IframeRuntimeExample: React.FunctionComponent = () => {
     redactInfo={boolean('redactInfo', false)}
     maxHistoryLength={number('maxHistoryLength', 1000)}
     maxOutputLength={number('maxOutputLength', 1000)}
-    initialHistory={['{x: 1, y: {z: 2}, k: [1, 2, 3]}']}
+    initialHistory={[
+      'show dbs',
+      'db.coll.stats()',
+      '{x: 1, y: {z: 2}, k: [1, 2, 3]}'
+    ]}
   /></div>);
 };

--- a/packages/browser-repl/src/index.stories.tsx
+++ b/packages/browser-repl/src/index.stories.tsx
@@ -21,7 +21,7 @@ class DemoServiceProvider {
   }
 
   async listDatabases(): Promise<any> {
-    await delay(1000);
+    await delay(2000);
 
     return {
       databases: [

--- a/packages/compass-shell/src/components/compass-shell/compass-shell.jsx
+++ b/packages/compass-shell/src/components/compass-shell/compass-shell.jsx
@@ -94,7 +94,9 @@ export class CompassShell extends Component {
 
   shellToggleClicked = () => {
     if (this.state.isExpanded) {
-      this.lastOpenHeight = this.resizableRef.sizeStyle.height;
+      // Apply bounds to height to ensure it's always visible to the user.
+      const heightToResume = Math.max(60, this.resizableRef.size.height);
+      this.lastOpenHeight = heightToResume;
 
       this.resizableRef.updateSize({
         width: '100%',
@@ -105,7 +107,7 @@ export class CompassShell extends Component {
 
       this.resizableRef.updateSize({
         width: '100%',
-        height: this.lastOpenHeight
+        height: Math.min(this.lastOpenHeight, window.innerHeight - 40)
       });
     }
 

--- a/packages/compass-shell/src/components/compass-shell/compass-shell.spec.js
+++ b/packages/compass-shell/src/components/compass-shell/compass-shell.spec.js
@@ -34,7 +34,7 @@ describe('CompassShell', () => {
           emitShellPluginOpened: mockOnOpenShellPlugin
         });
         shell.resizableRef = {
-          sizeStyle: {
+          size: {
             height: 100
           },
           updateSize: () => {}
@@ -125,7 +125,7 @@ describe('CompassShell', () => {
         const shell = new CompassShell({ isExpanded: true });
         let sizeSetTo = {};
         shell.resizableRef = {
-          sizeStyle: {
+          size: {
             height: 100
           },
           updateSize: newSize => {
@@ -149,7 +149,7 @@ describe('CompassShell', () => {
           };
         };
         shell.resizableRef = {
-          sizeStyle: {
+          size: {
             height: 100
           },
           updateSize: () => { }
@@ -173,7 +173,7 @@ describe('CompassShell', () => {
           };
           let sizeSetTo = {};
           shell.resizableRef = {
-            sizeStyle: {
+            size: {
               height: 99
             },
             updateSize: newSize => {


### PR DESCRIPTION
Disables the input while a command is being executed. Fixes usability issues with slow commands:

![Aug-03-2020 17-58-38](https://user-images.githubusercontent.com/334881/89215426-f3e0e880-d5c8-11ea-8eb8-848611308d61.gif)
