### PR TITLE
WIP - Add passwordPrompt() support for the CLI

### DIFF
--- a/packages/cli-repl/package-lock.json
+++ b/packages/cli-repl/package-lock.json
@@ -168,6 +168,11 @@
 			"resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.1.tgz",
 			"integrity": "sha512-Z/JnaVEXv+A9xabHzN43FiiiWEE7gPCRXMrVmRm00tWbjZRul1iHm7ECzlyNq1p4a4ATXz+G9FJ3GqGOkOV3fg=="
 		},
+		"askpassword": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/askpassword/-/askpassword-1.0.1.tgz",
+			"integrity": "sha512-7CadYL6ivDALZ+FifrR8Sqpcld1sGKJsJmNA1bKZrHHl2QpQTck2QPORrTUzCgnDtmnOVKLRtO6urJjA6lTdjw=="
+		},
 		"atomic-sleep": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/atomic-sleep/-/atomic-sleep-1.0.0.tgz",

--- a/packages/cli-repl/package.json
+++ b/packages/cli-repl/package.json
@@ -49,6 +49,7 @@
     "acorn-static-class-features": "^0.2.1",
     "analytics-node": "^3.4.0-beta.1",
     "ansi-escape-sequences": "^5.1.2",
+    "askpassword": "^1.0.1",
     "fast-json-parse": "^1.0.3",
     "is-recoverable-error": "^1.0.0",
     "lodash.set": "^4.3.2",

--- a/packages/cli-repl/src/cli-repl.ts
+++ b/packages/cli-repl/src/cli-repl.ts
@@ -25,6 +25,7 @@ import read from 'read';
 import os from 'os';
 import fs from 'fs';
 import semver from 'semver';
+import askpassword from 'askpassword';
 
 /**
  * Connecting text key.
@@ -474,6 +475,14 @@ class CliRepl {
     // `as any` becomes unnecessary after
     // https://github.com/DefinitelyTyped/DefinitelyTyped/pull/48646
     (this.repl as any).output.write(joined + '\n');
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async onPrompt(question: string, type: 'password'): Promise<string> {
+    // Same as above for `as any`.
+    const passwordPromise = askpassword(process.stdin);
+    (this.repl as any).output.write(question + '\n');
+    return (await passwordPromise).toString();
   }
 }
 

--- a/packages/i18n/src/locales/en_US.js
+++ b/packages/i18n/src/locales/en_US.js
@@ -117,6 +117,10 @@ const translations = {
             },
             load: {
               description: 'Load a file into the shell context. Not currently implemented, if running mongosh from the CLI you can use .load <filename> as an alternative'
+            },
+            passwordPrompt: {
+              description: 'Prompts for the password in the mongo shell. The entered password is not displayed in the shell.',
+              link: 'https://docs.mongodb.com/manual/reference/method/passwordPrompt/'
             }
           }
         },

--- a/packages/shell-api/src/shell-api.ts
+++ b/packages/shell-api/src/shell-api.ts
@@ -90,6 +90,15 @@ export default class ShellApi extends ShellApiClass {
     return await this.internalState.currentCursor._it();
   }
 
+  @returnsPromise
+  async passwordPrompt(): Promise<string> {
+    const { evaluationListener } = this.internalState;
+    if (!evaluationListener.onPrompt) {
+      throw new Error('passwordPrompt() is not available in this shell');
+    }
+    return evaluationListener.onPrompt('Enter password', 'password');
+  }
+
   version(): string {
     const version = require('../package.json').version;
     return version;

--- a/packages/shell-api/src/shell-internal-state.ts
+++ b/packages/shell-api/src/shell-internal-state.ts
@@ -26,6 +26,11 @@ export interface EvaluationListener {
    * Called when print() or printjson() is run from the shell.
    */
   onPrint?: (value: ShellResult[]) => Promise<void> | void;
+
+  /**
+   * Called when e.g. passwordPrompt() is called from the shell.
+   */
+  onPrompt?: (question: string, type: 'password') => Promise<string> | string;
 }
 
 /**
@@ -168,6 +173,13 @@ export default class ShellInternalState {
         get: () => (this.currentDb)
       });
     }
+
+    contextObject.passwordPrompt = async(): Promise<string> => {
+      if (!this.evaluationListener.onPrompt) {
+        throw new Error('passwordPrompt() is not available in this shell');
+      }
+      return await this.evaluationListener.onPrompt('Enter password', 'password');
+    };
 
     this.messageBus.emit(
       'mongosh:setCtx',

--- a/packages/shell-api/src/shell-internal-state.ts
+++ b/packages/shell-api/src/shell-internal-state.ts
@@ -49,7 +49,7 @@ export default class ShellInternalState {
   public shellApi: ShellApi;
   public shellBson: any;
   public cliOptions: any;
-  private evaluationListener: EvaluationListener;
+  public evaluationListener: EvaluationListener;
   constructor(initialServiceProvider: ServiceProvider, messageBus: any = new EventEmitter(), cliOptions: any = {}) {
     this.initialServiceProvider = initialServiceProvider;
     this.messageBus = messageBus;
@@ -173,13 +173,6 @@ export default class ShellInternalState {
         get: () => (this.currentDb)
       });
     }
-
-    contextObject.passwordPrompt = async(): Promise<string> => {
-      if (!this.evaluationListener.onPrompt) {
-        throw new Error('passwordPrompt() is not available in this shell');
-      }
-      return await this.evaluationListener.onPrompt('Enter password', 'password');
-    };
 
     this.messageBus.emit(
       'mongosh:setCtx',


### PR DESCRIPTION
This is missing support in the async rewriter
for auto-awaiting `passwordPrompt()`.

Partial implementation of:

- MONGOSH-314
- MONGOSH-315