### PR TITLE
Fix generate-homebrew-formula script

### DIFF
--- a/scripts/generate-homebrew-formula.js
+++ b/scripts/generate-homebrew-formula.js
@@ -91,10 +91,8 @@ if (require.main === module) {
   const version = getLatestVersion();
 
   generateHomebrewFormula(
-    path.resolve(
-      __dirname, '..', 'tmp', 'homebrew-brew', `${Date.now()}`,
-      version
-    )
+    path.resolve(__dirname, "..", "tmp", "homebrew-brew", `${Date.now()}`),
+    version
   );
 } else {
   module.exports = generateHomebrewFormula;


### PR DESCRIPTION
Pass version as a second argument when running as a standalone script