### PR TITLE
MONGOSH-237 - Allow custom print/printjson for individual platforms

### DIFF
--- a/packages/browser-repl/package.json
+++ b/packages/browser-repl/package.json
@@ -42,7 +42,7 @@
     "@mongosh/history": "^0.4.2",
     "@mongosh/i18n": "^0.4.2",
     "@mongosh/service-provider-core": "^0.4.2",
-    "@mongosh/shell-api": "^0.4.2",
+    "@mongosh/shell-evaluator": "^0.4.2",
     "pretty-bytes": "^5.3.0",
     "text-table": "^0.2.0"
   },

--- a/packages/browser-repl/src/components/shell.spec.tsx
+++ b/packages/browser-repl/src/components/shell.spec.tsx
@@ -35,7 +35,8 @@ describe('<Shell />', () => {
     elementFocus = sinon.spy(HTMLElement.prototype, 'focus');
 
     fakeRuntime = {
-      evaluate: sinon.fake.returns({ printable: 'some result' })
+      evaluate: sinon.fake.returns({ printable: 'some result' }),
+      setEvaluationListener: () => {}
     };
 
     onOutputChangedSpy = sinon.spy();
@@ -247,7 +248,8 @@ describe('<Shell />', () => {
           return new Promise(resolve => {
             onInputDone = resolve;
           });
-        }
+        },
+        setEvaluationListener: () => {}
       } as any}
     />);
 
@@ -354,5 +356,13 @@ describe('<Shell />', () => {
     container.prop('onClick')(fakeMouseEvent);
 
     expect(HTMLElement.prototype.focus).to.not.have.been.called;
+  });
+
+  it('updated the output when .onPrint is called', () => {
+    wrapper.instance().onPrint([{ type: null, printable: 42 }]);
+
+    expect(onOutputChangedSpy).to.have.been.calledWith([
+      { format: 'output', value: 42, type: null }
+    ]);
   });
 });

--- a/packages/browser-repl/src/components/shell.tsx
+++ b/packages/browser-repl/src/components/shell.tsx
@@ -104,6 +104,7 @@ export class Shell extends Component<ShellProps, ShellState> {
     let outputLine;
 
     try {
+      this.props.runtime.setEvaluationListener(this);
       const result = await this.props.runtime.evaluate(code);
       outputLine = {
         format: 'output',
@@ -156,6 +157,16 @@ export class Shell extends Component<ShellProps, ShellState> {
     this.props.onOutputChanged(output);
   };
 
+  onPrint = (result: { type: string | null; printable: any }[]): void => {
+    const output = this.addEntriesToOutput(result.map((entry) => ({
+      format: 'output',
+      type: entry.type,
+      value: entry.printable
+    })));
+    this.setState({ output });
+    this.props.onOutputChanged(output);
+  };
+
   private onInput = async(code: string): Promise<void> => {
     if (!code || code.trim() === '') {
       this.appendEmptyInput();
@@ -167,25 +178,22 @@ export class Shell extends Component<ShellProps, ShellState> {
       value: code
     };
 
+    let output = this.addEntriesToOutput([inputLine]);
     this.setState({
-      operationInProgress: true
+      operationInProgress: true,
+      output
     });
+    this.props.onOutputChanged(output);
 
     const outputLine = await this.evaluate(code);
 
-    const output = this.addEntriesToOutput([
-      inputLine,
-      outputLine
-    ]);
-
+    output = this.addEntriesToOutput([outputLine]);
     const history = this.addEntryToHistory(code);
-
     this.setState({
       operationInProgress: false,
       output,
       history
     });
-
     this.props.onOutputChanged(output);
     this.props.onHistoryChanged(history);
   };

--- a/packages/browser-runtime-core/src/open-context-runtime.ts
+++ b/packages/browser-runtime-core/src/open-context-runtime.ts
@@ -6,7 +6,7 @@ import { Runtime } from './runtime';
 import { EventEmitter } from 'events';
 import { ShellInternalState, ShellResult } from '@mongosh/shell-api';
 
-import ShellEvaluator from '@mongosh/shell-evaluator';
+import { ShellEvaluator, EvaluationListener } from '@mongosh/shell-evaluator';
 
 /**
  * This class is the core implementation for a runtime which is not isolated
@@ -22,6 +22,7 @@ export class OpenContextRuntime implements Runtime {
   private autocompleter: ShellApiAutocompleter;
   private shellEvaluator: ShellEvaluator;
   private internalState: ShellInternalState;
+  private evaluationListener: EvaluationListener | null = null;
 
   constructor(
     serviceProvider: ServiceProvider,
@@ -54,5 +55,11 @@ export class OpenContextRuntime implements Runtime {
       this.interpreterEnvironment.getContextObject(),
       ''
     );
+  }
+
+  setEvaluationListener(listener: EvaluationListener): EvaluationListener | null {
+    const prev = this.evaluationListener;
+    this.shellEvaluator.setEvaluationListener(listener);
+    return prev;
   }
 }

--- a/packages/browser-runtime-core/src/runtime.ts
+++ b/packages/browser-runtime-core/src/runtime.ts
@@ -1,9 +1,18 @@
 import { Completion } from './autocompleter/autocompleter';
-import { ShellResult } from '@mongosh/shell-api';
+import { ShellResult, EvaluationListener } from '@mongosh/shell-evaluator';
 
 export type ContextValue = any;
 
 export interface Runtime {
+  /**
+   * Sets a listener for certain events, e.g. onPrint() when print() is called
+   * in the shell.
+   *
+   * @param {EvaluationListener} listener - The new listener.
+   * @return {EvaluationListener | null} The previous listener, if any.
+   */
+  setEvaluationListener(listener: EvaluationListener): EvaluationListener | null;
+
   /**
    * Evaluates code
    *

--- a/packages/browser-runtime-electron/package.json
+++ b/packages/browser-runtime-electron/package.json
@@ -31,7 +31,7 @@
   "dependencies": {
     "@mongosh/browser-runtime-core": "^0.4.2",
     "@mongosh/service-provider-core": "^0.4.2",
-    "@mongosh/shell-api": "^0.4.2"
+    "@mongosh/shell-evaluator": "^0.4.2"
   },
   "devDependencies": {
     "@mongosh/service-provider-server": "^0.4.2",

--- a/packages/browser-runtime-electron/src/electron-runtime.ts
+++ b/packages/browser-runtime-electron/src/electron-runtime.ts
@@ -10,7 +10,7 @@ import {
 } from '@mongosh/browser-runtime-core';
 
 import { ServiceProvider } from '@mongosh/service-provider-core';
-import { ShellResult } from '@mongosh/shell-api';
+import { ShellResult, EvaluationListener } from '@mongosh/shell-evaluator';
 
 declare const __webpack_require__: any;
 declare const __non_webpack_require__: any;
@@ -41,6 +41,10 @@ export class ElectronRuntime implements Runtime {
       new ElectronInterpreterEnvironment({ require: requireFunc }),
       messageBus
     );
+  }
+
+  setEvaluationListener(listener: EvaluationListener): EvaluationListener | null {
+    return this.openContextRuntime.setEvaluationListener(listener);
   }
 
   async evaluate(code: string): Promise<ShellResult> {

--- a/packages/shell-api/src/index.ts
+++ b/packages/shell-api/src/index.ts
@@ -5,7 +5,7 @@ import Database from './database';
 import Explainable from './explainable';
 import ExplainableCursor from './explainable-cursor';
 import Help from './help';
-import ShellInternalState from './shell-internal-state';
+import ShellInternalState, { EvaluationListener } from './shell-internal-state';
 import toIterator from './toIterator';
 import Shard from './shard';
 import ReplicaSet from './replica-set';
@@ -41,6 +41,7 @@ export {
   ExplainableCursor,
   Help,
   ShellInternalState,
+  EvaluationListener,
   BulkWriteResult,
   CommandResult,
   DeleteResult,

--- a/packages/shell-evaluator/src/index.ts
+++ b/packages/shell-evaluator/src/index.ts
@@ -1,2 +1,12 @@
-import ShellEvaluator from './shell-evaluator';
+import {
+  ShellResult,
+  ShellEvaluator,
+  EvaluationListener
+} from './shell-evaluator';
+
+export {
+  ShellResult,
+  ShellEvaluator,
+  EvaluationListener
+};
 export default ShellEvaluator;

--- a/packages/shell-evaluator/src/shell-evaluator.spec.ts
+++ b/packages/shell-evaluator/src/shell-evaluator.spec.ts
@@ -3,7 +3,7 @@ import sinon from 'ts-sinon';
 const sinonChai = require('sinon-chai'); // weird with import
 use(sinonChai);
 
-import ShellEvaluator from './shell-evaluator';
+import ShellEvaluator from './index';
 import { EventEmitter } from 'events';
 
 describe('ShellEvaluator', () => {

--- a/packages/shell-evaluator/src/shell-evaluator.ts
+++ b/packages/shell-evaluator/src/shell-evaluator.ts
@@ -2,7 +2,8 @@
 import {
   ShellInternalState,
   toShellResult,
-  ShellResult
+  ShellResult,
+  EvaluationListener
 } from '@mongosh/shell-api';
 
 interface Container {
@@ -28,6 +29,10 @@ class ShellEvaluator {
 
   public saveState(): void {
     this.internalState.asyncWriter.symbols.saveState();
+  }
+
+  public setEvaluationListener(listener: EvaluationListener): void {
+    this.internalState.setEvaluationListener(listener);
   }
 
   /**
@@ -103,4 +108,8 @@ class ShellEvaluator {
   }
 }
 
-export default ShellEvaluator;
+export {
+  ShellResult,
+  ShellEvaluator,
+  EvaluationListener
+};


### PR DESCRIPTION
Fwiw, alternatives that I’ve considered are a) passing this over the `messageBus` instead or b) changing the return value of `ShellEvaluator.customEval()` (to e.g. an async iterable instead of a plain promise), but in the end this seemed like the best choice to me because this might be helpful if we ever need another way to customize shell evaluation.