### PR TITLE
test: fix test for 'version' command

### DIFF
--- a/packages/cli-repl/test/e2e.spec.ts
+++ b/packages/cli-repl/test/e2e.spec.ts
@@ -124,7 +124,7 @@ describe('e2e', function() {
       client.close();
     });
 
-    describe('version', async() => {
+    it('version', async() => {
       const expected = require('../package.json').version;
       await shell.executeLine('version()');
       shell.assertContainsOutput(expected);


### PR DESCRIPTION
This otherwise results in an unhandled rejection, because
`describe()` callbacks run immediately, without waiting for
`beforeEach()` to populate the `shell` variable.