### PR TITLE
chore: Add CentOS / SUSE / Amazon Linux for rpm in download center

### DIFF
--- a/packages/build/src/download-center.ts
+++ b/packages/build/src/download-center.ts
@@ -75,7 +75,7 @@ const CONFIG = `
         {
           "arch": "x64",
           "os": "rhel",
-          "name": "Redhat 64-bit",
+          "name": "Redhat / CentOS / SUSE / Amazon Linux 64-bit",
           "download_link": "https://downloads.mongodb.com/compass/mongosh-{{version}}-x86_64.rpm"
         }
       ]


### PR DESCRIPTION
I think we can do what `mongocli` does and add more distributions to the rpm.

```
maurizio ~/Downloads $ docker run --rm -it -v $PWD/mongosh-0.5.0-x86_64.rpm:/mongosh-0.5.0-x86_64.rpm opensuse/leap bash
91cab0958513:/ # rpm -i mongosh-0.5.0-x86_64.rpm 
91cab0958513:/ # mongosh 
Current sessionID:  31394d3592d87bba9e239b00
Connecting to:      mongodb://127.0.0.1:27017
```

```
maurizio ~/Downloads $ docker run --rm -it -v $PWD/mongosh-0.5.0-x86_64.rpm:/mongosh-0.5.0-x86_64.rpm amazonlinux bash
bash-4.2# rpm -i mongosh-0.5.0-x86_64.rpm 
bash-4.2# mongosh
Current sessionID:  3141ffe94f80899c2fa196a4
Connecting to:      mongodb://127.0.0.1:27017
```