### PR TITLE
test: unconditionally set `eventually()` timeout to 10s

### DIFF
--- a/packages/cli-repl/test/helpers.ts
+++ b/packages/cli-repl/test/helpers.ts
@@ -1,7 +1,7 @@
 export async function eventually(fn: Function, options: { frequency?: number; timeout?: number } = {}): Promise<any> {
   options = {
     frequency: 100,
-    timeout: process.env.IS_CI ? 10000 : 1000,
+    timeout: 10000,
     ...options
   };
 


### PR DESCRIPTION
This makes a lot more tests pass locally for me, and it shouldn’t
really increase the time it takes to run the tests.