### PR TITLE
MONGOSH-341: Fix wrong values with NumberLong for numbers > Number.MAX_SAFE_INTEGER

### DIFF
--- a/packages/cli-repl/test/e2e-bson.spec.ts
+++ b/packages/cli-repl/test/e2e-bson.spec.ts
@@ -247,6 +247,14 @@ describe('BSON e2e', function() {
       });
       shell.assertNoErrors();
     });
+    it('NumberLong prints when created by user (> MAX_SAFE_INTEGER)', async() => {
+      const value = 'NumberLong("345678654321234561")';
+      await shell.writeInputLine(value);
+      await eventually(() => {
+        shell.assertContainsOutput('NumberLong(345678654321234561)');
+      });
+      shell.assertNoErrors();
+    });
     it('Timestamp prints when created by user', async() => {
       const value = 'Timestamp(0, 100)';
       await shell.writeInputLine(value);

--- a/packages/cli-repl/test/e2e-bson.spec.ts
+++ b/packages/cli-repl/test/e2e-bson.spec.ts
@@ -243,7 +243,7 @@ describe('BSON e2e', function() {
       const value = 'NumberLong("64")';
       await shell.writeInputLine(value);
       await eventually(() => {
-        shell.assertContainsOutput('NumberLong(64)');
+        shell.assertContainsOutput('NumberLong("64")');
       });
       shell.assertNoErrors();
     });
@@ -251,7 +251,7 @@ describe('BSON e2e', function() {
       const value = 'NumberLong("345678654321234561")';
       await shell.writeInputLine(value);
       await eventually(() => {
-        shell.assertContainsOutput('NumberLong(345678654321234561)');
+        shell.assertContainsOutput('NumberLong("345678654321234561")');
       });
       shell.assertNoErrors();
     });

--- a/packages/cli-repl/test/e2e-bson.spec.ts
+++ b/packages/cli-repl/test/e2e-bson.spec.ts
@@ -288,7 +288,7 @@ describe('BSON e2e', function() {
       shell.assertNoErrors();
     });
     it('Decimal128 prints when created by user', async() => {
-      const value = 'NumberDecimal(100)';
+      const value = 'NumberDecimal("100")';
       await shell.writeInputLine(value);
       await eventually(() => {
         shell.assertContainsOutput('NumberDecimal("100")');

--- a/packages/service-provider-core/src/printable-bson.ts
+++ b/packages/service-provider-core/src/printable-bson.ts
@@ -65,7 +65,7 @@ export default function(bson): void {
   bson.Int32.prototype.asPrintable = bson.Int32.prototype[toString];
 
   bson.Long.prototype[toString] = function(): string {
-    return `NumberLong(${this.toString()})`;
+    return `NumberLong("${this.toString()}")`;
   };
   bson.Long.prototype.asPrintable = bson.Long.prototype[toString];
 

--- a/packages/service-provider-core/src/printable-bson.ts
+++ b/packages/service-provider-core/src/printable-bson.ts
@@ -65,7 +65,7 @@ export default function(bson): void {
   bson.Int32.prototype.asPrintable = bson.Int32.prototype[toString];
 
   bson.Long.prototype[toString] = function(): string {
-    return `NumberLong(${this.toNumber()})`;
+    return `NumberLong(${this.toString()})`;
   };
   bson.Long.prototype.asPrintable = bson.Long.prototype[toString];
 

--- a/packages/shell-api/src/shell-bson.spec.ts
+++ b/packages/shell-api/src/shell-bson.spec.ts
@@ -225,4 +225,66 @@ describe('Shell BSON', () => {
       expect(shellBson.bsonsize({})).to.equal(5);
     });
   });
+
+  describe('NumberLong', () => {
+    it('creates a bson.Long', () => {
+      const n = shellBson.NumberLong('123');
+      expect(n).to.be.instanceOf(bson.Long);
+      expect(bson.Long.fromString('123').eq(n)).to.be.true;
+    });
+
+    it('throws if the argument is not a string', () => {
+      expect(() => {
+        shellBson.NumberLong(123);
+      }).to.throw('NumberLong can only be constructed from a string, received: number');
+    });
+
+    it('constructs 0 if the argument is not provided', () => {
+      expect(bson.Long.fromString('0').eq(shellBson.NumberLong())).to.be.true;
+    });
+
+    it('correctly constructs numbers > MAX_SAFE_INTEGER', () => {
+      expect(shellBson.NumberLong('345678654321234552').toString()).to.equal('345678654321234552');
+    });
+  });
+
+  describe('NumberDecimal', () => {
+    it('creates a bson.Decimal128', () => {
+      const n = shellBson.NumberDecimal('123.1');
+      expect(n).to.be.instanceOf(bson.Decimal128);
+      expect(n.toString()).to.equal('123.1');
+    });
+
+    it('throws if the argument is not a string', () => {
+      expect(() => {
+        shellBson.NumberDecimal(123.1);
+      }).to.throw('NumberDecimal can only be constructed from a string, received: number');
+    });
+
+    it('constructs 0 if the argument is not provided', () => {
+      expect(shellBson.NumberDecimal().toString()).to.equal('0');
+    });
+
+    it('correctly constructs numbers > MAX_SAFE_INTEGER', () => {
+      expect(shellBson.NumberDecimal('345678654321234552.0').toString()).to.equal('345678654321234552.0');
+    });
+  });
+
+  describe('NumberInt', () => {
+    it('creates a bson.Int32 from string', () => {
+      const n = shellBson.NumberInt('1');
+      expect(n).to.be.instanceOf(bson.Int32);
+      expect(n.value).to.equal(1);
+    });
+
+    it('creates a bson.Int32 from number', () => {
+      const n = shellBson.NumberInt(1);
+      expect(n).to.be.instanceOf(bson.Int32);
+      expect(n.value).to.equal(1);
+    });
+
+    it('constructs 0 if the argument is not provided', () => {
+      expect(shellBson.NumberInt().value).to.equal(0);
+    });
+  });
 });

--- a/packages/shell-api/src/shell-bson.spec.ts
+++ b/packages/shell-api/src/shell-bson.spec.ts
@@ -236,7 +236,7 @@ describe('Shell BSON', () => {
     it('throws if the argument is not a string', () => {
       expect(() => {
         shellBson.NumberLong(123);
-      }).to.throw('NumberLong can only be constructed from a string, received: number');
+      }).to.throw('NumberLong can only be constructed from a string, received: number. Please use NumberLong(string).');
     });
 
     it('constructs 0 if the argument is not provided', () => {
@@ -258,7 +258,7 @@ describe('Shell BSON', () => {
     it('throws if the argument is not a string', () => {
       expect(() => {
         shellBson.NumberDecimal(123.1);
-      }).to.throw('NumberDecimal can only be constructed from a string, received: number');
+      }).to.throw('NumberDecimal can only be constructed from a string, received: number. Please use NumberDecimal(string).');
     });
 
     it('constructs 0 if the argument is not provided', () => {

--- a/packages/shell-api/src/shell-bson.ts
+++ b/packages/shell-api/src/shell-bson.ts
@@ -25,6 +25,15 @@ function dateHelper(...args: DateConstructorArguments): Date {
   return new Date(Date.UTC(...args));
 }
 
+function requireStringAsConstructorArgument(typeName, arg): void {
+  const argumentType = typeof(arg);
+  if (argumentType !== 'string') {
+    throw new MongoshInvalidInputError(
+      `${typeName} can only be constructed from a string, received: ${argumentType}. Please use ${typeName}(string).`
+    );
+  }
+}
+
 /**
  * This method modifies the BSON class passed in as argument. This is required so that
  * we can have help, serverVersions, and other metadata on the bson classes constructed by the user.
@@ -111,11 +120,7 @@ export default function constructShellBson(bson: any): any {
         s = '0';
       }
 
-      if (typeof s !== 'string') {
-        throw new MongoshInvalidInputError(
-          'NumberDecimal can only be constructed from a string, received: ' + (typeof s)
-        );
-      }
+      requireStringAsConstructorArgument('NumberDecimal', s);
 
       return bson.Decimal128.fromString(s.toString());
     },
@@ -126,18 +131,14 @@ export default function constructShellBson(bson: any): any {
 
       return new bson.Int32(parseInt(v, 10));
     },
-    NumberLong: function(v): any {
-      if (v === undefined) {
-        v = '0';
+    NumberLong: function(s): any {
+      if (s === undefined) {
+        s = '0';
       }
 
-      if (typeof v !== 'string') {
-        throw new MongoshInvalidInputError(
-          'NumberLong can only be constructed from a string, received: ' + (typeof v)
-        );
-      }
+      requireStringAsConstructorArgument('NumberLong', s);
 
-      return bson.Long.fromString(v);
+      return bson.Long.fromString(s);
     },
     Date: function(...args: DateConstructorArguments): Date | string {
       const date = dateHelper(...args);

--- a/packages/shell-api/src/shell-bson.ts
+++ b/packages/shell-api/src/shell-bson.ts
@@ -1,7 +1,7 @@
 import { ALL_PLATFORMS, ALL_SERVER_VERSIONS, ALL_TOPOLOGIES, ServerVersions } from './enums';
 import Help from './help';
 import { bson as BSON } from '@mongosh/service-provider-core';
-import { MongoshInternalError } from '@mongosh/errors';
+import { MongoshInternalError, MongoshInvalidInputError } from '@mongosh/errors';
 
 function constructHelp(className): Help {
   const classHelpKeyPrefix = `shell-api.classes.${className}.help`;
@@ -110,16 +110,34 @@ export default function constructShellBson(bson: any): any {
       if (s === undefined) {
         s = '0';
       }
+
+      if (typeof s !== 'string') {
+        throw new MongoshInvalidInputError(
+          'NumberDecimal can only be constructed from a string, received: ' + (typeof s)
+        );
+      }
+
       return bson.Decimal128.fromString(s.toString());
     },
-    NumberInt: function(s): any {
-      return new bson.Int32(parseInt(s, 10));
-    },
-    NumberLong: function(v): any {
+    NumberInt: function(v): any {
       if (v === undefined) {
         v = 0;
       }
-      return bson.Long.fromNumber(v);
+
+      return new bson.Int32(parseInt(v, 10));
+    },
+    NumberLong: function(v): any {
+      if (v === undefined) {
+        v = '0';
+      }
+
+      if (typeof v !== 'string') {
+        throw new MongoshInvalidInputError(
+          'NumberLong can only be constructed from a string, received: ' + (typeof v)
+        );
+      }
+
+      return bson.Long.fromString(v);
     },
     Date: function(...args: DateConstructorArguments): Date | string {
       const date = dateHelper(...args);


### PR DESCRIPTION
- Allows to create `NumberLong` bigger than `Number.MAX_SAFE_INTEGER`.
- Requires the argument of `NumberLong` and `NumberDecimal` to always be a string so to prevent users to get a misrepresented value by mistake.
- Makes `NumberInt()` to be equivalent to `NumberInt(0)`, aligning the behaviour with the other constructors and with the old shell.

