### PR TITLE
Wait for all assets before release

### DIFF
--- a/packages/build/src/download-center.ts
+++ b/packages/build/src/download-center.ts
@@ -19,7 +19,10 @@ async function verifyDownloadCenterConfig(downloadCenterJson: Record<string, any
   }
 
   if (Object.keys(errors).length) {
-    throw new Error(`Download center urls broken: ${JSON.stringify(errors)}`);
+    const error = new Error(`Download center urls broken: ${JSON.stringify(errors)}`);
+    (error as any).retry = true;
+
+    throw error;
   }
 }
 
@@ -134,6 +137,11 @@ const waitAllDownloadAssetsAvailable = async(config): Promise<void> => {
       break;
     } catch (error) {
       console.error('verifyDownloadCenterConfig: attempt failed.', error);
+
+      if (!error.retry) {
+        break;
+      }
+
       await delay(checkInterval);
     }
   }


### PR DESCRIPTION
A temporary fix to prevent the release to take place if some of the assets where not generated properly.

We retry the validation of download centre config until succeeds for 1 hour. If after 1 hour the config would still be missing assets the release will fail.

As soon as the validation succeeds the release goes on.
