### PR TITLE
Make saslprep bundle-able

### DIFF
--- a/packages/service-provider-server/package-lock.json
+++ b/packages/service-provider-server/package-lock.json
@@ -60,8 +60,7 @@
 		"memory-pager": {
 			"version": "1.5.0",
 			"resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
-			"integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
-			"optional": true
+			"integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg=="
 		},
 		"mongodb": {
 			"version": "3.6.1",
@@ -122,10 +121,8 @@
 			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
 		},
 		"saslprep": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
-			"integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
-			"optional": true,
+			"version": "github:mongodb-js/saslprep#9813a626d0685f54e4f2fac6160470d6e01d8c96",
+			"from": "github:mongodb-js/saslprep#v1.0.4",
 			"requires": {
 				"sparse-bitfield": "^3.0.3"
 			}
@@ -139,7 +136,6 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
 			"integrity": "sha1-/0rm5oZWBWuks+eSqzM004JzyhE=",
-			"optional": true,
 			"requires": {
 				"memory-pager": "^1.0.2"
 			}

--- a/packages/service-provider-server/package.json
+++ b/packages/service-provider-server/package.json
@@ -43,6 +43,6 @@
     "@types/sinon": "^7.5.1",
     "@types/sinon-chai": "^3.2.3",
     "mongodb": "^3.6.1",
-    "saslprep": "^1.0.3"
+    "saslprep": "mongodb-js/saslprep#v1.0.4"
   }
 }


### PR DESCRIPTION
Use mongodb-js/saslprep@b7aeb7b2e8fd4861ba8c45cfde90ae3f12c8f879,
which reduces file size significantly and lets us bundle the library
in the dist .js file, because this stops saslprep from loading files
from disk manually.