### PR TITLE
fix: Ctrl+C should work after exceptions

### DIFF
--- a/packages/cli-repl/src/cli-repl.ts
+++ b/packages/cli-repl/src/cli-repl.ts
@@ -140,7 +140,47 @@ class CliRepl {
       }
     });
 
-    const originalEval = util.promisify(this.repl.eval);
+    type REPLEvalArgs = REPLServer extends {
+      eval(...args: infer T);
+    } ? T : never;
+    const replEval = this.repl.eval.bind(this.repl);
+    const originalEval = util.promisify((...args: REPLEvalArgs) => {
+      const { Domain } = require('domain');
+      const origEmit = Domain.prototype.emit;
+
+      // When the Node.js core REPL encounters an exception during synchronous
+      // evaluation, it does not pass the exception value to the callback
+      // (or in this case, reject the Promise here), as one might inspect.
+      // Instead, it skips straight ahead to abandoning evaluation and acts
+      // as if the error had been thrown asynchronously. This works for them,
+      // but for us that's not great, because we rely on the core eval function
+      // calling its callback in order to be informed about a possible error
+      // that occurred (... and in order for this async function to finish at all.)
+      // We monkey-patch `process.domain.emit()` to avoid that, and instead
+      // handle a possible error ourselves:
+      // https://github.com/nodejs/node/blob/59ca56eddefc78bab87d7e8e074b3af843ab1bc3/lib/repl.js#L488-L493
+      // It's not clear why this is done this way in Node.js, however,
+      // removing the linked code does lead to failures in the Node.js test
+      // suite, so somebody sufficiently motivated could probably find out.
+      // For now, this is a hack and probably not considered officially
+      // supported, but it works.
+      // We *may* want to consider not relying on the built-in eval function
+      // at all at some point.
+      Domain.prototype.emit = function(ev, ...eventArgs): void {
+        if (ev === 'error') {
+          throw eventArgs[0];
+        }
+        return origEmit.call(this, ev, ...eventArgs);
+      };
+
+      try {
+        return replEval(...args);
+      } finally {
+        // Reset the `emit` function after synchronous evaluation, because
+        // we need the Domain functionality for the asynchronous bits.
+        Domain.prototype.emit = origEmit;
+      }
+    });
 
     const customEval = async(input, context, filename, callback): Promise<any> => {
       this.lineByLineInput.enableBlockOnNewLine();

--- a/packages/cli-repl/test/e2e.spec.ts
+++ b/packages/cli-repl/test/e2e.spec.ts
@@ -1,3 +1,4 @@
+import assert from 'assert';
 import { MongoClient } from 'mongodb';
 import { eventually } from './helpers';
 import { TestShell } from './test-shell';
@@ -295,6 +296,14 @@ describe('e2e', function() {
       setTimeout(() => shell.kill('SIGINT'), 1000);
       await result;
       shell.assertContainsError('interrupted');
+    });
+    it('behaves normally after an exception', async() => {
+      await shell.executeLine('throw new Error()');
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      shell.kill('SIGINT');
+      await shell.waitForPrompt();
+      await new Promise((resolve) => setTimeout(resolve, 100));
+      assert(!/interrupted/.test(shell.output));
     });
   });
 });

--- a/packages/cli-repl/test/e2e.spec.ts
+++ b/packages/cli-repl/test/e2e.spec.ts
@@ -1,4 +1,3 @@
-import assert from 'assert';
 import { MongoClient } from 'mongodb';
 import { eventually } from './helpers';
 import { TestShell } from './test-shell';
@@ -303,7 +302,7 @@ describe('e2e', function() {
       shell.kill('SIGINT');
       await shell.waitForPrompt();
       await new Promise((resolve) => setTimeout(resolve, 100));
-      assert(!/interrupted/.test(shell.output));
+      shell.assertNotContainsOutput('interrupted');
     });
   });
 });

--- a/packages/cli-repl/test/test-shell.ts
+++ b/packages/cli-repl/test/test-shell.ts
@@ -148,6 +148,17 @@ export class TestShell {
     }
   }
 
+  assertNotContainsOutput(unexpectedOutput: string): void {
+    const onlyOutputLines = this._getOutputLines();
+    if (onlyOutputLines.join('\n').includes(unexpectedOutput)) {
+      throw new assert.AssertionError({
+        message: `Expected shell output not  to include ${JSON.stringify(unexpectedOutput)}`,
+        actual: this._output,
+        expected: `NOT ${unexpectedOutput}`
+      });
+    }
+  }
+
   private _getOutputLines(): string[] {
     return this._output.split('\n')
       .filter((line) => !line.match(PROMPT_PATTERN));

--- a/packages/shell-evaluator/src/shell-evaluator.ts
+++ b/packages/shell-evaluator/src/shell-evaluator.ts
@@ -74,8 +74,49 @@ class ShellEvaluator {
             { original: removeCommand(input.trim()), rewritten: removeCommand(rewrittenInput.trim()) }
           );
         }
+
+        let Domain;
         try {
-          return await originalEval(rewrittenInput, context, filename);
+          Domain = require('domain').Domain;
+        } catch {} // eslint-disable-line no-empty
+        Domain = Domain || class { emit(): void {} };
+        const origEmit = Domain.prototype.emit;
+        try {
+          // When the Node.js core REPL encounters an exception during synchronous
+          // evaluation, it does not pass the exception value to the callback
+          // (or in this case, reject the Promise here), as one might inspect.
+          // Instead, it skips straight ahead to abandoning evaluation and acts
+          // as if the error had been thrown asynchronously. This works for them,
+          // but for us that's not great, because we rely on the core eval function
+          // calling its callback in order to be informed about a possible error
+          // that occurred (... and in order for this async function to finish at all.)
+          // We monkey-patch `process.domain.emit()` to avoid that, and instead
+          // handle a possible error ourselves:
+          // https://github.com/nodejs/node/blob/59ca56eddefc78bab87d7e8e074b3af843ab1bc3/lib/repl.js#L488-L493
+          // It's not clear why this is done this way in Node.js, however,
+          // removing the linked code does lead to failures in the Node.js test
+          // suite, so somebody sufficiently motivated could probably find out.
+          // For now, this is a hack and probably not considered officially
+          // supported, but it works.
+          // We *may* want to consider not relying on the built-in eval function
+          // at all at some point.
+          Domain.prototype.emit = function(ev, ...args): void {
+            if (ev === 'error') {
+              throw args[0];
+            }
+            return origEmit.call(this, ev, ...args);
+          };
+
+          let syncResult;
+          try {
+            syncResult = originalEval(rewrittenInput, context, filename);
+          } finally {
+            // Reset the `emit` function after synchronous evaluation, because
+            // we need the Domain functionality for the asynchronous bits.
+            Domain.prototype.emit = origEmit;
+          }
+
+          return await syncResult;
         } catch (err) {
           // This is for browser/Compass
           this.revertState();

--- a/packages/shell-evaluator/src/shell-evaluator.ts
+++ b/packages/shell-evaluator/src/shell-evaluator.ts
@@ -74,49 +74,8 @@ class ShellEvaluator {
             { original: removeCommand(input.trim()), rewritten: removeCommand(rewrittenInput.trim()) }
           );
         }
-
-        let Domain;
         try {
-          Domain = require('domain').Domain;
-        } catch {} // eslint-disable-line no-empty
-        Domain = Domain || class { emit(): void {} };
-        const origEmit = Domain.prototype.emit;
-        try {
-          // When the Node.js core REPL encounters an exception during synchronous
-          // evaluation, it does not pass the exception value to the callback
-          // (or in this case, reject the Promise here), as one might inspect.
-          // Instead, it skips straight ahead to abandoning evaluation and acts
-          // as if the error had been thrown asynchronously. This works for them,
-          // but for us that's not great, because we rely on the core eval function
-          // calling its callback in order to be informed about a possible error
-          // that occurred (... and in order for this async function to finish at all.)
-          // We monkey-patch `process.domain.emit()` to avoid that, and instead
-          // handle a possible error ourselves:
-          // https://github.com/nodejs/node/blob/59ca56eddefc78bab87d7e8e074b3af843ab1bc3/lib/repl.js#L488-L493
-          // It's not clear why this is done this way in Node.js, however,
-          // removing the linked code does lead to failures in the Node.js test
-          // suite, so somebody sufficiently motivated could probably find out.
-          // For now, this is a hack and probably not considered officially
-          // supported, but it works.
-          // We *may* want to consider not relying on the built-in eval function
-          // at all at some point.
-          Domain.prototype.emit = function(ev, ...args): void {
-            if (ev === 'error') {
-              throw args[0];
-            }
-            return origEmit.call(this, ev, ...args);
-          };
-
-          let syncResult;
-          try {
-            syncResult = originalEval(rewrittenInput, context, filename);
-          } finally {
-            // Reset the `emit` function after synchronous evaluation, because
-            // we need the Domain functionality for the asynchronous bits.
-            Domain.prototype.emit = origEmit;
-          }
-
-          return await syncResult;
+          return await originalEval(rewrittenInput, context, filename);
         } catch (err) {
           // This is for browser/Compass
           this.revertState();


### PR DESCRIPTION
The added comment goes into a bit more detail here, but basically,
our shell evaluation function was under the wrong assumption that the
built-in eval code would always call its callback, even if evaluation
of the code threw an error. That does not turn out to be the case
for Node.js; instead, the REPL would handle the error internally
and not call its callback, leaving us with an async function that
never finishes.

This had the side effect that listeners for SIGINT would not be removed
(because from the cli-repl perspective, the inner eval would never
finish), leading to odd results when entering Ctrl+C after an earlier
statement had thrown an exception.

The solution here is hacky; we should probably take the time
at some point to find a better one.