### PR TITLE
[java-shell] fix "show collections" command (it always uses "test" database)

### DIFF
--- a/packages/java-shell/src/test/resources/db/showCollections.expected.txt
+++ b/packages/java-shell/src/test/resources/db/showCollections.expected.txt
@@ -1,1 +1,2 @@
-ArrayResult
+{ "acknowledged": true, "insertedIds": [ ] }
+[ "coll" ]

--- a/packages/java-shell/src/test/resources/db/showCollections.js
+++ b/packages/java-shell/src/test/resources/db/showCollections.js
@@ -1,2 +1,8 @@
-// command dontCheckValue
+// before
+use test_show_collections
+// command
+db.coll.insert({});
+// command
 show collections
+// clear
+db.coll.drop();

--- a/packages/shell-api/src/shell-internal-state.ts
+++ b/packages/shell-api/src/shell-internal-state.ts
@@ -12,7 +12,7 @@ import {
 } from './index';
 import constructShellBson from './shell-bson';
 import { EventEmitter } from 'events';
-import { Document, ServiceProvider, DEFAULT_DB } from '@mongosh/service-provider-core';
+import { Document, ServiceProvider, DEFAULT_DB, ReplPlatform } from '@mongosh/service-provider-core';
 import { MongoshInvalidInputError } from '@mongosh/errors';
 import AsyncWriter from '@mongosh/async-rewriter';
 import { toIgnore } from './decorators';
@@ -137,14 +137,14 @@ export default class ShellInternalState {
       return this.setDbFunc(newDb);
     };
 
-    try {
+    if (this.initialServiceProvider.platform === ReplPlatform.JavaShell) {
+      contextObject.db = this.setDbFunc(this.currentDb); // java shell, can't use getters/setters
+    } else {
       Object.defineProperty(contextObject, 'db', {
         configurable: true,
         set: setFunc,
         get: () => (this.currentDb)
       });
-    } catch (e) { // java shell, can't use getters/setters
-      contextObject.db = this.setDbFunc(this.currentDb);
     }
 
     this.messageBus.emit(


### PR DESCRIPTION
 GraalJS does not allow to define property on top context, so we need to update database in internal state manually.