### PR TITLE
chore: ignore lib/ directories in .nycrc

### DIFF
--- a/.nycrc
+++ b/.nycrc
@@ -5,6 +5,7 @@
     "config",
     "**/*.d.ts",
     "**/*.spec.{ts,js,tsx,jsx,cjs,mjs}",
-    "**/*.config.{ts,js,tsx,jsx,cjs,mjs}"
+    "**/*.config.{ts,js,tsx,jsx,cjs,mjs}",
+    "**/lib/*.js"
   ]
 }


### PR DESCRIPTION
This might help resolve flaky CI coverage by avoiding coverage
for already-transpiled files.