### PR TITLE
fix: allow running mongosh with Node.js release candidates

### DIFF
--- a/packages/cli-repl/src/cli-repl.ts
+++ b/packages/cli-repl/src/cli-repl.ts
@@ -314,9 +314,11 @@ class CliRepl {
 
   verifyNodeVersion(): void {
     const { engines } = require('../package.json');
-    if (!semver.satisfies(process.version, engines.node)) {
+    // Strip -rc.0, -pre, etc. from the Node.js version because semver rejects those otherwise.
+    const baseNodeVersion = process.version.replace(/-.*$/, '');
+    if (!semver.satisfies(baseNodeVersion, engines.node)) {
       const warning = new MongoshWarning(`Mismatched node version. Required version: ${engines.node}. Currently using: ${process.version}. Exiting...\n\n`);
-      console.log(formatError(warning));
+      console.warn(formatError(warning));
       process.exit(1);
     }
   }


### PR DESCRIPTION
When Node.js pushes a release candidate, the version will contain
a suffix like `-rc.0`, but semver doesn’t account for that in its
`satisfies()` function and rejects all versions tagged that way.