### PR TITLE
feat(shell-api): MONGOSH-358 add rs.config, rs.intiate, rs.reconfig commands

### DIFF
--- a/packages/i18n/src/locales/en_US.js
+++ b/packages/i18n/src/locales/en_US.js
@@ -1144,7 +1144,25 @@ const translations = {
       },
       ReplicaSet: {
         help: {
-          description: 'Replica Set Class'
+          description: 'Replica Set Class',
+          link: 'https://docs.mongodb.com/manual/reference/method/js-replication/',
+          attributes: {
+            initiate: {
+              link: 'https://docs.mongodb.com/manual/reference/method/rs.initiate',
+              description: 'Initiates the replica set.',
+              example: 'rs.initiate()'
+            },
+            config: {
+              link: 'https://docs.mongodb.com/manual/reference/method/rs.conf',
+              description: 'Returns a document that contains the current replica set configuration.',
+              example: 'rs.config()'
+            },
+            reconfig: {
+              link: 'https://docs.mongodb.com/manual/reference/method/rs.reconfig',
+              description: 'Reconfigures an existing replica set, overwriting the existing replica set configuration.',
+              example: 'rs.reconfig()'
+            }
+          }
         }
       },
       Shard: {

--- a/packages/shell-api/src/replica-set.spec.ts
+++ b/packages/shell-api/src/replica-set.spec.ts
@@ -1,25 +1,203 @@
-import { expect } from 'chai';
-import sinon from 'ts-sinon';
+import { bson, ServiceProvider } from '@mongosh/service-provider-core';
+import { StubbedInstance, stubInterface } from 'ts-sinon';
+import ShellInternalState from './shell-internal-state';
+import { signatures } from './decorators';
 import ReplicaSet from './replica-set';
-// import { asShellResult } from './enums';
+import { EventEmitter } from 'events';
+import { expect } from 'chai';
+import Mongo from './mongo';
+import {
+  ADMIN_DB,
+  ALL_PLATFORMS,
+  ALL_SERVER_VERSIONS,
+  ALL_TOPOLOGIES,
+  asShellResult
+} from './enums';
 
 describe('ReplicaSet', () => {
-  describe('unimplemented', () => {
-    it('throws', () => {
-      const mSpy = sinon.spy();
-      const rs = new ReplicaSet(mSpy);
-      try {
-        (rs as any).anything();
-      } catch (e) {
-        expect(e.name).to.be.equal('MongoshUnimplementedError');
-      }
+  describe('help', () => {
+    const apiClass: any = new ReplicaSet({});
+
+    it('calls help function', async() => {
+      expect((await apiClass.help()[asShellResult]()).type).to.equal('Help');
+      expect((await apiClass.help[asShellResult]()).type).to.equal('Help');
+    });
+
+    it('calls help function for methods', async() => {
+      expect((await apiClass.initiate.help()[asShellResult]()).type).to.equal('Help');
+      expect((await apiClass.initiate.help[asShellResult]()).type).to.equal('Help');
     });
   });
-  // describe('help', () => {
-  //   const apiClass: any = new ReplicaSet({});
-  //   it('calls help function', async() => {
-  //     expect((await apiClass.help()[asShellResult]()).type).to.equal('Help');
-  //     expect((await apiClass.help[asShellResult]()).type).to.equal('Help');
-  //   });
-  // });
+
+  describe('signatures', () => {
+    it('type', () => {
+      expect(signatures.ReplicaSet.type).to.equal('ReplicaSet');
+    });
+
+    it('attributes', () => {
+      expect(signatures.ReplicaSet.attributes.initiate).to.deep.equal({
+        type: 'function',
+        returnsPromise: true,
+        returnType: { type: 'unknown', attributes: {} },
+        platforms: ALL_PLATFORMS,
+        topologies: ALL_TOPOLOGIES,
+        serverVersions: ALL_SERVER_VERSIONS
+      });
+    });
+
+    it('hasAsyncChild', () => {
+      expect(signatures.ReplicaSet.hasAsyncChild).to.equal(true);
+    });
+  });
+
+  describe('commands', () => {
+    let mongo: Mongo;
+    let serviceProvider: StubbedInstance<ServiceProvider>;
+    let rs: ReplicaSet;
+    let bus: StubbedInstance<EventEmitter>;
+    let internalState: ShellInternalState;
+
+    beforeEach(() => {
+      bus = stubInterface<EventEmitter>();
+      serviceProvider = stubInterface<ServiceProvider>();
+      serviceProvider.initialDb = 'test';
+      serviceProvider.bsonLibrary = bson;
+      serviceProvider.runCommand.resolves({ ok: 1 });
+      serviceProvider.runCommandWithCheck.resolves({ ok: 1 });
+      internalState = new ShellInternalState(serviceProvider, bus);
+      mongo = new Mongo(internalState);
+      rs = new ReplicaSet(mongo);
+    });
+
+    describe('initiate', () => {
+      const configDoc = {
+        _id: 'my_replica_set',
+        members: [
+          { _id: 0, host: 'rs1.example.net:27017' },
+          { _id: 1, host: 'rs2.example.net:27017' },
+          { _id: 2, host: 'rs3.example.net', arbiterOnly: true },
+        ]
+      };
+
+      it('calls serviceProvider.runCommandWithCheck without optional arg', async() => {
+        await rs.initiate();
+
+        expect(serviceProvider.runCommandWithCheck).to.have.been.calledWith(
+          ADMIN_DB,
+          {
+            replSetInitiate: undefined
+          }
+        );
+      });
+
+      it('calls serviceProvider.runCommandWithCheck with arg', async() => {
+        await rs.initiate(configDoc);
+
+        expect(serviceProvider.runCommandWithCheck).to.have.been.calledWith(
+          ADMIN_DB,
+          {
+            replSetInitiate: configDoc
+          }
+        );
+      });
+
+      it('returns whatever serviceProvider.runCommandWithCheck returns', async() => {
+        const expectedResult = { ok: 1 };
+        serviceProvider.runCommandWithCheck.resolves(expectedResult);
+        const result = await rs.initiate(configDoc);
+
+        expect(result).to.deep.equal(expectedResult);
+      });
+
+      it('throws if serviceProvider.runCommandWithCheck rejects', async() => {
+        const expectedError = new Error();
+        serviceProvider.runCommandWithCheck.rejects(expectedError);
+        const caughtError = await rs.initiate(configDoc)
+          .catch(e => e);
+
+        expect(caughtError).to.equal(expectedError);
+      });
+    });
+
+    describe('config', () => {
+      it('calls serviceProvider.runCommandWithCheck', async() => {
+        await rs.config();
+
+        expect(serviceProvider.runCommandWithCheck).to.have.been.calledWith(
+          ADMIN_DB,
+          {
+            replSetReconfig: 1
+          }
+        );
+      });
+
+      it('returns whatever serviceProvider.runCommandWithCheck returns', async() => {
+        // not using the full object for expected result, as we should check this in an e2e test.
+        const expectedResult = { version: 1, members: [], settings: {} };
+        serviceProvider.runCommandWithCheck.resolves(expectedResult);
+        const result = await rs.config();
+
+        expect(result).to.deep.equal(expectedResult);
+      });
+
+      it('throws if serviceProvider.runCommandWithCheck rejects', async() => {
+        const expectedError = new Error();
+        serviceProvider.runCommandWithCheck.rejects(expectedError);
+        const caughtError = await rs.config()
+          .catch(e => e);
+
+        expect(caughtError).to.equal(expectedError);
+      });
+    });
+
+    describe('reconfig', () => {
+      const configDoc = {
+        _id: 'my_replica_set',
+        members: [
+          { _id: 0, host: 'rs1.example.net:27017' },
+          { _id: 1, host: 'rs2.example.net:27017' },
+          { _id: 2, host: 'rs3.example.net', arbiterOnly: true },
+        ]
+      };
+
+      it('calls serviceProvider.runCommandWithCheck without optional arg', async() => {
+        await rs.reconfig(configDoc);
+
+        expect(serviceProvider.runCommandWithCheck).to.have.been.calledWith(
+          ADMIN_DB,
+          {
+            replSetReconfig: {
+              _id: 'my_replica_set',
+              members: [
+                { _id: 0, host: 'rs1.example.net:27017' },
+                { _id: 1, host: 'rs2.example.net:27017' },
+                { _id: 2, host: 'rs3.example.net', arbiterOnly: true },
+              ],
+              version: 1
+            }
+          }
+        );
+      });
+
+      it('calls serviceProvider.runCommandWithCheck with arg', async() => {
+        await rs.reconfig(configDoc, { force: true });
+
+        expect(serviceProvider.runCommandWithCheck).to.have.been.calledWith(
+          ADMIN_DB,
+          {
+            replSetReconfig: {
+              _id: 'my_replica_set',
+              members: [
+                { _id: 0, host: 'rs1.example.net:27017' },
+                { _id: 1, host: 'rs2.example.net:27017' },
+                { _id: 2, host: 'rs3.example.net', arbiterOnly: true },
+              ],
+              version: 1
+            },
+            force: true
+          }
+        );
+      });
+    });
+  });
 });

--- a/packages/shell-api/src/replica-set.spec.ts
+++ b/packages/shell-api/src/replica-set.spec.ts
@@ -85,7 +85,7 @@ describe('ReplicaSet', () => {
         expect(serviceProvider.runCommandWithCheck).to.have.been.calledWith(
           ADMIN_DB,
           {
-            replSetInitiate: undefined
+            replSetInitiate: {}
           }
         );
       });

--- a/packages/shell-api/src/replica-set.ts
+++ b/packages/shell-api/src/replica-set.ts
@@ -27,7 +27,7 @@ export default class ReplicaSet extends ShellApiClass {
    * @param config
    */
   @returnsPromise
-  async initiate(config?: any): Promise<any> {
+  async initiate(config = {}): Promise<any> {
     this._emitReplicaSetApiCall('initiate', { config });
     return this._mongo._serviceProvider.runCommandWithCheck(ADMIN_DB, { replSetInitiate: config });
   }
@@ -50,7 +50,7 @@ export default class ReplicaSet extends ShellApiClass {
    *  @param options
    */
   @returnsPromise
-  async reconfig(config: any, options?: any): Promise<any> {
+  async reconfig(config: any, options = {}): Promise<any> {
     assertArgsDefined(config);
     assertArgsType([ config, options ], ['object', 'object']);
     this._emitReplicaSetApiCall('reconfig', { config, options });
@@ -59,7 +59,7 @@ export default class ReplicaSet extends ShellApiClass {
 
     config.version = conf.version ? conf.version + 1 : 1;
     const cmd = { replSetReconfig: config };
-    const reconfigCmd = options !== undefined ? { ...cmd, ...options } : cmd;
+    const reconfigCmd = { ...cmd, ...options };
 
     return this._mongo._serviceProvider.runCommandWithCheck(ADMIN_DB, reconfigCmd);
   }
@@ -74,8 +74,8 @@ export default class ReplicaSet extends ShellApiClass {
   /**
    * internal helper for emitting replicaset api call events.
    *
-   * @param methodname
-   * @param methodarguments
+   * @param methodName
+   * @param methodArguments
    * @private
    */
   private _emitReplicaSetApiCall(methodName: string, methodArguments: Document = {}): void {

--- a/packages/shell-api/src/replica-set.ts
+++ b/packages/shell-api/src/replica-set.ts
@@ -2,7 +2,8 @@ import Mongo from './mongo';
 import {
   shellApiClassDefault,
   hasAsyncChild,
-  ShellApiClass, returnsPromise
+  ShellApiClass,
+  returnsPromise
 } from './decorators';
 
 import {
@@ -72,7 +73,7 @@ export default class ReplicaSet extends ShellApiClass {
   }
 
   /**
-   * internal helper for emitting replicaset api call events.
+   * Internal helper for emitting ReplicaSet API call events.
    *
    * @param methodName
    * @param methodArguments

--- a/packages/shell-api/src/replica-set.ts
+++ b/packages/shell-api/src/replica-set.ts
@@ -2,13 +2,14 @@ import Mongo from './mongo';
 import {
   shellApiClassDefault,
   hasAsyncChild,
-  ShellApiClass
+  ShellApiClass, returnsPromise
 } from './decorators';
 
 import {
   Document
 } from '@mongosh/service-provider-core';
-import { MongoshUnimplementedError } from '@mongosh/errors';
+import { ADMIN_DB } from './enums';
+import { assertArgsDefined, assertArgsType } from './helpers';
 
 @shellApiClassDefault
 @hasAsyncChild
@@ -18,15 +19,49 @@ export default class ReplicaSet extends ShellApiClass {
   constructor(mongo) {
     super();
     this._mongo = mongo;
-    const proxy = new Proxy(this, {
-      get: (obj, prop): any => {
-        if (!(prop in obj)) {
-          throw new MongoshUnimplementedError('rs not currently supported');
-        }
-        return obj[prop];
-      }
-    });
-    return proxy;
+  }
+
+  /**
+   *  rs.initiate calls replSetInitiate admin command.
+   *
+   * @param config
+   */
+  @returnsPromise
+  async initiate(config?: any): Promise<any> {
+    this._emitReplicaSetApiCall('initiate', { config });
+    return this._mongo._serviceProvider.runCommandWithCheck(ADMIN_DB, { replSetInitiate: config });
+  }
+
+  /**
+   *  rs.config calls replSetReconfig admin command.
+   *
+   *  Returns a document that contains the current replica set configuration.
+   */
+  @returnsPromise
+  async config(): Promise<any> {
+    this._emitReplicaSetApiCall('config', {});
+    return this._mongo._serviceProvider.runCommandWithCheck(ADMIN_DB, { replSetReconfig: 1 });
+  }
+
+  /**
+   *  rs.reconfig calls replSetReconfig admin command.
+   *
+   *  @param config
+   *  @param options
+   */
+  @returnsPromise
+  async reconfig(config: any, options?: any): Promise<any> {
+    assertArgsDefined(config);
+    assertArgsType([ config, options ], ['object', 'object']);
+    this._emitReplicaSetApiCall('reconfig', { config, options });
+
+    const conf = await this.config();
+
+    config.version = conf.version ? conf.version + 1 : 1;
+    const cmd = { replSetReconfig: config };
+    const reconfigCmd = options !== undefined ? { ...cmd, ...options } : cmd;
+
+    return this._mongo._serviceProvider.runCommandWithCheck(ADMIN_DB, reconfigCmd);
   }
 
   /**
@@ -37,10 +72,10 @@ export default class ReplicaSet extends ShellApiClass {
   }
 
   /**
-   * Internal helper for emitting ReplicaSet API call events.
+   * internal helper for emitting replicaset api call events.
    *
-   * @param methodName
-   * @param methodArguments
+   * @param methodname
+   * @param methodarguments
    * @private
    */
   private _emitReplicaSetApiCall(methodName: string, methodArguments: Document = {}): void {


### PR DESCRIPTION
## Description

This PR removes MongoshUnimplementedError for Replica Set API and adds
rs.config, rs.initiate, rs.reconfig APIs. 

This PR exludes end-to-end tests, as it would be good to have a few more
implemented APIs so we can test replication properly.