### PR TITLE
fix(service-provider-server): perform db caching MONGOSH-464

### DIFF
--- a/packages/service-provider-server/src/cli-service-provider.integration.spec.ts
+++ b/packages/service-provider-server/src/cli-service-provider.integration.spec.ts
@@ -2,6 +2,7 @@ import CliServiceProvider from './cli-service-provider';
 import { expect } from 'chai';
 import { MongoClient } from 'mongodb';
 import { startTestServer, skipIfServerVersion } from '../../../testing/integration-testing-hooks';
+import { ReadPreferenceMode } from '@mongosh/service-provider-core';
 
 describe('CliServiceProvider [integration]', function() {
   const testServer = startTestServer('shared');
@@ -639,6 +640,26 @@ describe('CliServiceProvider [integration]', function() {
         },
         name: '_id_'
       });
+    });
+  });
+
+  describe('db fetching', () => {
+    it('returns the same db instance when used with the same name and options', () => {
+      const db1 = serviceProvider._dbTestWrapper('foo', { readPreference: { mode: ReadPreferenceMode.secondary } });
+      const db2 = serviceProvider._dbTestWrapper('foo', { readPreference: { mode: ReadPreferenceMode.secondary } });
+      expect(db1).to.equal(db2);
+    });
+
+    it('returns the different db instances when used with different names', () => {
+      const db1 = serviceProvider._dbTestWrapper('bar', { readPreference: { mode: ReadPreferenceMode.secondary } });
+      const db2 = serviceProvider._dbTestWrapper('foo', { readPreference: { mode: ReadPreferenceMode.secondary } });
+      expect(db1).not.to.equal(db2);
+    });
+
+    it('returns the different db instances when used with different options', () => {
+      const db1 = serviceProvider._dbTestWrapper('foo', { readPreference: { mode: ReadPreferenceMode.primary } });
+      const db2 = serviceProvider._dbTestWrapper('foo', { readPreference: { mode: ReadPreferenceMode.secondary } });
+      expect(db1).not.to.equal(db2);
     });
   });
 });


### PR DESCRIPTION
We disabled caching the database objects on the driver level so that
we would be able to access the same database multiple times with
different options, and not get the same cached instance (with the
options from the first call) every time.

This has the major drawback that every time we do any operation that
uses such a database object, we create a new one. Due to the way
the driver creates those objects, they essentially cannot be gargage
collected for the lifetime of the `MongoClient` instance.
This is a memory leak that can crash mongosh.

To resolve this, we perform our own caching of the database instance
that also takes the options into account.