### PR TITLE
fix(cli-repl): turn LineByLineInput into Readable stream MONGOSH-401

### DIFF
--- a/packages/cli-repl/src/line-by-line-input.spec.ts
+++ b/packages/cli-repl/src/line-by-line-input.spec.ts
@@ -15,6 +15,7 @@ describe('LineByLineInput', () => {
     decoder = new StringDecoder();
     forwardedChunks = [];
     lineByLineInput = new LineByLineInput(stdinMock);
+    lineByLineInput.start();
     lineByLineInput.on('data', (chunk) => {
       const decoded = decoder.write(chunk);
       if (decoded) {

--- a/packages/cli-repl/src/mongosh-repl.ts
+++ b/packages/cli-repl/src/mongosh-repl.ts
@@ -143,6 +143,9 @@ class MongoshNodeRepl {
     });
 
     internalState.setCtx(repl.context);
+    // Only start reading from the input *after* we set up everything, including
+    // internalState.setCtx().
+    this.lineByLineInput.start();
   }
 
   /**

--- a/packages/cli-repl/test/e2e.spec.ts
+++ b/packages/cli-repl/test/e2e.spec.ts
@@ -344,5 +344,21 @@ describe('e2e', function() {
       expect(result).to.match(/Telemetry is now disabled/);
     });
   });
+
+  describe('pipe from stdin', () => {
+    it('reads and runs code from stdin', async() => {
+      const shell = TestShell.start({ args: [ await testServer.connectionString() ] });
+      const dbName = `test-${Date.now()}`;
+      shell.process.stdin.write(`
+      use ${dbName};
+      db.coll1.insertOne({ foo: 55 });
+      db.coll1.insertOne({ foo: 89 });
+      db.coll1.aggregate([{$group: {_id: null, total: {$sum: '$foo'}}}])
+      `);
+      await eventually(() => {
+        shell.assertContainsOutput('total: 144');
+      });
+    });
+  });
 });
 

--- a/packages/cli-repl/test/test-shell.ts
+++ b/packages/cli-repl/test/test-shell.ts
@@ -95,6 +95,10 @@ export class TestShell {
     return this._output;
   }
 
+  get process(): ChildProcess {
+    return this._process;
+  }
+
   async waitForPrompt(start = 0): Promise<void> {
     await eventually(() => {
       if (!this._output.slice(start).match(PROMPT_PATTERN)) {

--- a/packages/java-shell/src/test/js/run-tests.ts
+++ b/packages/java-shell/src/test/js/run-tests.ts
@@ -2,6 +2,7 @@
 import child_process from 'child_process';
 import fs from 'fs';
 import path from 'path';
+import { once } from 'events';
 import { startTestServer } from '../../../../../testing/integration-testing-hooks';
 
 describe('java-shell tests', function() {
@@ -13,35 +14,16 @@ describe('java-shell tests', function() {
     process.env.JAVA_SHELL_MONGOSH_TEST_URI = await testServer.connectionString();
 
     const connectionString = await testServer.connectionString();
-      return new Promise((resolve, reject) => {
-      // We can probably turn this into execFile once
-      // https://jira.mongodb.org/browse/MONGOSH-401 is fixed
-      const mongosh = child_process.spawn(
-        process.execPath,
-        [ path.resolve(packageRoot, '..', 'cli-repl', 'bin', 'mongosh.js'), connectionString ],
-        { stdio: [ 'pipe', 'pipe', 'inherit' ], env: { ...process.env, NO_COLOR: '1' } });
-      let out = '';
-      let wroteCreateUser = false;
-      let isDone = false;
-      mongosh.on('error', reject);
-      mongosh.stdout.setEncoding('utf8').on('data', (chunk) => {
-        out += chunk;
-        process.stderr.write(chunk);
-        if (out.includes('> ') && !wroteCreateUser) {
-          wroteCreateUser = true;
-          mongosh.stdin.write(`
-            use admin;
-            db.createUser({ user: "admin", pwd: "admin", roles: ["root"]});
-          `);
-        }
-        if ((out.includes('{ ok: 1 }') ||
-             out.includes('User "admin@admin" already exists')) && !isDone) {
-          isDone = true;
-          mongosh.kill();
-          resolve();
-        }
-      });
-    });
+    const mongosh = child_process.spawn(
+      process.execPath,
+      [ path.resolve(packageRoot, '..', 'cli-repl', 'bin', 'mongosh.js'), connectionString ],
+      { stdio: [ 'pipe', 'inherit', 'inherit' ] });
+    mongosh.stdin.write(`
+      use admin;
+      db.createUser({ user: "admin", pwd: "admin", roles: ["root"]});
+      .exit
+    `);
+    await once(mongosh, 'exit');
   });
 
   it('passes the JavaShell tests', () => {


### PR DESCRIPTION
Instead of controlling whether `data` events are emitted or not
in the LineByLineInput implementation, make LineByLineInput
an actual Readable stream and emit data that way.

This ensures that the relative timing of `'data'` events is the
same as it would otherwise be for streams, which the Node.js
readline implementation expects.