### PR TITLE
MONGOSH-224: fix windows tests

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -105,6 +105,17 @@ functions:
       params:
         file: tmp\expansions.yaml
         redacted: true
+    - command: host.create
+      params:
+        provider: docker
+        distro: rhel70-small
+        image: mongo:latest
+        publish_ports: true
+    - command: host.list
+      params:
+        num_hosts: 1
+        path: tmp\hosts.yaml
+        timeout_seconds: 600
     - command: shell.exec
       params:
         working_dir: src
@@ -114,7 +125,9 @@ functions:
           $Env:MONGOSH_TEST_EXECUTABLE_PATH = $(Join-Path -Path '.' -ChildPath 'dist/mongosh.exe' -Resolve)
           echo "$Env:MONGOSH_TEST_EXECUTABLE_PATH"
           $Env:EVERGREEN_EXPANSIONS_PATH = $(Join-Path -Path '..' -ChildPath 'tmp/expansions.yaml' -Resolve)
+          $Env:HOST_MAPPINGS_PATH = $(Join-Path -Path '..' -ChildPath 'tmp/hosts.yaml' -Resolve)
           $Env:MONGODB_VERSION = "4.2.8"
+          cat $Env:HOST_MAPPINGS_PATH
           npm run compile-exec
           npm run test-ci
   release_macos:

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -108,7 +108,7 @@ functions:
     - command: host.create
       params:
         provider: docker
-        distro: archlinux-parent
+        distro: ubuntu1604-container
         image: mongo:latest
         publish_ports: true
     - command: host.list

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -105,30 +105,18 @@ functions:
       params:
         file: tmp\expansions.yaml
         redacted: true
-    - command: host.create
-      params:
-        provider: docker
-        distro: ubuntu1604-container
-        image: mongo:latest
-        publish_ports: true
-    - command: host.list
-      params:
-        num_hosts: 1
-        path: tmp\hosts.yaml
-        timeout_seconds: 600
     - command: shell.exec
       params:
         working_dir: src
         shell: powershell
         script: |
           .\.evergreen\SetupEnv
-          $Env:MONGOSH_TEST_EXECUTABLE_PATH = $(Join-Path -Path '.' -ChildPath 'dist/mongosh.exe' -Resolve)
-          echo "$Env:MONGOSH_TEST_EXECUTABLE_PATH"
+          .\.evergreen\DownloadAndRunMongod
           $Env:EVERGREEN_EXPANSIONS_PATH = $(Join-Path -Path '..' -ChildPath 'tmp/expansions.yaml' -Resolve)
-          $Env:HOST_MAPPINGS_PATH = $(Join-Path -Path '..' -ChildPath 'tmp/hosts.yaml' -Resolve)
-          $Env:MONGODB_VERSION = "4.2.8"
-          cat $Env:HOST_MAPPINGS_PATH
           npm run compile-exec
+          $Env:MONGOSH_TEST_EXECUTABLE_PATH = $(Join-Path -Path '.' -ChildPath 'dist/mongosh.exe' -Resolve)
+          $Env:MONGOSH_TEST_SERVER_URL = "mongodb://localhost:27018"
+          echo "$Env:MONGOSH_TEST_EXECUTABLE_PATH"
           npm run test-ci
   release_macos:
     - command: expansions.write

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -114,6 +114,8 @@ functions:
           $Env:MONGOSH_TEST_EXECUTABLE_PATH = $(Join-Path -Path '.' -ChildPath 'dist/mongosh.exe' -Resolve)
           echo "$Env:MONGOSH_TEST_EXECUTABLE_PATH"
           $Env:EVERGREEN_EXPANSIONS_PATH = $(Join-Path -Path '..' -ChildPath 'tmp/expansions.yaml' -Resolve)
+          $Env:MONGODB_VERSION = "4.2.8"
+          npm run compile-exec
           npm run test-ci
   release_macos:
     - command: expansions.write
@@ -207,7 +209,7 @@ buildvariants:
     run_on: windows-64-vs2019-test
     tasks:
       - name: check_ps
-      # - name: test_ps
+      - name: test_ps
       - name: release_win_ps
 #  - name: ubuntuppc
 #    display_name: "Ubuntu 18.04 PPC"

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -108,7 +108,7 @@ functions:
     - command: host.create
       params:
         provider: docker
-        distro: rhel70-docker
+        distro: archlinux-parent
         image: mongo:latest
         publish_ports: true
     - command: host.list

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -108,7 +108,7 @@ functions:
     - command: host.create
       params:
         provider: docker
-        distro: rhel70-small
+        distro: rhel70-docker
         image: mongo:latest
         publish_ports: true
     - command: host.list

--- a/.evergreen/DownloadAndRunMongod.ps1
+++ b/.evergreen/DownloadAndRunMongod.ps1
@@ -1,0 +1,54 @@
+$platform = "win32"
+$version = "mongodb-win32-x86_64-2012plus-4.2.8"
+$port = "27018"
+
+$platformPath = "$PSScriptRoot\mongodb\$platform"
+$versionPath = "$platformPath\$version"
+$binaryPath = "$versionPath\bin\mongod.exe"
+$dataPath = "$versionPath\data\db"
+$logDir = "$versionPath\logs"
+
+if (!(Test-Path $binaryPath)) {
+  $url = "https://fastdl.mongodb.org/$platform/$name.zip";
+  $output = "$PSScriptRoot\mongodb.zip"
+  Write-Output "Downloading $url"
+
+  [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+  (New-Object System.Net.WebClient).DownloadFile($url, $output)
+
+  Write-Output "Downloaded $url"
+
+  Expand-Archive $output -DestinationPath $platformPath
+} else {
+  Write-Output "$binaryPath already exists, skipping download"
+}
+
+if (!(Test-Path $dataPath)) {
+  mkdir $dataPath
+} else {
+  Write-Output "$dataPath already exists, skipping mkdir"
+}
+
+if (!(Test-Path $logDir)) {
+  mkdir $logDir
+} else {
+  Write-Output "$logDir already exists, skipping mkdir"
+}
+
+Start-Job -ScriptBlock {
+  & $using:binaryPath --dbpath $using:dataPath --bind_ip_all --port $using:port --logpath $using:logDir\mongod.log
+}
+
+$timeout = New-TimeSpan -Seconds 10
+$endTime = (Get-Date).Add($timeout)
+
+do {
+  Write-Host "waiting for mongo..."
+  Start-Sleep 3
+} until(((Get-Date) -gt $endTime) -or (Test-NetConnection "localhost" -Port "$port" | Where-Object { $_.TcpTestSucceeded }))
+
+if (Test-NetConnection "localhost" -Port "$port" | Where-Object { $_.TcpTestSucceeded }) {
+  Write-Host "mongod ready on port $port"
+} else {
+  throw "Failed to start mongo"
+}

--- a/.evergreen/DownloadAndRunMongod.ps1
+++ b/.evergreen/DownloadAndRunMongod.ps1
@@ -9,7 +9,7 @@ $dataPath = "$versionPath\data\db"
 $logDir = "$versionPath\logs"
 
 if (!(Test-Path $binaryPath)) {
-  $url = "https://fastdl.mongodb.org/$platform/$name.zip";
+  $url = "https://fastdl.mongodb.org/$platform/$version.zip";
   $output = "$PSScriptRoot\mongodb.zip"
   Write-Output "Downloading $url"
 
@@ -18,7 +18,7 @@ if (!(Test-Path $binaryPath)) {
 
   Write-Output "Downloaded $url"
 
-  Expand-Archive $output -DestinationPath $platformPath
+  Microsoft.PowerShell.Archive\Expand-Archive $output -DestinationPath $platformPath
 } else {
   Write-Output "$binaryPath already exists, skipping download"
 }

--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ node_modules/
 .cache/
 expansions.yaml
 tmp/expansions.yaml
+.evergreen/mongodb

--- a/packages/browser-repl/config/webpack.config.base.js
+++ b/packages/browser-repl/config/webpack.config.base.js
@@ -1,4 +1,5 @@
 module.exports = {
+  stats: 'errors-only',
   resolve: {
     extensions: ['.tsx', '.ts', '.jsx', '.js', '.less']
   },

--- a/packages/compass-shell/config/webpack.base.config.js
+++ b/packages/compass-shell/config/webpack.base.config.js
@@ -2,6 +2,7 @@ const path = require('path');
 const project = require('./project');
 
 module.exports = {
+  stats: 'errors-only',
   resolve: {
     modules: ['node_modules'],
     extensions: ['.js', '.jsx', '.json', '.less', '.wasm'],

--- a/packages/service-provider-server/src/cli-service-provider.integration.spec.ts
+++ b/packages/service-provider-server/src/cli-service-provider.integration.spec.ts
@@ -1,7 +1,7 @@
 import CliServiceProvider from './cli-service-provider';
 import { expect } from 'chai';
 import { MongoClient } from 'mongodb';
-import { startTestServer } from '../../../testing/integration-testing-hooks';
+import { startTestServer, skipIfServerVersion } from '../../../testing/integration-testing-hooks';
 
 describe('CliServiceProvider [integration]', function() {
   const connectionString = startTestServer();
@@ -76,8 +76,9 @@ describe('CliServiceProvider [integration]', function() {
   });
 
   describe('#aggregate', () => {
-    // NOTE: this will only run on 4.4+, so if we change mongodb-runner to a different version we should be aware this will fail.
-    context('when passing a $function to be serialized by the driver', () => {
+    context('when passing a $function to be serialized by the driver', function() {
+      skipIfServerVersion('< 4.4');
+
       let result;
 
       beforeEach(async() => {
@@ -102,6 +103,7 @@ describe('CliServiceProvider [integration]', function() {
         expect(docs).to.deep.equal([]);
       });
     });
+
     context('when running against a collection', () => {
       let result;
 

--- a/packages/shell-api/src/integration.spec.ts
+++ b/packages/shell-api/src/integration.spec.ts
@@ -715,7 +715,7 @@ describe('Shell API (integration)', function() {
           { serverStatus: 1 }
         );
         expect(result.ok).to.equal(1);
-        expect(result.process).to.match(/^mongo/);
+        expect(result.process).to.match(/mongo/);
       });
     });
 

--- a/testing/integration-testing-hooks.ts
+++ b/testing/integration-testing-hooks.ts
@@ -1,8 +1,14 @@
 const mongodbRunnerBefore = require('mongodb-runner/mocha/before');
 const mongodbRunnerAfter = require('mongodb-runner/mocha/after');
+const semver = require('semver');
+const { MongoClient } = require('mongodb');
 
 export const LOCAL_INSTANCE_PORT = 27018;
 export const LOCAL_INSTANCE_HOST = 'localhost';
+
+const envConnectionString = process.env.MONGOSH_TEST_SERVER_URL;
+const localConnectionString = `mongodb://${LOCAL_INSTANCE_HOST}:${LOCAL_INSTANCE_PORT}`;
+const connectionString = envConnectionString || localConnectionString;
 
 /**
  * Starts a local server unless the `MONGOSH_TEST_SERVER_URL`
@@ -18,10 +24,6 @@ export const LOCAL_INSTANCE_HOST = 'localhost';
  * @returns {string} - uri that can be used to connect to the server.
  */
 export function startTestServer(): string {
-  const envConnectionString = process.env.MONGOSH_TEST_SERVER_URL;
-  const localConnectionString = `mongodb://${LOCAL_INSTANCE_HOST}:${LOCAL_INSTANCE_PORT}`;
-  const connectionString = envConnectionString || localConnectionString;
-
   if (!envConnectionString) {
     console.info(
       'MONGOSH_TEST_SERVER_URL not provided. A local server will be started on',
@@ -51,4 +53,42 @@ export function startTestServer(): string {
   }
 
   return connectionString;
+}
+
+let testServerVersion;
+
+async function getServerVersion(connectionString: string) {
+  let client;
+  try {
+    client = await MongoClient.connect(connectionString, {
+      useUnifiedTopology: true,
+      useNewUrlParser: true
+    });
+
+    return (await client.db().admin().serverStatus()).version;
+  } finally {
+    if (client) {
+      client.close();
+    }
+  }
+}
+
+/**
+ * Skip tests in the suite if the test server version matches a specific semver
+ * condition.
+ *
+ * describe('...', () => {
+ *   ie. skipIfServerVersion('< 4.4')
+ * });
+ *
+ * @export
+ * @returns {string} - uri that can be used to connect to the server.
+ */
+export function skipIfServerVersion(semverCondition) {
+  before(async function() {
+    testServerVersion = testServerVersion || await getServerVersion(connectionString);
+    if (semver.satisfies(testServerVersion, semverCondition)) {
+      this.skip();
+    }
+  });
 }


### PR DESCRIPTION
Changes:

- Just download and run mongo on windows instead of using `mongo-runner`
- Add `skipIfServerVersion(<semver-expr>)` helper to skip tests in case the mongodb version under test does not apply to the test suite `ie. skipIfServerVersion('< 4.4')`.