### PR TITLE
MONGOSH-376 - Include metadata about data source in result

### DIFF
--- a/packages/i18n/src/locales/en_US.js
+++ b/packages/i18n/src/locales/en_US.js
@@ -1603,6 +1603,13 @@ const translations = {
             }
           }
         }
+      },
+      Document: {
+        help: {
+          link: 'https://docs.mongodb.com/manual/core/document/',
+          description: 'A generic MongoDB document, without any methods.',
+          attributes: {}
+        }
       }
     }
   },

--- a/packages/shell-api/src/aggregation-cursor.ts
+++ b/packages/shell-api/src/aggregation-cursor.ts
@@ -5,7 +5,8 @@ import {
   returnType,
   hasAsyncChild,
   ShellApiClass,
-  ShellResult
+  ShellResult,
+  resultSource
 } from './decorators';
 import {
   Cursor as ServiceProviderCursor,
@@ -47,7 +48,8 @@ export default class AggregationCursor extends ShellApiClass {
   async [asShellResult](): Promise<ShellResult> {
     return {
       type: 'AggregationCursor',
-      value: this._mongo._serviceProvider.platform === ReplPlatform.JavaShell ? this : await this._asPrintable()
+      value: this._mongo._serviceProvider.platform === ReplPlatform.JavaShell ? this : await this._asPrintable(),
+      source: this[resultSource] ?? undefined
     };
   }
 

--- a/packages/shell-api/src/collection.spec.ts
+++ b/packages/shell-api/src/collection.spec.ts
@@ -1133,8 +1133,6 @@ describe('Collection', () => {
         expect(result.value.length).to.not.equal(0);
         expect(result.value[0]._id).to.equal('abc');
         expect(result.source).to.deep.equal({
-          arguments: [],
-          call: 'find',
           namespace: {
             db: 'db1',
             collection: 'coll1'
@@ -1149,8 +1147,6 @@ describe('Collection', () => {
         expect(result.type).to.equal('Document');
         expect(result.value._id).to.equal('abc');
         expect(result.source).to.deep.equal({
-          arguments: [ { hasBanana: true } ],
-          call: 'findOne',
           namespace: {
             db: 'db1',
             collection: 'coll1'
@@ -1167,8 +1163,6 @@ describe('Collection', () => {
         expect(result.type).to.equal(null);
         expect(result.value).to.deep.equal([ fakeIndex ]);
         expect(result.source).to.deep.equal({
-          arguments: [],
-          call: 'getIndexes',
           namespace: {
             db: 'db1',
             collection: 'coll1'

--- a/packages/shell-api/src/collection.ts
+++ b/packages/shell-api/src/collection.ts
@@ -6,7 +6,10 @@ import {
   ShellApiClass,
   returnsPromise,
   returnType,
-  serverVersions
+  serverVersions,
+  Namespace,
+  namespaceInfo,
+  addSourceToResults
 } from './decorators';
 import { ADMIN_DB, ServerVersions } from './enums';
 import {
@@ -36,6 +39,7 @@ import PlanCache from './plan-cache';
 
 @shellApiClassDefault
 @hasAsyncChild
+@addSourceToResults
 export default class Collection extends ShellApiClass {
   _mongo: Mongo;
   _database: any; // to avoid circular ref
@@ -62,6 +66,10 @@ export default class Collection extends ShellApiClass {
       }
     });
     return proxy;
+  }
+
+  [namespaceInfo](): Namespace {
+    return { db: this._database.getName(), collection: this._name };
   }
 
   /**
@@ -408,6 +416,7 @@ export default class Collection extends ShellApiClass {
    * @returns {Cursor} The promise of the cursor.
    */
   @returnsPromise
+  @returnType('Document')
   async findOne(query = {}, projection?): Promise<Document> {
     const options: any = {};
     if (projection) {
@@ -467,6 +476,7 @@ export default class Collection extends ShellApiClass {
    * @returns {Document} The promise of the result.
    */
   @returnsPromise
+  @returnType('Document')
   @serverVersions(['3.2.0', ServerVersions.latest])
   async findOneAndDelete(filter, options = {}): Promise<Document> {
     assertArgsDefined(filter);
@@ -496,6 +506,7 @@ export default class Collection extends ShellApiClass {
    * @returns {Document} The promise of the result.
    */
   @returnsPromise
+  @returnType('Document')
   @serverVersions(['3.2.0', ServerVersions.latest])
   async findOneAndReplace(filter, replacement, options = {}): Promise<any> {
     assertArgsDefined(filter);
@@ -531,6 +542,7 @@ export default class Collection extends ShellApiClass {
    * @returns {Document} The promise of the result.
    */
   @returnsPromise
+  @returnType('Document')
   @serverVersions(['3.2.0', ServerVersions.latest])
   async findOneAndUpdate(filter, update, options = {}): Promise<any> {
     assertArgsDefined(filter);

--- a/packages/shell-api/src/cursor.ts
+++ b/packages/shell-api/src/cursor.ts
@@ -7,7 +7,8 @@ import {
   serverVersions,
   ShellApiClass,
   shellApiClassDefault,
-  ShellResult
+  ShellResult,
+  resultSource
 } from './decorators';
 import { asShellResult, ServerVersions } from './enums';
 import {
@@ -33,7 +34,8 @@ export default class Cursor extends ShellApiClass {
   async [asShellResult](): Promise<ShellResult> {
     return {
       type: 'Cursor',
-      value: this._mongo._serviceProvider.platform === ReplPlatform.JavaShell ? this : await this._asPrintable()
+      value: this._mongo._serviceProvider.platform === ReplPlatform.JavaShell ? this : await this._asPrintable(),
+      source: this[resultSource] ?? undefined
     };
   }
 

--- a/packages/shell-api/src/helpers.ts
+++ b/packages/shell-api/src/helpers.ts
@@ -477,3 +477,12 @@ export function tsToSeconds(x): number {
   }
   return x / 4294967296; // low 32 bits are ordinal #s within a second
 }
+
+export function addHiddenDataProperty(target: object, key: string|symbol, value: any): void {
+  Object.defineProperty(target, key, {
+    value,
+    enumerable: false,
+    writable: true,
+    configurable: true
+  });
+}


### PR DESCRIPTION
For results from calls on collections, add metadata about the source of
the returned data (database name, collection name, method, arguments)
so that consumers of the shell can figure out from what source
the result was generated, e.g. in order to understand how to modify
that original data.

This also adds a fake `Document` type to the `ShellResult` reported
for e.g. `findOne()`, so that it is possible to tell those apart
from other plain JavaScript objects, e.g. in order to be able to
know whether the result is a modifiable object in the database or not.