### PR TITLE
fix(build): tar.c takes gzip as an option

### DIFF
--- a/packages/build/src/tarball.ts
+++ b/packages/build/src/tarball.ts
@@ -44,7 +44,7 @@ const filterOut = (pathToFilter: string): boolean => {
  * @param {string} filename - the tarball filename.
  */
 export const tarballPosix = async(outputDir: string, filename: string): Promise<void> => {
-  const options = { gtarball: true, file: filename, cwd: outputDir, filter: filterOut };
+  const options = { gzip: true, file: filename, cwd: outputDir, filter: filterOut };
   await tar.c(options, [ '.' ]);
 };
 


### PR DESCRIPTION
## Description

`tar.c` does not use `gtarball` as an option. It should be `gzip` instead.