### PR TITLE
[java-shell] Don't fetch cursor twice

### DIFF
--- a/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/MongoShell.kt
+++ b/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/MongoShell.kt
@@ -20,8 +20,9 @@ class MongoShell(client: MongoClient) {
                 args.associateBy { (idx++).toString() }
             })
         } else {
-            val value = result.getMember("rawValue")
-            context.extract(null, value)
+            val printable = result.getMember("printable")
+            val type = result.getMember("type").toString()
+            context.extract(printable, type)
         }
     }
 

--- a/packages/java-shell/src/test/resources/collection/aggregateWithNegativeBatchSize.expected.txt
+++ b/packages/java-shell/src/test/resources/collection/aggregateWithNegativeBatchSize.expected.txt
@@ -1,1 +1,1 @@
-com.mongodb.MongoCommandException: Command failed with error 2 (BadValue): 'cursor.batchSize must not be negative' on server %mongohostport%. The full response is {"ok": 0.0, "errmsg": "cursor.batchSize must not be negative", "code": 2, "codeName": "BadValue"}
+org.graalvm.polyglot.PolyglotException: Command failed with error 2 (BadValue): 'cursor.batchSize must not be negative' on server %mongohostport%. The full response is {"ok": 0.0, "errmsg": "cursor.batchSize must not be negative", "code": 2, "codeName": "BadValue"}

--- a/packages/java-shell/src/test/resources/cursor/tailable.expected.txt
+++ b/packages/java-shell/src/test/resources/cursor/tailable.expected.txt
@@ -1,1 +1,1 @@
-com.mongodb.MongoQueryException: Query failed with error code 2 and error message 'error processing query: ns=admin.collTree: $and
+org.graalvm.polyglot.PolyglotException: Query failed with error code 2 and error message 'error processing query: ns=admin.collTree: $and

--- a/packages/shell-evaluator/src/shell-evaluator.spec.ts
+++ b/packages/shell-evaluator/src/shell-evaluator.spec.ts
@@ -9,7 +9,7 @@ import { EventEmitter } from 'events';
 describe('ShellEvaluator', () => {
   let shellEvaluator: ShellEvaluator;
   let busMock: EventEmitter;
-  let internalStateMock;
+  let internalStateMock: any;
   let useSpy: any;
 
   beforeEach(() => {
@@ -68,6 +68,13 @@ describe('ShellEvaluator', () => {
       await shellEvaluator.customEval(originalEval, 'anything()', {}, '');
       expect(revertSpy.calledOnce).to.be.false;
       expect(saveSpy.calledOnce).to.be.true;
+    });
+    it('allows specifying custom result handlers', async() => {
+      const shellEvaluator = new ShellEvaluator<string>(internalStateMock, JSON.stringify);
+      const originalEval = sinon.stub();
+      originalEval.returns({ a: 1 });
+      const result = await shellEvaluator.customEval(originalEval, 'doSomething();', {}, '');
+      expect(result).to.equal('{"a":1}');
     });
   });
 });


### PR DESCRIPTION
This PR includes:
1. commit 170142901052e0e167dae068c8945c2fcf450f81 from @addaleax that allows to set custom result handler
2. my commit that adds custom result handler to java shell so cursor is not fetched before it's returned to user

BTW: after these commits are merges java shell will not need `rawValue` field in shell result, so maybe it should be removed.