### PR TITLE
fix(shell-api): MONGOSH-381 update ServerVersions enum to include 4.4.1

### DIFF
--- a/packages/shell-api/src/enums.ts
+++ b/packages/shell-api/src/enums.ts
@@ -1,5 +1,5 @@
 export enum ServerVersions {
-  latest = '4.4.0',
+  latest = '999.999.999', // set a really high max value
   earliest = '0.0.0'
 }
 


### PR DESCRIPTION
## Description

ServerVersions are used to determine whether a particular feature is available
in 'autocomplete'. This allows for autocomplete to work on latest mongodb.