### PR TITLE
chore: remove `value` from `ShellResult`

### DIFF
--- a/packages/browser-runtime-electron/src/electron-runtime.spec.ts
+++ b/packages/browser-runtime-electron/src/electron-runtime.spec.ts
@@ -29,7 +29,7 @@ describe('Electron runtime', function() {
 
   it('can evaluate simple js', async() => {
     const result = await electronRuntime.evaluate('2 + 2');
-    expect(result.value).to.equal(4);
+    expect(result.printable).to.equal(4);
   });
   it('prints BSON help correctly', async() => {
     const result = await electronRuntime.evaluate('ObjectId().help');
@@ -38,16 +38,16 @@ describe('Electron runtime', function() {
 
   it('allows do declare variables', async() => {
     await electronRuntime.evaluate('var x = 2');
-    expect((await electronRuntime.evaluate('x')).value).to.equal(2);
+    expect((await electronRuntime.evaluate('x')).printable).to.equal(2);
     await electronRuntime.evaluate('let y = 2');
-    expect((await electronRuntime.evaluate('y')).value).to.equal(2);
+    expect((await electronRuntime.evaluate('y')).printable).to.equal(2);
     await electronRuntime.evaluate('const z = 2');
-    expect((await electronRuntime.evaluate('z')).value).to.equal(2);
+    expect((await electronRuntime.evaluate('z')).printable).to.equal(2);
   });
 
   it('allows do declare functions', async() => {
     await electronRuntime.evaluate('function f() { return 2; }');
-    expect((await electronRuntime.evaluate('f()')).value).to.equal(2);
+    expect((await electronRuntime.evaluate('f()')).printable).to.equal(2);
   });
 
   it('can run help', async() => {
@@ -66,18 +66,18 @@ describe('Electron runtime', function() {
 
   it('allows to use require', async() => {
     const result = await electronRuntime.evaluate('require("util").types.isDate(new Date())');
-    expect(result.value).to.equal(true);
+    expect(result.printable).to.equal(true);
   });
 
   it('can switch database', async() => {
     expect(
-      (await electronRuntime.evaluate('db')).value
+      (await electronRuntime.evaluate('db')).printable
     ).not.to.equal('db1');
 
     await electronRuntime.evaluate('use db1');
 
     expect(
-      (await electronRuntime.evaluate('db')).value
+      (await electronRuntime.evaluate('db')).printable
     ).to.equal('db1');
   });
 

--- a/packages/shell-api/src/collection.spec.ts
+++ b/packages/shell-api/src/collection.spec.ts
@@ -1130,8 +1130,8 @@ describe('Collection', () => {
         const cursor = await collection.find();
         const result = await toShellResult(cursor);
         expect(result.type).to.equal('Cursor');
-        expect(result.value.length).to.not.equal(0);
-        expect(result.value[0]._id).to.equal('abc');
+        expect(result.printable.length).to.not.equal(0);
+        expect(result.printable[0]._id).to.equal('abc');
         expect(result.source).to.deep.equal({
           namespace: {
             db: 'db1',
@@ -1145,7 +1145,7 @@ describe('Collection', () => {
         const document = await collection.findOne({ hasBanana: true });
         const result = await toShellResult(document);
         expect(result.type).to.equal('Document');
-        expect(result.value._id).to.equal('abc');
+        expect(result.printable._id).to.equal('abc');
         expect(result.source).to.deep.equal({
           namespace: {
             db: 'db1',
@@ -1161,7 +1161,7 @@ describe('Collection', () => {
         const indexResult = await collection.getIndexes();
         const result = await toShellResult(indexResult);
         expect(result.type).to.equal(null);
-        expect(result.value).to.deep.equal([ fakeIndex ]);
+        expect(result.printable).to.deep.equal([ fakeIndex ]);
         expect(result.source).to.deep.equal({
           namespace: {
             db: 'db1',

--- a/packages/shell-api/src/decorators.ts
+++ b/packages/shell-api/src/decorators.ts
@@ -49,9 +49,6 @@ export interface ShellResult {
 
   /// Optional information about the original data source of the result.
   source?: ShellResultSourceInformation;
-
-  /// @deprecated Use either `printable` or `rawValue`.
-  value: any;
 }
 
 export class ShellApiClass implements ShellApiInterface {
@@ -76,8 +73,7 @@ export async function toShellResult(rawValue: any): Promise<ShellResult> {
     return {
       type: null,
       rawValue: rawValue,
-      printable: rawValue,
-      value: rawValue
+      printable: rawValue
     };
   }
 
@@ -95,7 +91,6 @@ export async function toShellResult(rawValue: any): Promise<ShellResult> {
     type: getShellApiType(rawValue),
     rawValue: rawValue,
     printable: printable,
-    value: printable,
     source: source
   };
 }

--- a/packages/shell-api/src/mongo.spec.ts
+++ b/packages/shell-api/src/mongo.spec.ts
@@ -40,7 +40,7 @@ describe('Mongo', () => {
     describe('toShellResult', () => {
       const mongo = new Mongo({} as any, 'localhost:37017');
       it('value', async() => {
-        expect((await toShellResult(mongo)).value).to.equal('mongodb://localhost:37017/test');
+        expect((await toShellResult(mongo)).printable).to.equal('mongodb://localhost:37017/test');
       });
       it('type', async() => {
         expect((await toShellResult(mongo)).type).to.equal('Mongo');


### PR DESCRIPTION
This is no longer used in any dependants.