### PR TITLE
MONGOSH-121: upload rpm to downloads centre

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -197,6 +197,7 @@ tasks:
   - name: release_debian
     depends_on:
       - name: check
+      - name: test
     commands:
       - func: checkout
       - func: install
@@ -249,4 +250,5 @@ buildvariants:
     run_on: debian10-large
     tasks:
       - name: check
+      - name: test
       - name: release_debian

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -197,6 +197,7 @@ tasks:
   - name: release_debian
     depends_on:
       - name: check
+      - name: test
     commands:
       - func: checkout
       - func: install
@@ -204,6 +205,7 @@ tasks:
   - name: release_rhel
     depends_on:
       - name: check
+      - name: test
     commands:
       - func: checkout
       - func: install
@@ -250,4 +252,5 @@ buildvariants:
     run_on: debian10-large
     tasks:
       - name: check
+      - name: test
       - name: release_debian

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -253,5 +253,4 @@ buildvariants:
     run_on: debian10-large
     tasks:
       - name: check
-      - name: test
       - name: release_debian

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -198,6 +198,7 @@ tasks:
     depends_on:
       - name: check
       - name: test
+        variant: linux
     commands:
       - func: checkout
       - func: install
@@ -205,6 +206,8 @@ tasks:
   - name: release_rhel
     depends_on:
       - name: check
+      - name: test
+        variant: linux
     commands:
       - func: checkout
       - func: install

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -136,6 +136,12 @@ functions:
         file: tmp/expansions.yaml
         redacted: true
     - <<: *compile_and_release
+  release_rhel:
+    - command: expansions.write
+      params:
+        file: tmp/expansions.yaml
+        redacted: true
+    - <<: *compile_and_release
   release_win_ps:
     - command: expansions.write
       params:
@@ -195,6 +201,13 @@ tasks:
       - func: checkout
       - func: install
       - func: release_debian
+  - name: release_rhel
+    depends_on:
+      - name: check
+    commands:
+      - func: checkout
+      - func: install
+      - func: release_rhel
   - name: release_win_ps
     depends_on:
       - name: check_ps
@@ -224,7 +237,7 @@ buildvariants:
     tasks:
       - name: check
       - name: test
-      - name: release_linux
+      - name: release_rhel
   - name: win32
     display_name: "Windows VS 2019 PowerShell"
     run_on: windows-64-vs2019-test

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -218,6 +218,13 @@ buildvariants:
       - name: check
       - name: test
       - name: release_linux
+  - name: rhel
+    display_name: "RHEL 8.0"
+    run_on: rhel80-large
+    tasks:
+      - name: check
+      - name: test
+      - name: release_linux
   - name: win32
     display_name: "Windows VS 2019 PowerShell"
     run_on: windows-64-vs2019-test

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -197,7 +197,6 @@ tasks:
   - name: release_debian
     depends_on:
       - name: check
-      - name: test
     commands:
       - func: checkout
       - func: install
@@ -205,7 +204,6 @@ tasks:
   - name: release_rhel
     depends_on:
       - name: check
-      - name: test
     commands:
       - func: checkout
       - func: install
@@ -238,7 +236,6 @@ buildvariants:
     run_on: rhel80-large
     tasks:
       - name: check
-      - name: test
       - name: release_rhel
   - name: win32
     display_name: "Windows VS 2019 PowerShell"
@@ -252,5 +249,4 @@ buildvariants:
     run_on: debian10-large
     tasks:
       - name: check
-      - name: test
       - name: release_debian

--- a/package-lock.json
+++ b/package-lock.json
@@ -16084,8 +16084,9 @@
       }
     },
     "pkg-rpm": {
-      "version": "1.0.0",
-      "resolved": "github:mongodb-js/pkg-rpm#c8abb6a7794375f7030c9e0247d173d07423d66f",
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/pkg-rpm/-/pkg-rpm-1.0.1.tgz",
+      "integrity": "sha512-uUhgEcdIs3TorpsXUufU/YlVGfEKfHQipybqwozvrYOI5hyTxb9drHTUI2B0Hcmeex1raDdAu/yQxSzQzVJFiQ==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14348,7 +14348,7 @@
       "dev": true
     },
     "node-codesign": {
-      "version": "github:durran/node-codesign#92863a258c2108556c0a33284d26f635729041da",
+      "version": "github:durran/node-codesign#8f7adaf9889a6be26f4fd60efa610967cfdf8730",
       "from": "github:durran/node-codesign",
       "dev": true,
       "requires": {
@@ -16080,6 +16080,59 @@
           "requires": {
             "has-flag": "^4.0.0"
           }
+        }
+      }
+    },
+    "pkg-rpm": {
+      "version": "github:mongodb-js/pkg-rpm#d9075c10e68fe7e2caba541091e4f53a7b1f28f4",
+      "from": "github:mongodb-js/pkg-rpm",
+      "dev": true,
+      "requires": {
+        "debug": "^4.1.1",
+        "fs-extra": "^9.0.0",
+        "get-folder-size": "^2.0.1",
+        "lodash.template": "^4.5.0",
+        "parse-author": "^2.0.0",
+        "tmp-promise": "^3.0.2",
+        "word-wrap": "^1.2.3"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.1.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+          "integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+          "dev": true,
+          "requires": {
+            "ms": "^2.1.1"
+          }
+        },
+        "fs-extra": {
+          "version": "9.0.1",
+          "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-9.0.1.tgz",
+          "integrity": "sha512-h2iAoN838FqAFJY2/qVpzFXy+EBxfVE220PalAqQLDVsFOHLJrZvut5puAbCdNv6WJk+B8ihI+k0c7JK5erwqQ==",
+          "dev": true,
+          "requires": {
+            "at-least-node": "^1.0.0",
+            "graceful-fs": "^4.2.0",
+            "jsonfile": "^6.0.1",
+            "universalify": "^1.0.0"
+          }
+        },
+        "jsonfile": {
+          "version": "6.0.1",
+          "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.0.1.tgz",
+          "integrity": "sha512-jR2b5v7d2vIOust+w3wtFKZIfpC2pnRmFAhAC/BuweZFQR8qZzxH1OyrQ10HmdVYiXWkYUqPVsz91cG7EL2FBg==",
+          "dev": true,
+          "requires": {
+            "graceful-fs": "^4.1.6",
+            "universalify": "^1.0.0"
+          }
+        },
+        "universalify": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/universalify/-/universalify-1.0.0.tgz",
+          "integrity": "sha512-rb6X1W158d7pRQBg5gkR8uPaSfiids68LTJQYOtEUhoJUWBdaQHsuT/EUduxXYxcrt4r5PJ4fuHW1MHT6p0qug==",
+          "dev": true
         }
       }
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -16084,13 +16084,14 @@
       }
     },
     "pkg-rpm": {
-      "version": "github:mongodb-js/pkg-rpm#d9075c10e68fe7e2caba541091e4f53a7b1f28f4",
-      "from": "github:mongodb-js/pkg-rpm",
+      "version": "1.0.0",
+      "resolved": "github:mongodb-js/pkg-rpm#c8abb6a7794375f7030c9e0247d173d07423d66f",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",
         "fs-extra": "^9.0.0",
         "get-folder-size": "^2.0.1",
+        "glob": "^7.1.6",
         "lodash.template": "^4.5.0",
         "parse-author": "^2.0.0",
         "tmp-promise": "^3.0.2",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "parcel-bundler": "^1.12.4",
     "pkg": "^4.4.3",
     "pkg-deb": "^1.1.1",
-    "pkg-rpm": "mongodb-js/pkg-rpm",
+    "pkg-rpm": "^1.0.0",
     "rimraf": "^3.0.2",
     "semver": "^7.3.2",
     "sinon": "^7.5.0",

--- a/package.json
+++ b/package.json
@@ -75,6 +75,7 @@
     "axios": "^0.19.2",
     "browserify": "^16.5.0",
     "chai": "^4.2.0",
+    "command-exists": "^1.2.9",
     "cross-env": "^6.0.3",
     "electron-notarize": "mongodb-js/electron-notarize",
     "eslint": "^6.8.0",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "parcel-bundler": "^1.12.4",
     "pkg": "^4.4.3",
     "pkg-deb": "^1.1.1",
-    "pkg-rpm": "^1.0.0",
+    "pkg-rpm": "^1.0.1",
     "rimraf": "^3.0.2",
     "semver": "^7.3.2",
     "sinon": "^7.5.0",

--- a/package.json
+++ b/package.json
@@ -98,6 +98,7 @@
     "parcel-bundler": "^1.12.4",
     "pkg": "^4.4.3",
     "pkg-deb": "^1.1.1",
+    "pkg-rpm": "mongodb-js/pkg-rpm",
     "rimraf": "^3.0.2",
     "semver": "^7.3.2",
     "sinon": "^7.5.0",

--- a/packages/build/README.md
+++ b/packages/build/README.md
@@ -11,18 +11,19 @@ root of the project.
 Current build and release flow is as follows:
 
 - A commit triggers an evergreen build based on currently available build
-  variants: MacOS, Windows, Linux, Debiam.
-- MacOS, Linux and Windows run three tasks: check, test, and release. Debian
-  runs two tasks: check and release.
-- Identical bundle and binary are built on all three variants.
-- Each variant creates its own tarball (`.zip`, `.tgz`, `.deb`). Type of tarball is
-  determined by the current build variant.
+  variants: MacOS, Windows, Linux, Debian, and RedHat.
+- MacOS, Linux and Windows run three tasks: check, test, and release. Debian and
+  Redhat run two tasks: check and release. Debian and Redhat also depend on
+  tests to pass on Linux.
+- Identical bundle and binary are built on all five variants.
+- Each variant creates its own tarball (`.zip`, `.tgz`, `.deb`, `.rpm`). Type of
+  tarball is determined by the current build variant.
 - Each variant uploads its own tarball to Evergreen’s AWS.
 - MacOS build variant uploads config file with information about the new version
   for each platform to Downloads Centre. This only happens on a tagged commit.
 - MacOS build variant creates a github release. This only happens on a tagged
   commit.
-- The three build variants run in parallel.
+- The five build variants run in parallel.
 
 ![build flow][build-img]
 

--- a/packages/build/src/build-variant.spec.ts
+++ b/packages/build/src/build-variant.spec.ts
@@ -25,4 +25,10 @@ describe('BuildVariant', () => {
       expect(BuildVariant.Debian).to.equal('debian');
     });
   });
+
+  describe('BuildVariant.Redhat', () => {
+    it('returns rhel', () => {
+      expect(BuildVariant.Redhat).to.equal('rhel');
+    });
+  });
 });

--- a/packages/build/src/build-variant.ts
+++ b/packages/build/src/build-variant.ts
@@ -8,7 +8,8 @@ enum BuildVariant {
   Windows = 'win32',
   MacOs = 'darwin',
   Linux = 'linux',
-  Debian = 'debian'
+  Debian = 'debian',
+  Redhat = 'rhel'
 }
 
 export default BuildVariant;

--- a/packages/build/src/download-center.ts
+++ b/packages/build/src/download-center.ts
@@ -67,16 +67,16 @@ const CONFIG = `
           "download_link": "https://downloads.mongodb.com/compass/mongosh-{{version}}-linux.tgz"
         },
         {
-          "arch": "amd64",
+          "arch": "x64",
           "os": "debian",
           "name": "Debian 64-bit",
           "download_link": "https://downloads.mongodb.com/compass/mongosh_{{version}}_amd64.deb"
         }
         {
-          "arch": "amd64",
+          "arch": "x64",
           "os": "rhel",
           "name": "Redhat 64-bit",
-          "download_link": "https://downloads.mongodb.com/compass/mongosh-{{version}}-amd64.deb"
+          "download_link": "https://downloads.mongodb.com/compass/mongosh-{{version}}-x86_64.deb"
         }
       ]
     }

--- a/packages/build/src/download-center.ts
+++ b/packages/build/src/download-center.ts
@@ -67,10 +67,16 @@ const CONFIG = `
           "download_link": "https://downloads.mongodb.com/compass/mongosh-{{version}}-linux.tgz"
         },
         {
-          "arch": "x64",
+          "arch": "amd64",
           "os": "debian",
           "name": "Debian 64-bit",
           "download_link": "https://downloads.mongodb.com/compass/mongosh_{{version}}_amd64.deb"
+        }
+        {
+          "arch": "amd64",
+          "os": "rhel",
+          "name": "Redhat 64-bit",
+          "download_link": "https://downloads.mongodb.com/compass/mongosh-{{version}}-amd64.deb"
         }
       ]
     }

--- a/packages/build/src/download-center.ts
+++ b/packages/build/src/download-center.ts
@@ -76,7 +76,7 @@ const CONFIG = `
           "arch": "x64",
           "os": "rhel",
           "name": "Redhat 64-bit",
-          "download_link": "https://downloads.mongodb.com/compass/mongosh-{{version}}-x86_64.deb"
+          "download_link": "https://downloads.mongodb.com/compass/mongosh-{{version}}-x86_64.rpm"
         }
       ]
     }

--- a/packages/build/src/tarball.spec.ts
+++ b/packages/build/src/tarball.spec.ts
@@ -103,7 +103,7 @@ describe('tarball module', () => {
       });
 
       it('builds the executable', async() => {
-        await tarballDebian(inputFile, __dirname, version, path.join(__dirname, '../../..'));
+        await tarballRedhat(inputFile, __dirname, version, path.join(__dirname, '../../..'));
 
         let accessErr;
         try {

--- a/packages/build/src/tarball.spec.ts
+++ b/packages/build/src/tarball.spec.ts
@@ -99,7 +99,7 @@ describe('tarball module', () => {
 
     // Apt does not have `rpmbuild` package, so we will not able to install it
     // on ubuntu's build variant. We can, however, uncomment this test once we
-    // specifically test on redhat80-large.
+    // specifically test on rhel80-large.
 
     // describe('.tarballRedhat', () => {
     //   const version = '1.0.0';

--- a/packages/build/src/tarball.spec.ts
+++ b/packages/build/src/tarball.spec.ts
@@ -6,6 +6,7 @@ import {
   createTarball,
   tarballPath,
   tarballPosix,
+  tarballRedhat,
   tarballDebian,
   tarballWindows
 } from './tarball';

--- a/packages/build/src/tarball.spec.ts
+++ b/packages/build/src/tarball.spec.ts
@@ -56,7 +56,7 @@ describe('tarball module', () => {
 
       let accessErr;
       try {
-        fs.access(expectedTarball);
+        await fs.access(expectedTarball);
       } catch (err) {
         accessErr = err;
       }
@@ -82,7 +82,7 @@ describe('tarball module', () => {
 
         let accessErr;
         try {
-          fs.access(expectedTarball);
+          await fs.access(expectedTarball);
         } catch (err) {
           accessErr = err;
         }
@@ -133,7 +133,7 @@ describe('tarball module', () => {
 
       let accessErr;
       try {
-        fs.access(expectedTarball);
+        await fs.access(expectedTarball);
       } catch (err) {
         accessErr = err;
       }
@@ -158,7 +158,7 @@ describe('tarball module', () => {
 
       let accessErr;
       try {
-        fs.access(expectedTarball);
+        await fs.access(expectedTarball);
       } catch (err) {
         accessErr = err;
       }

--- a/packages/build/src/tarball.spec.ts
+++ b/packages/build/src/tarball.spec.ts
@@ -92,6 +92,33 @@ describe('tarball module', () => {
     });
   }
 
+  // macos and windows build variants does not come with installed 'rpmbuild' so
+  // this test fails. Run this test only on linux platforms.
+  if (os.platform() === Platform.Linux) {
+    describe('.tarballRedhat', () => {
+      const version = '1.0.0';
+      const inputFile = path.join(__dirname, '..', 'examples', 'input.js');
+      const expectedTarball = tarballPath(__dirname, BuildVariant.Redhat, version);
+
+      after(async () => {
+        await fs.unlink(expectedTarball);
+      });
+
+      it('builds the executable', async() => {
+        await tarballDebian(inputFile, __dirname, version, path.join(__dirname, '../../..'));
+
+        let accessErr;
+        try {
+          fs.access(expectedTarball);
+        } catch (err) {
+          accessErr = err;
+        }
+
+        expect(accessErr).to.be.undefined;
+      });
+    });
+  }
+
   describe('.tarballWindows', () => {
     const version = '1.0.0';
     const expectedTarball = tarballPath(__dirname, BuildVariant.Windows, version);

--- a/packages/build/src/tarball.spec.ts
+++ b/packages/build/src/tarball.spec.ts
@@ -109,7 +109,7 @@ describe('tarball module', () => {
 
         let accessErr;
         try {
-          fs.access(expectedTarball);
+          await fs.access(expectedTarball);
         } catch (err) {
           accessErr = err;
         }

--- a/packages/build/src/tarball.spec.ts
+++ b/packages/build/src/tarball.spec.ts
@@ -1,8 +1,6 @@
-import os from 'os';
 import { promises as fs } from 'fs';
 import path from 'path';
 import { expect } from 'chai';
-import Platform from './platform';
 import BuildVariant from './build-variant';
 import {
   createTarball,
@@ -67,7 +65,7 @@ describe('tarball module', () => {
 
   // macos and windows build variants does not come with installed 'dpkg' so
   // this test fails. Run this test only on linux platforms.
-  if (os.platform() === Platform.Linux) {
+  if (process.env.BUILD_VARIANT  === BuildVariant.Debian) {
     describe('.tarballDebian', () => {
       const version = '1.0.0';
       const inputFile = path.join(__dirname, '..', 'examples', 'input.js');
@@ -94,7 +92,7 @@ describe('tarball module', () => {
 
   // macos and windows build variants does not come with installed 'rpmbuild' so
   // this test fails. Run this test only on linux platforms.
-  if (os.platform() === Platform.Linux) {
+  if (process.env.BUILD_VARIANT  === BuildVariant.Redhat) {
     describe('.tarballRedhat', () => {
       const version = '1.0.0';
       const inputFile = path.join(__dirname, '..', 'examples', 'input.js');

--- a/packages/build/src/tarball.spec.ts
+++ b/packages/build/src/tarball.spec.ts
@@ -1,4 +1,5 @@
 import BuildVariant from './build-variant';
+import commandExists from 'command-exists';
 import { promises as fs } from 'fs';
 import Platform from './platform';
 import { expect } from 'chai';
@@ -92,38 +93,48 @@ describe('tarball module', () => {
       });
     });
 
-    // Our ubuntu box, which for the time being runs this test, does not come
-    // with `rpmbuild` installed, so we end up getting:
+    describe('.tarballRedhat', () => {
+      const version = '1.0.0';
+      const inputFile = path.join(__dirname, '..', 'examples', 'input.js');
+      const expectedTarball = tarballPath(__dirname, BuildVariant.Redhat, version);
 
-    // Error: spawn rpmbuild ENOENT
+      // Our ubuntu box, which for the time being runs this test, does not come
+      // with `rpmbuild` installed, so we end up getting:
 
-    // Apt does not have `rpmbuild` package, so we will not able to install it
-    // on ubuntu's build variant. We can, however, uncomment this test once we
-    // specifically test on rhel80-large.
+      // Error: spawn rpmbuild ENOENT
 
-    // describe('.tarballRedhat', () => {
-    //   const version = '1.0.0';
-    //   const inputFile = path.join(__dirname, '..', 'examples', 'input.js');
-    //   const expectedTarball = tarballPath(__dirname, BuildVariant.Redhat, version);
+      // Apt does not have `rpmbuild` package, so we will not able to install it
+      // on ubuntu's build variant. We can, however, run this test fully once we
+      // specifically test on rhel80-large. For now just skip if `rpmbuild` is
+      // not available.
+      beforeEach(function() {
+        if(!commandExists.sync('rpmbuild')) {
+          this.skip();
+        }
+      });
 
-    //   after(async () => {
-    //     await fs.unlink(expectedTarball);
-    //   });
+      afterEach(async () => {
+        // only run this afterEach if we have rpmbuild command available, i.e.
+        // this test was not skipped.
+        if(commandExists.sync('rpmbuild')) {
+          await fs.unlink(expectedTarball);
+        }
+      });
 
-    //   it('builds the executable', async() => {
-    //     await tarballRedhat(inputFile, __dirname, version, path.join(__dirname, '../../..'));
-    //     console.log('tarball built')
+      it('builds the executable', async() => {
+        await tarballRedhat(inputFile, __dirname, version, path.join(__dirname, '../../..'));
+        console.log('tarball built')
 
-    //     let accessErr;
-    //     try {
-    //       await fs.access(expectedTarball);
-    //     } catch (err) {
-    //       accessErr = err;
-    //     }
+        let accessErr;
+        try {
+          await fs.access(expectedTarball);
+        } catch (err) {
+          accessErr = err;
+        }
 
-    //     expect(accessErr).to.be.undefined;
-    //   });
-    // });
+        expect(accessErr).to.be.undefined;
+      });
+    });
   }
 
   describe('.tarballWindows', () => {

--- a/packages/build/src/tarball.spec.ts
+++ b/packages/build/src/tarball.spec.ts
@@ -92,28 +92,38 @@ describe('tarball module', () => {
       });
     });
 
-    describe('.tarballRedhat', () => {
-      const version = '1.0.0';
-      const inputFile = path.join(__dirname, '..', 'examples', 'input.js');
-      const expectedTarball = tarballPath(__dirname, BuildVariant.Redhat, version);
+    // Our ubuntu box, which for the time being runs this test, does not come
+    // with `rpmbuild` installed, so we end up getting:
 
-      after(async () => {
-        await fs.unlink(expectedTarball);
-      });
+    // Error: spawn rpmbuild ENOENT
 
-      it('builds the executable', async() => {
-        await tarballRedhat(inputFile, __dirname, version, path.join(__dirname, '../../..'));
+    // Apt does not have `rpmbuild` package, so we will not able to install it
+    // on ubuntu's build variant. We can, however, uncomment this test once we
+    // specifically test on redhat80-large.
 
-        let accessErr;
-        try {
-          await fs.access(expectedTarball);
-        } catch (err) {
-          accessErr = err;
-        }
+    // describe('.tarballRedhat', () => {
+    //   const version = '1.0.0';
+    //   const inputFile = path.join(__dirname, '..', 'examples', 'input.js');
+    //   const expectedTarball = tarballPath(__dirname, BuildVariant.Redhat, version);
 
-        expect(accessErr).to.be.undefined;
-      });
-    });
+    //   after(async () => {
+    //     await fs.unlink(expectedTarball);
+    //   });
+
+    //   it('builds the executable', async() => {
+    //     await tarballRedhat(inputFile, __dirname, version, path.join(__dirname, '../../..'));
+    //     console.log('tarball built')
+
+    //     let accessErr;
+    //     try {
+    //       await fs.access(expectedTarball);
+    //     } catch (err) {
+    //       accessErr = err;
+    //     }
+
+    //     expect(accessErr).to.be.undefined;
+    //   });
+    // });
   }
 
   describe('.tarballWindows', () => {

--- a/packages/build/src/tarball.spec.ts
+++ b/packages/build/src/tarball.spec.ts
@@ -1,7 +1,9 @@
-import { promises as fs } from 'fs';
-import path from 'path';
-import { expect } from 'chai';
 import BuildVariant from './build-variant';
+import { promises as fs } from 'fs';
+import Platform from './platform';
+import { expect } from 'chai';
+import path from 'path';
+import os from 'os';
 import {
   createTarball,
   tarballPath,
@@ -66,7 +68,7 @@ describe('tarball module', () => {
 
   // macos and windows build variants does not come with installed 'dpkg' so
   // this test fails. Run this test only on linux platforms.
-  if (process.env.BUILD_VARIANT  === BuildVariant.Debian) {
+  if (os.platform() === Platform.Linux) {
     describe('.tarballDebian', () => {
       const version = '1.0.0';
       const inputFile = path.join(__dirname, '..', 'examples', 'input.js');
@@ -89,11 +91,7 @@ describe('tarball module', () => {
         expect(accessErr).to.be.undefined;
       });
     });
-  }
 
-  // macos and windows build variants does not come with installed 'rpmbuild' so
-  // this test fails. Run this test only on linux platforms.
-  if (process.env.BUILD_VARIANT  === BuildVariant.Redhat) {
     describe('.tarballRedhat', () => {
       const version = '1.0.0';
       const inputFile = path.join(__dirname, '..', 'examples', 'input.js');

--- a/packages/build/src/tarball.ts
+++ b/packages/build/src/tarball.ts
@@ -101,6 +101,7 @@ export const tarballRedhat = async(
     dest: outputDir,
     src: rootDir, // pkg-rpm will look for package.json in src to get info
     input: input,
+    loggger: console.log,
     arch: 'amd64' // should this be x86_64?
   }
 
@@ -141,7 +142,7 @@ export async function createTarball(
 ): Promise<TarballFile> {
   const filename = tarballPath(outputDir, buildVariant, version);
 
-  console.info('mongosh: tarballping:', filename);
+  console.info('mongosh: gzipping:', filename);
 
   if (buildVariant === BuildVariant.Linux) {
     await tarballPosix(outputDir, filename);
@@ -162,7 +163,6 @@ export async function createTarball(
 
     return {
       path: filename,
-      // this might have to be application/gzip MIME type
       contentType: 'application/vnd.debian.binary-package'
     }
   } else {

--- a/packages/build/src/tarball.ts
+++ b/packages/build/src/tarball.ts
@@ -101,7 +101,6 @@ export const tarballRedhat = async(
     dest: outputDir,
     src: rootDir,
     input: input,
-    logger: console.log,
     arch: 'x86_64'
   }
 

--- a/packages/build/src/tarball.ts
+++ b/packages/build/src/tarball.ts
@@ -101,6 +101,7 @@ export const tarballRedhat = async(
     dest: outputDir,
     src: rootDir,
     input: input,
+    loggger: console.log,
     arch: 'x86_64'
   }
 

--- a/packages/build/src/tarball.ts
+++ b/packages/build/src/tarball.ts
@@ -101,7 +101,7 @@ export const tarballRedhat = async(
     dest: outputDir,
     src: rootDir, // pkg-rpm will look for package.json in src to get info
     input: input,
-    loggger: console.log,
+    logger: console.log,
     arch: 'amd64' // should this be x86_64?
   }
 

--- a/packages/build/src/tarball.ts
+++ b/packages/build/src/tarball.ts
@@ -18,7 +18,7 @@ export const tarballPath = (outputDir: string, buildVariant: string, version: st
   if (buildVariant === BuildVariant.Linux) {
     return path.join(outputDir, `mongosh-${version}-${buildVariant}.tgz`);
   } else if (buildVariant === BuildVariant.Redhat) {
-    return path.join(outputDir, `mongosh-${version}-${buildVariant}.rpm`);
+    return path.join(outputDir, `mongosh-${version}-amd64.rpm`);
   } else if (buildVariant === BuildVariant.Debian) {
     // debian packages are required to be separated by _ and have arch in the
     // name: https://www.debian.org/doc/manuals/debian-faq/pkg-basics.en.html

--- a/packages/build/src/tarball.ts
+++ b/packages/build/src/tarball.ts
@@ -152,7 +152,6 @@ export async function createTarball(
     };
   } else if (buildVariant === BuildVariant.Redhat) {
     await tarballRedhat(input, outputDir, version, rootDir);
-    console.info('mongosh: built redhat tarball');
 
     return {
       path: filename,

--- a/packages/build/src/tarball.ts
+++ b/packages/build/src/tarball.ts
@@ -18,7 +18,7 @@ export const tarballPath = (outputDir: string, buildVariant: string, version: st
   if (buildVariant === BuildVariant.Linux) {
     return path.join(outputDir, `mongosh-${version}-${buildVariant}.tgz`);
   } else if (buildVariant === BuildVariant.Redhat) {
-    return path.join(outputDir, `mongosh-${version}-amd64.rpm`);
+    return path.join(outputDir, `mongosh-${version}-x86_64.rpm`);
   } else if (buildVariant === BuildVariant.Debian) {
     // debian packages are required to be separated by _ and have arch in the
     // name: https://www.debian.org/doc/manuals/debian-faq/pkg-basics.en.html
@@ -102,7 +102,7 @@ export const tarballRedhat = async(
     src: rootDir, // pkg-rpm will look for package.json in src to get info
     input: input,
     logger: console.log,
-    arch: 'amd64' // should this be x86_64?
+    arch: 'x86_64'
   }
 
   console.log('mongosh: writing redhat package')

--- a/packages/build/src/tarball.ts
+++ b/packages/build/src/tarball.ts
@@ -99,7 +99,7 @@ export const tarballRedhat = async(
     version: version,
     name: 'mongosh',
     dest: outputDir,
-    src: rootDir, // pkg-rpm will look for package.json in src to get info
+    src: rootDir,
     input: input,
     logger: console.log,
     arch: 'x86_64'
@@ -153,6 +153,7 @@ export async function createTarball(
     };
   } else if (buildVariant === BuildVariant.Redhat) {
     await tarballRedhat(input, outputDir, version, rootDir);
+    console.info('mongosh: built redhat tarball');
 
     return {
       path: filename,

--- a/packages/build/src/tarball.ts
+++ b/packages/build/src/tarball.ts
@@ -101,7 +101,6 @@ export const tarballRedhat = async(
     dest: outputDir,
     src: rootDir,
     input: input,
-    loggger: console.log,
     arch: 'x86_64'
   }
 


### PR DESCRIPTION
## Description

Uses [pkg-rpm](github.com/mongodb-js/pkg-rpm) to create an rpm package. This
package will be uploaded to download's centre when doing a release.

Additionally, this PR adds `rhel80-large` build variant. This build variant runs a
`check` and `release` tasks, and depends on tests passing on our existing linux
build variant.