### PR TITLE
feat(cli-repl): add passwordPrompt() support MONGOSH-315

### DIFF
--- a/packages/cli-repl/package-lock.json
+++ b/packages/cli-repl/package-lock.json
@@ -56,15 +56,6 @@
 			"integrity": "sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY=",
 			"dev": true
 		},
-		"@types/mkdirp": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-1.0.1.tgz",
-			"integrity": "sha512-HkGSK7CGAXncr8Qn/0VqNtExEE+PHMWb+qlR1faHMao7ng6P3tAaoWWBMdva0gL5h4zprjIO89GJOLXsMcDm1Q==",
-			"dev": true,
-			"requires": {
-				"@types/node": "*"
-			}
-		},
 		"@types/node": {
 			"version": "14.14.6",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.14.6.tgz",
@@ -256,6 +247,11 @@
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.1.tgz",
 			"integrity": "sha512-Z/JnaVEXv+A9xabHzN43FiiiWEE7gPCRXMrVmRm00tWbjZRul1iHm7ECzlyNq1p4a4ATXz+G9FJ3GqGOkOV3fg=="
+		},
+		"askpassword": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/askpassword/-/askpassword-1.2.1.tgz",
+			"integrity": "sha512-b/yF3tgDZK0QuCRVCW/BYoFC+t8UpughpB+bih2KjpgF9YC0t9bNo7atxlHyHUpH3pZxJRKJgQq2ZIB3IpzsJQ=="
 		},
 		"atomic-sleep": {
 			"version": "1.0.0",
@@ -514,11 +510,6 @@
 			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
 			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
 		},
-		"mkdirp": {
-			"version": "1.0.4",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-1.0.4.tgz",
-			"integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw=="
-		},
 		"mongodb-ace-autocompleter": {
 			"version": "0.4.8",
 			"resolved": "https://registry.npmjs.org/mongodb-ace-autocompleter/-/mongodb-ace-autocompleter-0.4.8.tgz",
@@ -549,11 +540,6 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
-		},
-		"mute-stream": {
-			"version": "0.0.8",
-			"resolved": "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.8.tgz",
-			"integrity": "sha512-nnbWWOkoWyUsTjKrhgD0dcz22mdkSnpYqbEjIm2nhwhuxlSkpywJmBo8h0ZqJdkp73mb90SssHkN4rsRaBAfAA=="
 		},
 		"nanoassert": {
 			"version": "1.1.0",
@@ -671,14 +657,6 @@
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-3.0.3.tgz",
 			"integrity": "sha512-dy1yjycmn9blucmJLXOfZDx1ikZJUi6E8bBZLnhPG5gBrVhHXx2xVyqqgKBubVNEXmx51dBACMHpoMQK/N/AXQ=="
-		},
-		"read": {
-			"version": "1.0.7",
-			"resolved": "https://registry.npmjs.org/read/-/read-1.0.7.tgz",
-			"integrity": "sha1-s9oZvQUkMal2cdRKQmNK33ELQMQ=",
-			"requires": {
-				"mute-stream": "~0.0.4"
-			}
 		},
 		"readable-stream": {
 			"version": "3.6.0",

--- a/packages/cli-repl/package.json
+++ b/packages/cli-repl/package.json
@@ -45,6 +45,7 @@
     "@mongosh/shell-evaluator": "^0.5.2",
     "analytics-node": "^3.4.0-beta.1",
     "ansi-escape-sequences": "^5.1.2",
+    "askpassword": "^1.2.1",
     "is-recoverable-error": "^1.0.2",
     "lodash.set": "^4.3.2",
     "minimist": "^1.2.5",
@@ -56,7 +57,6 @@
     "pino-pretty": "^4.0.0",
     "pretty-bytes": "^5.3.0",
     "pretty-repl": "^2.3.1",
-    "read": "^1.0.7",
     "semver": "^7.1.2",
     "text-table": "^0.2.0"
   },

--- a/packages/cli-repl/src/cli-repl.spec.ts
+++ b/packages/cli-repl/src/cli-repl.spec.ts
@@ -6,7 +6,7 @@ import { once } from 'events';
 import rimraf from 'rimraf';
 import CliRepl, { CliReplOptions } from './cli-repl';
 import { startTestServer } from '../../../testing/integration-testing-hooks';
-import { expect, useTmpdir, waitEval } from '../test/repl-helpers';
+import { expect, useTmpdir, waitEval, fakeTTYProps } from '../test/repl-helpers';
 
 describe('CliRepl', () => {
   let cliReplOptions: CliReplOptions;
@@ -179,15 +179,15 @@ describe('CliRepl', () => {
           setImmediate(() => input.write('\u0003')); // Ctrl+C
         }
       });
-      (outputStream as any).isTTY = true;
-      (outputStream as any).getColorDepth = () => 256;
+      Object.assign(outputStream, fakeTTYProps);
+      Object.assign(input, fakeTTYProps);
       const auth = { user: 'foo', password: '' };
       const errored = once(cliRepl.bus, 'mongosh:error');
       try {
         await cliRepl.start(await testServer.connectionString(), { auth });
       } catch { /* not empty */ }
       const [ err ] = await errored;
-      expect(err.message).to.equal('canceled');
+      expect(err.message).to.equal('The request was aborted by the user');
     });
   });
 });

--- a/packages/cli-repl/src/mongosh-repl.ts
+++ b/packages/cli-repl/src/mongosh-repl.ts
@@ -16,6 +16,7 @@ import formatOutput, { formatError } from './format-output';
 import clr, { StyleDefinition } from './clr';
 import { TELEMETRY_GREETING_MESSAGE, MONGOSH_WIKI } from './constants';
 import { promisify } from 'util';
+import askpassword from 'askpassword';
 
 export type MongoshCliOptions = ShellCliOptions & {
   redactInfo?: boolean;
@@ -208,6 +209,17 @@ class MongoshNodeRepl {
   onPrint(values: ShellResult[]): void {
     const joined = values.map((value) => this.writer(value)).join(' ');
     this.output.write(joined + '\n');
+  }
+
+  // eslint-disable-next-line @typescript-eslint/no-unused-vars
+  async onPrompt(question: string, type: 'password'): Promise<string> {
+    const passwordPromise = askpassword({
+      input: this.input,
+      output: this.output,
+      replacementCharacter: '*'
+    });
+    this.output.write(question + '\n');
+    return (await passwordPromise).toString();
   }
 
   formatOutput(value: any): string {

--- a/packages/cli-repl/test/repl-helpers.ts
+++ b/packages/cli-repl/test/repl-helpers.ts
@@ -37,10 +37,18 @@ async function waitEval(bus: any) {
   await tick();
 }
 
+const fakeTTYProps = {
+  isTTY: true,
+  isRaw: true,
+  setRawMode() { return false; },
+  getColorDepth() { return 256; }
+};
+
 export {
   expect,
   sinon,
   useTmpdir,
   tick,
-  waitEval
+  waitEval,
+  fakeTTYProps
 };

--- a/packages/shell-api/src/shell-api.ts
+++ b/packages/shell-api/src/shell-api.ts
@@ -112,4 +112,14 @@ export default class ShellApi extends ShellApiClass {
   async disableTelemetry(): Promise<any> {
     return await this.internalState.evaluationListener.toggleTelemetry?.(false);
   }
+
+  @returnsPromise
+  @platforms([ ReplPlatform.CLI ] )
+  async passwordPrompt(): Promise<string> {
+    const { evaluationListener } = this.internalState;
+    if (!evaluationListener.onPrompt) {
+      throw new Error('passwordPrompt() is not available in this shell');
+    }
+    return await evaluationListener.onPrompt('Enter password', 'password');
+  }
 }

--- a/packages/shell-api/src/shell-internal-state.ts
+++ b/packages/shell-api/src/shell-internal-state.ts
@@ -37,6 +37,11 @@ export interface EvaluationListener {
    * the call.
    */
   toggleTelemetry?: (enabled: boolean) => any;
+
+  /**
+   * Called when e.g. passwordPrompt() is called from the shell.
+   */
+  onPrompt?: (question: string, type: 'password') => Promise<string> | string;
 }
 
 /**


### PR DESCRIPTION
This is a partial implementation of

* MONGOSH-314
* MONGOSH-315

and picks up https://github.com/mongodb-js/mongosh/pull/381 again
now that it’s easier to test this. :)