### PR TITLE
MONGOSH-328: debounce telemetry

### DIFF
--- a/packages/cli-repl/package-lock.json
+++ b/packages/cli-repl/package-lock.json
@@ -483,6 +483,11 @@
 			"resolved": "https://registry.npmjs.org/nanoassert/-/nanoassert-1.1.0.tgz",
 			"integrity": "sha1-TzFS4JVA/eKMdvRLGbvNHVpCR40="
 		},
+		"nanobounce": {
+			"version": "1.1.0",
+			"resolved": "https://registry.npmjs.org/nanobounce/-/nanobounce-1.1.0.tgz",
+			"integrity": "sha512-S67Qnq3KWbv3vaMbSe4XKAl1lOgLoJ/C0hy4YfFO4Qc+I0zDKrBS580f6JtIfOtL01aJ9WPU3mYOz/pE8nrlsA=="
+		},
 		"nanobus": {
 			"version": "4.4.0",
 			"resolved": "https://registry.npmjs.org/nanobus/-/nanobus-4.4.0.tgz",

--- a/packages/cli-repl/package.json
+++ b/packages/cli-repl/package.json
@@ -57,6 +57,7 @@
     "mongodb-ace-autocompleter": "^0.4.1",
     "mongodb-build-info": "^1.1.0",
     "mongodb-redact": "^0.2.0",
+    "nanobounce": "^1.1.0",
     "nanobus": "^4.4.0",
     "pino": "^5.16.0",
     "pino-pretty": "^4.0.0",

--- a/packages/cli-repl/src/logger.spec.ts
+++ b/packages/cli-repl/src/logger.spec.ts
@@ -1,0 +1,37 @@
+/* eslint camelcase: 0, @typescript-eslint/camelcase: 0, no-sync: 0*/
+import logger from './logger';
+import Nanobus from 'nanobus';
+import { expect } from 'chai';
+import sinon from 'ts-sinon';
+import tmp from 'tmp';
+
+describe('logger', () => {
+  const bus = new Nanobus('mongosh');
+  const logDirectory = tmp.dirSync({ unsafeCleanup: true });
+  logger(bus, logDirectory.name);
+
+  context('mongosh:connect', () => {
+    const connectEvent = {
+      is_atlas: false,
+      is_localhost: true,
+      server_version: '4.40',
+      is_enterprise: false,
+      is_data_lake: false,
+      is_genuine: true,
+      non_genuine_server_name: 'mongodb',
+      node_version: '12.4.0',
+      uri: 'localhost:27017'
+    };
+    const listener = bus.listeners('mongosh:connect');
+
+    it('mongosh:connect listener is not undefined', () => {
+      expect(listener).to.not.be.undefined;
+    });
+
+    it('mongosh:connect listener is called', () => {
+      const spy = sinon.spy(listener);
+      bus.emit('mongosh:connect', connectEvent);
+      expect(spy).to.have.been.called;
+    });
+  });
+});

--- a/packages/cli-repl/src/logger.spec.ts
+++ b/packages/cli-repl/src/logger.spec.ts
@@ -2,7 +2,6 @@
 import logger from './logger';
 import Nanobus from 'nanobus';
 import { expect } from 'chai';
-import sinon from 'ts-sinon';
 import tmp from 'tmp';
 
 describe('logger', () => {
@@ -11,27 +10,82 @@ describe('logger', () => {
   logger(bus, logDirectory.name);
 
   context('mongosh:connect', () => {
-    const connectEvent = {
-      is_atlas: false,
-      is_localhost: true,
-      server_version: '4.40',
-      is_enterprise: false,
-      is_data_lake: false,
-      is_genuine: true,
-      non_genuine_server_name: 'mongodb',
-      node_version: '12.4.0',
-      uri: 'localhost:27017'
-    };
     const listener = bus.listeners('mongosh:connect');
 
     it('mongosh:connect listener is not undefined', () => {
       expect(listener).to.not.be.undefined;
     });
+  });
 
-    it('mongosh:connect listener is called', () => {
-      const spy = sinon.spy(listener);
-      bus.emit('mongosh:connect', connectEvent);
-      expect(spy).to.have.been.called;
+  context('mongosh:new-user', () => {
+    const listener = bus.listeners('mongosh:new-user');
+
+    it('mongosh:new-user listener is not undefined', () => {
+      expect(listener).to.not.be.undefined;
+    });
+  });
+
+  context('mongosh:update-user', () => {
+    const listener = bus.listeners('mongosh:update-user');
+
+    it('mongosh:update-user listener is not undefined', () => {
+      expect(listener).to.not.be.undefined;
+    });
+  });
+
+  context('mongosh:error', () => {
+    const listener = bus.listeners('mongosh:error');
+
+    it('mongosh:error listener is not undefined', () => {
+      expect(listener).to.not.be.undefined;
+    });
+  });
+
+  context('mongosh:help', () => {
+    const listener = bus.listeners('mongosh:help');
+
+    it('mongosh:help listener is not undefined', () => {
+      expect(listener).to.not.be.undefined;
+    });
+  });
+
+  context('mongosh:rewritten-async-input', () => {
+    const listener = bus.listeners('mongosh:rewritten-async-input');
+
+    it('mongosh:rewritten-async-input listener is not undefined', () => {
+      expect(listener).to.not.be.undefined;
+    });
+  });
+
+  context('mongosh:use', () => {
+    const listener = bus.listeners('mongosh:use');
+
+    it('mongosh:use listener is not undefined', () => {
+      expect(listener).to.not.be.undefined;
+    });
+  });
+
+  context('mongosh:show', () => {
+    const listener = bus.listeners('mongosh:show');
+
+    it('mongosh:show listener is not undefined', () => {
+      expect(listener).to.not.be.undefined;
+    });
+  });
+
+  context('mongosh:setCtx', () => {
+    const listener = bus.listeners('mongosh:setCtx');
+
+    it('mongosh:setCtx listener is not undefined', () => {
+      expect(listener).to.not.be.undefined;
+    });
+  });
+
+  context('mongosh:api-call', () => {
+    const listener = bus.listeners('mongosh:apiEvent');
+
+    it('mongosh:api-call listener is not undefined', () => {
+      expect(listener).to.not.be.undefined;
     });
   });
 });

--- a/packages/cli-repl/src/logger.ts
+++ b/packages/cli-repl/src/logger.ts
@@ -74,6 +74,8 @@ export default function logger(bus: any, logDir: string): void {
     bus.emit('mongosh:error', e);
   }
 
+  // Use Nanobounce to debounce some of our analytics calls.
+  // Current timer is set to 1000ms.
   const nanobounce = new Nanobounce(1000);
 
   bus.on('mongosh:connect', function(args: ConnectEvent) {


### PR DESCRIPTION
## Description

Uses [`nanobounce`](github.com/choojs/nanobounce) to debounce sending analytics event for `mongosh:api-call`. I feel like all other events are quite singular, and for now, we can only just debounce api calls. Debounce timing is set to `1000`, but we can of course push it to more, if we feel like this will still flood Segment.

Added a few small tests super quickly to check if listeners are attached to our events, since we had no tests at all (this is on me!) in this module. 