### PR TITLE
chore: generate homebrew formula

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "release": "node scripts/release.js",
     "publish-npm": "lerna publish --force-publish",
     "report-missing-help": "lerna run --scope @mongosh/shell-api report-missing-help",
-    "report-supported-api": "lerna run --scope @mongosh/shell-api report-supported-api"
+    "report-supported-api": "lerna run --scope @mongosh/shell-api report-supported-api",
+    "generate-homebrew-formula": "node scripts/generate-homebrew-formula"
   },
   "config": {
     "unsafe-perm": true

--- a/scripts/generate-homebrew-formula.js
+++ b/scripts/generate-homebrew-formula.js
@@ -1,0 +1,55 @@
+const https = require('https');
+const crypto = require('crypto');
+const { execSync } = require('child_process');
+
+function httpsSha256(url) {
+  return new Promise((resolve, reject) => {
+    https.get(url, (stream) => {
+      const hash = crypto.createHash('sha256');
+      stream.on('error', err => reject(err));
+      stream.on('data', chunk => hash.update(chunk));
+      stream.on('end', () => resolve(hash.digest('hex')));
+    });
+  });
+}
+
+function render(context) {
+  return `require "language/node"
+
+class Mongosh < Formula
+  desc "The MongoDB Shell"
+  homepage "https://github.com/mongodb-js/mongosh#readme"
+  url "https://registry.npmjs.org/@mongosh/cli-repl/-/cli-repl-${context.version}.tgz"
+  version "${context.version}"
+
+  # This is the checksum of the archive. Can be obtained with:
+  # curl -s https://registry.npmjs.org/@mongosh/cli-repl/-/cli-repl-${context.version}.tgz | shasum -a 256
+  sha256 "${context.sha}"
+
+  depends_on "node@12"
+
+  def install
+    system "#{Formula["node@12"].bin}/npm", "install", *Language::Node.std_npm_install_args(libexec)
+    (bin/"mongosh").write_env_script libexec/"bin/mongosh", :PATH => "#{Formula["node@12"].opt_bin}:$PATH"
+  end
+
+  test do
+    system "#{bin}/mongosh --version"
+  end
+end
+`
+}
+
+function getLatestVersion() {
+  return execSync(`npm view @mongosh/cli-repl .dist-tags.latest`).toString().trim();
+}
+
+async function main() {
+  const version = getLatestVersion();
+  const url = `https://registry.npmjs.org/@mongosh/cli-repl/-/cli-repl-${version}.tgz`;
+  const sha = await httpsSha256(url);
+  const formula = await render({version, sha})
+  console.log(formula);
+}
+
+main();


### PR DESCRIPTION
Generates and print (no automated PR), the homebrew formula for the latest release of `@mongosh/cli-repl`. Gets the latest version with `npm view` and then renders a `mongosh.rb` template to the standard output with the correct `sha`.