### PR TITLE
MONGOSH-346 - enable Ctrl+C in shell for sync and async operations

### DIFF
--- a/packages/cli-repl/src/cli-repl.ts
+++ b/packages/cli-repl/src/cli-repl.ts
@@ -115,7 +115,8 @@ class CliRepl {
       prompt: '> ',
       writer: this.writer,
       completer: completer.bind(null, version),
-      terminal: true
+      terminal: true,
+      breakEvalOnSigint: true,
     });
 
     const originalDisplayPrompt = this.repl.displayPrompt.bind(this.repl);
@@ -147,7 +148,34 @@ class CliRepl {
       let result;
 
       try {
-        result = await this.shellEvaluator.customEval(originalEval, input, context, filename);
+        let sigintListener: () => void;
+        let previousSigintListeners: any[];
+        try {
+          result = await new Promise((resolve, reject) => {
+            // Handle SIGINT (Ctrl+C) that occurs while we are stuck in `await`
+            // by racing a listener for 'SIGINT' against the evalResult Promise.
+            // We remove all 'SIGINT' listeners and install our own.
+            sigintListener = (): void => {
+              // Reject with an exception similar to one thrown by Node.js
+              // itself if the `customEval` itself is interrupted.
+              reject(new Error('Asynchronous execution was interrupted by `SIGINT`'));
+            };
+            previousSigintListeners = this.repl.rawListeners('SIGINT');
+
+            this.repl.removeAllListeners('SIGINT');
+            this.repl.once('SIGINT', sigintListener);
+
+            const evalResult = this.shellEvaluator.customEval(originalEval, input, context, filename);
+
+            evalResult.then(resolve, reject);
+          });
+        } finally {
+          // Remove our 'SIGINT' listener and re-install the REPL one(s).
+          this.repl.removeListener('SIGINT', sigintListener);
+          for (const listener of previousSigintListeners) {
+            this.repl.on('SIGINT', listener);
+          }
+        }
       } catch (err) {
         if (isRecoverableError(input)) {
           return callback(new Recoverable(err));

--- a/packages/cli-repl/src/cli-repl.ts
+++ b/packages/cli-repl/src/cli-repl.ts
@@ -167,11 +167,13 @@ class CliRepl {
 
             const evalResult = this.shellEvaluator.customEval(originalEval, input, context, filename);
 
+            process.once('SIGINT', sigintListener);
             evalResult.then(resolve, reject);
           });
         } finally {
           // Remove our 'SIGINT' listener and re-install the REPL one(s).
           this.repl.removeListener('SIGINT', sigintListener);
+          process.removeListener('SIGINT', sigintListener);
           for (const listener of previousSigintListeners) {
             this.repl.on('SIGINT', listener);
           }

--- a/packages/cli-repl/test/e2e.spec.ts
+++ b/packages/cli-repl/test/e2e.spec.ts
@@ -238,5 +238,26 @@ describe('e2e', function() {
       shell.assertNoErrors();
     });
   });
+
+  describe('Ctrl+C aka SIGINT', () => {
+    let shell;
+    beforeEach(async() => {
+      shell = TestShell.start({ args: [ '--nodb' ] });
+      await shell.waitForPrompt();
+      shell.assertNoErrors();
+    });
+    it('interrupts sync execution', async() => {
+      const result = shell.executeLine('while(true);');
+      setTimeout(() => shell.kill('SIGINT'), 1000);
+      await result;
+      shell.assertContainsError('interrupted');
+    });
+    it('interrupts async awaiting', async() => {
+      const result = shell.executeLine('new Promise(() => {});');
+      setTimeout(() => shell.kill('SIGINT'), 1000);
+      await result;
+      shell.assertContainsError('interrupted');
+    });
+  });
 });
 

--- a/packages/cli-repl/test/e2e.spec.ts
+++ b/packages/cli-repl/test/e2e.spec.ts
@@ -240,6 +240,12 @@ describe('e2e', function() {
   });
 
   describe('Ctrl+C aka SIGINT', () => {
+    before(function() {
+      if (process.platform === 'win32') {
+        this.skip(); // There is no SIGINT on Windows.
+      }
+    });
+
     let shell;
     beforeEach(async() => {
       shell = TestShell.start({ args: [ '--nodb' ] });

--- a/packages/cli-repl/test/test-shell.ts
+++ b/packages/cli-repl/test/test-shell.ts
@@ -7,6 +7,8 @@ import path from 'path';
 import stripAnsi from 'strip-ansi';
 import assert from 'assert';
 
+type SignalType = ChildProcess extends { kill: (signal: infer T) => any } ? T : never;
+
 const PROMPT_PATTERN = /^> /m;
 const ERROR_PATTERN_1 = /Thrown:\n([^>]*)/m; // node <= 12.14
 const ERROR_PATTERN_2 = /Uncaught[:\n ]+([^>]*)/m;
@@ -92,8 +94,8 @@ export class TestShell {
     return this._onClose;
   }
 
-  kill(): void {
-    this._process.kill();
+  kill(signal?: SignalType): void {
+    this._process.kill(signal);
   }
 
   writeInput(chars: string): void {


### PR DESCRIPTION
This enables Ctrl+C to interrupt both the current synchronous JS
execution and awaiting the result.

Refs: https://nodejs.org/api/repl.html#repl_repl_start_options