### PR TITLE
Check if package exists while checking the access rights before publishing

### DIFF
--- a/scripts/publish-npm.js
+++ b/scripts/publish-npm.js
@@ -71,6 +71,15 @@ function markTaskAsDone(task, releaseDirPath) {
   fs.writeFileSync(taskDoneFilePath(task, releaseDirPath), '');
 }
 
+function isPackageExists(packageName) {
+  try {
+    execSync(`npm view ${packageName}`, { stdio: 'ignore' });
+    return true;
+  } catch (_e) {
+    return false;
+  }
+}
+
 function checkUserPermissionsToPublish() {
   const lerna = path.resolve(rootPath, 'node_modules', '.bin', 'lerna');
 
@@ -81,7 +90,10 @@ function checkUserPermissionsToPublish() {
   const missingAccess = [];
 
   for (const repo of lernaPackages) {
-    if (userPackagesAccess[repo.name] !== 'read-write') {
+    if (
+      userPackagesAccess[repo.name] !== "read-write" &&
+      isPackageExists(repo.name)
+    ) {
       missingAccess.push(repo.name);
     }
   }


### PR DESCRIPTION
Tiny inconvenience that we stumbled on during the release today:

In cases where new package was added to the repo and is published for the first time with the others the access rights check can return a false-positive while checking for access rights: the package is not on remote yet so read-write is not returned. In addition to checking the access rights we will additionally check if the package exists already to allow publishing new packages.