### PR TITLE
chore(cli-repl): move toggleTelemetry to evaluation listener

### DIFF
--- a/packages/cli-repl/src/cli-repl.ts
+++ b/packages/cli-repl/src/cli-repl.ts
@@ -121,7 +121,7 @@ class CliRepl {
 
     const initialServiceProvider = await this.connect(driverUri, driverOptions);
     this.internalState = new ShellInternalState(initialServiceProvider, this.bus, this.options);
-    this.shellEvaluator = new ShellEvaluator(this.internalState, this);
+    this.shellEvaluator = new ShellEvaluator(this.internalState);
     this.shellEvaluator.setEvaluationListener(this);
     await this.internalState.fetchConnectionInfo();
     this.start();

--- a/packages/cli-repl/test/e2e.spec.ts
+++ b/packages/cli-repl/test/e2e.spec.ts
@@ -327,5 +327,22 @@ describe('e2e', function() {
       expect(result).not.to.match(/\b42[\s\r\n]*42\b/);
     });
   });
+
+  describe('telemetry toggling', () => {
+    let shell;
+    beforeEach(async() => {
+      shell = TestShell.start({ args: [ '--nodb' ] });
+      await shell.waitForPrompt();
+      shell.assertNoErrors();
+    });
+    it('enableTelemetry() yields a success response', async() => {
+      const result = await shell.executeLine('enableTelemetry()');
+      expect(result).to.match(/Telemetry is now enabled/);
+    });
+    it('disableTelemetry() yields a success response', async() => {
+      const result = await shell.executeLine('disableTelemetry();');
+      expect(result).to.match(/Telemetry is now disabled/);
+    });
+  });
 });
 

--- a/packages/i18n/src/locales/en_US.ts
+++ b/packages/i18n/src/locales/en_US.ts
@@ -119,6 +119,12 @@ const translations: Catalog = {
             },
             load: {
               description: 'Load a file into the shell context. Not currently implemented, if running mongosh from the CLI you can use .load <filename> as an alternative'
+            },
+            enableTelemetry: {
+              description: 'Enables collection of anonymous usage data to improve the mongosh CLI'
+            },
+            disableTelemetry: {
+              description: 'Disables collection of anonymous usage data to improve the mongosh CLI'
             }
           }
         },

--- a/packages/shell-api/src/shell-api.ts
+++ b/packages/shell-api/src/shell-api.ts
@@ -100,4 +100,16 @@ export default class ShellApi extends ShellApiClass {
       'load is not currently implemented. If you are running mongosh from the CLI ' +
       'then you can use .load <filename> as an alternative.');
   }
+
+  @returnsPromise
+  @platforms([ ReplPlatform.CLI ] )
+  async enableTelemetry(): Promise<any> {
+    return await this.internalState.evaluationListener.toggleTelemetry?.(true);
+  }
+
+  @returnsPromise
+  @platforms([ ReplPlatform.CLI ] )
+  async disableTelemetry(): Promise<any> {
+    return await this.internalState.evaluationListener.toggleTelemetry?.(false);
+  }
 }

--- a/packages/shell-api/src/shell-internal-state.ts
+++ b/packages/shell-api/src/shell-internal-state.ts
@@ -26,6 +26,13 @@ export interface EvaluationListener {
    * Called when print() or printjson() is run from the shell.
    */
   onPrint?: (value: ShellResult[]) => Promise<void> | void;
+
+  /**
+   * Called when enableTelemetry() or disableTelemetry() is run from the shell.
+   * The return value may be a Promise. Its value is printed as the result of
+   * the call.
+   */
+  toggleTelemetry?: (enabled: boolean) => any;
 }
 
 /**
@@ -44,7 +51,7 @@ export default class ShellInternalState {
   public shellApi: ShellApi;
   public shellBson: any;
   public cliOptions: any;
-  private evaluationListener: EvaluationListener;
+  public evaluationListener: EvaluationListener;
   constructor(initialServiceProvider: ServiceProvider, messageBus: any = new EventEmitter(), cliOptions: any = {}) {
     this.initialServiceProvider = initialServiceProvider;
     this.messageBus = messageBus;

--- a/packages/shell-evaluator/src/shell-evaluator.spec.ts
+++ b/packages/shell-evaluator/src/shell-evaluator.spec.ts
@@ -8,7 +8,6 @@ import { EventEmitter } from 'events';
 
 describe('ShellEvaluator', () => {
   let shellEvaluator: ShellEvaluator;
-  let containerMock;
   let busMock: EventEmitter;
   let internalStateMock;
   let useSpy: any;
@@ -26,12 +25,8 @@ describe('ShellEvaluator', () => {
       }
     } as any;
     busMock = new EventEmitter();
-    containerMock = { toggleTelemetry: sinon.spy() };
 
-    shellEvaluator = new ShellEvaluator(
-      internalStateMock,
-      containerMock
-    );
+    shellEvaluator = new ShellEvaluator(internalStateMock);
   });
 
   describe('customEval', () => {

--- a/packages/shell-evaluator/src/shell-evaluator.ts
+++ b/packages/shell-evaluator/src/shell-evaluator.ts
@@ -6,23 +6,14 @@ import {
   EvaluationListener
 } from '@mongosh/shell-api';
 
-interface Container {
-  toggleTelemetry(enable: boolean): any;
-}
-
 type EvaluationFunction = (input: string, context: object, filename: string) => Promise<any>;
 
 import { HIDDEN_COMMANDS, removeCommand } from '@mongosh/history';
 
 class ShellEvaluator {
   private internalState: ShellInternalState;
-  private container?: Container;
-  constructor(
-    internalState: ShellInternalState,
-    container?: Container
-  ) {
+  constructor(internalState: ShellInternalState) {
     this.internalState = internalState;
-    this.container = container;
   }
 
   public revertState(): void {
@@ -59,10 +50,6 @@ class ShellEvaluator {
       case 'exit':
       case 'quit':
         return await this.internalState.shellApi.exit();
-      case 'enableTelemetry()':
-        return await this.container?.toggleTelemetry(true);
-      case 'disableTelemetry()':
-        return await this.container?.toggleTelemetry(false);
       default:
         this.saveState();
         const rewrittenInput = this.internalState.asyncWriter.process(input);


### PR DESCRIPTION
(Following up to https://github.com/mongodb-js/mongosh/pull/414#discussion_r525383389)

Remove the `Container` argument that the `ShellEvaluator` class took,
and instead handle `toggleTelemetry()` like `print()`/`console.log()`.
This moves the user-facing methods to the shell-api,
including adding documentation for them.