### PR TITLE
fix: report explicit error when invalid connection URI is passed

### DIFF
--- a/packages/service-provider-core/src/uri-generator.spec.ts
+++ b/packages/service-provider-core/src/uri-generator.spec.ts
@@ -146,4 +146,14 @@ describe('uri-generator.generate-uri', () => {
       });
     });
   });
+
+
+  context('when an invalid URI is provided', () => {
+    const uri = '/x';
+    const options = { _: [ uri ] };
+
+    it('returns the uri', () => {
+      expect(() => generateUri(options)).to.throw('Invalid URI: /x');
+    });
+  });
 });

--- a/packages/service-provider-core/src/uri-generator.ts
+++ b/packages/service-provider-core/src/uri-generator.ts
@@ -121,6 +121,10 @@ function generateUri(options: CliOptions): string {
   const uriMatch = /^([A-Za-z0-9][A-Za-z0-9.-]+):?(\d+)?[\/]?(\S+)?$/gi;
   const parts = uriMatch.exec(uri);
 
+  if (parts === null) {
+    throw new MongoshInvalidInputError(`Invalid URI: ${uri}`);
+  }
+
   let host = parts[1];
   const port = parts[2];
   let db = parts[3];


### PR DESCRIPTION
Because this gives a better error than

```
$ mongosh /x
Cannot read property '1' of null
```

:)