### PR TITLE
Add 10s wait before checking if npm version has been published

### DIFF
--- a/scripts/publish-npm.js
+++ b/scripts/publish-npm.js
@@ -2,10 +2,14 @@ const { execSync, execFileSync } = require('child_process');
 const fs = require('fs');
 const path = require('path');
 const assert = require('assert');
-const {gitClone, getLatestVersion, confirm} = require('./utils');
+const { gitClone, getLatestVersion, confirm } = require('./utils');
 const generateHomebrewFormula = require('./generate-homebrew-formula');
 
 const rootPath = path.resolve(__dirname, '..');
+
+const wait = (ms = 1000) => {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+};
 
 function requireSegmentApiKey() {
   const { MONGOSH_SEGMENT_API_KEY } = process.env;
@@ -131,6 +135,9 @@ async function publish() {
       ['publish', '--force-publish'],
       { cwd: cloneDirPath, stdio: 'inherit' }
     );
+
+    // Wait 10s to ensure the npm tags are updated after the publish.
+    await wait(10000);
 
     const versionAfter = getLatestVersion();
 


### PR DESCRIPTION
`0.4.2` release errored out on the version verification:
```Successfully published:
 - @mongosh/async-rewriter@0.4.2
 - @mongosh/browser-repl@0.4.2
 - @mongosh/browser-runtime-core@0.4.2
 - @mongosh/browser-runtime-electron@0.4.2
 - @mongosh/cli-repl@0.4.2
 - @mongodb-js/compass-shell@0.4.2
 - @mongosh/errors@0.4.2
 - @mongosh/history@0.4.2
 - @mongosh/i18n@0.4.2
 - mongosh@0.4.2
 - @mongosh/service-provider-core@0.4.2
 - @mongosh/service-provider-server@0.4.2
 - @mongosh/shell-api@0.4.2
 - @mongosh/shell-evaluator@0.4.2
lerna success published 14 packages
(node:88007) UnhandledPromiseRejectionWarning: AssertionError [ERR_ASSERTION]: The published version should have been changed: before 0.4.1, after: 0.4.1
    at publish (/private/tmp/mongosh/scripts/publish-npm.js:137:12)
    at main (/private/tmp/mongosh/scripts/publish-npm.js:170:3)
    at processTicksAndRejections (internal/process/task_queues.js:97:5)
(node:88007) UnhandledPromiseRejectionWarning: Unhandled promise rejection. This error originated either by throwing inside of an async function without a catch block
```

Probably the npm version check `npm view @mongosh/cli-repl .dist-tags.latest` does not update to the new version for a few seconds. This PR just adds a 10s sleep before we run the check to ensure it has time. I haven't tested if this is enough time (or if it's too much), with the `0.4.1` release this error didn't occur so I think it's probably a short amount of time before the version is updated.