### PR TITLE
chore: switch node-codesign to official package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14072,8 +14072,9 @@
       "dev": true
     },
     "node-codesign": {
-      "version": "github:addaleax/node-codesign#845437573cd3550f18d2d758009ed946c1c37878",
-      "from": "github:addaleax/node-codesign",
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/node-codesign/-/node-codesign-0.3.0.tgz",
+      "integrity": "sha512-sjxvRp8ZxQ8XPqqxi8DLqpXv0NqlfI7AuDFcpZIq55JdlyxyZAetLKyUpp71spS9mhH9kxbklbankoMHG1iFow==",
       "dev": true,
       "requires": {
         "async": "^2.1.2",

--- a/package.json
+++ b/package.json
@@ -98,7 +98,7 @@
     "mocha": "^7.1.2",
     "mongodb-js-precommit": "^2.0.0",
     "mongodb-runner": "^4.7.5",
-    "node-codesign": "github:addaleax/node-codesign",
+    "node-codesign": "^0.3.0",
     "node-fetch": "^2.6.1",
     "parcel-bundler": "^1.12.4",
     "pkg-deb": "^1.1.1",


### PR DESCRIPTION
Now that signing Works™, use a public package instead of my
personal fork. :)