### PR TITLE
feat(browser-repl): support passwordPrompt() MONGOSH-315

### DIFF
--- a/packages/browser-repl/src/components/password-prompt.less
+++ b/packages/browser-repl/src/components/password-prompt.less
@@ -1,0 +1,12 @@
+@import '~@leafygreen-ui/palette/dist/ui-colors.less';
+@import './common.less';
+
+.password-prompt input {
+  .font();
+
+  background-color: @leafygreen__gray--dark-3;
+  color: @leafygreen__gray--light-3;
+  padding: 0 3px;
+  border: 1px solid @leafygreen__gray--light-3;
+  border-radius: 3px;
+}

--- a/packages/browser-repl/src/components/password-prompt.less
+++ b/packages/browser-repl/src/components/password-prompt.less
@@ -1,6 +1,10 @@
 @import '~@leafygreen-ui/palette/dist/ui-colors.less';
 @import './common.less';
 
+.password-prompt {
+  padding-left: 23px;
+}
+
 .password-prompt input {
   .font();
 

--- a/packages/browser-repl/src/components/password-prompt.tsx
+++ b/packages/browser-repl/src/components/password-prompt.tsx
@@ -1,0 +1,40 @@
+import React, { Component } from 'react';
+import classnames from 'classnames';
+
+const styles = require('./password-prompt.less');
+
+interface PasswordPromptProps {
+  onFinish: (result: string) => void;
+  onCancel: () => void;
+  prompt: string;
+}
+
+export class PasswordPrompt extends Component<PasswordPromptProps> {
+  constructor(props: PasswordPromptProps) {
+    super(props);
+  }
+
+  onKeyDown = (ev: React.KeyboardEvent<HTMLInputElement>): void => {
+    switch (ev.key) {
+      case 'Enter':
+        this.props.onFinish((ev.target as HTMLInputElement).value);
+        break;
+      case 'Esc':
+      case 'Escape':
+        this.props.onCancel();
+        break;
+      default:
+        break;
+    }
+  };
+
+  render(): JSX.Element {
+    const className = classnames(styles['password-prompt']);
+
+    return (
+      <label className={className}>
+        {this.props.prompt}:&nbsp;
+        <input type="password" onKeyDown={this.onKeyDown} autoFocus />
+      </label>);
+  }
+}


### PR DESCRIPTION
Adds a password prompt feature to the browser-repl for parity with
the CLI.

![Example run](https://addaleax.net/browser-repl-passwordprompt.gif)