### PR TITLE
MONGOSH-323 - Pretty-print BinData values

### DIFF
--- a/packages/cli-repl/test/e2e-bson.spec.ts
+++ b/packages/cli-repl/test/e2e-bson.spec.ts
@@ -49,7 +49,7 @@ describe('BSON e2e', function() {
       Symbol: '"abc"',
       Code: '{ "code" : "abc" }',
       NumberDecimal: 'NumberDecimal("1")',
-      BinData: 'BinData(128, "1234")'
+      BinData: 'BinData(128, "MTIzNA==")'
     };
     it('Entire doc prints when returned from the server', async() => {
       const buffer = Buffer.from('MTIzNA==', 'base64');
@@ -195,7 +195,7 @@ describe('BSON e2e', function() {
       await db.collection('test').insertOne({ value: value });
       await shell.writeInputLine('db.test.findOne().value');
       await eventually(() => {
-        shell.assertContainsOutput('BinData(128, "1234")');
+        shell.assertContainsOutput('BinData(128, "MTIzNA==")');
       });
       shell.assertNoErrors();
     });
@@ -301,7 +301,31 @@ describe('BSON e2e', function() {
       const value = 'BinData(128, "MTIzNA==")';
       await shell.writeInputLine(value);
       await eventually(() => {
-        shell.assertContainsOutput('BinData(128, "1234")');
+        shell.assertContainsOutput(value);
+      });
+      shell.assertNoErrors();
+    });
+    it('BinData prints as UUID when created by user as such', async() => {
+      const value = 'UUID("01234567-89ab-cdef-0123-456789abcdef")';
+      await shell.writeInputLine(value);
+      await eventually(() => {
+        shell.assertContainsOutput(value);
+      });
+      shell.assertNoErrors();
+    });
+    it('BinData prints as MD5 when created by user as such', async() => {
+      const value = 'MD5("0123456789abcdef0123456789abcdef")';
+      await shell.writeInputLine(value);
+      await eventually(() => {
+        shell.assertContainsOutput(value);
+      });
+      shell.assertNoErrors();
+    });
+    it('BinData prints as BinData when created as invalid UUID', async() => {
+      const value = 'UUID("abcdef")';
+      await shell.writeInputLine(value);
+      await eventually(() => {
+        shell.assertContainsOutput('BinData(4, "q83v")');
       });
       shell.assertNoErrors();
     });

--- a/packages/shell-api/src/shell-bson.spec.ts
+++ b/packages/shell-api/src/shell-bson.spec.ts
@@ -200,6 +200,10 @@ describe('Shell BSON', () => {
       expect(h.help()[asShellResult]().type).to.equal('Help');
       expect(h.serverVersions).to.deep.equal(ALL_SERVER_VERSIONS);
     });
+    it('strips dashes from input', () => {
+      expect(shellBson.UUID('01234567-89ab-cdef-0123-456789abcdef').value())
+        .to.equal(shellBson.UUID('0123456789abcdef0123456789abcdef').value());
+    });
   });
   describe('MD5', () => {
     const b = shellBson.BinData(5, b64_1234);

--- a/packages/shell-api/src/shell-bson.ts
+++ b/packages/shell-api/src/shell-bson.ts
@@ -159,7 +159,9 @@ export default function constructShellBson(bson: any): any {
       return new bson.Binary(buffer, subtype);
     },
     UUID: function(hexstr): any {
-      const buffer = Buffer.from(hexstr, 'hex');
+      // Strip any dashes, as they occur in the standard UUID formatting
+      // (e.g. 01234567-89ab-cdef-0123-456789abcdef).
+      const buffer = Buffer.from(hexstr.replace(/-/g, ''), 'hex');
       return new bson.Binary(buffer, bson.Binary.SUBTYPE_UUID);
     },
     MD5: function(hexstr): any {


### PR DESCRIPTION
Print `BinData` values in a way that accounts for their subtype
(i.e. format UUID and MD5 in their common representation) and
generic `BinData` values as base64, to ensure that binary data is not
written directly to the terminal. This also enables copy-pasting of
the output for `BinData` values to be used as input for other
operations.