### PR TITLE
Support for Sessions & Transactions

### DIFF
--- a/package.json
+++ b/package.json
@@ -118,7 +118,6 @@
     "karma-typescript": "^4.1.1",
     "lerna": "^3.10.7",
     "mocha": "^7.1.2",
-    "mongodb": "^3.6.3",
     "mongodb-download-url": "^0.6.1",
     "mongodb-js-precommit": "^2.0.0",
     "node-codesign": "^0.3.2",

--- a/package.json
+++ b/package.json
@@ -118,6 +118,7 @@
     "karma-typescript": "^4.1.1",
     "lerna": "^3.10.7",
     "mocha": "^7.1.2",
+    "mongodb": "3.6.3",
     "mongodb-download-url": "^0.6.1",
     "mongodb-js-precommit": "^2.0.0",
     "node-codesign": "^0.3.2",

--- a/packages/java-shell/package-lock.json
+++ b/packages/java-shell/package-lock.json
@@ -842,12 +842,6 @@
 			"integrity": "sha512-YZc5EwyO4f2kWCax7oegfuSr9mFz1ZvieNYBEjmukLxgXfBUbxAWGVF7GZf0zidYtoBl3WvC07YK0wT76a+Rtw==",
 			"dev": true
 		},
-		"is-negative-zero": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/is-negative-zero/-/is-negative-zero-2.0.0.tgz",
-			"integrity": "sha1-lVOxIbD6wohp2p7UWeIMdUN4hGE=",
-			"dev": true
-		},
 		"is-regex": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.1.1.tgz",
@@ -1351,67 +1345,23 @@
 			}
 		},
 		"string.prototype.trimend": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.2.tgz",
-			"integrity": "sha512-8oAG/hi14Z4nOVP0z6mdiVZ/wqjDtWSLygMigTzAb+7aPEDTleeFf+WrF+alzecxIRkckkJVn+dTlwzJXORATw==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimend/-/string.prototype.trimend-1.0.3.tgz",
+			"integrity": "sha512-ayH0pB+uf0U28CtjlLvL7NaohvR1amUvVZk+y3DYb0Ey2PUV5zPkkKy9+U1ndVEIXO8hNg18eIv9Jntbii+dKw==",
 			"dev": true,
 			"requires": {
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.18.0-next.1"
-			},
-			"dependencies": {
-				"es-abstract": {
-					"version": "1.18.0-next.1",
-					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
-					"integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
-					"dev": true,
-					"requires": {
-						"es-to-primitive": "^1.2.1",
-						"function-bind": "^1.1.1",
-						"has": "^1.0.3",
-						"has-symbols": "^1.0.1",
-						"is-callable": "^1.2.2",
-						"is-negative-zero": "^2.0.0",
-						"is-regex": "^1.1.1",
-						"object-inspect": "^1.8.0",
-						"object-keys": "^1.1.1",
-						"object.assign": "^4.1.1",
-						"string.prototype.trimend": "^1.0.1",
-						"string.prototype.trimstart": "^1.0.1"
-					}
-				}
+				"call-bind": "^1.0.0",
+				"define-properties": "^1.1.3"
 			}
 		},
 		"string.prototype.trimstart": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.2.tgz",
-			"integrity": "sha512-7F6CdBTl5zyu30BJFdzSTlSlLPwODC23Od+iLoVH8X6+3fvDPPuBVVj9iaB1GOsSTSIgVfsfm27R2FGrAPznWg==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/string.prototype.trimstart/-/string.prototype.trimstart-1.0.3.tgz",
+			"integrity": "sha512-oBIBUy5lea5tt0ovtOFiEQaBkoBBkyJhZXzJYrSmDo5IUUqbOPvVezuRs/agBIdZ2p2Eo1FD6bD9USyBLfl3xg==",
 			"dev": true,
 			"requires": {
-				"define-properties": "^1.1.3",
-				"es-abstract": "^1.18.0-next.1"
-			},
-			"dependencies": {
-				"es-abstract": {
-					"version": "1.18.0-next.1",
-					"resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.18.0-next.1.tgz",
-					"integrity": "sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==",
-					"dev": true,
-					"requires": {
-						"es-to-primitive": "^1.2.1",
-						"function-bind": "^1.1.1",
-						"has": "^1.0.3",
-						"has-symbols": "^1.0.1",
-						"is-callable": "^1.2.2",
-						"is-negative-zero": "^2.0.0",
-						"is-regex": "^1.1.1",
-						"object-inspect": "^1.8.0",
-						"object-keys": "^1.1.1",
-						"object.assign": "^4.1.1",
-						"string.prototype.trimend": "^1.0.1",
-						"string.prototype.trimstart": "^1.0.1"
-					}
-				}
+				"call-bind": "^1.0.0",
+				"define-properties": "^1.1.3"
 			}
 		},
 		"string_decoder": {

--- a/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/service/JavaServiceProvider.kt
+++ b/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/service/JavaServiceProvider.kt
@@ -32,7 +32,7 @@ internal class JavaServiceProvider(private val client: MongoClient, private val 
     }
 
     @HostAccess.Export
-    override fun runCommandWithCheck(database: String, spec: Value): Value = promise {
+    override fun runCommandWithCheck(database: String, spec: Value, options: Value?): Value = promise {
         getDatabase(database, null).map { db ->
             val res = if (spec.isString) {
                 db.runCommand(Document(spec.asString(), 1))
@@ -154,7 +154,7 @@ internal class JavaServiceProvider(private val client: MongoClient, private val 
     }
 
     @HostAccess.Export
-    override fun dropDatabase(database: String, writeConcern: Value?, dbOptions: Value?): Value = promise<Any?> {
+    override fun dropDatabase(database: String, option: Value?, dbOptions: Value?): Value = promise<Any?> {
         Left(NotImplementedError())
     }
 
@@ -449,7 +449,7 @@ internal class JavaServiceProvider(private val client: MongoClient, private val 
     }
 
     @HostAccess.Export
-    override fun getIndexes(database: String, collection: String): Value = promise {
+    override fun getIndexes(database: String, collection: String, options: Value?): Value = promise {
         getDatabase(database, null).map { db ->
             db.getCollection(collection).listIndexes()
         }
@@ -534,7 +534,7 @@ internal class JavaServiceProvider(private val client: MongoClient, private val 
     }
 
     @HostAccess.Export
-    override fun dropIndexes(database: String, collection: String, indexes: Value?): Value = promise<Any?> {
+    override fun dropIndexes(database: String, collection: String, indexes: Value?, options: Value?): Value = promise<Any?> {
         val indexes = if (indexes != null && !indexes.isNull) indexes else throw IllegalArgumentException("Indexes parameter must not be null")
         val indexesList = if (indexes.hasArrayElements()) toList(indexes, "indexes")!!
         else listOf(context.extract(indexes).value)
@@ -557,7 +557,7 @@ internal class JavaServiceProvider(private val client: MongoClient, private val 
     }
 
     @HostAccess.Export
-    override fun dropCollection(database: String, collection: String): Value = promise {
+    override fun dropCollection(database: String, collection: String, option: Value?): Value = promise {
         getDatabase(database, null).map { db ->
             db.getCollection(collection).drop()
         }

--- a/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/service/JavaServiceProvider.kt
+++ b/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/service/JavaServiceProvider.kt
@@ -154,7 +154,7 @@ internal class JavaServiceProvider(private val client: MongoClient, private val 
     }
 
     @HostAccess.Export
-    override fun dropDatabase(database: String, option: Value?, dbOptions: Value?): Value = promise<Any?> {
+    override fun dropDatabase(database: String, options: Value?, dbOptions: Value?): Value = promise<Any?> {
         Left(NotImplementedError())
     }
 
@@ -557,7 +557,7 @@ internal class JavaServiceProvider(private val client: MongoClient, private val 
     }
 
     @HostAccess.Export
-    override fun dropCollection(database: String, collection: String, option: Value?): Value = promise {
+    override fun dropCollection(database: String, collection: String, options: Value?): Value = promise {
         getDatabase(database, null).map { db ->
             db.getCollection(collection).drop()
         }

--- a/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/service/ReadableServiceProvider.kt
+++ b/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/service/ReadableServiceProvider.kt
@@ -15,7 +15,7 @@ internal interface ReadableServiceProvider {
     fun find(database: String, collection: String, filter: Value?, options: Value?): Cursor
     fun getTopology(): Value
     fun isCapped(database: String, collection: String): Value
-    fun getIndexes(database: String, collection: String): Value
+    fun getIndexes(database: String, collection: String, options: Value?): Value
     fun listCollections(database: String, filter: Value?, options: Value?): Value
     fun stats(database: String, collection: String, options: Value?): Value
 }

--- a/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/service/WritableServiceProvider.kt
+++ b/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/service/WritableServiceProvider.kt
@@ -7,8 +7,8 @@ import org.graalvm.polyglot.Value
  */
 internal interface WritableServiceProvider {
     fun runCommand(database: String, spec: Value): Value
-    fun runCommandWithCheck(database: String, spec: Value): Value
-    fun dropDatabase(database: String, writeConcern: Value?, dbOptions: Value?): Value
+    fun runCommandWithCheck(database: String, spec: Value, options: Value?): Value
+    fun dropDatabase(database: String, options: Value?, dbOptions: Value?): Value
     fun bulkWrite(database: String, collection: String, requests: Value, options: Value?, dbOptions: Value?): Value
     fun deleteMany(database: String, collection: String, filter: Value, options: Value?, dbOptions: Value?): Value
     fun deleteOne(database: String, collection: String, filter: Value, options: Value?, dbOptions: Value?): Value
@@ -26,9 +26,9 @@ internal interface WritableServiceProvider {
     fun remove(database: String, collection: String, query: Value, options: Value?, dbOptions: Value?): Value
     fun convertToCapped(database: String, collection: String, size: Number, options: Value?): Value
     fun createIndexes(database: String, collection: String, indexSpecs: Value?): Value
-    fun dropIndexes(database: String, collection: String, indexes: Value?): Value
+    fun dropIndexes(database: String, collection: String, indexes: Value?, options: Value?): Value
     fun reIndex(database: String, collection: String, options: Value?, dbOptions: Value?): Value
-    fun dropCollection(database: String, collection: String): Value
+    fun dropCollection(database: String, collection: String, options: Value?): Value
     fun renameCollection(database: String, oldName: String, newName: String, options: Value?, dbOptions: Value?): Value
     fun initializeBulkOp(database: String, collection: String, ordered: Boolean, options: Value?, dbOptions: Value?): Value
 }

--- a/packages/java-shell/src/test/resources/URI.txt
+++ b/packages/java-shell/src/test/resources/URI.txt
@@ -1,0 +1,1 @@
+mongodb://localhost:27017

--- a/packages/java-shell/src/test/resources/URI.txt
+++ b/packages/java-shell/src/test/resources/URI.txt
@@ -1,1 +1,0 @@
-mongodb://localhost:27017

--- a/packages/service-provider-core/src/admin.ts
+++ b/packages/service-provider-core/src/admin.ts
@@ -7,6 +7,8 @@ import ReadPreference from './read-preference';
 import ReadConcern from './read-concern';
 import WriteConcern from './write-concern';
 import Document from './document';
+import SessionOptions from './session-options';
+import ServiceProviderSession from './session';
 
 export default interface Admin {
   /**
@@ -91,4 +93,6 @@ export default interface Admin {
    * @param options
    */
   resetConnectionOptions(options: Document): Promise<void>;
+
+  startSession(options: SessionOptions): ServiceProviderSession;
 }

--- a/packages/service-provider-core/src/index.ts
+++ b/packages/service-provider-core/src/index.ts
@@ -18,6 +18,8 @@ const DEFAULT_DB = 'test';
 import * as bson from 'bson';
 import ServiceProviderBulkOp, { ServiceProviderBulkFindOp, BulkBatch } from './bulk';
 import makePrintableBson, { bsonStringifiers } from './printable-bson';
+import SessionOptions, { TransactionOptions } from './session-options';
+import ServiceProviderSession from './session';
 
 export {
   ServiceProvider,
@@ -47,5 +49,8 @@ export {
   bsonStringifiers,
   ServiceProviderBulkFindOp,
   ServiceProviderBulkOp,
-  BulkBatch
+  BulkBatch,
+  SessionOptions,
+  ServiceProviderSession,
+  TransactionOptions
 };

--- a/packages/service-provider-core/src/readable.ts
+++ b/packages/service-provider-core/src/readable.ts
@@ -169,6 +169,7 @@ export default interface Readable {
   getIndexes(
     database: string,
     collection: string,
+    options: Document,
     dbOptions?: DatabaseOptions): Promise<any[]>;
 
   /**

--- a/packages/service-provider-core/src/session-options.ts
+++ b/packages/service-provider-core/src/session-options.ts
@@ -1,0 +1,17 @@
+import ReadConcern from './read-concern';
+import WriteConcern from './write-concern';
+import ReadPreference from './read-preference';
+
+export default interface SessionOptions {
+  causalConsistency?: boolean;
+  maxCommitTimeMS?: number;
+  readConcern?: ReadConcern;
+  writeConcern?: WriteConcern;
+  readPreference?: ReadPreference;
+}
+
+export interface TransactionOptions {
+  readConcern?: ReadConcern;
+  writeConcern?: WriteConcern;
+  readPreference?: ReadPreference;
+}

--- a/packages/service-provider-core/src/session.ts
+++ b/packages/service-provider-core/src/session.ts
@@ -1,0 +1,14 @@
+import { TransactionOptions } from './session-options';
+import Document from './document';
+
+export default interface ServiceProviderSession {
+  abortTransaction(): Promise<void>;
+  advanceOperationTime(operationTime: any): void;
+  commitTransaction(): Promise<void>;
+  endSession(): Promise<void>;
+  startTransaction(options?: TransactionOptions): void;
+  hasEnded?: boolean;
+  clusterTime?: any; // TODO: see MONGOSH-427
+  operationTime?: any; // timestamp,
+  id: Document
+}

--- a/packages/service-provider-core/src/writable.ts
+++ b/packages/service-provider-core/src/writable.ts
@@ -2,7 +2,6 @@ import Document from './document';
 import Result from './result';
 import BulkWriteResult from './bulk-write-result';
 import CommandOptions from './command-options';
-import WriteConcern from './write-concern';
 import DatabaseOptions from './database-options';
 
 type DeleteWriteResult = {
@@ -76,14 +75,14 @@ export default interface Writable {
    * Drop a database
    *
    * @param {String} database - The database name.
-   * @param {WriteConcern} writeConcern - The write concern.
+   * @param {Document} options - The options.
    * @param {DatabaseOptions} dbOptions - The database options
    *
    * @returns {Promise<Result>} The result of the operation.
    */
   dropDatabase(
     database: string,
-    writeConcern?: WriteConcern,
+    options?: Document,
     dbOptions?: DatabaseOptions
   ): Promise<Result>;
 
@@ -432,6 +431,7 @@ export default interface Writable {
   dropCollection(
     database: string,
     collection: string,
+    options: Document,
     dbOptions?: DatabaseOptions
   ): Promise<boolean>;
 

--- a/packages/shell-api/src/collection.spec.ts
+++ b/packages/shell-api/src/collection.spec.ts
@@ -1263,9 +1263,7 @@ describe('Collection', () => {
       }
     });
     it('all commands that use other methods', async() => {
-      for (const method of Object.getOwnPropertyNames(Collection.prototype).filter(
-        k => Object.keys(exceptions).includes(k)
-      )) {
+      for (const method of Object.keys(exceptions)) {
         const customA = exceptions[method].a || args;
         const customM = exceptions[method].m || method;
         const customI = exceptions[method].i || 3;

--- a/packages/shell-api/src/collection.spec.ts
+++ b/packages/shell-api/src/collection.spec.ts
@@ -8,7 +8,12 @@ import Mongo from './mongo';
 import Collection from './collection';
 import AggregationCursor from './aggregation-cursor';
 import Explainable from './explainable';
-import { Cursor as ServiceProviderCursor, ServiceProvider, bson } from '@mongosh/service-provider-core';
+import {
+  Cursor as ServiceProviderCursor,
+  ServiceProvider,
+  bson,
+  ServiceProviderSession
+} from '@mongosh/service-provider-core';
 import ShellInternalState from './shell-internal-state';
 
 const sinonChai = require('sinon-chai'); // weird with import
@@ -838,7 +843,7 @@ describe('Collection', () => {
           someOption: 1
         });
 
-        expect(serviceProvider.runCommand).to.have.been.calledWith(
+        expect(serviceProvider.runCommandWithCheck).to.have.been.calledWith(
           collection._database._name,
           {
             someCommand: collection._name,
@@ -850,7 +855,7 @@ describe('Collection', () => {
       it('can be called without options', async() => {
         await collection.runCommand('someCommand');
 
-        expect(serviceProvider.runCommand).to.have.been.calledWith(
+        expect(serviceProvider.runCommandWithCheck).to.have.been.calledWith(
           collection._database._name,
           {
             someCommand: collection._name
@@ -1090,7 +1095,7 @@ describe('Collection', () => {
       it('calls serviceProvider.runCommand on the database with options', async() => {
         await collection.getShardVersion();
 
-        expect(serviceProvider.runCommand).to.have.been.calledWith(
+        expect(serviceProvider.runCommandWithCheck).to.have.been.calledWith(
           ADMIN_DB,
           {
             getShardVersion: `${database._name}.${collection._name}`
@@ -1100,14 +1105,14 @@ describe('Collection', () => {
 
       it('returns whatever serviceProvider.runCommand returns', async() => {
         const expectedResult = { ok: 1 };
-        serviceProvider.runCommand.resolves(expectedResult);
+        serviceProvider.runCommandWithCheck.resolves(expectedResult);
         const result = await collection.getShardVersion();
         expect(result).to.deep.equal(expectedResult);
       });
 
       it('throws if serviceProvider.runCommand rejects', async() => {
         const expectedError = new Error();
-        serviceProvider.runCommand.rejects(expectedError);
+        serviceProvider.runCommandWithCheck.rejects(expectedError);
         const catchedError = await collection.getShardVersion()
           .catch(e => e);
         expect(catchedError).to.equal(expectedError);
@@ -1168,6 +1173,117 @@ describe('Collection', () => {
           }
         });
       });
+    });
+  });
+  describe('with session', () => {
+    let serviceProvider: StubbedInstance<ServiceProvider>;
+    let collection: Collection;
+    let internalSession: StubbedInstance<ServiceProviderSession>;
+    const exceptions = {
+      renameCollection: { a: ['name'] },
+      createIndexes: { a: [[]] },
+      runCommand: { a: ['coll', {} ], m: 'runCommandWithCheck', i: 2 },
+      findOne: { m: 'find' },
+      insert: { m: 'insertMany' },
+      update: { m: 'updateOne', i: 4 },
+      createIndex: { m: 'createIndexes', i: 2 },
+      ensureIndex: { m: 'createIndexes', i: 2 },
+      getIndexSpecs: { m: 'getIndexes', i: 2 },
+      getIndices: { m: 'getIndexes', i: 2 },
+      getIndexKeys: { m: 'getIndexes', i: 2 },
+      dropIndex: { m: 'dropIndexes' },
+      dataSize: { m: 'stats', i: 2 },
+      storageSize: { m: 'stats', i: 2 },
+      totalSize: { m: 'stats', i: 2 },
+      totalIndexSize: { a: [], m: 'stats', i: 2 },
+      drop: { m: 'dropCollection', i: 2 },
+      exists: { m: 'listCollections', i: 2 },
+      stats: { m: 'runCommandWithCheck', i: 2 },
+      mapReduce: { m: 'runCommandWithCheck', i: 2 },
+      validate: { m: 'runCommandWithCheck', i: 2 },
+      getShardVersion: { m: 'runCommandWithCheck', i: 2 },
+      latencyStats: { m: 'aggregate' },
+      initializeOrderedBulkOp: { m: 'initializeBulkOp' },
+      initializeUnorderedBulkOp: { m: 'initializeBulkOp' },
+      distinct: { i: 4 },
+      estimatedDocumentCount: { i: 2 },
+      findAndModify: { i: 5 },
+      findOneAndReplace: { i: 4 },
+      findOneAndUpdate: { i: 4 },
+      replaceOne: { i: 4 },
+      updateMany: { i: 4 },
+      updateOne: { i: 4 },
+      getIndexes: { i: 2 },
+      reIndex: { i: 2 },
+    };
+    const ignore = [ 'getShardDistribution', 'stats', 'isCapped' ];
+    const args = [ { query: {} }, {}, { out: 'coll' } ];
+    beforeEach(() => {
+      const bus = stubInterface<EventEmitter>();
+      serviceProvider = stubInterface<ServiceProvider>();
+      serviceProvider.initialDb = 'test';
+      serviceProvider.bsonLibrary = bson;
+      internalSession = stubInterface<ServiceProviderSession>();
+      serviceProvider.startSession.returns(internalSession);
+      serviceProvider.aggregate.returns(stubInterface<ServiceProviderCursor>());
+      serviceProvider.find.returns(stubInterface<ServiceProviderCursor>());
+      serviceProvider.getIndexes.resolves([]);
+      serviceProvider.stats.resolves({ storageSize: 1, totalIndexSize: 1 });
+      serviceProvider.listCollections.resolves([]);
+      serviceProvider.countDocuments.resolves(1);
+
+      serviceProvider.runCommandWithCheck.resolves({ ok: 1, version: 1, bits: 1, commands: 1, users: [], roles: [], logComponentVerbosity: 1 });
+      [ 'bulkWrite', 'deleteMany', 'deleteOne', 'insert', 'insertMany',
+        'insertOne', 'replaceOne', 'update', 'updateOne', 'updateMany',
+        'findOneAndDelete', 'findOneAndReplace', 'findOneAndUpdate',
+        'findAndModify'
+      ].forEach(
+        k => serviceProvider[k].resolves({ result: {}, value: {} })
+      );
+      const internalState = new ShellInternalState(serviceProvider, bus);
+      const mongo = new Mongo(internalState);
+      const session = mongo.startSession();
+      collection = session.getDatabase('db1').getCollection('coll');
+    });
+    it('all commands that use the same command in sp', async() => {
+      for (const method of Object.getOwnPropertyNames(Collection.prototype).filter(
+        k => !ignore.includes(k) && !Object.keys(exceptions).includes(k)
+      )) {
+        if (!method.startsWith('_') &&
+          !method.startsWith('print') &&
+          collection[method].returnsPromise) {
+          try {
+            await collection[method](...args);
+          } catch (e) {
+            expect.fail(`${method} failed, error thrown ${e.message}`);
+          }
+          expect(serviceProvider[method].calledOnce).to.equal(true, `expected ${method} to be called but it was not`);
+          expect((serviceProvider[method].getCall(-1).args[3] as any).session).to.equal(internalSession);
+        }
+      }
+    });
+    it('all commands that use other methods', async() => {
+      for (const method of Object.getOwnPropertyNames(Collection.prototype).filter(
+        k => Object.keys(exceptions).includes(k)
+      )) {
+        const customA = exceptions[method].a || args;
+        const customM = exceptions[method].m || method;
+        const customI = exceptions[method].i || 3;
+        try {
+          await collection[method](...customA);
+        } catch (e) {
+          expect.fail(`${method} failed, error thrown ${e.message}`);
+        }
+        expect(serviceProvider[customM].called).to.equal(true, `expecting ${customM} to be called but it was not`);
+        const call = serviceProvider[customM].getCall(-1).args[customI];
+        if (Array.isArray(call)) {
+          for (const k of call) {
+            expect(k.session).to.equal(internalSession);
+          }
+        } else {
+          expect(call.session).to.equal(internalSession);
+        }
+      }
     });
   });
 });

--- a/packages/shell-api/src/collection.ts
+++ b/packages/shell-api/src/collection.ts
@@ -118,7 +118,7 @@ export default class Collection extends ShellApiClass {
       { options, pipeline }
     );
     const {
-      providerOptions,
+      aggOptions,
       dbOptions,
       explain
     } = adaptAggregateOptions(options);
@@ -127,7 +127,7 @@ export default class Collection extends ShellApiClass {
       this._database._name,
       this._name,
       pipeline,
-      providerOptions,
+      { ...this._database._baseOptions, ...aggOptions },
       dbOptions
     );
     const cursor = new AggregationCursor(this._mongo, providerCursor);
@@ -173,7 +173,7 @@ export default class Collection extends ShellApiClass {
       this._database._name,
       this._name,
       operations,
-      options,
+      { ...this._database._baseOptions, ...options },
       dbOptions
     );
 
@@ -213,7 +213,13 @@ export default class Collection extends ShellApiClass {
       dbOpts.readConcern = options.readConcern;
     }
 
-    return this._mongo._serviceProvider.count(this._database._name, this._name, query, options, dbOpts);
+    return this._mongo._serviceProvider.count(
+      this._database._name,
+      this._name,
+      query,
+      { ...this._database._baseOptions, ...options },
+      dbOpts
+    );
   }
 
   /**
@@ -229,7 +235,12 @@ export default class Collection extends ShellApiClass {
   @serverVersions(['4.0.3', ServerVersions.latest])
   async countDocuments(query: Document, options: Document = {}): Promise<number> {
     this._emitCollectionApiCall('countDocuments', { query, options });
-    return this._mongo._serviceProvider.countDocuments(this._database._name, this._name, query, options);
+    return this._mongo._serviceProvider.countDocuments(
+      this._database._name,
+      this._name,
+      query,
+      { ...this._database._baseOptions, ...options }
+    );
   }
 
   /**
@@ -258,7 +269,7 @@ export default class Collection extends ShellApiClass {
       this._database._name,
       this._name,
       filter,
-      options,
+      { ...this._database._baseOptions, ...options },
       dbOptions
     );
 
@@ -293,7 +304,7 @@ export default class Collection extends ShellApiClass {
       this._database._name,
       this._name,
       filter,
-      options,
+      { ...this._database._baseOptions, ...options },
       dbOptions
     );
 
@@ -318,7 +329,7 @@ export default class Collection extends ShellApiClass {
   @returnsPromise
   async distinct(field: string, query: Document, options: Document = {}): Promise<any> {
     this._emitCollectionApiCall('distinct', { field, query, options });
-    return this._mongo._serviceProvider.distinct(this._database._name, this._name, field, query, options);
+    return this._mongo._serviceProvider.distinct(this._database._name, this._name, field, query, { ...this._database._baseOptions, ...options });
   }
 
   /**
@@ -333,7 +344,7 @@ export default class Collection extends ShellApiClass {
   @serverVersions(['4.0.3', ServerVersions.latest])
   async estimatedDocumentCount(options: Document = {}): Promise<number> {
     this._emitCollectionApiCall('estimatedDocumentCount', { options });
-    return this._mongo._serviceProvider.estimatedDocumentCount(this._database._name, this._name, options);
+    return this._mongo._serviceProvider.estimatedDocumentCount(this._database._name, this._name, { ...this._database._baseOptions, ...options });
   }
 
   /**
@@ -357,7 +368,7 @@ export default class Collection extends ShellApiClass {
     this._emitCollectionApiCall('find', { query, options });
     const cursor = new Cursor(
       this._mongo,
-      this._mongo._serviceProvider.find(this._database._name, this._name, query, options)
+      this._mongo._serviceProvider.find(this._database._name, this._name, query, { ...this._database._baseOptions, ...options })
     );
 
     this._mongo._internalState.currentCursor = cursor;
@@ -386,6 +397,7 @@ export default class Collection extends ShellApiClass {
       { options: { ...options, update: !!options.update } }
     );
     const providerOptions = {
+      ...this._database._baseOptions,
       ...options
     };
 
@@ -426,7 +438,7 @@ export default class Collection extends ShellApiClass {
     this._emitCollectionApiCall('findOne', { query, options });
     return new Cursor(
       this._mongo,
-      this._mongo._serviceProvider.find(this._database._name, this._name, query, options)
+      this._mongo._serviceProvider.find(this._database._name, this._name, query, { ...this._database._baseOptions, ...options })
     ).limit(1).next();
   }
 
@@ -446,7 +458,7 @@ export default class Collection extends ShellApiClass {
         this._database._name,
         this._name,
         newName,
-        { dropTarget: !!dropTarget }
+        { ...this._database._baseOptions, dropTarget: !!dropTarget }
       );
 
       return {
@@ -485,7 +497,7 @@ export default class Collection extends ShellApiClass {
       this._database._name,
       this._name,
       filter,
-      options,
+      { ...this._database._baseOptions, ...options },
     );
 
     return result.value;
@@ -510,7 +522,7 @@ export default class Collection extends ShellApiClass {
   @serverVersions(['3.2.0', ServerVersions.latest])
   async findOneAndReplace(filter: Document, replacement: Document, options: Document = {}): Promise<any> {
     assertArgsDefined(filter);
-    const findOneAndReplaceOptions: any = { ...options };
+    const findOneAndReplaceOptions: any = { ...this._database._baseOptions, ...options };
 
     if ('returnNewDocument' in findOneAndReplaceOptions) {
       findOneAndReplaceOptions.returnDocument = findOneAndReplaceOptions.returnNewDocument;
@@ -546,7 +558,7 @@ export default class Collection extends ShellApiClass {
   @serverVersions(['3.2.0', ServerVersions.latest])
   async findOneAndUpdate(filter: Document, update: Document, options: Document = {}): Promise<any> {
     assertArgsDefined(filter);
-    const findOneAndUpdateOptions: any = { ...options };
+    const findOneAndUpdateOptions: any = { ...this._database._baseOptions, ...options };
 
     if ('returnNewDocument' in findOneAndUpdateOptions) {
       findOneAndUpdateOptions.returnDocument = findOneAndUpdateOptions.returnNewDocument;
@@ -594,7 +606,7 @@ export default class Collection extends ShellApiClass {
       this._database._name,
       this._name,
       d,
-      options,
+      { ...this._database._baseOptions, ...options },
       dbOptions
     );
 
@@ -632,7 +644,7 @@ export default class Collection extends ShellApiClass {
       this._database._name,
       this._name,
       docs,
-      options,
+      { ...this._database._baseOptions, ...options },
       dbOptions
     );
 
@@ -670,7 +682,7 @@ export default class Collection extends ShellApiClass {
       this._database._name,
       this._name,
       doc,
-      options,
+      { ...this._database._baseOptions, ...options },
       dbOptions
     );
 
@@ -730,7 +742,7 @@ export default class Collection extends ShellApiClass {
       this._database._name,
       this._name,
       query,
-      removeOptions,
+      { ...this._database._baseOptions, ...removeOptions },
       dbOptions
     );
   }
@@ -750,7 +762,7 @@ export default class Collection extends ShellApiClass {
       Object.assign(dbOptions, options.writeConcern);
     }
 
-    return this._mongo._serviceProvider.save(this._database._name, this._name, doc, options, dbOptions);
+    return this._mongo._serviceProvider.save(this._database._name, this._name, doc, { ...this._database._baseOptions, ...options }, dbOptions);
   }
 
   /**
@@ -783,7 +795,7 @@ export default class Collection extends ShellApiClass {
       this._name,
       filter,
       replacement,
-      options,
+      { ...this._database._baseOptions, ...options },
       dbOptions
     );
     return new UpdateResult(
@@ -812,7 +824,7 @@ export default class Collection extends ShellApiClass {
         this._name,
         filter,
         update,
-        options,
+        { ...this._database._baseOptions, ...options },
       );
     } else {
       result = await this._mongo._serviceProvider.updateOne(
@@ -820,7 +832,7 @@ export default class Collection extends ShellApiClass {
         this._name,
         filter,
         update,
-        options,
+        { ...this._database._baseOptions, ...options },
       );
     }
     return new UpdateResult(
@@ -859,7 +871,7 @@ export default class Collection extends ShellApiClass {
       this._name,
       filter,
       update,
-      options,
+      { ...this._database._baseOptions, ...options },
       dbOptions
     );
 
@@ -903,7 +915,7 @@ export default class Collection extends ShellApiClass {
       this._name,
       filter,
       update,
-      options,
+      { ...this._database._baseOptions, ...options },
       dbOptions
     );
 
@@ -929,7 +941,8 @@ export default class Collection extends ShellApiClass {
     return await this._mongo._serviceProvider.convertToCapped(
       this._database._name,
       this._name,
-      size
+      size,
+      this._database._baseOptions
     );
   }
 
@@ -960,7 +973,7 @@ export default class Collection extends ShellApiClass {
 
     this._emitCollectionApiCall('createIndexes', { specs });
 
-    return await this._mongo._serviceProvider.createIndexes(this._database._name, this._name, specs);
+    return await this._mongo._serviceProvider.createIndexes(this._database._name, this._name, specs, this._database._baseOptions);
   }
 
   /**
@@ -985,7 +998,7 @@ export default class Collection extends ShellApiClass {
     }
     this._emitCollectionApiCall('createIndex', { keys, options });
 
-    const spec = { ...options, key: keys };
+    const spec = { ...this._database._baseOptions, ...options, key: keys };
     return await this._mongo._serviceProvider.createIndexes(this._database._name, this._name, [spec]);
   }
 
@@ -1011,7 +1024,7 @@ export default class Collection extends ShellApiClass {
     }
     this._emitCollectionApiCall('ensureIndex', { keys, options });
 
-    const spec = { ...options, key: keys };
+    const spec = { ...this._database._baseOptions, ...options, key: keys };
     return await this._mongo._serviceProvider.createIndexes(this._database._name, this._name, [spec]);
   }
 
@@ -1025,7 +1038,7 @@ export default class Collection extends ShellApiClass {
   @serverVersions(['3.2.0', ServerVersions.latest])
   async getIndexes(): Promise<any[]> {
     this._emitCollectionApiCall('getIndexes');
-    return await this._mongo._serviceProvider.getIndexes(this._database._name, this._name);
+    return await this._mongo._serviceProvider.getIndexes(this._database._name, this._name, this._database._baseOptions);
   }
 
   /**
@@ -1038,7 +1051,7 @@ export default class Collection extends ShellApiClass {
   @serverVersions(['3.2.0', ServerVersions.latest])
   async getIndexSpecs(): Promise<any[]> {
     this._emitCollectionApiCall('getIndexSpecs');
-    return await this._mongo._serviceProvider.getIndexes(this._database._name, this._name);
+    return await this._mongo._serviceProvider.getIndexes(this._database._name, this._name, this._database._baseOptions);
   }
 
   /**
@@ -1050,7 +1063,7 @@ export default class Collection extends ShellApiClass {
   @returnsPromise
   async getIndices(): Promise<any[]> {
     this._emitCollectionApiCall('getIndices');
-    return await this._mongo._serviceProvider.getIndexes(this._database._name, this._name);
+    return await this._mongo._serviceProvider.getIndexes(this._database._name, this._name, this._database._baseOptions);
   }
 
   /**
@@ -1062,7 +1075,7 @@ export default class Collection extends ShellApiClass {
   @serverVersions(['3.2.0', ServerVersions.latest])
   async getIndexKeys(): Promise<any> {
     this._emitCollectionApiCall('getIndexKeys');
-    const indexes = await this._mongo._serviceProvider.getIndexes(this._database._name, this._name);
+    const indexes = await this._mongo._serviceProvider.getIndexes(this._database._name, this._name, this._database._baseOptions);
     return indexes.map(i => i.key);
   }
 
@@ -1078,7 +1091,7 @@ export default class Collection extends ShellApiClass {
     assertArgsDefined(indexes);
     this._emitCollectionApiCall('dropIndexes', { indexes });
     try {
-      return await this._mongo._serviceProvider.dropIndexes(this._database._name, this._name, indexes);
+      return await this._mongo._serviceProvider.dropIndexes(this._database._name, this._name, indexes, this._database._baseOptions);
     } catch (error) {
       if (error.codeName === 'IndexNotFound') {
         return {
@@ -1112,7 +1125,7 @@ export default class Collection extends ShellApiClass {
     }
 
     try {
-      return await this._mongo._serviceProvider.dropIndexes(this._database._name, this._name, index);
+      return await this._mongo._serviceProvider.dropIndexes(this._database._name, this._name, index, this._database._baseOptions);
     } catch (error) {
       if (error.codeName === 'IndexNotFound') {
         return {
@@ -1141,7 +1154,7 @@ export default class Collection extends ShellApiClass {
       );
     }
 
-    const stats = await this._mongo._serviceProvider.stats(this._database._name, this._name, {});
+    const stats = await this._mongo._serviceProvider.stats(this._database._name, this._name, this._database._baseOptions);
     return stats.totalIndexSize;
   }
 
@@ -1153,7 +1166,7 @@ export default class Collection extends ShellApiClass {
   @returnsPromise
   async reIndex(): Promise<any> {
     this._emitCollectionApiCall('reIndex');
-    return await this._mongo._serviceProvider.reIndex(this._database._name, this._name);
+    return await this._mongo._serviceProvider.reIndex(this._database._name, this._name, this._database._baseOptions);
   }
 
   /**
@@ -1186,7 +1199,7 @@ export default class Collection extends ShellApiClass {
   @returnsPromise
   async dataSize(): Promise<number> {
     this._emitCollectionApiCall('dataSize');
-    const stats = await this._mongo._serviceProvider.stats(this._database._name, this._name, {});
+    const stats = await this._mongo._serviceProvider.stats(this._database._name, this._name, this._database._baseOptions);
     return stats.size;
   }
 
@@ -1198,7 +1211,7 @@ export default class Collection extends ShellApiClass {
   @returnsPromise
   async storageSize(): Promise<number> {
     this._emitCollectionApiCall('storageSize');
-    const stats = await this._mongo._serviceProvider.stats(this._database._name, this._name, {});
+    const stats = await this._mongo._serviceProvider.stats(this._database._name, this._name, this._database._baseOptions);
     return stats.storageSize;
   }
 
@@ -1210,7 +1223,7 @@ export default class Collection extends ShellApiClass {
   @returnsPromise
   async totalSize(): Promise<number> {
     this._emitCollectionApiCall('totalSize');
-    const stats = await this._mongo._serviceProvider.stats(this._database._name, this._name, {});
+    const stats = await this._mongo._serviceProvider.stats(this._database._name, this._name, this._database._baseOptions);
     return (stats.storageSize || 0) + (stats.totalIndexSize || 0);
   }
 
@@ -1226,7 +1239,8 @@ export default class Collection extends ShellApiClass {
     try {
       return await this._mongo._serviceProvider.dropCollection(
         this._database._name,
-        this._name
+        this._name,
+        this._database._baseOptions
       );
     } catch (error) {
       if (error.codeName === 'NamespaceNotFound') {
@@ -1256,7 +1270,8 @@ export default class Collection extends ShellApiClass {
       this._database._name,
       {
         name: this._name
-      }
+      },
+      this._database._baseOptions
     );
 
     return collectionInfos[0] || null;
@@ -1287,12 +1302,13 @@ export default class Collection extends ShellApiClass {
     if (!hiddenCommands.test(commandName)) {
       this._emitCollectionApiCall('runCommand', { commandName });
     }
-    return await this._mongo._serviceProvider.runCommand(
+    return await this._mongo._serviceProvider.runCommandWithCheck(
       this._database._name,
       {
         [commandName]: this._name,
         ...options
-      }
+      },
+      this._database._baseOptions
     );
   }
 
@@ -1325,14 +1341,15 @@ export default class Collection extends ShellApiClass {
       this._database._name,
       {
         collStats: this._name, scale: options.scale
-      }
+      },
+      this._database._baseOptions
     );
     if (!result) {
       throw new MongoshRuntimeError(`Error running collStats command on ${this.getFullName()}`);
     }
     let filterIndexName = options.indexDetailsName;
     if (!filterIndexName && options.indexDetailsKey) {
-      const indexes = await this._mongo._serviceProvider.getIndexes(this._database._name, this._name);
+      const indexes = await this._mongo._serviceProvider.getIndexes(this._database._name, this._name, this._database._baseOptions);
       indexes.forEach((spec) => {
         if (JSON.stringify(spec.key) === JSON.stringify(options.indexDetailsKey)) {
           filterIndexName = spec.name;
@@ -1380,7 +1397,7 @@ export default class Collection extends ShellApiClass {
       this._database._name,
       this._name,
       pipeline,
-      {}
+      this._database._baseOptions
     );
     return await providerCursor.toArray();
   }
@@ -1392,7 +1409,8 @@ export default class Collection extends ShellApiClass {
     const innerBulk = await this._mongo._serviceProvider.initializeBulkOp(
       this._database._name,
       this._name,
-      true
+      true,
+      this._database._baseOptions
     );
     return new Bulk(this, innerBulk, true);
   }
@@ -1404,7 +1422,8 @@ export default class Collection extends ShellApiClass {
     const innerBulk = await this._mongo._serviceProvider.initializeBulkOp(
       this._database._name,
       this._name,
-      false
+      false,
+      this._database._baseOptions
     );
     return new Bulk(this, innerBulk);
   }
@@ -1436,7 +1455,8 @@ export default class Collection extends ShellApiClass {
 
     return await this._mongo._serviceProvider.runCommandWithCheck(
       this._database._name,
-      cmd
+      cmd,
+      this._database._baseOptions
     );
   }
 
@@ -1448,18 +1468,20 @@ export default class Collection extends ShellApiClass {
       {
         validate: this._name,
         full: full
-      }
+      },
+      this._database._baseOptions
     );
   }
 
   @returnsPromise
   async getShardVersion(): Promise<any> {
     this._emitCollectionApiCall('getShardVersion', {});
-    return await this._mongo._serviceProvider.runCommand(
+    return await this._mongo._serviceProvider.runCommandWithCheck(
       ADMIN_DB,
       {
         getShardVersion: `${this._database._name}.${this._name}`
-      }
+      },
+      this._database._baseOptions
     );
   }
 

--- a/packages/shell-api/src/database.spec.ts
+++ b/packages/shell-api/src/database.spec.ts
@@ -1,3 +1,4 @@
+/* eslint-disable key-spacing */
 import { expect } from 'chai';
 import sinon, { StubbedInstance, stubInterface } from 'ts-sinon';
 import { EventEmitter } from 'events';
@@ -6,7 +7,11 @@ import { signatures, toShellResult } from './index';
 import Database from './database';
 import Collection from './collection';
 import Mongo from './mongo';
-import { Cursor as ServiceProviderCursor, ServiceProvider, bson } from '@mongosh/service-provider-core';
+import {
+  Cursor as ServiceProviderCursor,
+  ServiceProvider,
+  bson, ServiceProviderSession
+} from '@mongosh/service-provider-core';
 import ShellInternalState from './shell-internal-state';
 import crypto from 'crypto';
 import { ADMIN_DB } from './enums';
@@ -164,7 +169,7 @@ describe('Database', () => {
       it('calls serviceProvider.runCommand on the database', async() => {
         await database.runCommand({ someCommand: 'someCollection' });
 
-        expect(serviceProvider.runCommand).to.have.been.calledWith(
+        expect(serviceProvider.runCommandWithCheck).to.have.been.calledWith(
           database._name,
           {
             someCommand: 'someCollection'
@@ -174,14 +179,14 @@ describe('Database', () => {
 
       it('returns whatever serviceProvider.runCommand returns', async() => {
         const expectedResult = { ok: 1 };
-        serviceProvider.runCommand.resolves(expectedResult);
+        serviceProvider.runCommandWithCheck.resolves(expectedResult);
         const result = await database.runCommand({ someCommand: 'someCollection' });
         expect(result).to.deep.equal(expectedResult);
       });
 
       it('throws if serviceProvider.runCommand rejects', async() => {
         const expectedError = new Error();
-        serviceProvider.runCommand.rejects(expectedError);
+        serviceProvider.runCommandWithCheck.rejects(expectedError);
         const catchedError = await database.runCommand({ someCommand: 'someCollection' })
           .catch(e => e);
         expect(catchedError).to.equal(expectedError);
@@ -192,7 +197,7 @@ describe('Database', () => {
       it('calls serviceProvider.runCommand with the admin database', async() => {
         await database.adminCommand({ someCommand: 'someCollection' });
 
-        expect(serviceProvider.runCommand).to.have.been.calledWith(
+        expect(serviceProvider.runCommandWithCheck).to.have.been.calledWith(
           'admin',
           {
             someCommand: 'someCollection'
@@ -202,13 +207,13 @@ describe('Database', () => {
 
       it('returns whatever serviceProvider.runCommand returns', async() => {
         const expectedResult = { ok: 1 };
-        serviceProvider.runCommand.resolves(expectedResult);
+        serviceProvider.runCommandWithCheck.resolves(expectedResult);
         const result = await database.adminCommand({ someCommand: 'someCollection' });
         expect(result).to.deep.equal(expectedResult);
       });
       it('throws if serviceProvider.runCommand rejects', async() => {
         const expectedError = new Error();
-        serviceProvider.runCommand.rejects(expectedError);
+        serviceProvider.runCommandWithCheck.rejects(expectedError);
         const catchedError = await database.adminCommand({ someCommand: 'someCollection' })
           .catch(e => e);
         expect(catchedError).to.equal(expectedError);
@@ -365,7 +370,7 @@ describe('Database', () => {
 
         expect(serviceProvider.dropDatabase).to.have.been.calledWith(
           database._name,
-          { w: 1 }
+          { writeConcern: { w: 1 } }
         );
       });
 
@@ -579,7 +584,6 @@ describe('Database', () => {
           {
             updateUser: 'anna',
             pwd: 'pwd',
-            writeConcern: {}
           }
         );
       });
@@ -630,7 +634,7 @@ describe('Database', () => {
 
         expect(serviceProvider.runCommandWithCheck).to.have.been.calledWith(
           database._name,
-          { dropUser: 'anna', writeConcern: {} }
+          { dropUser: 'anna' }
         );
       });
 
@@ -655,7 +659,7 @@ describe('Database', () => {
 
         expect(serviceProvider.runCommandWithCheck).to.have.been.calledWith(
           database._name,
-          { dropAllUsersFromDatabase: 1, writeConcern: {} }
+          { dropAllUsersFromDatabase: 1 }
         );
       });
 
@@ -724,7 +728,7 @@ describe('Database', () => {
 
         expect(serviceProvider.runCommandWithCheck).to.have.been.calledWith(
           database._name,
-          { grantRolesToUser: 'anna', roles: ['role1'], writeConcern: {} }
+          { grantRolesToUser: 'anna', roles: ['role1'] }
         );
       });
 
@@ -749,7 +753,7 @@ describe('Database', () => {
 
         expect(serviceProvider.runCommandWithCheck).to.have.been.calledWith(
           database._name,
-          { revokeRolesFromUser: 'anna', roles: ['role1'], writeConcern: {} }
+          { revokeRolesFromUser: 'anna', roles: ['role1'] }
         );
       });
 
@@ -1070,7 +1074,7 @@ describe('Database', () => {
 
         expect(serviceProvider.runCommandWithCheck).to.have.been.calledWith(
           database._name,
-          { dropRole: 'anna', writeConcern: {} }
+          { dropRole: 'anna' }
         );
       });
 
@@ -1095,7 +1099,7 @@ describe('Database', () => {
 
         expect(serviceProvider.runCommandWithCheck).to.have.been.calledWith(
           database._name,
-          { dropAllRolesFromDatabase: 1, writeConcern: {} }
+          { dropAllRolesFromDatabase: 1 }
         );
       });
 
@@ -1120,7 +1124,7 @@ describe('Database', () => {
 
         expect(serviceProvider.runCommandWithCheck).to.have.been.calledWith(
           database._name,
-          { grantRolesToRole: 'anna', roles: ['role1'], writeConcern: {} }
+          { grantRolesToRole: 'anna', roles: ['role1'] }
         );
       });
 
@@ -1145,7 +1149,7 @@ describe('Database', () => {
 
         expect(serviceProvider.runCommandWithCheck).to.have.been.calledWith(
           database._name,
-          { revokeRolesFromRole: 'anna', roles: ['role1'], writeConcern: {} }
+          { revokeRolesFromRole: 'anna', roles: ['role1'] }
         );
       });
 
@@ -1171,7 +1175,7 @@ describe('Database', () => {
 
         expect(serviceProvider.runCommandWithCheck).to.have.been.calledWith(
           database._name,
-          { grantPrivilegesToRole: 'anna', privileges: ['privilege1'], writeConcern: {} }
+          { grantPrivilegesToRole: 'anna', privileges: ['privilege1'] }
         );
       });
 
@@ -1196,7 +1200,7 @@ describe('Database', () => {
 
         expect(serviceProvider.runCommandWithCheck).to.have.been.calledWith(
           database._name,
-          { revokePrivilegesFromRole: 'anna', privileges: ['privilege1'], writeConcern: {} }
+          { revokePrivilegesFromRole: 'anna', privileges: ['privilege1'] }
         );
       });
 
@@ -2132,6 +2136,79 @@ describe('Database', () => {
         const result = await database.getLastErrorObj();
         expect(result).to.deep.equal(expectedError);
       });
+    });
+  });
+  describe('with session', () => {
+    let serviceProvider: StubbedInstance<ServiceProvider>;
+    let database: Database;
+    let internalSession: StubbedInstance<ServiceProviderSession>;
+    const exceptions = {
+      getCollectionNames: { m: 'listCollections' },
+      getCollectionInfos: { m: 'listCollections' },
+      aggregate: { m: 'aggregateDb' },
+      dropDatabase: { m: 'dropDatabase', i: 1 },
+      createCollection: { m: 'createCollection' },
+      createView: { m: 'createCollection' },
+      createUser: { a: [{ user: 'a', pwd: 'p', roles: [] }] },
+      createRole: { a: [{ role: 'a', privileges: [], roles: [] }] },
+      setLogLevel: { a: ['a'] }
+    };
+    const ignore = [
+      'auth',
+      'enableFreeMonitoring',
+      'cloneDatabase',
+      'cloneCollection',
+      'copyDatabase',
+      'getReplicationInfo',
+    ];
+    const args = [ {}, {}, {} ];
+    beforeEach(() => {
+      const bus = stubInterface<EventEmitter>();
+      serviceProvider = stubInterface<ServiceProvider>();
+      serviceProvider.initialDb = 'test';
+      serviceProvider.bsonLibrary = bson;
+      internalSession = stubInterface<ServiceProviderSession>();
+      serviceProvider.startSession.returns(internalSession);
+      serviceProvider.runCommandWithCheck.resolves({ ok: 1, version: 1, bits: 1, commands: 1, users: [], roles: [], logComponentVerbosity: 1 });
+      serviceProvider.runCommand.resolves({ ok: 1 });
+      serviceProvider.listCollections.resolves([]);
+      const internalState = new ShellInternalState(serviceProvider, bus);
+      const mongo = new Mongo(internalState);
+      const session = mongo.startSession();
+      database = session.getDatabase('db1');
+    });
+    it('all commands that use runCommandWithCheck', async() => {
+      for (const method of Object.getOwnPropertyNames(Database.prototype).filter(
+        k => !ignore.includes(k) && !Object.keys(exceptions).includes(k)
+      )) {
+        if (!method.startsWith('_') &&
+            !method.startsWith('print') &&
+            database[method].returnsPromise) {
+          try {
+            await database[method](...args);
+          } catch (e) {
+            expect.fail(`${method} failed, error thrown ${e.message}`);
+          }
+          expect(serviceProvider.runCommandWithCheck.called).to.be.true;
+          expect((serviceProvider.runCommandWithCheck.getCall(-1).args[2] as any).session).to.equal(internalSession);
+        }
+      }
+    });
+    it('all commands that use other methods', async() => {
+      for (const method of Object.getOwnPropertyNames(Database.prototype).filter(
+        k => Object.keys(exceptions).includes(k)
+      )) {
+        const customA = exceptions[method].a || args;
+        const customM = exceptions[method].m || 'runCommandWithCheck';
+        const customI = exceptions[method].i || 2;
+        try {
+          await database[method](...customA);
+        } catch (e) {
+          expect.fail(`${method} failed, error thrown ${e.message}`);
+        }
+        expect(serviceProvider[customM].called).to.equal(true, `expecting ${customM} to be called but it was not`);
+        expect((serviceProvider[customM].getCall(-1).args[customI] as any).session).to.equal(internalSession);
+      }
     });
   });
 });

--- a/packages/shell-api/src/database.spec.ts
+++ b/packages/shell-api/src/database.spec.ts
@@ -2195,9 +2195,7 @@ describe('Database', () => {
       }
     });
     it('all commands that use other methods', async() => {
-      for (const method of Object.getOwnPropertyNames(Database.prototype).filter(
-        k => Object.keys(exceptions).includes(k)
-      )) {
+      for (const method of Object.keys(exceptions)) {
         const customA = exceptions[method].a || args;
         const customM = exceptions[method].m || 'runCommandWithCheck';
         const customI = exceptions[method].i || 2;

--- a/packages/shell-api/src/database.ts
+++ b/packages/shell-api/src/database.ts
@@ -242,7 +242,7 @@ export default class Database extends ShellApiClass {
     const providerCursor = this._mongo._serviceProvider.aggregateDb(
       this._name,
       pipeline,
-      { ...aggOptions, ...this._baseOptions },
+      { ...this._baseOptions, ...aggOptions },
       dbOptions
     ) as ServiceProviderCursor;
     const cursor = new AggregationCursor(this._mongo, providerCursor);
@@ -287,7 +287,7 @@ export default class Database extends ShellApiClass {
   async dropDatabase(writeConcern?: WriteConcern): Promise<any> {
     return await this._mongo._serviceProvider.dropDatabase(
       this._name,
-      { writeConcern, ...this._baseOptions }
+      { ...this._baseOptions, writeConcern }
     );
   }
 

--- a/packages/shell-api/src/database.ts
+++ b/packages/shell-api/src/database.ts
@@ -13,7 +13,7 @@ import { ServerVersions, ADMIN_DB, asPrintable } from './enums';
 import {
   adaptAggregateOptions,
   adaptOptions,
-  assertArgsDefined,
+  assertArgsDefined, assertArgsType,
   assertKeysDefined, getPrintableShardStatus,
   processDigestPassword, tsToSeconds
 } from './helpers';
@@ -31,6 +31,7 @@ import {
   MongoshUnimplementedError
 } from '@mongosh/errors';
 import { HIDDEN_COMMANDS } from '@mongosh/history';
+import Session from './session';
 
 @shellApiClassDefault
 @hasAsyncChild
@@ -38,13 +39,18 @@ export default class Database extends ShellApiClass {
   _mongo: Mongo;
   _name: string;
   _collections: Record<string, Collection>;
+  _baseOptions: Record<string, any>;
 
-  constructor(mongo: Mongo, name: string) {
+  constructor(mongo: Mongo, name: string, session?: Session) {
     super();
     this._mongo = mongo;
     this._name = name;
     const collections: Record<string, Collection> = {};
     this._collections = collections;
+    this._baseOptions = {};
+    if (session !== undefined) {
+      this._baseOptions.session = session._session;
+    }
     const proxy = new Proxy(this, {
       get: (target, prop): any => {
         if (prop in target) {
@@ -92,6 +98,54 @@ export default class Database extends ShellApiClass {
     });
   }
 
+  // Private helpers to avoid sending telemetry events for internal calls. Public so rs/sh can use them
+
+  public async _runCommand(cmd: Document, options = {}): Promise<any> {
+    return this._mongo._serviceProvider.runCommandWithCheck(
+      this._name,
+      cmd,
+      { ...this._baseOptions, ...options }
+    );
+  }
+
+  public async _runAdminCommand(cmd: Document, options = {}): Promise<any> {
+    return this._mongo._serviceProvider.runCommandWithCheck(
+      ADMIN_DB,
+      cmd,
+      { ...this._baseOptions, ...options }
+    );
+  }
+
+  private async _listCollections(filter: Document, options: Document): Promise<string[]> {
+    return await this._mongo._serviceProvider.listCollections(
+      this._name,
+      filter,
+      { ...this._baseOptions, ...options }
+    );
+  }
+
+  async _getLastErrorObj(w?: number|string, wTimeout?: number, j?: boolean): Promise<any> {
+    const cmd = { getlasterror: 1 } as any;
+    if (w) {
+      cmd.w = w;
+    }
+    if (wTimeout) {
+      cmd.wtimeout = wTimeout;
+    }
+    if (j !== undefined) {
+      cmd.j = j;
+    }
+    try {
+      return await this._mongo._serviceProvider.runCommand(
+        this._name,
+        cmd,
+        this._baseOptions
+      );
+    } catch (e) {
+      return e;
+    }
+  }
+
   @returnType('Mongo')
   getMongo(): Mongo {
     return this._mongo;
@@ -109,7 +163,7 @@ export default class Database extends ShellApiClass {
   @returnsPromise
   async getCollectionNames(): Promise<string[]> {
     this._emitDatabaseApiCall('getCollectionNames');
-    const infos = await this.getCollectionInfos({}, { nameOnly: true });
+    const infos = await this._listCollections({}, { nameOnly: true });
     return infos.map((collection: any) => collection.name);
   }
 
@@ -125,8 +179,7 @@ export default class Database extends ShellApiClass {
   @serverVersions(['3.0.0', ServerVersions.latest])
   async getCollectionInfos(filter: Document = {}, options: Document = {}): Promise<any> {
     this._emitDatabaseApiCall('getCollectionInfos', { filter, options });
-    return await this._mongo._serviceProvider.listCollections(
-      this._name,
+    return await this._listCollections(
       filter,
       options
     );
@@ -146,7 +199,7 @@ export default class Database extends ShellApiClass {
     if (!Object.keys(cmd).some(k => hiddenCommands.test(k))) {
       this._emitDatabaseApiCall('runCommand', { cmd });
     }
-    return this._mongo._serviceProvider.runCommand(this._name, cmd);
+    return this._runCommand(cmd);
   }
 
   /**
@@ -158,13 +211,13 @@ export default class Database extends ShellApiClass {
    */
   @returnsPromise
   @serverVersions(['3.4.0', ServerVersions.latest])
-  adminCommand(cmd: any): Promise<any> {
+  async adminCommand(cmd: any): Promise<any> {
     assertArgsDefined(cmd);
     const hiddenCommands = new RegExp(HIDDEN_COMMANDS);
     if (!Object.keys(cmd).some(k => hiddenCommands.test(k))) {
       this._emitDatabaseApiCall('adminCommand', { cmd });
     }
-    return this._mongo._serviceProvider.runCommand(ADMIN_DB, cmd);
+    return await this._runAdminCommand(cmd, {});
   }
 
   /**
@@ -181,7 +234,7 @@ export default class Database extends ShellApiClass {
     this._emitDatabaseApiCall('aggregate', { options, pipeline });
 
     const {
-      providerOptions,
+      aggOptions,
       dbOptions,
       explain
     } = adaptAggregateOptions(options);
@@ -189,7 +242,7 @@ export default class Database extends ShellApiClass {
     const providerCursor = this._mongo._serviceProvider.aggregateDb(
       this._name,
       pipeline,
-      providerOptions,
+      { ...aggOptions, ...this._baseOptions },
       dbOptions
     ) as ServiceProviderCursor;
     const cursor = new AggregationCursor(this._mongo, providerCursor);
@@ -206,18 +259,17 @@ export default class Database extends ShellApiClass {
   getSiblingDB(db: string): Database {
     assertArgsDefined(db);
     this._emitDatabaseApiCall('getSiblingDB', { db });
+    if (this._baseOptions.session) {
+      return this._baseOptions.session.getDatabase(db);
+    }
     return this._mongo._getDb(db);
   }
 
   @returnType('Collection')
   getCollection(coll: string): Collection {
     assertArgsDefined(coll);
+    assertArgsType([coll], ['string']);
     this._emitDatabaseApiCall('getCollection', { coll });
-    if (typeof coll !== 'string') {
-      throw new MongoshInvalidInputError(
-        `Collection name must be a string. Received ${typeof coll}.`);
-    }
-
     if (!coll.trim()) {
       throw new MongoshInvalidInputError('Collection name cannot be empty.');
     }
@@ -235,12 +287,12 @@ export default class Database extends ShellApiClass {
   async dropDatabase(writeConcern?: WriteConcern): Promise<any> {
     return await this._mongo._serviceProvider.dropDatabase(
       this._name,
-      writeConcern
+      { writeConcern, ...this._baseOptions }
     );
   }
 
   @returnsPromise
-  async createUser(user: Document, writeConcern: WriteConcern = {}): Promise<any> {
+  async createUser(user: Document, writeConcern?: WriteConcern): Promise<any> {
     assertArgsDefined(user);
     assertKeysDefined(user, ['user', 'roles', 'pwd']);
     this._emitDatabaseApiCall('createUser', {});
@@ -249,21 +301,21 @@ export default class Database extends ShellApiClass {
     }
     const command = adaptOptions(
       { user: 'createUser', passwordDigestor: null },
-      {
-        writeConcern: writeConcern
-      },
+      {},
       user
     );
+    if (writeConcern) {
+      command.writeConcern = writeConcern;
+    }
     const digestPwd = processDigestPassword(user.user, user.passwordDigestor, command);
     const orderedCmd = { createUser: command.createUser, ...command, ...digestPwd };
-    return await this._mongo._serviceProvider.runCommandWithCheck(
-      this._name,
+    return await this._runCommand(
       orderedCmd
     );
   }
 
   @returnsPromise
-  async updateUser(username: string, userDoc: Document, writeConcern: WriteConcern = {}): Promise<any> {
+  async updateUser(username: string, userDoc: Document, writeConcern?: WriteConcern): Promise<any> {
     assertArgsDefined(username, userDoc);
     this._emitDatabaseApiCall('updateUser', {});
     if (userDoc.passwordDigestor && userDoc.passwordDigestor !== 'server' && userDoc.passwordDigestor !== 'client') {
@@ -273,35 +325,38 @@ export default class Database extends ShellApiClass {
     const command = adaptOptions(
       { passwordDigestor: null },
       {
-        updateUser: username,
-        writeConcern: writeConcern
+        updateUser: username
       },
       userDoc
     );
+    if (writeConcern) {
+      command.writeConcern = writeConcern;
+    }
     const digestPwd = processDigestPassword(username, userDoc.passwordDigestor, command);
     const orderedCmd = { updateUser: command.updateUser, ...command, ...digestPwd };
-    return await this._mongo._serviceProvider.runCommandWithCheck(
-      this._name,
+    return await this._runCommand(
       orderedCmd
     );
   }
 
   @returnsPromise
-  async changeUserPassword(username: string, password: string, writeConcern: WriteConcern = {}): Promise<any> {
+  async changeUserPassword(username: string, password: string, writeConcern?: WriteConcern): Promise<any> {
     assertArgsDefined(username, password);
     this._emitDatabaseApiCall('changeUserPassword', {});
     const command = adaptOptions(
       {},
       {
         updateUser: username,
-        pwd: password,
-        writeConcern: writeConcern
+        pwd: password
       },
       {}
     );
+    if (writeConcern) {
+      command.writeConcern = writeConcern;
+    }
+
     const orderedCmd = { updateUser: command.updateUser, ...command };
-    return await this._mongo._serviceProvider.runCommandWithCheck(
-      this._name,
+    return await this._runCommand(
       orderedCmd
     );
   }
@@ -309,26 +364,28 @@ export default class Database extends ShellApiClass {
   @returnsPromise
   async logout(): Promise<any> {
     this._emitDatabaseApiCall('logout', {});
-    return await this._mongo._serviceProvider.runCommandWithCheck(this._name, { logout: 1 });
+    return await this._runCommand({ logout: 1 });
   }
 
   @returnsPromise
-  async dropUser(username: string, writeConcern: WriteConcern = {}): Promise<any> {
+  async dropUser(username: string, writeConcern?: WriteConcern): Promise<any> {
     assertArgsDefined(username);
     this._emitDatabaseApiCall('dropUser', {});
-    return await this._mongo._serviceProvider.runCommandWithCheck(
-      this._name,
-      { dropUser: username, writeConcern: writeConcern }
-    );
+    const cmd = { dropUser: username } as Document;
+    if (writeConcern) {
+      cmd.writeConcern = writeConcern;
+    }
+    return await this._runCommand(cmd);
   }
 
   @returnsPromise
-  async dropAllUsers(writeConcern: WriteConcern = {}): Promise<any> {
+  async dropAllUsers(writeConcern?: WriteConcern): Promise<any> {
     this._emitDatabaseApiCall('dropAllUsers', {});
-    return await this._mongo._serviceProvider.runCommandWithCheck(
-      this._name,
-      { dropAllUsersFromDatabase: 1, writeConcern: writeConcern }
-    );
+    const cmd = { dropAllUsersFromDatabase: 1 } as Document;
+    if (writeConcern) {
+      cmd.writeConcern = writeConcern;
+    }
+    return await this._runCommand(cmd);
   }
 
   @returnsPromise
@@ -356,23 +413,25 @@ export default class Database extends ShellApiClass {
   }
 
   @returnsPromise
-  async grantRolesToUser(username: string, roles: any, writeConcern: WriteConcern = {}): Promise<any> {
+  async grantRolesToUser(username: string, roles: any, writeConcern?: WriteConcern): Promise<any> {
     assertArgsDefined(username, roles);
     this._emitDatabaseApiCall('grantRolesToUser', {});
-    return await this._mongo._serviceProvider.runCommandWithCheck(
-      this._name,
-      { grantRolesToUser: username, writeConcern: writeConcern, roles: roles }
-    );
+    const cmd = { grantRolesToUser: username, roles: roles } as Document;
+    if (writeConcern) {
+      cmd.writeConcern = writeConcern;
+    }
+    return await this._runCommand(cmd);
   }
 
   @returnsPromise
-  async revokeRolesFromUser(username: string, roles: any, writeConcern: WriteConcern = {}): Promise<any> {
+  async revokeRolesFromUser(username: string, roles: any, writeConcern?: WriteConcern): Promise<any> {
     assertArgsDefined(username, roles);
     this._emitDatabaseApiCall('revokeRolesFromUser', {});
-    return await this._mongo._serviceProvider.runCommandWithCheck(
-      this._name,
-      { revokeRolesFromUser: username, writeConcern: writeConcern, roles: roles }
-    );
+    const cmd = { revokeRolesFromUser: username, roles: roles } as Document;
+    if (writeConcern) {
+      cmd.writeConcern = writeConcern;
+    }
+    return await this._runCommand(cmd);
   }
 
   @returnsPromise
@@ -386,10 +445,7 @@ export default class Database extends ShellApiClass {
     );
     const result: {
       users: any[]
-    } = await this._mongo._serviceProvider.runCommandWithCheck(
-      this._name,
-      command
-    );
+    } = await this._runCommand(command);
     for (let i = 0; i < result.users.length; i++) {
       if (result.users[i].user === username) {
         return result.users[i];
@@ -406,8 +462,7 @@ export default class Database extends ShellApiClass {
       { usersInfo: 1 },
       options
     );
-    return await this._mongo._serviceProvider.runCommandWithCheck(
-      this._name,
+    return await this._runCommand(
       command
     );
   }
@@ -419,7 +474,7 @@ export default class Database extends ShellApiClass {
     return await this._mongo._serviceProvider.createCollection(
       this._name,
       name,
-      options
+      { ...this._baseOptions, ...options }
     );
   }
 
@@ -428,8 +483,9 @@ export default class Database extends ShellApiClass {
     assertArgsDefined(name, source, pipeline);
     this._emitDatabaseApiCall('createView', { name, source, pipeline, options });
     const ccOpts = {
+      ...this._baseOptions,
       viewOn: source,
-      pipeline: pipeline,
+      pipeline: pipeline
     } as any;
     if (options.collation) {
       ccOpts.collation = options.collation;
@@ -442,7 +498,7 @@ export default class Database extends ShellApiClass {
   }
 
   @returnsPromise
-  async createRole(role: Document, writeConcern: WriteConcern = {}): Promise<any> {
+  async createRole(role: Document, writeConcern?: WriteConcern): Promise<any> {
     assertArgsDefined(role);
     assertKeysDefined(role, ['role', 'privileges', 'roles']);
     this._emitDatabaseApiCall('createRole', {});
@@ -451,94 +507,101 @@ export default class Database extends ShellApiClass {
     }
     const command = adaptOptions(
       { role: 'createRole' },
-      {
-        writeConcern: writeConcern
-      },
+      {},
       role
     );
+    if (writeConcern) {
+      command.writeConcern = writeConcern;
+    }
     const orderedCmd = { createRole: command.createRole, ...command };
-    return await this._mongo._serviceProvider.runCommandWithCheck(
-      this._name,
+    return await this._runCommand(
       orderedCmd
     );
   }
 
   @returnsPromise
-  async updateRole(rolename: string, roleDoc: Document, writeConcern: WriteConcern = {}): Promise<any> {
+  async updateRole(rolename: string, roleDoc: Document, writeConcern?: WriteConcern): Promise<any> {
     assertArgsDefined(rolename, roleDoc);
     this._emitDatabaseApiCall('updateRole', {});
     const command = adaptOptions(
       {},
       {
-        updateRole: rolename,
-        writeConcern: writeConcern
+        updateRole: rolename
       },
       roleDoc
     );
+    if (writeConcern) {
+      command.writeConcern = writeConcern;
+    }
     const orderedCmd = { updateRole: command.updateRole, ...command };
-    return await this._mongo._serviceProvider.runCommandWithCheck(
-      this._name,
+    return await this._runCommand(
       orderedCmd
     );
   }
 
   @returnsPromise
-  async dropRole(rolename: string, writeConcern: WriteConcern = {}): Promise<any> {
+  async dropRole(rolename: string, writeConcern?: WriteConcern): Promise<any> {
     assertArgsDefined(rolename);
     this._emitDatabaseApiCall('dropRole', {});
-    return await this._mongo._serviceProvider.runCommandWithCheck(
-      this._name,
-      { dropRole: rolename, writeConcern: writeConcern }
-    );
+    const cmd = { dropRole: rolename } as Document;
+    if (writeConcern) {
+      cmd.writeConcern = writeConcern;
+    }
+    return await this._runCommand(cmd);
   }
 
   @returnsPromise
-  async dropAllRoles(writeConcern: WriteConcern = {}): Promise<any> {
+  async dropAllRoles(writeConcern?: WriteConcern): Promise<any> {
     this._emitDatabaseApiCall('dropAllRoles', {});
-    return await this._mongo._serviceProvider.runCommandWithCheck(
-      this._name,
-      { dropAllRolesFromDatabase: 1, writeConcern: writeConcern }
-    );
+    const cmd = { dropAllRolesFromDatabase: 1 } as Document;
+    if (writeConcern) {
+      cmd.writeConcern = writeConcern;
+    }
+    return await this._runCommand(cmd);
   }
 
   @returnsPromise
-  async grantRolesToRole(rolename: string, roles: any, writeConcern: WriteConcern = {}): Promise<any> {
+  async grantRolesToRole(rolename: string, roles: any, writeConcern?: WriteConcern): Promise<any> {
     assertArgsDefined(rolename, roles);
     this._emitDatabaseApiCall('grantRolesToRole', {});
-    return await this._mongo._serviceProvider.runCommandWithCheck(
-      this._name,
-      { grantRolesToRole: rolename, roles: roles, writeConcern: writeConcern }
-    );
+    const cmd = { grantRolesToRole: rolename, roles: roles } as Document;
+    if (writeConcern) {
+      cmd.writeConcern = writeConcern;
+    }
+    return await this._runCommand(cmd);
   }
 
   @returnsPromise
-  async revokeRolesFromRole(rolename: string, roles: any, writeConcern: WriteConcern = {}): Promise<any> {
+  async revokeRolesFromRole(rolename: string, roles: any, writeConcern?: WriteConcern): Promise<any> {
     assertArgsDefined(rolename, roles);
     this._emitDatabaseApiCall('revokeRolesFromRole', {});
-    return await this._mongo._serviceProvider.runCommandWithCheck(
-      this._name,
-      { revokeRolesFromRole: rolename, roles: roles, writeConcern: writeConcern }
-    );
+    const cmd = { revokeRolesFromRole: rolename, roles: roles } as Document;
+    if (writeConcern) {
+      cmd.writeConcern = writeConcern;
+    }
+    return await this._runCommand(cmd);
   }
 
   @returnsPromise
-  async grantPrivilegesToRole(rolename: string, privileges: any, writeConcern: WriteConcern = {}): Promise<any> {
+  async grantPrivilegesToRole(rolename: string, privileges: any, writeConcern?: WriteConcern): Promise<any> {
     assertArgsDefined(rolename, privileges);
     this._emitDatabaseApiCall('grantPrivilegesToRole', {});
-    return await this._mongo._serviceProvider.runCommandWithCheck(
-      this._name,
-      { grantPrivilegesToRole: rolename, privileges: privileges, writeConcern: writeConcern }
-    );
+    const cmd = { grantPrivilegesToRole: rolename, privileges: privileges } as Document;
+    if (writeConcern) {
+      cmd.writeConcern = writeConcern;
+    }
+    return await this._runCommand(cmd);
   }
 
   @returnsPromise
-  async revokePrivilegesFromRole(rolename: string, privileges: any, writeConcern: WriteConcern = {}): Promise<any> {
+  async revokePrivilegesFromRole(rolename: string, privileges: any, writeConcern?: WriteConcern): Promise<any> {
     assertArgsDefined(rolename, privileges);
     this._emitDatabaseApiCall('revokePrivilegesFromRole', {});
-    return await this._mongo._serviceProvider.runCommandWithCheck(
-      this._name,
-      { revokePrivilegesFromRole: rolename, privileges: privileges, writeConcern: writeConcern }
-    );
+    const cmd = { revokePrivilegesFromRole: rolename, privileges: privileges } as Document;
+    if (writeConcern) {
+      cmd.writeConcern = writeConcern;
+    }
+    return await this._runCommand(cmd);
   }
 
 
@@ -553,8 +616,7 @@ export default class Database extends ShellApiClass {
     );
     const result: {
       roles: any[];
-    } = await this._mongo._serviceProvider.runCommandWithCheck(
-      this._name,
+    } = await this._runCommand(
       command
     );
     for (let i = 0; i < result.roles.length; i++) {
@@ -573,8 +635,7 @@ export default class Database extends ShellApiClass {
       { rolesInfo: 1 },
       options
     );
-    return await this._mongo._serviceProvider.runCommandWithCheck(
-      this._name,
+    return await this._runCommand(
       command
     );
   }
@@ -582,8 +643,7 @@ export default class Database extends ShellApiClass {
   @returnsPromise
   async currentOp(opts: any = {}): Promise<any> {
     this._emitDatabaseApiCall('currentOp', { opts: opts });
-    return await this._mongo._serviceProvider.runCommandWithCheck(
-      ADMIN_DB,
+    return await this._runAdminCommand(
       {
         currentOp: 1,
         ...opts
@@ -595,8 +655,7 @@ export default class Database extends ShellApiClass {
   async killOp(opId: number): Promise<any> {
     assertArgsDefined(opId);
     this._emitDatabaseApiCall('killOp', { opId });
-    return await this._mongo._serviceProvider.runCommandWithCheck(
-      ADMIN_DB,
+    return await this._runAdminCommand(
       {
         killOp: 1,
         op: opId
@@ -607,8 +666,7 @@ export default class Database extends ShellApiClass {
   @returnsPromise
   async shutdownServer(opts: any = {}): Promise<any> {
     this._emitDatabaseApiCall('shutdownServer', { opts: opts });
-    return await this._mongo._serviceProvider.runCommandWithCheck(
-      ADMIN_DB,
+    return await this._runAdminCommand(
       {
         shutdown: 1,
         ...opts
@@ -619,8 +677,7 @@ export default class Database extends ShellApiClass {
   @returnsPromise
   async fsyncLock(): Promise<any> {
     this._emitDatabaseApiCall('fsyncLock', {});
-    return await this._mongo._serviceProvider.runCommandWithCheck(
-      ADMIN_DB,
+    return await this._runAdminCommand(
       {
         fsync: 1,
         lock: true
@@ -631,8 +688,7 @@ export default class Database extends ShellApiClass {
   @returnsPromise
   async fsyncUnlock(): Promise<any> {
     this._emitDatabaseApiCall('fsyncUnlock', {});
-    return await this._mongo._serviceProvider.runCommandWithCheck(
-      ADMIN_DB,
+    return await this._runAdminCommand(
       {
         fsyncUnlock: 1
       }
@@ -642,8 +698,7 @@ export default class Database extends ShellApiClass {
   @returnsPromise
   async version(): Promise<any> {
     this._emitDatabaseApiCall('version', {});
-    const info: any = await this._mongo._serviceProvider.runCommandWithCheck(
-      ADMIN_DB,
+    const info: any = await this._runAdminCommand(
       {
         buildInfo: 1,
       }
@@ -657,8 +712,7 @@ export default class Database extends ShellApiClass {
   @returnsPromise
   async serverBits(): Promise<any> {
     this._emitDatabaseApiCall('serverBits', {});
-    const info: any = await this._mongo._serviceProvider.runCommandWithCheck(
-      ADMIN_DB,
+    const info: any = await this._runAdminCommand(
       {
         buildInfo: 1,
       }
@@ -672,8 +726,7 @@ export default class Database extends ShellApiClass {
   @returnsPromise
   async isMaster(): Promise<any> {
     this._emitDatabaseApiCall('isMaster', {});
-    return await this._mongo._serviceProvider.runCommandWithCheck(
-      this._name,
+    return await this._runCommand(
       {
         isMaster: 1,
       }
@@ -683,8 +736,7 @@ export default class Database extends ShellApiClass {
   @returnsPromise
   async serverBuildInfo(): Promise<any> {
     this._emitDatabaseApiCall('serverBuildInfo', {});
-    return await this._mongo._serviceProvider.runCommandWithCheck(
-      ADMIN_DB,
+    return await this._runAdminCommand(
       {
         buildInfo: 1,
       }
@@ -694,8 +746,7 @@ export default class Database extends ShellApiClass {
   @returnsPromise
   async serverStatus(opts = {}): Promise<any> {
     this._emitDatabaseApiCall('serverStatus', { options: opts });
-    return await this._mongo._serviceProvider.runCommandWithCheck(
-      ADMIN_DB,
+    return await this._runAdminCommand(
       {
         serverStatus: 1, ...opts
       }
@@ -705,9 +756,7 @@ export default class Database extends ShellApiClass {
   @returnsPromise
   async stats(scale = 1): Promise<any> {
     this._emitDatabaseApiCall('stats', { scale: scale });
-    return await this._mongo._serviceProvider.runCommandWithCheck(
-
-      ADMIN_DB,
+    return await this._runAdminCommand(
       {
         dbStats: 1,
         scale: scale
@@ -718,8 +767,7 @@ export default class Database extends ShellApiClass {
   @returnsPromise
   async hostInfo(): Promise<any> {
     this._emitDatabaseApiCall('hostInfo', {});
-    return await this._mongo._serviceProvider.runCommandWithCheck(
-      ADMIN_DB,
+    return await this._runAdminCommand(
       {
         hostInfo: 1,
       }
@@ -729,9 +777,7 @@ export default class Database extends ShellApiClass {
   @returnsPromise
   async serverCmdLineOpts(): Promise<any> {
     this._emitDatabaseApiCall('serverCmdLineOpts', {});
-    return await this._mongo._serviceProvider.runCommandWithCheck(
-
-      ADMIN_DB,
+    return await this._runAdminCommand(
       {
         getCmdLineOpts: 1,
       }
@@ -759,9 +805,7 @@ export default class Database extends ShellApiClass {
   @returnsPromise
   async getFreeMonitoringStatus(): Promise<any> {
     this._emitDatabaseApiCall('getFreeMonitoringStatus', {});
-    return await this._mongo._serviceProvider.runCommandWithCheck(
-
-      ADMIN_DB,
+    return await this._runAdminCommand(
       {
         getFreeMonitoringStatus: 1,
       }
@@ -771,9 +815,7 @@ export default class Database extends ShellApiClass {
   @returnsPromise
   async disableFreeMonitoring(): Promise<any> {
     this._emitDatabaseApiCall('disableFreeMonitoring', {});
-    return await this._mongo._serviceProvider.runCommandWithCheck(
-
-      ADMIN_DB,
+    return await this._runAdminCommand(
       {
         setFreeMonitoring: 1,
         action: 'disable'
@@ -784,7 +826,7 @@ export default class Database extends ShellApiClass {
   @returnsPromise
   async enableFreeMonitoring(): Promise<any> {
     this._emitDatabaseApiCall('enableFreeMonitoring', {});
-    const isMaster: any = await this._mongo._serviceProvider.runCommand(this._name, { isMaster: 1 });
+    const isMaster: any = await this._mongo._serviceProvider.runCommand(this._name, { isMaster: 1 }, this._baseOptions);
     if (!isMaster.ismaster) {
       throw new MongoshInvalidInputError('db.enableFreeMonitoring() may only be run on a primary');
     }
@@ -795,14 +837,16 @@ export default class Database extends ShellApiClass {
       {
         setFreeMonitoring: 1,
         action: 'enable'
-      }
+      },
+      this._baseOptions
     );
     let result: any;
     let error: any;
     try {
       result = await this._mongo._serviceProvider.runCommand(
         ADMIN_DB,
-        { getFreeMonitoringStatus: 1 }
+        { getFreeMonitoringStatus: 1 },
+        this._baseOptions
       );
     } catch (err) {
       error = err;
@@ -818,7 +862,8 @@ export default class Database extends ShellApiClass {
         {
           getParameter: 1,
           cloudFreeMonitoringEndpointURL: 1
-        }
+        },
+        this._baseOptions
       );
       return `Unable to get immediate response from the Cloud Monitoring service. Please check your firewall settings to ensure that mongod can communicate with '${urlResult.cloudFreeMonitoringEndpointURL || '<unknown>'}'`;
     }
@@ -828,9 +873,7 @@ export default class Database extends ShellApiClass {
   @returnsPromise
   async getProfilingStatus(): Promise<any> {
     this._emitDatabaseApiCall('getProfilingStatus', {});
-    return await this._mongo._serviceProvider.runCommandWithCheck(
-
-      this._name,
+    return await this._runCommand(
       {
         profile: -1,
       }
@@ -847,8 +890,7 @@ export default class Database extends ShellApiClass {
       opts = { slowms: opts };
     }
     this._emitDatabaseApiCall('setProfilingLevel', { opts: opts });
-    return await this._mongo._serviceProvider.runCommandWithCheck(
-      this._name,
+    return await this._runCommand(
       {
         profile: level,
         ...opts
@@ -881,8 +923,7 @@ export default class Database extends ShellApiClass {
     //   cmdObj = driverSession._serverSession.injectSessionId(cmdObj);
     // }
 
-    return await this._mongo._serviceProvider.runCommandWithCheck(
-      ADMIN_DB,
+    return await this._runAdminCommand(
       cmdObj
     );
   }
@@ -897,8 +938,7 @@ export default class Database extends ShellApiClass {
     //   cmdObj = driverSession._serverSession.injectSessionId(cmdObj);
     // }
 
-    const result = await this._mongo._serviceProvider.runCommandWithCheck(
-      ADMIN_DB,
+    const result = await this._runAdminCommand(
       cmdObj
     );
     if (!result || result.logComponentVerbosity === undefined) {
@@ -929,8 +969,7 @@ export default class Database extends ShellApiClass {
     command[name] = 1;
     command.help = true;
 
-    const result = await this._mongo._serviceProvider.runCommandWithCheck(
-      this._name,
+    const result = await this._runCommand(
       command
     );
     if (!result || result.help === undefined) {
@@ -942,8 +981,7 @@ export default class Database extends ShellApiClass {
   @returnsPromise
   async listCommands(): Promise<any> {
     this._emitDatabaseApiCall('listCommands', {});
-    const result = await this._mongo._serviceProvider.runCommandWithCheck(
-      this._name,
+    const result = await this._runCommand(
       {
         listCommands: 1,
       }
@@ -957,46 +995,28 @@ export default class Database extends ShellApiClass {
   @returnsPromise
   async getLastErrorObj(w?: number|string, wTimeout?: number, j?: boolean): Promise<any> {
     this._emitDatabaseApiCall('getLastErrorObj', { w: w, wTimeout: wTimeout, j: j });
-
-    const cmd = { getlasterror: 1 } as any;
-    if (w) {
-      cmd.w = w;
-    }
-    if (wTimeout) {
-      cmd.wtimeout = wTimeout;
-    }
-    if (j !== undefined) {
-      cmd.j = j;
-    }
-    try {
-      return await this._mongo._serviceProvider.runCommand(
-        this._name,
-        cmd
-      );
-    } catch (e) {
-      return e;
-    }
+    return await this._getLastErrorObj(w, wTimeout, j);
   }
 
   @returnsPromise
   async getLastError(w?: number|string, wTimeout?: number): Promise<any> {
     this._emitDatabaseApiCall('getLastError', { w: w, wTimeout: wTimeout });
-    const result = await this.getLastErrorObj(w, wTimeout);
+    const result = await this._getLastErrorObj(w, wTimeout);
     return result.err || null;
   }
 
   @returnsPromise
   async printShardingStatus(verbose = false): Promise<any> {
     this._emitDatabaseApiCall('printShardingStatus', { verbose });
-    const result = await getPrintableShardStatus(this._mongo, verbose);
+    const result = await getPrintableShardStatus(this, verbose);
     return new CommandResult('StatsResult', result);
   }
 
   @returnsPromise
   async printSecondaryReplicationInfo(): Promise<any> {
     let startOptimeDate = null;
-    const local = this._mongo.getDB('local');
-    const admin = this._mongo.getDB(ADMIN_DB);
+    const local = this.getSiblingDB('local');
+    const admin = this.getSiblingDB(ADMIN_DB);
 
     if (await local.getCollection('system.replset').countDocuments({}) !== 0) {
       const status = await admin.runCommand({ 'replSetGetStatus': 1 });
@@ -1114,7 +1134,7 @@ export default class Database extends ShellApiClass {
     try {
       replInfo = await this.getReplicationInfo();
     } catch (error) {
-      const isMaster = await this.isMaster();
+      const isMaster = await this._runCommand({ isMaster: 1 });
       if (isMaster.arbiterOnly) {
         return new CommandResult('StatsResult', { message: 'cannot provide replication status from an arbiter' });
       } else if (!isMaster.ismaster) {

--- a/packages/shell-api/src/mongo.spec.ts
+++ b/packages/shell-api/src/mongo.spec.ts
@@ -286,33 +286,30 @@ describe('Mongo', () => {
       });
     });
     describe('getReadPrefMode', () => {
-      it('throws unimplemented error for now', () => {
-        try {
-          mongo.getReadPrefMode();
-        } catch (e) {
-          return expect(e.name).to.equal('MongoshUnimplementedError');
-        }
-        expect.fail();
+      it('calls serviceProvider.getReadPreference', () => {
+        const expectedResult = { mode: 'primary', tagSet: [] } as any;
+        serviceProvider.getReadPreference.returns(expectedResult);
+        const res = mongo.getReadPrefMode();
+        expect(serviceProvider.getReadPreference).to.have.been.calledWith();
+        expect(res).to.equal(expectedResult.mode);
       });
     });
     describe('getReadPref', () => {
-      it('throws unimplemented error for now', () => {
-        try {
-          mongo.getReadPref();
-        } catch (e) {
-          return expect(e.name).to.equal('MongoshUnimplementedError');
-        }
-        expect.fail();
+      it('calls serviceProvider.getReadPreference', () => {
+        const expectedResult = { mode: 'primary', tagSet: [] } as any;
+        serviceProvider.getReadPreference.returns(expectedResult);
+        const res = mongo.getReadPref();
+        expect(serviceProvider.getReadPreference).to.have.been.calledWith();
+        expect(res).to.equal(expectedResult);
       });
     });
     describe('getReadPrefTagSet', () => {
-      it('throws unimplemented error for now', () => {
-        try {
-          mongo.getReadPrefTagSet();
-        } catch (e) {
-          return expect(e.name).to.equal('MongoshUnimplementedError');
-        }
-        expect.fail();
+      it('calls serviceProvider.getReadPreference', () => {
+        const expectedResult = { mode: 'primary', tagSet: [] } as any;
+        serviceProvider.getReadPreference.returns(expectedResult);
+        const res = mongo.getReadPrefTagSet();
+        expect(serviceProvider.getReadPreference).to.have.been.calledWith();
+        expect(res).to.equal(expectedResult.tags);
       });
     });
     describe('getReadConcern', () => {
@@ -386,6 +383,40 @@ describe('Mongo', () => {
           return expect(catchedError).to.equal(expectedError);
         }
         expect.fail();
+      });
+    });
+    describe('startSession', () => {
+      it('calls serviceProvider.startSession', () => {
+        const driverSession = { driverSession: 1 };
+        const opts = { causalConsistency: false };
+        serviceProvider.startSession.returns(driverSession as any);
+        const s = mongo.startSession(opts);
+        expect(serviceProvider.startSession).to.have.been.calledWith();
+        expect(s._session).to.deep.equal(driverSession);
+        expect(s._options).to.deep.equal(opts);
+      });
+
+      it('throws if startSession errors', () => {
+        const expectedError = new Error();
+        serviceProvider.startSession.throws(expectedError);
+        try {
+          mongo.startSession({});
+        } catch (catchedError) {
+          return expect(catchedError).to.equal(expectedError);
+        }
+        expect.fail();
+      });
+    });
+    describe('deprecated mongo methods', () => {
+      ['setCausalConsistency', 'isCausalConsistency', 'setSlaveOk', 'setSecondaryOk'].forEach((t) => {
+        it(t, () => {
+          try {
+            mongo[t]();
+          } catch (e) {
+            return expect(e.name).to.equal('MongoshInvalidInputError');
+          }
+          expect.fail();
+        });
       });
     });
   });

--- a/packages/shell-api/src/replica-set.spec.ts
+++ b/packages/shell-api/src/replica-set.spec.ts
@@ -646,7 +646,7 @@ describe('ReplicaSet', () => {
     });
 
     beforeEach(async() => {
-      await ensureMaster(rs, 1000, cfg);
+      await ensureMaster(rs, 1000, await srv0.hostport());
       expect((await rs.conf()).members.length).to.equal(3);
     });
 

--- a/packages/shell-api/src/session.spec.ts
+++ b/packages/shell-api/src/session.spec.ts
@@ -1,0 +1,325 @@
+import { expect } from 'chai';
+import Session from './session';
+import { ServiceProvider, ServiceProviderSession } from '@mongosh/service-provider-core';
+import { StubbedInstance, stubInterface } from 'ts-sinon';
+import ShellInternalState from './shell-internal-state';
+import { signatures, toShellResult } from './index';
+import Mongo from './mongo';
+import {
+  ADMIN_DB,
+  ALL_PLATFORMS,
+  ALL_SERVER_VERSIONS,
+  ALL_TOPOLOGIES
+} from './enums';
+import { CliServiceProvider } from '../../service-provider-server';
+import { startTestCluster } from '../../../testing/integration-testing-hooks';
+import util from 'util';
+import Database from './database';
+
+describe('Session', () => {
+  describe('help', () => {
+    const apiClass = new Session({} as Mongo, {}, {} as ServiceProviderSession);
+    it('calls help function', async() => {
+      expect((await toShellResult(apiClass.help())).type).to.equal('Help');
+      expect((await toShellResult(apiClass.help)).type).to.equal('Help');
+    });
+  });
+  describe('signature', () => {
+    it('signature for class correct', () => {
+      expect(signatures.Session.type).to.equal('Session');
+      expect(signatures.Session.hasAsyncChild).to.equal(true);
+    });
+    it('map signature', () => {
+      expect(signatures.Session.attributes.endSession).to.deep.equal({
+        type: 'function',
+        returnsPromise: true,
+        returnType: { type: 'unknown', attributes: {} },
+        platforms: ALL_PLATFORMS,
+        topologies: ALL_TOPOLOGIES,
+        serverVersions: ALL_SERVER_VERSIONS
+      });
+    });
+  });
+  describe('instance', () => {
+    let serviceProviderSession: StubbedInstance<ServiceProviderSession>;
+    let mongo: StubbedInstance<Mongo>;
+    let options;
+    let session: Session;
+    beforeEach(() => {
+      options = {
+        causalConsistency: false,
+        readConcern: { level: 'majority' },
+        writeConcern: { w: 1, j: false, wtimeout: 0 },
+        readPreference: { mode: 'primary', tagSet: [] }
+      };
+      serviceProviderSession = stubInterface<ServiceProviderSession>();
+      serviceProviderSession.id = { id: 1 };
+      mongo = stubInterface<Mongo>();
+      mongo._serviceProvider = stubInterface<ServiceProvider>();
+      session = new Session(mongo, options, serviceProviderSession);
+    });
+
+    it('sets dynamic properties', async() => {
+      expect((await toShellResult(session)).type).to.equal('Session');
+      expect((await toShellResult(session)).printable).to.deep.equal(serviceProviderSession.id);
+      expect((await toShellResult(session.help)).type).to.equal('Help');
+    });
+    it('getDatabase', () => {
+      const db = session.getDatabase('test');
+      expect(db).to.deep.equal(new Database(mongo, 'test', session));
+      expect(session.getDatabase('test')).to.equal(db); // reuses db
+    });
+    it('advanceOperationTime', () => {
+      const ts = { ts: 1 } as any;
+      session.advanceOperationTime(ts);
+      expect(serviceProviderSession.advanceOperationTime).to.have.been.calledOnceWith(ts);
+    });
+    it('advanceClusterTime', () => {
+      try {
+        session.advanceClusterTime();
+      } catch (e) {
+        return expect(e.name).to.equal('MongoshUnimplementedError');
+      }
+      expect.fail('Error not thrown');
+    });
+    it('endSession', () => {
+      session.endSession();
+      expect(serviceProviderSession.endSession).to.have.been.calledOnceWith();
+    });
+    it('getClusterTime', () => {
+      serviceProviderSession.clusterTime = 100;
+      expect(session.getClusterTime()).to.equal(100);
+    });
+    it('getOperationTime', () => {
+      serviceProviderSession.operationTime = 200;
+      expect(session.getOperationTime()).to.equal(200);
+    });
+    it('hasEnded', () => {
+      serviceProviderSession.hasEnded = 100 as any; // mystery: testing with false makes this error bc of the spy
+      expect(session.hasEnded()).to.equal(100);
+    });
+    it('startTransaction', () => {
+      serviceProviderSession.startTransaction.returns();
+      session.startTransaction({ readPreference: options.readPreference });
+      expect(serviceProviderSession.startTransaction).to.have.been.calledOnceWith({ readPreference: options.readPreference });
+    });
+    it('commitTransaction', () => {
+      serviceProviderSession.commitTransaction.resolves();
+      session.commitTransaction();
+      expect(serviceProviderSession.commitTransaction).to.have.been.calledOnceWith();
+    });
+    it('abortTransaction', () => {
+      serviceProviderSession.abortTransaction.resolves();
+      session.abortTransaction();
+      expect(serviceProviderSession.abortTransaction).to.have.been.calledOnceWith();
+    });
+  });
+  describe('integration', () => {
+    const replId = 'rs0';
+
+    const testServers = startTestCluster(
+      ['--single', '--replSet', replId],
+      ['--single', '--replSet', replId],
+      ['--single', '--replSet', replId],
+      ['--single', '--replSet', replId]
+    );
+    let cfg: {_id: string, members: {_id: number, host: string, priority: number}[]};
+    let serviceProvider: CliServiceProvider;
+    let internalState: ShellInternalState;
+    let mongo: Mongo;
+    let session: Session;
+
+    const delay = util.promisify(setTimeout);
+    const ensureMaster = async(timeout): Promise<void> => {
+      while (!(await mongo.getDB(ADMIN_DB).isMaster()).ismaster) {
+        if (timeout > 32000) {
+          return expect.fail(`Waited for ${cfg.members[0].host} to become master, never happened`);
+        }
+        await delay(timeout);
+        timeout *= 2; // try again but wait double
+      }
+    };
+
+    const localSessionIds = async() => {
+      return (await (await mongo.getDB('config').aggregate([{ $listLocalSessions: {} }])).toArray()).map(k => JSON.stringify(k._id.id));
+    };
+
+    const ensureSessionExists = async(timeout, sessionId): Promise<void> => {
+      let ls = await localSessionIds();
+      while (!ls.includes(sessionId)) {
+        if (timeout > 32000) {
+          throw new Error(`Waited for session id ${sessionId}, never happened ${ls}`);
+        }
+        await delay(timeout);
+        timeout *= 2; // try again but wait double
+        ls = await localSessionIds();
+      }
+    };
+
+    before(async function() {
+      this.timeout(100_000);
+      const [ srv0, srv1, srv2 ] = await Promise.all(testServers);
+      cfg = {
+        _id: replId,
+        members: [
+          { _id: 0, host: `${srv0.host()}:${srv0.port()}`, priority: 1 },
+          { _id: 1, host: `${srv1.host()}:${srv1.port()}`, priority: 0 },
+          { _id: 2, host: `${srv2.host()}:${srv2.port()}`, priority: 0 }
+        ]
+      };
+      serviceProvider = await CliServiceProvider.connect(srv0.connectionString());
+      await serviceProvider.runCommand(ADMIN_DB, { replSetInitiate: cfg });
+      internalState = new ShellInternalState(serviceProvider);
+      mongo = new Mongo(internalState);
+    });
+
+    beforeEach(async() => {
+      await ensureMaster(1000);
+    });
+
+    afterEach(async() => {
+      await session.endSession();
+    });
+
+    after(() => {
+      return serviceProvider.close(true);
+    });
+
+    describe('server starts and stops sessions', () => {
+      it('starts a session', async() => {
+        session = mongo.startSession();
+        await session.getDatabase('test').getCollection('coll').insertOne({});
+        await ensureSessionExists(1000, JSON.stringify(session.id.id));
+        expect(session.hasEnded()).to.be.false;
+        await session.endSession();
+        expect(session.hasEnded()).to.be.true;
+        try {
+          await session.getDatabase('test').getCollection('coll').insertOne({});
+        } catch (e) {
+          return expect(e.message).to.include('expired sessions');
+        }
+        expect.fail('Error not thrown');
+      });
+      it('handles multiple sessions', async() => {
+        const sessions = [
+          mongo.startSession(),
+          mongo.startSession(),
+          mongo.startSession()
+        ];
+        for (const s of sessions) {
+          await s.getDatabase('test').getCollection('coll').insertOne({});
+          expect(s.hasEnded()).to.be.false;
+          await ensureSessionExists(1000, JSON.stringify(s.id.id));
+        }
+        for (const s of sessions) {
+          await s.endSession();
+          expect(s.hasEnded()).to.be.true;
+          try {
+            await s.getDatabase('test').getCollection('coll').insertOne({});
+          } catch (e) {
+            expect(e.message).to.include('expired sessions');
+            continue;
+          }
+          expect.fail('Error not thrown');
+        }
+      });
+      it('errors if session expired', async() => {
+        session = mongo.startSession();
+        await session.endSession();
+        try {
+          await session.getDatabase('test').getCollection('coll').insertOne({});
+        } catch (e) {
+          return expect(e.message).to.include('expired');
+        }
+        expect.fail('Error not thrown');
+      });
+    });
+    describe('transaction methods are called', () => {
+      it('cannot call start transaction twice', async() => {
+        session = mongo.startSession();
+        session.startTransaction();
+        try {
+          session.startTransaction();
+        } catch (e) {
+          return expect(e.message).to.include('in progress');
+        }
+        expect.fail('Error not thrown');
+      });
+      it('cannot abort when not started', async() => {
+        session = mongo.startSession();
+        try {
+          await session.abortTransaction();
+        } catch (e) {
+          return expect(e.message).to.include('transaction started');
+        }
+        expect.fail('Error not thrown');
+      });
+      it('cannot commit when not started', async() => {
+        session = mongo.startSession();
+        try {
+          await session.commitTransaction();
+        } catch (e) {
+          return expect(e.message).to.include('transaction started');
+        }
+        expect.fail('Error not thrown');
+      });
+      it('commits a transaction', async() => {
+        const doc = { value: 'test', count: 0 };
+        const testColl = mongo.getDB('test').getCollection('coll');
+        await testColl.drop();
+        await testColl.insertOne(doc);
+        expect((await testColl.findOne({ value: 'test' })).count).to.equal(0);
+        session = mongo.startSession();
+        session.startTransaction();
+        const sessionColl = session.getDatabase('test').getCollection('coll');
+        expect((await sessionColl.updateOne(
+          { value: 'test' },
+          { $inc: { count: 1 } }
+        )).acknowledged).to.be.true;
+        expect((await testColl.findOne({ value: 'test' })).count).to.equal(0);
+        await session.commitTransaction();
+        expect((await testColl.findOne({ value: 'test' })).count).to.equal(1);
+      });
+      it('aborts a transaction', async() => {
+        const doc = { value: 'test', count: 0 };
+        const testColl = mongo.getDB('test').getCollection('coll');
+        await testColl.drop();
+        await testColl.insertOne(doc);
+        expect((await testColl.findOne({ value: 'test' })).count).to.equal(0);
+        session = mongo.startSession();
+        session.startTransaction();
+        const sessionColl = session.getDatabase('test').getCollection('coll');
+        expect((await sessionColl.updateOne(
+          { value: 'test' },
+          { $inc: { count: 1 } }
+        )).acknowledged).to.be.true;
+        expect((await testColl.findOne({ value: 'test' })).count).to.equal(0);
+        await session.abortTransaction();
+        expect((await testColl.findOne({ value: 'test' })).count).to.equal(0);
+      });
+    });
+    describe('after resetting connection will error with expired session', () => {
+      it('reset connection options', async() => {
+        session = mongo.startSession();
+        await mongo.setReadConcern('majority');
+        try {
+          await session.getDatabase('test').getCollection('coll').insertOne({});
+        } catch (e) {
+          return expect(e.message).to.include('expired');
+        }
+      });
+      it('authentication', async() => {
+        await mongo.getDB('test').createUser({ user: 'anna', pwd: 'pwd', roles: [] });
+        session = mongo.startSession();
+        await mongo.getDB('test').auth('anna', 'pwd');
+        try {
+          await session.getDatabase('test').getCollection('coll').insertOne({});
+        } catch (e) {
+          await mongo.getDB('test').logout();
+          return expect(e.message).to.include('expired');
+        }
+      });
+    });
+  });
+});
+

--- a/packages/shell-api/src/session.ts
+++ b/packages/shell-api/src/session.ts
@@ -1,0 +1,99 @@
+import {
+  classPlatforms,
+  classReturnsPromise,
+  hasAsyncChild,
+  returnsPromise,
+  ShellApiClass,
+  shellApiClassDefault
+} from './decorators';
+import { Document, ReplPlatform, ServiceProviderSession, SessionOptions, TransactionOptions } from '@mongosh/service-provider-core';
+import { asPrintable } from './enums';
+import Mongo from './mongo';
+import Database from './database';
+import { MongoshInvalidInputError, MongoshUnimplementedError } from '@mongosh/errors';
+import { assertArgsDefined, assertArgsType } from './helpers';
+
+@shellApiClassDefault
+@hasAsyncChild
+@classReturnsPromise
+@classPlatforms([ ReplPlatform.CLI ] )
+export default class Session extends ShellApiClass {
+  public id: Document;
+  public _session: ServiceProviderSession;
+  public _options: SessionOptions;
+  private _mongo: Mongo;
+  private _databases: Record<string, Database>;
+
+  constructor(mongo: Mongo, options: SessionOptions, session: ServiceProviderSession) {
+    super();
+    this._session = session;
+    this._options = options;
+    this._mongo = mongo;
+    this._databases = {};
+    this.id = session.id;
+  }
+
+  /**
+   * Internal method to determine what is printed for this class.
+   */
+  [asPrintable](): Document {
+    return this._session.id;
+  }
+
+  getDatabase(name: string): Database {
+    assertArgsDefined(name);
+    assertArgsType([name], ['string']);
+
+    if (!name.trim()) {
+      throw new MongoshInvalidInputError('Database name cannot be empty.');
+    }
+
+    if (!(name in this._databases)) {
+      this._databases[name] = new Database(this._mongo, name, this);
+    }
+    return this._databases[name];
+  }
+
+  advanceOperationTime(ts: any): void {
+    this._session.advanceOperationTime(ts);
+  }
+
+  advanceClusterTime(): void {
+    throw new MongoshUnimplementedError('Calling advanceClusterTime is not currently supported due it not being supported in the driver, see NODE-2843.');
+  }
+
+  @returnsPromise
+  async endSession(): Promise<void> {
+    return await this._session.endSession();
+  }
+
+  hasEnded(): boolean | undefined {
+    return this._session.hasEnded;
+  }
+
+  getClusterTime(): any {
+    return this._session.clusterTime;
+  }
+
+  getOperationTime(): any {
+    return this._session.operationTime;
+  }
+
+  getOptions(): SessionOptions {
+    return this._options;
+  }
+
+  startTransaction(options: TransactionOptions = {}): void {
+    return this._session.startTransaction(options);
+  }
+
+  @returnsPromise
+  async commitTransaction(): Promise<void> {
+    return await this._session.commitTransaction();
+  }
+
+  @returnsPromise
+  async abortTransaction(): Promise<void> {
+    return await this._session.abortTransaction();
+  }
+}

--- a/packages/shell-api/src/shell-internal-state.ts
+++ b/packages/shell-api/src/shell-internal-state.ts
@@ -101,8 +101,8 @@ export default class ShellInternalState {
 
   public setDbFunc(newDb: any): Database {
     this.currentDb = newDb;
-    this.context.rs = new ReplicaSet(this.currentDb._mongo);
-    this.context.sh = new Shard(this.currentDb._mongo);
+    this.context.rs = new ReplicaSet(this.currentDb);
+    this.context.sh = new Shard(this.currentDb);
     this.fetchConnectionInfo();
     return newDb;
   }
@@ -151,8 +151,8 @@ export default class ShellInternalState {
       };
     }
 
-    contextObject.rs = new ReplicaSet(this.currentDb._mongo);
-    contextObject.sh = new Shard(this.currentDb._mongo);
+    contextObject.rs = new ReplicaSet(this.currentDb);
+    contextObject.sh = new Shard(this.currentDb);
 
     // Add global shell objects
     const apiObjects = {

--- a/testing/helpers.ts
+++ b/testing/helpers.ts
@@ -2,10 +2,10 @@ import util from 'util';
 import {expect} from 'chai';
 
 const delay = util.promisify(setTimeout);
-export const ensureMaster = async(cls, timeout, cfg): Promise<void> => {
+export const ensureMaster = async(cls, timeout, hp): Promise<void> => {
   while (!(await cls.isMaster()).ismaster) {
     if (timeout > 32000) {
-      return expect.fail(`Waited for ${cfg.members[0].host} to become master, never happened`);
+      return expect.fail(`Waited for ${hp} to become master, never happened`);
     }
     await delay(timeout);
     timeout *= 2; // try again but wait double

--- a/testing/helpers.ts
+++ b/testing/helpers.ts
@@ -1,0 +1,30 @@
+import util from 'util';
+import {expect} from 'chai';
+
+const delay = util.promisify(setTimeout);
+export const ensureMaster = async(cls, timeout, cfg): Promise<void> => {
+  while (!(await cls.isMaster()).ismaster) {
+    if (timeout > 32000) {
+      return expect.fail(`Waited for ${cfg.members[0].host} to become master, never happened`);
+    }
+    await delay(timeout);
+    timeout *= 2; // try again but wait double
+  }
+};
+
+const localSessionIds = async(mongo) => {
+  return (await (await mongo.getDB('config').aggregate([{ $listLocalSessions: {} }])).toArray()).map(k => JSON.stringify(k._id.id));
+};
+
+export const ensureSessionExists = async(mongo, timeout, sessionId): Promise<void> => {
+  let ls = await localSessionIds(mongo);
+  while (!ls.includes(sessionId)) {
+    if (timeout > 32000) {
+      throw new Error(`Waited for session id ${sessionId}, never happened ${ls}`);
+    }
+    await delay(timeout);
+    timeout *= 2; // try again but wait double
+    ls = await localSessionIds(mongo);
+  }
+};
+


### PR DESCRIPTION
This PR includes tickets:
- MONGOSH-444 - Create Session Object
- MONGOSH-445 - Session Object Methods
- MONGOSH-448 - Throw for unsupported sessions methods
- MONGOSH-446 - Transaction Methods
- MONGOSH-342 - Mongo.readPreference methods
- MONGOSH-449 - Investigate if reconnecting MongoClient will interfere with sessions
  - If a user has an active session, then calls a command like `db.auth` or `db.setReadPreference` then nothing will error. However if they try to use the session again, any command will fail with `inactive session`. I think this behavior is acceptable and no further work is required from us because the user should expect that resetting connection-wide options or reauthenticating should close a current session.

For more information about driver sessions, see [the spec](https://github.com/mongodb/specifications/blob/master/source/sessions/driver-sessions.rst#high-level-summary-of-the-api-changes-for-sessions).

The changes include:

- A new `Session` object that wraps the driver session.
- The `Database` class now has a set of `baseOptions` that are passed into every driver call, including anything from the `Collection` class. Right now it only contains `session` but in the future could contain any database-wide option that needs to be tracked outside the driver. 
- Some ServiceProvider methods did not accept an options object, so they have been updated to forward options to the driver. NOTE: this required changes to the java-shell project so I would like @kornilova203 to approve this PR to make sure I didn't do anything wrong there, and to see if there are any other changes required.
- The CliServiceProvider now forwards a `baseCmdOptions` object to all driver methods.
- [NODE-2807](https://jira.mongodb.org/browse/NODE-2807) was completed so I updated the shell code to reflect the change [MONGOSH-342](https://jira.mongodb.org/browse/MONGOSH-342)
- Previously some shell-api methods were using other shell-api methods as helpers, which would end up with double the telemetry events. Added internal helper methods like `_runCommand` to avoid that for most cases (but not all).
- Since the `rs` and `sh` objects are session-aware, forward all their service-provider calls via the `Database` class instead of the `Mongo` class.
- The driver does not accept an empty writeConcern, so methods now send nothing in the options object instead of `{}` if the writeConcern is not set by the user.
- 2 bugfixes involving errors states and reconnecting the MongoClient 