### PR TITLE
Create cursors with expected Mongo instance

### DIFF
--- a/packages/shell-api/src/collection.ts
+++ b/packages/shell-api/src/collection.ts
@@ -115,7 +115,7 @@ export default class Collection extends ShellApiClass {
       providerOptions,
       dbOptions
     );
-    const cursor = new AggregationCursor(this, providerCursor);
+    const cursor = new AggregationCursor(this._mongo, providerCursor);
 
     if (explain) {
       return await cursor.explain('queryPlanner'); // TODO: set default or use optional argument
@@ -341,7 +341,7 @@ export default class Collection extends ShellApiClass {
 
     this._emitCollectionApiCall('find', { query, options });
     const cursor = new Cursor(
-      this,
+      this._mongo,
       this._mongo._serviceProvider.find(this._database._name, this._name, query, options)
     );
 

--- a/packages/shell-api/src/database.ts
+++ b/packages/shell-api/src/database.ts
@@ -187,7 +187,7 @@ export default class Database extends ShellApiClass {
       providerOptions,
       dbOptions
     ) as ServiceProviderCursor;
-    const cursor = new AggregationCursor(this, providerCursor);
+    const cursor = new AggregationCursor(this._mongo, providerCursor);
 
     if (explain) {
       return await cursor.explain('queryPlanner'); // TODO: set default or use optional argument


### PR DESCRIPTION
Cursors were created with `Collection` and `Database` instances instead of expected `Mongo`