### PR TITLE
Help cleanup

### DIFF
--- a/packages/cli-repl/src/constants.ts
+++ b/packages/cli-repl/src/constants.ts
@@ -16,8 +16,7 @@ export const USAGE = `
 
   ${clr(i18n.__('cli-repl.args.options'), ['bold', 'yellow'])}
 
-    -h, --help                                 ${i18n.__('cli-repl.args.help')} 
-        --ipv6                                 ${i18n.__('cli-repl.args.ipv6')}
+    -h, --help                                 ${i18n.__('cli-repl.args.help')}
         --host [arg]                           ${i18n.__('cli-repl.args.host')}
         --port [arg]                           ${i18n.__('cli-repl.args.port')}
         --version                              ${i18n.__('cli-repl.args.version')}
@@ -37,7 +36,6 @@ export const USAGE = `
         --tlsCertificateKeyFile [arg]          ${i18n.__('cli-repl.args.tlsCertificateKeyFile')}
         --tlsCertificateKeyFilePassword [arg]  ${i18n.__('cli-repl.args.tlsCertificateKeyPassword')}
         --tlsCAFile [arg]                      ${i18n.__('cli-repl.args.tlsCAFile')}
-        --tlsCRLFile [arg]                     ${i18n.__('cli-repl.args.tlsCRFile')}
         --tlsAllowInvalidHostnames             ${i18n.__('cli-repl.args.tlsAllowInvaludHostnames')}
         --tlsAllowInvalidCertificates          ${i18n.__('cli-repl.args.tlsAllowInvalidCertificates')}
         --tlsCertificateSelector [arg]         ${i18n.__('cli-repl.args.tlsCertificateSelector')}

--- a/packages/cli-repl/src/constants.ts
+++ b/packages/cli-repl/src/constants.ts
@@ -21,12 +21,8 @@ export const USAGE = `
         --host [arg]                           ${i18n.__('cli-repl.args.host')}
         --port [arg]                           ${i18n.__('cli-repl.args.port')}
         --version                              ${i18n.__('cli-repl.args.version')}
-        --shell                                ${i18n.__('cli-repl.args.shell')}
         --nodb                                 ${i18n.__('cli-repl.args.nodb')}
-        --norc                                 ${i18n.__('cli-repl.args.norc')}
-        --eval [arg]                           ${i18n.__('cli-repl.args.eval')}
         --retryWrites                          ${i18n.__('cli-repl.args.retryWrites')}
-${''/* TODO:        --disableImplicitSessions              ${i18n.__('cli-repl.args.disableImplicitSessions')}*/}
 
   ${clr(i18n.__('cli-repl.args.authenticationOptions'), ['bold', 'yellow'])}
 
@@ -34,8 +30,6 @@ ${''/* TODO:        --disableImplicitSessions              ${i18n.__('cli-repl.a
     -p, --password [arg]                       ${i18n.__('cli-repl.args.password')}
         --authenticationDatabase [arg]         ${i18n.__('cli-repl.args.authenticationDatabase')}
         --authenticationMechanism [arg]        ${i18n.__('cli-repl.args.authenticationMechanism')}
-        --gssapiServiceName [arg] (=mongodb)   ${i18n.__('cli-repl.args.')}
-        --gssapiHostName [arg]                 ${i18n.__('cli-repl.args.retryWrites')}
 
   ${clr(i18n.__('cli-repl.args.tlsOptions'), ['bold', 'yellow'])}
 
@@ -49,24 +43,12 @@ ${''/* TODO:        --disableImplicitSessions              ${i18n.__('cli-repl.a
         --tlsCertificateSelector [arg]         ${i18n.__('cli-repl.args.tlsCertificateSelector')}
         --tlsDisabledProtocols [arg]           ${i18n.__('cli-repl.args.tlsDisabledProtocols')}
 
-  ${clr(i18n.__('cli-repl.args.fleAwsOptions'), ['bold', 'yellow'])}
-
-        --awsAccessKeyId [arg]                 ${i18n.__('cli-repl.args.awsAccessKeyId')}
-        --awsSecretAccessKey [arg]             ${i18n.__('cli-repl.args.awsSecretAccessKey')}
-        --awsSessionToken [arg]                ${i18n.__('cli-repl.args.awsSessionToken')}
-        --keyVaultNamespace [arg]              ${i18n.__('cli-repl.args.keyVaultNamespace')}
-        --kmsURL [arg]                         ${i18n.__('cli-repl.args.kmsURL')}
-
   ${clr(i18n.__('cli-repl.args.dbAddressOptions'), ['bold', 'yellow'])}
 
         foo                                    ${i18n.__('cli-repl.args.dbAddress/foo')}
         192.168.0.5/foo                        ${i18n.__('cli-repl.args.dbAddress/192/foo')}
         192.168.0.5:9999/foo                   ${i18n.__('cli-repl.args.dbAddress/192/host/foo')}
         mongodb://192.168.0.5:9999/foo         ${i18n.__('cli-repl.args.dbAddress/connectionURI')}
-
-  ${clr(i18n.__('cli-repl.args.fileNames'), ['bold', 'yellow'])}
-
-        ${i18n.__('cli-repl.args.filenameDescription')}
 
   ${clr(i18n.__('cli-repl.args.examples'), ['bold', 'yellow'])}
 

--- a/packages/cli-repl/src/constants.ts
+++ b/packages/cli-repl/src/constants.ts
@@ -10,6 +10,8 @@ export const MONGOSH_WIKI = `
 ${i18n.__('cli-repl.cli-repl.wiki.info')} ${clr(i18n.__('cli-repl.cli-repl.wiki.link'), 'bold')}
 `;
 
+// See this PR for the options that were removed:
+// https://github.com/mongodb-js/mongosh/pull/333
 export const USAGE = `
 
   ${clr(i18n.__('cli-repl.args.usage'), 'bold')}


### PR DESCRIPTION
Cleaned up the `mongosh --help` output to only include things that are supported.

1. Removed options that are not yet supported (e.g. FLE, loading scripts from files, etc.)
2. Removed options that are not supported in the driver and therefore for the foreseeable future we won't support in the shell either:
   * `--ipv6`: if nothing is specified, the driver will try IPv6 first and fall back to IPv4 ([details](https://mongodb.github.io/node-mongodb-native/3.5/api/MongoClient.html#.connect))
   * `--tlsCRLFile`: this is not an option that the driver supports

Everything is removed rather than commented out to not leave big spaces in the help output. This PR is referenced as a comment in the code so we can go back and check what was removed.