### PR TITLE
fix(build): set NODE_JS_VERSION in Unix CI

### DIFF
--- a/.evergreen/.setup_env
+++ b/.evergreen/.setup_env
@@ -1,4 +1,5 @@
 set -e
+export NODE_JS_VERSION='12.18.4'
 export NVM_DIR="$HOME/.nvm"
 echo "Setting NVM environment home: $NVM_DIR"
 [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"


### PR DESCRIPTION
Otherwise, we just build with any newer Node.js 12.x version,
unlike Windows.

This bug led to the 0.5.1 release happening with Node.js 12.18.4
on Windows and Node.js 12.19.0 on other platforms.
Let’s pick a consistent version. Pick 12.18.4 rather than 12.19.0
because we’re currently seeing Node.js deprecation warnings being
shown with 12.19.0 (until
https://github.com/mongodb-js/boxednode/pull/9 is merged).