### PR TITLE
fix: guard against double print from console.log()

### DIFF
--- a/packages/cli-repl/test/e2e.spec.ts
+++ b/packages/cli-repl/test/e2e.spec.ts
@@ -1,3 +1,4 @@
+import { expect } from 'chai';
 import { MongoClient } from 'mongodb';
 import { eventually } from './helpers';
 import { TestShell } from './test-shell';
@@ -303,6 +304,25 @@ describe('e2e', function() {
       await shell.waitForPrompt();
       await new Promise((resolve) => setTimeout(resolve, 100));
       shell.assertNotContainsOutput('interrupted');
+    });
+  });
+
+  describe('printing', () => {
+    let shell;
+    beforeEach(async() => {
+      shell = TestShell.start({ args: [ '--nodb' ] });
+      await shell.waitForPrompt();
+      shell.assertNoErrors();
+    });
+    it('console.log() prints output exactly once', async() => {
+      const result = await shell.executeLine('console.log(42);');
+      expect(result).to.match(/\b42\b/);
+      expect(result).not.to.match(/\b42[\s\r\n]*42\b/);
+    });
+    it('print() prints output exactly once', async() => {
+      const result = await shell.executeLine('print(42);');
+      expect(result).to.match(/\b42\b/);
+      expect(result).not.to.match(/\b42[\s\r\n]*42\b/);
     });
   });
 });

--- a/packages/shell-api/src/shell-internal-state.ts
+++ b/packages/shell-api/src/shell-internal-state.ts
@@ -124,17 +124,10 @@ export default class ShellInternalState {
     contextObject.printjson = contextObject.print;
     Object.assign(contextObject, this.shellBson);
     if (contextObject.console === undefined) {
-      contextObject.console = {
-        log(): void {},
-        warn(): void {},
-        info(): void {},
-        error(): void {}
-      };
+      contextObject.console = {};
     }
     for (const key of ['log', 'warn', 'info', 'error']) {
-      const orig = contextObject.console[key];
       contextObject.console[key] = async(...args): Promise<void> => {
-        orig.call(contextObject.console, ...args);
         return await contextObject.print(...args);
       };
     }


### PR DESCRIPTION
Discovered during demoing :)

I’m not removing the `onPrint()` implementation for the cli-repl here because, while that might also fix this problem, I think we should stick to using a single source of truth for the output stream of the cli-repl.