### PR TITLE
[WIP][java-shell] Don't fetch Java cursor in toShellResult method

### DIFF
--- a/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/MongoShell.kt
+++ b/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/MongoShell.kt
@@ -2,11 +2,12 @@ package com.mongodb.mongosh
 
 import com.mongodb.client.MongoClient
 import com.mongodb.mongosh.result.MongoShellResult
+import org.intellij.lang.annotations.Language
 
 class MongoShell(client: MongoClient) {
     private val context = MongoShellContext(client)
 
-    fun eval(script: String): MongoShellResult<*> {
+    fun eval(@Language("js") script: String): MongoShellResult<*> {
         val result = context.unwrapPromise(context.eval(script, "user_script"))
         val value = result.getMember("rawValue")
         return context.extract(null, value)

--- a/packages/java-shell/src/test/kotlin/com/mongodb/mongosh/util.kt
+++ b/packages/java-shell/src/test/kotlin/com/mongodb/mongosh/util.kt
@@ -80,7 +80,7 @@ fun doTest(testName: String, shell: MongoShell, testDataPath: String, db: String
                     if (result is CursorResult) {
                         (result.value as Cursor<*>).close() // test close
                     }
-                    val normalized = if (cmd.options.dontReplaceId) actualValue.trim() else replaceUUID(replaceId(actualValue)).trim()
+                    val normalized = if (cmd.options.dontReplaceId) actualValue.trim() else normalize(actualValue)
                     sb.append(normalized)
                 } catch (e: Throwable) {
                     System.err.println("IGNORED:")
@@ -171,6 +171,8 @@ private fun replaceId(value: String): String {
 private fun replaceUUID(value: String): String {
     return MONGO_UUID_PATTERN.matcher(value).replaceAll("<UUID>")
 }
+
+fun normalize(value: String) = replaceUUID(replaceId(value)).trim()
 
 private val HEADER_PATTERN = Pattern.compile("//\\s*(?<name>\\S+)(?<properties>(\\s+\\S+)+)?")
 

--- a/packages/shell-api/src/cursor.ts
+++ b/packages/shell-api/src/cursor.ts
@@ -16,7 +16,7 @@ import {
   Cursor as ServiceProviderCursor,
   CursorFlag,
   CURSOR_FLAGS,
-  Document
+  Document, ReplPlatform
 } from '@mongosh/service-provider-core';
 import { MongoshInvalidInputError, MongoshUnimplementedError } from '@mongosh/errors';
 
@@ -36,8 +36,10 @@ export default class Cursor extends ShellApiClass {
   /**
    * Internal method to determine what is printed for this class.
    */
-  async [asPrintable](): Promise<CursorIterationResult> {
-    return this._currentIterationResult ?? await this._it();
+  async [asPrintable](): Promise<any> {
+    return this._mongo._serviceProvider.platform == ReplPlatform.JavaShell
+        ? null
+        : this._currentIterationResult ?? await this._it();
   }
 
   async _it(): Promise<CursorIterationResult> {


### PR DESCRIPTION
Java shell users want to have more control over cursor. E.g. execute `db.coll.find()`, then in Java code set batch size to the cursor and fetch it in Java code.

[toShellResult](https://github.com/mongodb-js/mongosh/blob/master/packages/shell-api/src/decorators.ts#L75) method fetch cursor itself. When `rawValue` cursor is returned by Java shell, it's already exhausted.

I added test case `testSetBatchSize` that throws [`query already executed`](https://github.com/mongodb-js/mongosh/blob/b709e3e4b4a21871bd3356c1f476d8711b5bc439/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/service/Cursor.kt#L242) exception when `toShellResult` fetches cursor.

I think there should be a way to override `asPrintable` method for cursor in Java shell.