### PR TITLE
chore: support Node.js 14.x for testing

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "access": "public"
   },
   "engines": {
-    "node": ">= 13.13.0"
+    "node": ">=12.4.0"
   },
   "devDependencies": {
     "@babel/compat-data": "^7.9.0",

--- a/packages/async-rewriter/package.json
+++ b/packages/async-rewriter/package.json
@@ -23,7 +23,7 @@
     "access": "public"
   },
   "engines": {
-    "node": "^12.4.0"
+    "node": ">=12.4.0"
   },
   "dependencies": {
     "@babel/core": "^7.9.0",

--- a/packages/browser-repl/package.json
+++ b/packages/browser-repl/package.json
@@ -3,7 +3,7 @@
   "version": "0.4.0",
   "description": "Browser presentation component for Mongo Shell",
   "engines": {
-    "node": "^12.4.0"
+    "node": ">=12.4.0"
   },
   "main": "lib/mongosh-browser-repl.js",
   "scripts": {

--- a/packages/browser-runtime-core/package.json
+++ b/packages/browser-runtime-core/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "engines": {
-    "node": "^12.4.0"
+    "node": ">=12.4.0"
   },
   "config": {
     "unsafe-perm": true

--- a/packages/browser-runtime-electron/package.json
+++ b/packages/browser-runtime-electron/package.json
@@ -5,7 +5,7 @@
   "main": "lib/index.js",
   "types": "lib/index.d.ts",
   "engines": {
-    "node": "^12.4.0"
+    "node": ">=12.4.0"
   },
   "config": {
     "unsafe-perm": true

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -22,7 +22,7 @@
     "access": "public"
   },
   "engines": {
-    "node": "^12.4.0"
+    "node": ">=12.4.0"
   },
   "dependency-check": {
     "entries": [

--- a/packages/cli-repl/package.json
+++ b/packages/cli-repl/package.json
@@ -31,7 +31,7 @@
     "access": "public"
   },
   "engines": {
-    "node": "^12.4.0"
+    "node": ">=12.4.0"
   },
   "dependencies": {
     "@mongosh/build": "^0.4.0",

--- a/packages/cli-repl/src/cli-repl.ts
+++ b/packages/cli-repl/src/cli-repl.ts
@@ -117,6 +117,7 @@ class CliRepl {
       completer: completer.bind(null, version),
       terminal: true,
       breakEvalOnSigint: true,
+      preview: false,
     });
 
     const originalDisplayPrompt = this.repl.displayPrompt.bind(this.repl);

--- a/packages/cli-repl/test/test-shell.ts
+++ b/packages/cli-repl/test/test-shell.ts
@@ -10,8 +10,8 @@ import assert from 'assert';
 type SignalType = ChildProcess extends { kill: (signal: infer T) => any } ? T : never;
 
 const PROMPT_PATTERN = /^> /m;
-const ERROR_PATTERN_1 = /Thrown:\n([^>]*)/m; // node <= 12.14
-const ERROR_PATTERN_2 = /Uncaught[:\n ]+([^>]*)/m;
+const ERROR_PATTERN_1 = /Thrown:\n([^>]*)/mg; // node <= 12.14
+const ERROR_PATTERN_2 = /Uncaught[:\n ]+([^>]*)/mg;
 
 /**
  * Test shell helper class.

--- a/packages/compass-shell/package.json
+++ b/packages/compass-shell/package.json
@@ -33,7 +33,7 @@
   "unsafe-perm": true
  },
  "engines": {
-  "node": "^12.4.0"
+  "node": ">=12.4.0"
  },
  "precommit": [
   "check"

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -14,7 +14,7 @@
     "url": "https://github.com/mongodb-js/mongosh"
   },
   "engines": {
-    "node": "^12.4.0"
+    "node": ">=12.4.0"
   },
   "scripts": {
     "test": "mocha -r \"../../scripts/import-expansions.js\" --timeout 15000 --colors -r ts-node/register \"./*.spec.ts\"",

--- a/packages/history/package.json
+++ b/packages/history/package.json
@@ -23,7 +23,7 @@
     "access": "public"
   },
   "engines": {
-    "node": "^12.4.0"
+    "node": ">=12.4.0"
   },
   "dependencies": {
     "mongodb-redact": "^0.2.0"

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -24,7 +24,7 @@
     "access": "public"
   },
   "engines": {
-    "node": "^12.4.0"
+    "node": ">=12.4.0"
   },
   "dependency-check": {
     "entries": [

--- a/packages/java-shell/package.json
+++ b/packages/java-shell/package.json
@@ -21,6 +21,6 @@
     "access": "public"
   },
   "engines": {
-    "node": "^12.4.0"
+    "node": ">=12.4.0"
   }
 }

--- a/packages/mongosh/package.json
+++ b/packages/mongosh/package.json
@@ -33,6 +33,6 @@
     "access": "public"
   },
   "engines": {
-    "node": "^12.4.0"
+    "node": ">=12.4.0"
   }
 }

--- a/packages/service-provider-core/package.json
+++ b/packages/service-provider-core/package.json
@@ -24,7 +24,7 @@
     "access": "public"
   },
   "engines": {
-    "node": "^12.4.0"
+    "node": ">=12.4.0"
   },
   "dependencies": {
     "@mongosh/errors": "^0.4.0",

--- a/packages/service-provider-server/package.json
+++ b/packages/service-provider-server/package.json
@@ -23,7 +23,7 @@
     "access": "public"
   },
   "engines": {
-    "node": "^12.4.0"
+    "node": ">=12.4.0"
   },
   "dependency-check": {
     "entries": [

--- a/packages/shell-api/package.json
+++ b/packages/shell-api/package.json
@@ -27,7 +27,7 @@
     "access": "public"
   },
   "engines": {
-    "node": "^12.4.0"
+    "node": ">=12.4.0"
   },
   "precommit": [
     "build"

--- a/packages/shell-evaluator/package.json
+++ b/packages/shell-evaluator/package.json
@@ -23,7 +23,7 @@
     "access": "public"
   },
   "engines": {
-    "node": "^12.4.0"
+    "node": ">=12.4.0"
   },
   "dependencies": {
     "@mongosh/async-rewriter": "^0.4.0",


### PR DESCRIPTION
- Disable REPL preview because it is not accurate for our evaluator
- Fix tests (`String.prototype.matchAll()` requires a global regexp)
- Update `package.json`s to not restrict to v12.x only