### PR TITLE
chore: generate AUTHORS by first commit

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,11 +1,11 @@
 Durran Jordan <durran@gmail.com>
-Maurizio Casimirri <maurizio.cas@gmail.com>
 Anna Herlihy <herlihyap@gmail.com>
+Maurizio Casimirri <maurizio.cas@gmail.com>
 Irina Shestak <shestak.irina@gmail.com>
-Rhys Howell <rhys@rhysh@live.com>
-Anna Henningsen <anna@addaleax.net>
-Massimiliano Marcon <me@marcon.me>
 Liudmila Kornilova <kornilova203@gmail.com>
 Lucas Hrabovsky <hrabovsky.lucas@gmail.com>
-Mark Smith <judy@judy.co.uk>
+Massimiliano Marcon <me@marcon.me>
+Rhys Howell <rhys@rhysh@live.com>
 Maxime <maxime.beugnet@gmail.com>
+Mark Smith <judy@judy.co.uk>
+Anna Henningsen <anna@addaleax.net>

--- a/packages/async-rewriter/AUTHORS
+++ b/packages/async-rewriter/AUTHORS
@@ -1,8 +1,8 @@
 Anna Herlihy <herlihyap@gmail.com>
 Durran Jordan <durran@gmail.com>
 Maurizio Casimirri <maurizio.cas@gmail.com>
-Irina Shestak <shestak.irina@gmail.com>
-Rhys Howell <rhys@rhysh@live.com>
-Anna Henningsen <anna@addaleax.net>
-Liudmila Kornilova <kornilova203@gmail.com>
 Massimiliano Marcon <me@marcon.me>
+Rhys Howell <rhys@rhysh@live.com>
+Irina Shestak <shestak.irina@gmail.com>
+Liudmila Kornilova <kornilova203@gmail.com>
+Anna Henningsen <anna@addaleax.net>

--- a/packages/browser-repl/AUTHORS
+++ b/packages/browser-repl/AUTHORS
@@ -1,7 +1,7 @@
-Maurizio Casimirri <maurizio.cas@gmail.com>
 Durran Jordan <durran@gmail.com>
+Maurizio Casimirri <maurizio.cas@gmail.com>
+Massimiliano Marcon <me@marcon.me>
+Rhys Howell <rhys@rhysh@live.com>
 Irina Shestak <shestak.irina@gmail.com>
 Anna Herlihy <herlihyap@gmail.com>
-Rhys Howell <rhys@rhysh@live.com>
 Anna Henningsen <anna@addaleax.net>
-Massimiliano Marcon <me@marcon.me>

--- a/packages/browser-runtime-core/AUTHORS
+++ b/packages/browser-runtime-core/AUTHORS
@@ -1,7 +1,7 @@
-Durran Jordan <durran@gmail.com>
 Maurizio Casimirri <maurizio.cas@gmail.com>
-Irina Shestak <shestak.irina@gmail.com>
+Durran Jordan <durran@gmail.com>
+Massimiliano Marcon <me@marcon.me>
 Rhys Howell <rhys@rhysh@live.com>
 Anna Herlihy <herlihyap@gmail.com>
+Irina Shestak <shestak.irina@gmail.com>
 Anna Henningsen <anna@addaleax.net>
-Massimiliano Marcon <me@marcon.me>

--- a/packages/browser-runtime-electron/AUTHORS
+++ b/packages/browser-runtime-electron/AUTHORS
@@ -1,7 +1,7 @@
 Maurizio Casimirri <maurizio.cas@gmail.com>
 Durran Jordan <durran@gmail.com>
-Irina Shestak <shestak.irina@gmail.com>
+Massimiliano Marcon <me@marcon.me>
 Rhys Howell <rhys@rhysh@live.com>
+Irina Shestak <shestak.irina@gmail.com>
 Anna Herlihy <herlihyap@gmail.com>
 Anna Henningsen <anna@addaleax.net>
-Massimiliano Marcon <me@marcon.me>

--- a/packages/build/AUTHORS
+++ b/packages/build/AUTHORS
@@ -1,6 +1,6 @@
 Durran Jordan <durran@gmail.com>
-Irina Shestak <shestak.irina@gmail.com>
 Maurizio Casimirri <maurizio.cas@gmail.com>
-Anna Henningsen <anna@addaleax.net>
-Anna Herlihy <herlihyap@gmail.com>
+Irina Shestak <shestak.irina@gmail.com>
 Rhys Howell <rhys@rhysh@live.com>
+Anna Herlihy <herlihyap@gmail.com>
+Anna Henningsen <anna@addaleax.net>

--- a/packages/cli-repl/AUTHORS
+++ b/packages/cli-repl/AUTHORS
@@ -1,7 +1,7 @@
-Irina Shestak <shestak.irina@gmail.com>
-Durran Jordan <durran@gmail.com>
 Anna Herlihy <herlihyap@gmail.com>
+Durran Jordan <durran@gmail.com>
+Irina Shestak <shestak.irina@gmail.com>
 Maurizio Casimirri <maurizio.cas@gmail.com>
-Anna Henningsen <anna@addaleax.net>
-Rhys Howell <rhys@rhysh@live.com>
 Massimiliano Marcon <me@marcon.me>
+Rhys Howell <rhys@rhysh@live.com>
+Anna Henningsen <anna@addaleax.net>

--- a/packages/compass-shell/AUTHORS
+++ b/packages/compass-shell/AUTHORS
@@ -1,7 +1,7 @@
 Maurizio Casimirri <maurizio.cas@gmail.com>
-Rhys Howell <rhys@rhysh@live.com>
 Durran Jordan <durran@gmail.com>
+Massimiliano Marcon <me@marcon.me>
+Rhys Howell <rhys@rhysh@live.com>
+Anna Herlihy <herlihyap@gmail.com>
 Irina Shestak <shestak.irina@gmail.com>
 Anna Henningsen <anna@addaleax.net>
-Anna Herlihy <herlihyap@gmail.com>
-Massimiliano Marcon <me@marcon.me>

--- a/packages/errors/AUTHORS
+++ b/packages/errors/AUTHORS
@@ -1,6 +1,6 @@
 Irina Shestak <shestak.irina@gmail.com>
 Maurizio Casimirri <maurizio.cas@gmail.com>
-Anna Henningsen <anna@addaleax.net>
-Durran Jordan <durran@gmail.com>
 Rhys Howell <rhys@rhysh@live.com>
+Durran Jordan <durran@gmail.com>
 Anna Herlihy <herlihyap@gmail.com>
+Anna Henningsen <anna@addaleax.net>

--- a/packages/history/AUTHORS
+++ b/packages/history/AUTHORS
@@ -1,7 +1,7 @@
 Maurizio Casimirri <maurizio.cas@gmail.com>
-Irina Shestak <shestak.irina@gmail.com>
-Rhys Howell <rhys@rhysh@live.com>
-Durran Jordan <durran@gmail.com>
-Anna Henningsen <anna@addaleax.net>
-Anna Herlihy <herlihyap@gmail.com>
 Massimiliano Marcon <me@marcon.me>
+Durran Jordan <durran@gmail.com>
+Rhys Howell <rhys@rhysh@live.com>
+Anna Herlihy <herlihyap@gmail.com>
+Irina Shestak <shestak.irina@gmail.com>
+Anna Henningsen <anna@addaleax.net>

--- a/packages/i18n/AUTHORS
+++ b/packages/i18n/AUTHORS
@@ -1,7 +1,7 @@
-Maurizio Casimirri <maurizio.cas@gmail.com>
-Anna Herlihy <herlihyap@gmail.com>
 Durran Jordan <durran@gmail.com>
+Maurizio Casimirri <maurizio.cas@gmail.com>
 Irina Shestak <shestak.irina@gmail.com>
-Rhys Howell <rhys@rhysh@live.com>
-Anna Henningsen <anna@addaleax.net>
 Massimiliano Marcon <me@marcon.me>
+Rhys Howell <rhys@rhysh@live.com>
+Anna Herlihy <herlihyap@gmail.com>
+Anna Henningsen <anna@addaleax.net>

--- a/packages/java-shell/AUTHORS
+++ b/packages/java-shell/AUTHORS
@@ -1,7 +1,7 @@
 Durran Jordan <durran@gmail.com>
-Irina Shestak <shestak.irina@gmail.com>
 Maurizio Casimirri <maurizio.cas@gmail.com>
-Anna Herlihy <herlihyap@gmail.com>
 Rhys Howell <rhys@rhysh@live.com>
-Anna Henningsen <anna@addaleax.net>
 Liudmila Kornilova <kornilova203@gmail.com>
+Irina Shestak <shestak.irina@gmail.com>
+Anna Herlihy <herlihyap@gmail.com>
+Anna Henningsen <anna@addaleax.net>

--- a/packages/service-provider-core/AUTHORS
+++ b/packages/service-provider-core/AUTHORS
@@ -1,7 +1,7 @@
-Maurizio Casimirri <maurizio.cas@gmail.com>
-Anna Herlihy <herlihyap@gmail.com>
 Durran Jordan <durran@gmail.com>
-Irina Shestak <shestak.irina@gmail.com>
-Rhys Howell <rhys@rhysh@live.com>
-Anna Henningsen <anna@addaleax.net>
+Maurizio Casimirri <maurizio.cas@gmail.com>
 Massimiliano Marcon <me@marcon.me>
+Rhys Howell <rhys@rhysh@live.com>
+Anna Herlihy <herlihyap@gmail.com>
+Irina Shestak <shestak.irina@gmail.com>
+Anna Henningsen <anna@addaleax.net>

--- a/packages/service-provider-server/AUTHORS
+++ b/packages/service-provider-server/AUTHORS
@@ -1,7 +1,7 @@
-Maurizio Casimirri <maurizio.cas@gmail.com>
 Durran Jordan <durran@gmail.com>
+Maurizio Casimirri <maurizio.cas@gmail.com>
 Anna Herlihy <herlihyap@gmail.com>
-Irina Shestak <shestak.irina@gmail.com>
-Rhys Howell <rhys@rhysh@live.com>
-Anna Henningsen <anna@addaleax.net>
 Massimiliano Marcon <me@marcon.me>
+Rhys Howell <rhys@rhysh@live.com>
+Irina Shestak <shestak.irina@gmail.com>
+Anna Henningsen <anna@addaleax.net>

--- a/packages/shell-api/AUTHORS
+++ b/packages/shell-api/AUTHORS
@@ -1,7 +1,7 @@
 Anna Herlihy <herlihyap@gmail.com>
-Maurizio Casimirri <maurizio.cas@gmail.com>
 Durran Jordan <durran@gmail.com>
 Irina Shestak <shestak.irina@gmail.com>
+Maurizio Casimirri <maurizio.cas@gmail.com>
+Massimiliano Marcon <me@marcon.me>
 Rhys Howell <rhys@rhysh@live.com>
 Anna Henningsen <anna@addaleax.net>
-Massimiliano Marcon <me@marcon.me>

--- a/packages/shell-evaluator/AUTHORS
+++ b/packages/shell-evaluator/AUTHORS
@@ -1,6 +1,6 @@
-Irina Shestak <shestak.irina@gmail.com>
 Anna Herlihy <herlihyap@gmail.com>
 Maurizio Casimirri <maurizio.cas@gmail.com>
+Irina Shestak <shestak.irina@gmail.com>
 Rhys Howell <rhys@rhysh@live.com>
-Anna Henningsen <anna@addaleax.net>
 Durran Jordan <durran@gmail.com>
+Anna Henningsen <anna@addaleax.net>

--- a/scripts/generate-authors.js
+++ b/scripts/generate-authors.js
@@ -17,31 +17,20 @@ const packageRootPath = path.resolve(__dirname, '..');
 
 function getAuthorsGitLog(packagePath) {
   return execSync(
-    `git log --format='%aN <%aE>' --use-mailmap -- ${packagePath}`,
+    `git log --reverse --format='%aN <%aE>' --use-mailmap -- ${packagePath}`,
     { cwd: packageRootPath }
   ).toString().trim().split('\n');
 }
 
-function getAuthorsOrderedByCommitNumber(packagePath) {
-  const authorsMap = {};
+function getAuthorsOrderedByFirstCommit(packagePath) {
+  const alreadyAdded = new Set();
+  const authors = [];
 
   for (const authorName of getAuthorsGitLog(packagePath)) {
-    authorsMap[authorName] =  authorName in authorsMap ? authorsMap[authorName] + 1 : 1;
+    if (alreadyAdded.has(authorName)) { continue; }
+    alreadyAdded.add(authorName);
+    authors.push(authorName);
   }
-
-  const compareAuthors = ([name1, commitCount1], [name2, commitCount2]) => {
-    if (commitCount1 === commitCount2) {
-      return (name1 > name2) ? 1: -1;
-    }
-
-    return commitCount1 > commitCount2 ? -1 : 1;
-  };
-
-  const authors = Object.entries(authorsMap)
-    .sort(compareAuthors)
-    .map(([name]) => {
-      return name;
-    });
 
   return authors;
 }
@@ -60,11 +49,11 @@ const packages = getAllPackages();
 
 for (const { location } of packages) {
   const packagePath = path.relative(packageRootPath, location);
-  const authors = getAuthorsOrderedByCommitNumber(packagePath);
+  const authors = getAuthorsOrderedByFirstCommit(packagePath);
   fs.writeFileSync(path.resolve(packagePath, 'AUTHORS'), renderAuthorsFileContent(authors));
 }
 
 fs.writeFileSync(
   path.resolve(packageRootPath, 'AUTHORS'),
-  renderAuthorsFileContent(getAuthorsOrderedByCommitNumber('.'))
+  renderAuthorsFileContent(getAuthorsOrderedByFirstCommit('.'))
 );


### PR DESCRIPTION
Fix for the previous PR, ordering commits by contribution date. Won't change  the files unless we have new authors.