### PR TITLE
chore(cli-repl): split out async eval bits of CliRepl MONGOSH-436

### DIFF
--- a/packages/cli-repl/src/async-repl.spec.ts
+++ b/packages/cli-repl/src/async-repl.spec.ts
@@ -63,14 +63,22 @@ describe('AsyncRepl', () => {
     await expectInStream(output, '89');
   });
 
-  it('allows sync interruption through SIGINT', async() => {
+  it('allows sync interruption through SIGINT', async function() {
+    if (process.platform === 'win32') {
+      this.skip(); // No SIGINT on Windows.
+    }
+
     const { input, output } = createDefaultAsyncRepl({ breakEvalOnSigint: true });
 
     input.write('while (true) { process.kill(process.pid, "SIGINT"); }\n');
     await expectInStream(output, 'execution was interrupted');
   });
 
-  it('allows async interruption through SIGINT', async() => {
+  it('allows async interruption through SIGINT', async function() {
+    if (process.platform === 'win32') {
+      this.skip(); // No SIGINT on Windows.
+    }
+
     const { input, output } = createDefaultAsyncRepl({ breakEvalOnSigint: true });
 
     input.write('new Promise(oopsIdontResolve => 0)\n');

--- a/packages/cli-repl/src/async-repl.spec.ts
+++ b/packages/cli-repl/src/async-repl.spec.ts
@@ -66,6 +66,7 @@ describe('AsyncRepl', () => {
   it('allows sync interruption through SIGINT', async function() {
     if (process.platform === 'win32') {
       this.skip(); // No SIGINT on Windows.
+      return;
     }
 
     const { input, output } = createDefaultAsyncRepl({ breakEvalOnSigint: true });
@@ -77,6 +78,7 @@ describe('AsyncRepl', () => {
   it('allows async interruption through SIGINT', async function() {
     if (process.platform === 'win32') {
       this.skip(); // No SIGINT on Windows.
+      return;
     }
 
     const { input, output } = createDefaultAsyncRepl({ breakEvalOnSigint: true });

--- a/packages/cli-repl/src/async-repl.spec.ts
+++ b/packages/cli-repl/src/async-repl.spec.ts
@@ -1,0 +1,189 @@
+import { start as originalStart, REPLServer } from 'repl';
+import { start, OriginalEvalFunction, AsyncREPLOptions } from './async-repl';
+import { Readable, Writable, PassThrough } from 'stream';
+import { promisify, inspect } from 'util';
+import chai, { expect } from 'chai';
+import sinon from 'ts-sinon';
+import sinonChai from 'sinon-chai';
+chai.use(sinonChai);
+
+const delay = promisify(setTimeout);
+
+function createDefaultAsyncRepl(extraOpts: Partial<AsyncREPLOptions> = {}): {
+  input: Writable;
+  output: Readable;
+  repl: REPLServer;
+} {
+  const input = new PassThrough();
+  const output = new PassThrough({ encoding: 'utf8' });
+
+  const repl = start({
+    input: input,
+    output: output,
+    prompt: '> ',
+    asyncEval: async(originalEval: OriginalEvalFunction, input: string, context: any, filename: string) => {
+      return originalEval(input, context, filename);
+    },
+    ...extraOpts
+  });
+  Object.assign(repl.context, { process, console });
+  return { input, output, repl };
+}
+
+async function expectInStream(stream: Readable, substring: string): Promise<void> {
+  let content = '';
+  let found = false;
+  for await (const chunk of stream) {
+    content += chunk;
+    if (content.includes(substring)) {
+      found = true;
+      break;
+    }
+  }
+  expect(found).to.be.true;
+}
+
+describe('AsyncRepl', () => {
+  before(() => {
+    // nyc adds its own SIGINT listener that annoys use here.
+    process.removeAllListeners('SIGINT');
+  });
+
+  it('performs basic synchronous evaluation', async() => {
+    const { input, output } = createDefaultAsyncRepl();
+
+    input.write('34 + 55\n');
+    await expectInStream(output, '89');
+  });
+
+  it('performs basic asynchronous evaluation', async() => {
+    const { input, output } = createDefaultAsyncRepl();
+
+    input.write('Promise.resolve(34 + 55)\n');
+    await expectInStream(output, '89');
+  });
+
+  it('allows sync interruption through SIGINT', async() => {
+    const { input, output } = createDefaultAsyncRepl({ breakEvalOnSigint: true });
+
+    input.write('while (true) { process.kill(process.pid, "SIGINT"); }\n');
+    await expectInStream(output, 'execution was interrupted');
+  });
+
+  it('allows async interruption through SIGINT', async() => {
+    const { input, output } = createDefaultAsyncRepl({ breakEvalOnSigint: true });
+
+    input.write('new Promise(oopsIdontResolve => 0)\n');
+    await delay(100);
+    process.kill(process.pid, 'SIGINT');
+    await expectInStream(output, 'execution was interrupted');
+  });
+
+  it('handles synchronous exceptions well', async() => {
+    const { input, output } = createDefaultAsyncRepl();
+
+    input.write('throw new Error("meow")\n');
+    await expectInStream(output, 'meow');
+  });
+
+  it('handles asynchronous exceptions well', async() => {
+    const { input, output } = createDefaultAsyncRepl();
+
+    input.write('Promise.reject(new Error("meow"))\n');
+    await expectInStream(output, 'meow');
+  });
+
+  it('handles recoverable syntax errors well', async() => {
+    const { input, output } = createDefaultAsyncRepl();
+
+    input.write('{ uid: process.getuid(\n');
+    let wroteClosingParenthesis = false;
+    let foundUid = false;
+    for await (const chunk of output) {
+      if (chunk.includes('...') && !wroteClosingParenthesis) {
+        input.write(')}\n');
+        wroteClosingParenthesis = true;
+      }
+      if (chunk.includes('uid:')) {
+        foundUid = true;
+        break;
+      }
+    }
+    expect(foundUid).to.be.true;
+  });
+
+  describe('allows handling exceptions from e.g. the writer function', () => {
+    it('for succesful completions', async() => {
+      const error = new Error('throwme');
+      const { input, output } = createDefaultAsyncRepl({
+        writer: (value: any): string => {
+          if (value === 'meow') {
+            throw error;
+          }
+          return inspect(value);
+        },
+        wrapCallbackError: (err: Error): Error => {
+          return new Error('saw this error: ' + err.message);
+        }
+      });
+
+      input.write('"meow"\n');
+      await expectInStream(output, 'saw this error: throwme');
+    });
+
+    it('for unsuccesful completions', async() => {
+      const error = new Error('throwme');
+      const { input, output } = createDefaultAsyncRepl({
+        writer: (value: any): string => {
+          if (value?.message === 'meow') {
+            throw error;
+          }
+          return inspect(value);
+        },
+        wrapCallbackError: (err: Error): Error => {
+          return new Error('saw this error: ' + err.message);
+        }
+      });
+
+      input.write('throw new Error("meow")\n');
+      await expectInStream(output, 'saw this error: throwme');
+    });
+
+    it('defaults to passing the error through as-is', async() => {
+      const error = new Error('raw error');
+      const { input, output } = createDefaultAsyncRepl({
+        writer: (value: any): string => {
+          if (value?.message === 'meow') {
+            throw error;
+          }
+          return inspect(value);
+        }
+      });
+
+      input.write('throw new Error("meow")\n');
+      await expectInStream(output, 'raw error');
+    });
+  });
+
+  it('allows customizing the repl.start function', async() => {
+    const { repl } = createDefaultAsyncRepl({
+      start: (options) => {
+        const repl = originalStart(options);
+        repl.pause();
+        return repl;
+      }
+    });
+
+    expect((repl as any).paused).to.be.true;
+  });
+
+  // This one is really just for test coverage. :)
+  it('allows emitting any kind of event on the active Domain', async() => {
+    const { input, output, repl } = createDefaultAsyncRepl();
+    repl.context.onEvent = sinon.spy();
+
+    input.write('process.domain.on("x", onEvent); process.domain.emit("x"); 0\n');
+    await expectInStream(output, '0');
+    expect(repl.context.onEvent).to.have.been.calledWith();
+  });
+});

--- a/packages/cli-repl/src/async-repl.spec.ts
+++ b/packages/cli-repl/src/async-repl.spec.ts
@@ -106,7 +106,7 @@ describe('AsyncRepl', () => {
   it('handles recoverable syntax errors well', async() => {
     const { input, output } = createDefaultAsyncRepl();
 
-    input.write('{ uid: process.getuid(\n');
+    input.write('{ uptime: process.uptime(\n');
     let wroteClosingParenthesis = false;
     let foundUid = false;
     for await (const chunk of output) {
@@ -114,7 +114,7 @@ describe('AsyncRepl', () => {
         input.write(')}\n');
         wroteClosingParenthesis = true;
       }
-      if (chunk.includes('uid:')) {
+      if (chunk.includes('uptime:')) {
         foundUid = true;
         break;
       }

--- a/packages/cli-repl/src/async-repl.ts
+++ b/packages/cli-repl/src/async-repl.ts
@@ -1,0 +1,131 @@
+import type { REPLServer, ReplOptions } from 'repl';
+import { Recoverable, start as originalStart } from 'repl';
+import isRecoverableError from 'is-recoverable-error';
+import { promisify } from 'util';
+import { Domain } from 'domain';
+
+// Utility, inverse of Readonly<T>
+type Mutable<T> = {
+  -readonly[P in keyof T]: T[P]
+};
+
+export type OriginalEvalFunction = (input: string, context: any, filename: string) => Promise<any>;
+export type AsyncEvalFunction = (originalEval: OriginalEvalFunction, input: string, context: any, filename: string) => Promise<any>;
+
+export type AsyncREPLOptions = Omit<ReplOptions, 'eval'> & {
+  start?: typeof originalStart,
+  wrapCallbackError?: (err: Error) => Error;
+  asyncEval: AsyncEvalFunction;
+};
+
+// Start a REPLSever that supports asynchronous evaluation, rather than just
+// synchronous, and integrates nicely with Ctrl+C handling in that respect.
+export function start(opts: AsyncREPLOptions): REPLServer {
+  const repl = (opts.start ?? originalStart)(opts);
+  const { asyncEval, wrapCallbackError = err => err, breakEvalOnSigint } = opts;
+  const originalEval = promisify(wrapNoSyncDomainError(repl.eval.bind(repl)));
+
+  (repl as Mutable<typeof repl>).eval = async(
+    input: string,
+    context: any,
+    filename: string,
+    callback: (err: Error|null, result?: any) => void): Promise<void> => {
+    let result;
+
+    try {
+      let sigintListener: (() => void) | undefined = undefined;
+      let previousSigintListeners: any[] = [];
+      try {
+        result = await new Promise((resolve, reject) => {
+          if (breakEvalOnSigint) {
+            // Handle SIGINT (Ctrl+C) that occurs while we are stuck in `await`
+            // by racing a listener for 'SIGINT' against the evalResult Promise.
+            // We remove all 'SIGINT' listeners and install our own.
+            sigintListener = (): void => {
+              // Reject with an exception similar to one thrown by Node.js
+              // itself if the `customEval` itself is interrupted.
+              reject(new Error('Asynchronous execution was interrupted by `SIGINT`'));
+            };
+            previousSigintListeners = repl.rawListeners('SIGINT');
+
+            repl.removeAllListeners('SIGINT');
+            repl.once('SIGINT', sigintListener);
+          }
+
+          const evalResult = asyncEval(originalEval, input, context, filename);
+
+          if (sigintListener !== undefined) {
+            process.once('SIGINT', sigintListener);
+          }
+          evalResult.then(resolve, reject);
+        });
+      } finally {
+        // Remove our 'SIGINT' listener and re-install the REPL one(s).
+        if (sigintListener !== undefined) {
+          repl.removeListener('SIGINT', sigintListener);
+          process.removeListener('SIGINT', sigintListener);
+        }
+        for (const listener of previousSigintListeners) {
+          repl.on('SIGINT', listener);
+        }
+      }
+    } catch (err) {
+      try {
+        if (isRecoverableError(input)) {
+          return callback(new Recoverable(err));
+        }
+        return callback(err);
+      } catch (callbackErr) {
+        return callback(wrapCallbackError(callbackErr));
+      }
+    }
+    try {
+      return callback(null, result);
+    } catch (callbackErr) {
+      return callback(wrapCallbackError(callbackErr));
+    }
+  };
+
+  return repl;
+}
+
+function wrapNoSyncDomainError<Args extends any[], Ret>(fn: (...args: Args) => Ret) {
+  return (...args: Args): Ret => {
+    const origEmit = Domain.prototype.emit;
+
+    // When the Node.js core REPL encounters an exception during synchronous
+    // evaluation, it does not pass the exception value to the callback
+    // (or in this case, reject the Promise here), as one might inspect.
+    // Instead, it skips straight ahead to abandoning evaluation and acts
+    // as if the error had been thrown asynchronously. This works for them,
+    // but for us that's not great, because we rely on the core eval function
+    // calling its callback in order to be informed about a possible error
+    // that occurred (... and in order for this async function to finish at all.)
+    // We monkey-patch `process.domain.emit()` to avoid that, and instead
+    // handle a possible error ourselves:
+    // https://github.com/nodejs/node/blob/59ca56eddefc78bab87d7e8e074b3af843ab1bc3/lib/repl.js#L488-L493
+    // It's not clear why this is done this way in Node.js, however,
+    // removing the linked code does lead to failures in the Node.js test
+    // suite, so somebody sufficiently motivated could probably find out.
+    // For now, this is a hack and probably not considered officially
+    // supported, but it works.
+    // We *may* want to consider not relying on the built-in eval function
+    // at all at some point.
+    Domain.prototype.emit = function(ev: string, ...eventArgs: any[]): boolean {
+      if (ev === 'error') {
+        this.exit();
+        throw eventArgs[0];
+      }
+      return origEmit.call(this, ev, ...eventArgs);
+    };
+
+    try {
+      return fn(...args);
+    } finally {
+      // Reset the `emit` function after synchronous evaluation, because
+      // we need the Domain functionality for the asynchronous bits.
+      Domain.prototype.emit = origEmit;
+    }
+  };
+}
+


### PR DESCRIPTION
Split out the parts of the `CliRepl` class that are specific to async
evaluation and test them entirely.