### PR TITLE
[java-shell] Refactor MongoShellContext

### DIFF
--- a/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/ConsoleLogSupport.kt
+++ b/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/ConsoleLogSupport.kt
@@ -1,0 +1,29 @@
+package com.mongodb.mongosh
+
+/**
+ * console.log() and print()
+ */
+internal class ConsoleLogSupport(context: MongoShellContext, converter: MongoShellConverter) {
+    private var printedValues: MutableList<List<Any?>>? = null
+
+    init {
+        val print = context.jsFun { args ->
+            printedValues?.add(args.map { converter.toJava(it).value })
+        }
+        context.bindings.putMember("print", print)
+        @Suppress("JSPrimitiveTypeWrapperUsage")
+        val console = context.eval("new Object()")
+        console.putMember("log", print)
+        console.putMember("error", print)
+        context.bindings.putMember("console", console)
+    }
+
+    fun <T> withConsoleLogEnabled(printedValues: MutableList<List<Any?>>, func: () -> T): T {
+        this.printedValues = printedValues
+        try {
+            return func()
+        } finally {
+            this.printedValues = null
+        }
+    }
+}

--- a/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/MongoShell.kt
+++ b/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/MongoShell.kt
@@ -6,12 +6,12 @@ import com.mongodb.mongosh.result.MongoShellResult
 import org.intellij.lang.annotations.Language
 
 class MongoShell(client: MongoClient) {
-    private val context = MongoShellContext(client)
+    private val evaluator = MongoShellEvaluator(client)
 
     fun eval(@Language("js") script: String): MongoShellResult<*> {
         val printedValues = mutableListOf<List<Any?>>()
-        val result = context.withConsoleLogEnabled(printedValues) {
-            context.unwrapPromise(context.eval(script, "user_script"))
+        val result = evaluator.withConsoleLogEnabled(printedValues) {
+            evaluator.unwrapPromise(evaluator.eval(script, "user_script"))
         }
         return if (printedValues.isNotEmpty()) {
             // [{"0": <value>, "1": <value>, ...}, {"0": <value>}, ...]
@@ -22,9 +22,9 @@ class MongoShell(client: MongoClient) {
         } else {
             val printable = result.getMember("printable")
             val type = result.getMember("type").toString()
-            context.extract(printable, type)
+            evaluator.extract(printable, type)
         }
     }
 
-    fun close() = context.close()
+    fun close() = evaluator.close()
 }

--- a/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/MongoShell.kt
+++ b/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/MongoShell.kt
@@ -9,10 +9,11 @@ class MongoShell(client: MongoClient) {
     private val context = MongoShellContext()
     private val converter = MongoShellConverter(context)
     private val evaluator = MongoShellEvaluator(client, context, converter)
+    private val consoleLog = ConsoleLogSupport(context, converter)
 
     fun eval(@Language("js") script: String): MongoShellResult<*> {
         val printedValues = mutableListOf<List<Any?>>()
-        val result = evaluator.withConsoleLogEnabled(printedValues) {
+        val result = consoleLog.withConsoleLogEnabled(printedValues) {
             converter.unwrapPromise(evaluator.eval(script, "user_script"))
         }
         return if (printedValues.isNotEmpty()) {

--- a/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/MongoShell.kt
+++ b/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/MongoShell.kt
@@ -6,7 +6,8 @@ import com.mongodb.mongosh.result.MongoShellResult
 import org.intellij.lang.annotations.Language
 
 class MongoShell(client: MongoClient) {
-    private val evaluator = MongoShellEvaluator(client)
+    private val context = MongoShellContext()
+    private val evaluator = MongoShellEvaluator(client, context)
 
     fun eval(@Language("js") script: String): MongoShellResult<*> {
         val printedValues = mutableListOf<List<Any?>>()

--- a/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/MongoShellContext.kt
+++ b/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/MongoShellContext.kt
@@ -1,0 +1,32 @@
+package com.mongodb.mongosh
+
+import org.graalvm.polyglot.Context
+import org.graalvm.polyglot.Source
+import org.graalvm.polyglot.Value
+import org.graalvm.polyglot.proxy.ProxyExecutable
+import org.intellij.lang.annotations.Language
+import java.lang.IllegalStateException
+
+internal class MongoShellContext {
+    private var ctx: Context? = Context.create()
+    val bindings: Value = ctx!!.getBindings("js")
+
+    /** Java functions don't have js methods such as apply, bind, call etc.
+     * So we need to create a real js function that wraps Java code */
+    private val functionProducer = eval("(fun) => function inner() { return fun(...arguments); }")
+
+    fun jsFun(func: (args: Array<Value>) -> Any?): Value = functionProducer.execute(ProxyExecutable { func(it) })
+
+    fun eval(@Language("js") script: String, name: String = "Unnamed"): Value {
+        return getCtx().eval(Source.newBuilder("js", script, name).build())
+    }
+
+    fun close() {
+        getCtx().close(true)
+        this.ctx = null
+    }
+
+    private fun getCtx(): Context {
+        return this.ctx ?: throw IllegalStateException("Context has already been closed")
+    }
+}

--- a/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/MongoShellConverter.kt
+++ b/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/MongoShellConverter.kt
@@ -1,0 +1,191 @@
+package com.mongodb.mongosh
+
+import com.mongodb.DBRef
+import com.mongodb.client.result.UpdateResult
+import com.mongodb.mongosh.result.*
+import com.mongodb.mongosh.service.Either
+import com.mongodb.mongosh.service.Left
+import com.mongodb.mongosh.service.Right
+import org.bson.Document
+import org.bson.json.JsonReader
+import org.bson.types.*
+import org.graalvm.polyglot.Value
+import org.graalvm.polyglot.proxy.ProxyExecutable
+import java.util.*
+import java.util.concurrent.CompletableFuture
+import java.util.concurrent.ExecutionException
+import java.util.concurrent.TimeUnit
+import java.util.regex.Pattern
+
+internal class MongoShellConverter(private val context: MongoShellContext) {
+    private val bsonTypes = BsonTypes(context)
+
+    fun toJs(o: Any?): Any? {
+        return when (o) {
+            is Iterable<*> -> toJs(o)
+            is Array<*> -> toJs(o)
+            is Map<*, *> -> toJs(o)
+            Unit -> context.eval("undefined")
+            else -> o
+        }
+    }
+
+    private fun toJs(map: Map<*, *>): Value {
+        @Suppress("JSPrimitiveTypeWrapperUsage")
+        val jsMap = context.eval("new Object()")
+        for ((key, value) in map.entries) {
+            jsMap.putMember(key as String, toJs(value))
+        }
+        return jsMap
+    }
+
+    private fun toJs(list: Iterable<Any?>): Value {
+        val array = context.eval("[]")
+        list.forEachIndexed { index, v ->
+            array.setArrayElement(index.toLong(), toJs(v))
+        }
+        return array
+    }
+
+    private fun toJs(list: Array<*>): Value {
+        val array = context.eval("[]")
+        list.forEachIndexed { index, v ->
+            array.setArrayElement(index.toLong(), toJs(v))
+        }
+        return array
+    }
+
+    fun <T> toJsPromise(promise: Either<T>): Value {
+        return when (promise) {
+            is Right -> context.eval("(v) => new Promise(((resolve) => resolve(v)))", "resolved_promise_script").execute(toJs(promise.value))
+            is Left -> context.eval("(v) => new Promise(((_, reject) => reject(v)))", "rejected_promise_script").execute(promise.value)
+        }
+    }
+
+    fun toJavaPromise(v: Value): CompletableFuture<Value> {
+        return if (v.instanceOf(context, "Promise"))
+            CompletableFuture<Value>().also { future ->
+                v.invokeMember("then", ProxyExecutable { args ->
+                    future.complete(args[0])
+                }).invokeMember("catch", ProxyExecutable { args ->
+                    val error = args[0]
+                    if (error.isHostObject && error.asHostObject<Any>() is Throwable) {
+                        future.completeExceptionally(error.asHostObject<Any>() as Throwable)
+                    } else {
+                        val message = error.toString() + (if (error.instanceOf(context, "Error")) "\n${error.getMember("stack").asString()}" else "")
+                        future.completeExceptionally(Exception(message))
+                    }
+                })
+            }
+        else CompletableFuture.completedFuture(v)
+    }
+
+    fun unwrapPromise(v: Value): Value {
+        try {
+            return toJavaPromise(v).get(1, TimeUnit.SECONDS)
+        } catch (e: ExecutionException) {
+            throw e.cause ?: e
+        }
+    }
+
+    fun toJava(v: Value, type: String? = null): MongoShellResult<*> {
+        return when {
+            type == "Help" -> toJava(v["attr"]!!)
+            type == "Cursor" -> FindCursorResult(FindCursor<Any?>(v, this))
+            // document with aggregation explain result also has type AggregationCursor, so we need to make sure that value contains cursor
+            type == "AggregationCursor" && v.hasMember("_cursor") -> CursorResult(Cursor<Any?>(v, this))
+            type == "InsertOneResult" -> InsertOneResult(v["acknowledged"]!!.asBoolean(), v["insertedId"]!!.asString())
+            type == "DeleteResult" -> DeleteResult(v["acknowledged"]!!.asBoolean(), v["deletedCount"]!!.asLong())
+            type == "UpdateResult" -> {
+                val res = if (v["acknowledged"]!!.asBoolean()) {
+                    UpdateResult.acknowledged(
+                            v["matchedCount"]!!.asLong(),
+                            v["modifiedCount"]!!.asLong(),
+                            null
+                    )
+                } else UpdateResult.unacknowledged()
+                MongoShellUpdateResult(res)
+            }
+            type == "BulkWriteResult" -> BulkWriteResult(
+                    v["acknowledged"]!!.asBoolean(),
+                    v["insertedCount"]!!.asLong(),
+                    v["matchedCount"]!!.asLong(),
+                    v["modifiedCount"]!!.asLong(),
+                    v["deletedCount"]!!.asLong(),
+                    v["upsertedCount"]!!.asLong(),
+                    (toJava(v["upsertedIds"]!!) as ArrayResult).value)
+            type == "InsertManyResult" -> InsertManyResult(v["acknowledged"]!!.asBoolean(), toJava(v["insertedIds"]!!).value as List<String>)
+            v.instanceOf(context, "RegExp") -> {
+                val pattern = v["source"]!!.asString()
+                val flags1 = v["flags"]!!.asString()
+                var f = 0
+                if (flags1.contains('m')) f = f.or(Pattern.MULTILINE)
+                if (flags1.contains('i')) f = f.or(Pattern.CASE_INSENSITIVE)
+                PatternResult(Pattern.compile(pattern, f))
+            }
+            v.instanceOf(context, bsonTypes.maxKey) -> MaxKeyResult()
+            v.instanceOf(context, bsonTypes.minKey) -> MinKeyResult()
+            v.instanceOf(context, bsonTypes.objectId) -> ObjectIdResult(JsonReader(v.invokeMember("toExtendedJSON").toString()).readObjectId())
+            v.instanceOf(context, bsonTypes.numberDecimal) -> Decimal128Result(JsonReader(v.invokeMember("toExtendedJSON").toString()).readDecimal128())
+            v.instanceOf(context, bsonTypes.numberInt) -> IntResult(JsonReader(v.invokeMember("toExtendedJSON").toString()).readInt32())
+            v.instanceOf(context, bsonTypes.bsonSymbol) -> SymbolResult(Symbol(JsonReader(v.invokeMember("toExtendedJSON").toString()).readSymbol()))
+            v.instanceOf(context, bsonTypes.timestamp) -> {
+                val timestamp = JsonReader(toJava(v.invokeMember("toExtendedJSON")).value.toLiteral()).readTimestamp()
+                BSONTimestampResult(BSONTimestamp(timestamp.time, timestamp.inc))
+            }
+            v.instanceOf(context, bsonTypes.code) -> {
+                val scope = toJava(v["scope"]!!).value as? Document
+                val code = v["code"]!!.asString()
+                if (scope == null) CodeResult(Code(code))
+                else CodeWithScopeResult(CodeWithScope(code, scope))
+            }
+            v.instanceOf(context, bsonTypes.dbRef) -> {
+                val databaseName = v["db"]?.let { if (it.isNull) null else it }?.asString()
+                val collectionName = v["collection"]!!.asString()
+                val value = toJava(v["oid"]!!).value
+                DBRefResult(DBRef(databaseName, collectionName, value))
+            }
+            v.instanceOf(context, bsonTypes.numberLong) -> LongResult(JsonReader(v.invokeMember("toExtendedJSON").toString()).readInt64())
+            v.instanceOf(context, bsonTypes.binData) -> {
+                val binary = JsonReader(v.invokeMember("toExtendedJSON").toString()).readBinaryData()
+                BinaryResult(Binary(binary.type, binary.data))
+            }
+            v.instanceOf(context, bsonTypes.hexData) -> {
+                val binary = JsonReader(v.invokeMember("toExtendedJSON").toString()).readBinaryData()
+                BinaryResult(Binary(binary.type, binary.data))
+            }
+            v.isString -> StringResult(v.asString())
+            v.isBoolean -> BooleanResult(v.asBoolean())
+            v.fitsInInt() -> IntResult(v.asInt())
+            v.fitsInLong() -> LongResult(v.asLong())
+            v.fitsInFloat() -> FloatResult(v.asFloat())
+            v.fitsInDouble() -> DoubleResult(v.asDouble())
+            v.equalsTo(context, "undefined") -> VoidResult
+            v.isNull -> NullResult
+            v.isHostObject && v.asHostObject<Any?>() is Unit -> VoidResult
+            v.isHostObject && v.asHostObject<Any?>() is Document -> DocumentResult(v.asHostObject())
+            v.isHostObject && v.asHostObject<Any?>() is ObjectId -> ObjectIdResult(v.asHostObject())
+            v.isHostObject && v.asHostObject<Any?>() is UUID -> UUIDResult(v.asHostObject())
+            v.isHostObject && v.asHostObject<Any?>() is Date -> DateResult(v.asHostObject())
+            v.hasArrayElements() -> ArrayResult((0 until v.arraySize).map { toJava(v.getArrayElement(it)).value })
+            v.canExecute() -> FunctionResult
+            v.hasMembers() -> DocumentResult(Document(v.memberKeys.associateWith { key -> toJava(v[key]!!).value })) // todo: handle recursion
+            else -> throw IllegalArgumentException("unknown result: $v")
+        }
+    }
+}
+
+private class BsonTypes(context: MongoShellContext) {
+    val maxKey: Value        by lazy { context.eval("new MaxKey().constructor") }
+    val minKey: Value        by lazy { context.eval("new MinKey().constructor") }
+    val objectId: Value      by lazy { context.eval("new ObjectId().constructor") }
+    val numberDecimal: Value by lazy { context.eval("new NumberDecimal().constructor") }
+    val numberInt: Value     by lazy { context.eval("new NumberInt().constructor") }
+    val timestamp: Value     by lazy { context.eval("new Timestamp().constructor") }
+    val code: Value          by lazy { context.eval("new Code().constructor") }
+    val dbRef: Value         by lazy { context.eval("new DBRef('', '', '').constructor") }
+    val bsonSymbol: Value    by lazy { context.eval("new BSONSymbol('').constructor") }
+    val numberLong: Value    by lazy { context.eval("new NumberLong().constructor") }
+    val binData: Value       by lazy { context.eval("new BinData(0, '').constructor") }
+    val hexData: Value       by lazy { context.eval("new HexData(0, '').constructor") }
+}

--- a/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/MongoShellEvaluator.kt
+++ b/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/MongoShellEvaluator.kt
@@ -1,16 +1,7 @@
 package com.mongodb.mongosh
 
-import com.mongodb.DBRef
 import com.mongodb.client.MongoClient
-import com.mongodb.client.result.UpdateResult
-import com.mongodb.mongosh.result.*
-import com.mongodb.mongosh.service.Either
 import com.mongodb.mongosh.service.JavaServiceProvider
-import com.mongodb.mongosh.service.Left
-import com.mongodb.mongosh.service.Right
-import org.bson.Document
-import org.bson.json.JsonReader
-import org.bson.types.*
 import org.graalvm.polyglot.Value
 import org.graalvm.polyglot.proxy.ProxyExecutable
 import org.intellij.lang.annotations.Language
@@ -24,18 +15,13 @@ import java.time.temporal.TemporalAccessor
 import java.time.temporal.TemporalField
 import java.time.temporal.UnsupportedTemporalTypeException
 import java.util.*
-import java.util.concurrent.CompletableFuture
-import java.util.concurrent.ExecutionException
-import java.util.concurrent.TimeUnit
-import java.util.regex.Pattern
 
-internal class MongoShellEvaluator(client: MongoClient, private val context: MongoShellContext) {
-    private val serviceProvider = JavaServiceProvider(client, this)
+internal class MongoShellEvaluator(client: MongoClient, private val context: MongoShellContext, private val converter: MongoShellConverter) {
+    private val serviceProvider = JavaServiceProvider(client, converter)
     private val shellEvaluator: Value
     private val shellInternalState: Value
     private val toShellResultFn: Value
     private val getShellApiTypeFn: Value
-    private val bsonTypes: BsonTypes
     private var printedValues: MutableList<List<Any?>>? = null
 
     init {
@@ -50,19 +36,6 @@ internal class MongoShellEvaluator(client: MongoClient, private val context: Mon
         val jsSymbol = context.bindings["Symbol"]!!
         shellInternalState.invokeMember("setCtx", context.bindings)
         initContext(context.bindings, jsSymbol)
-        bsonTypes = BsonTypes(
-                context.eval("new MaxKey().constructor"),
-                context.eval("new MinKey().constructor"),
-                context.eval("new ObjectId().constructor"),
-                context.eval("new NumberDecimal().constructor"),
-                context.eval("new NumberInt().constructor"),
-                context.eval("new Timestamp().constructor"),
-                context.eval("new Code().constructor"),
-                context.eval("new DBRef('', '', '').constructor"),
-                context.eval("new BSONSymbol('').constructor"),
-                context.eval("new NumberLong().constructor"),
-                context.eval("new BinData(0, '').constructor"),
-                context.eval("new HexData(0, '').constructor"))
     }
 
     private fun resultHandler() = context.jsFun { args ->
@@ -88,7 +61,7 @@ internal class MongoShellEvaluator(client: MongoClient, private val context: Mon
         bindings.putMember("UUID", context.jsFun { args -> if (args.isEmpty()) UUID.randomUUID() else UUID.fromString(args[0].asString()) })
         // init console.log
         val print = context.jsFun { args ->
-            printedValues?.add(args.map { extract(it).value })
+            printedValues?.add(args.map { converter.toJava(it).value })
         }
         context.bindings.putMember("print", print)
         @Suppress("JSPrimitiveTypeWrapperUsage")
@@ -107,7 +80,7 @@ internal class MongoShellEvaluator(client: MongoClient, private val context: Mon
         val date = when {
             args.isEmpty() -> MongoshDate(System.currentTimeMillis())
             args.size == 1 -> {
-                when (val v = extract(args[0]).value) {
+                when (val v = converter.toJava(args[0]).value) {
                     is String -> parseDate(v)
                     is Number -> MongoshDate(v.toLong())
                     else -> throw IllegalArgumentException("Expected number or string. Got: ${args[0]} ($v)")
@@ -149,121 +122,13 @@ internal class MongoShellEvaluator(client: MongoClient, private val context: Mon
         return null
     }
 
-    internal fun unwrapPromise(v: Value): Value {
-        try {
-            return if (v.instanceOf(context, "Promise"))
-                CompletableFuture<Value>().also { future ->
-                    v.invokeMember("then", ProxyExecutable { args ->
-                        future.complete(args[0])
-                    }).invokeMember("catch", ProxyExecutable { args ->
-                        val error = args[0]
-                        if (error.isHostObject && error.asHostObject<Any>() is Throwable) {
-                            future.completeExceptionally(error.asHostObject<Any>() as Throwable)
-                        } else {
-                            val message = error.toString() + (if (error.instanceOf(context, "Error")) "\n${error.getMember("stack").asString()}" else "")
-                            future.completeExceptionally(Exception(message))
-                        }
-                    })
-                }.get(1, TimeUnit.SECONDS)
-            else v
-        } catch (e: ExecutionException) {
-            throw e.cause ?: e
-        }
-    }
-
     fun getShellApiType(rawValue: Value): String? {
         val rawType = getShellApiTypeFn.execute(rawValue)
         return if (rawType.isString) rawType.asString() else null
     }
 
     fun toShellResult(rawValue: Value): Value {
-        return unwrapPromise(toShellResultFn.execute(rawValue))
-    }
-
-    fun extract(v: Value, type: String? = null): MongoShellResult<*> {
-        return when {
-            type == "Help" -> extract(v["attr"]!!)
-            type == "Cursor" -> FindCursorResult(FindCursor<Any?>(v, this))
-            // document with aggregation explain result also has type AggregationCursor, so we need to make sure that value contains cursor
-            type == "AggregationCursor" && v.hasMember("_cursor") -> CursorResult(Cursor<Any?>(v, this))
-            type == "InsertOneResult" -> InsertOneResult(v["acknowledged"]!!.asBoolean(), v["insertedId"]!!.asString())
-            type == "DeleteResult" -> DeleteResult(v["acknowledged"]!!.asBoolean(), v["deletedCount"]!!.asLong())
-            type == "UpdateResult" -> {
-                val res = if (v["acknowledged"]!!.asBoolean()) {
-                    UpdateResult.acknowledged(
-                            v["matchedCount"]!!.asLong(),
-                            v["modifiedCount"]!!.asLong(),
-                            null
-                    )
-                } else UpdateResult.unacknowledged()
-                MongoShellUpdateResult(res)
-            }
-            type == "BulkWriteResult" -> BulkWriteResult(
-                    v["acknowledged"]!!.asBoolean(),
-                    v["insertedCount"]!!.asLong(),
-                    v["matchedCount"]!!.asLong(),
-                    v["modifiedCount"]!!.asLong(),
-                    v["deletedCount"]!!.asLong(),
-                    v["upsertedCount"]!!.asLong(),
-                    (extract(v["upsertedIds"]!!) as ArrayResult).value)
-            type == "InsertManyResult" -> InsertManyResult(v["acknowledged"]!!.asBoolean(), extract(v["insertedIds"]!!).value as List<String>)
-            v.instanceOf(context, "RegExp") -> {
-                val pattern = v["source"]!!.asString()
-                val flags1 = v["flags"]!!.asString()
-                var f = 0
-                if (flags1.contains('m')) f = f.or(Pattern.MULTILINE)
-                if (flags1.contains('i')) f = f.or(Pattern.CASE_INSENSITIVE)
-                PatternResult(Pattern.compile(pattern, f))
-            }
-            v.instanceOf(context, bsonTypes.maxKey) -> MaxKeyResult()
-            v.instanceOf(context, bsonTypes.minKey) -> MinKeyResult()
-            v.instanceOf(context, bsonTypes.objectId) -> ObjectIdResult(JsonReader(v.invokeMember("toExtendedJSON").toString()).readObjectId())
-            v.instanceOf(context, bsonTypes.numberDecimal) -> Decimal128Result(JsonReader(v.invokeMember("toExtendedJSON").toString()).readDecimal128())
-            v.instanceOf(context, bsonTypes.numberInt) -> IntResult(JsonReader(v.invokeMember("toExtendedJSON").toString()).readInt32())
-            v.instanceOf(context, bsonTypes.bsonSymbol) -> SymbolResult(Symbol(JsonReader(v.invokeMember("toExtendedJSON").toString()).readSymbol()))
-            v.instanceOf(context, bsonTypes.timestamp) -> {
-                val timestamp = JsonReader(extract(v.invokeMember("toExtendedJSON")).value.toLiteral()).readTimestamp()
-                BSONTimestampResult(BSONTimestamp(timestamp.time, timestamp.inc))
-            }
-            v.instanceOf(context, bsonTypes.code) -> {
-                val scope = extract(v["scope"]!!).value as? Document
-                val code = v["code"]!!.asString()
-                if (scope == null) CodeResult(Code(code))
-                else CodeWithScopeResult(CodeWithScope(code, scope))
-            }
-            v.instanceOf(context, bsonTypes.dbRef) -> {
-                val databaseName = v["db"]?.let { if (it.isNull) null else it }?.asString()
-                val collectionName = v["collection"]!!.asString()
-                val value = extract(v["oid"]!!).value
-                DBRefResult(DBRef(databaseName, collectionName, value!!))
-            }
-            v.instanceOf(context, bsonTypes.numberLong) -> LongResult(JsonReader(v.invokeMember("toExtendedJSON").toString()).readInt64())
-            v.instanceOf(context, bsonTypes.binData) -> {
-                val binary = JsonReader(v.invokeMember("toExtendedJSON").toString()).readBinaryData()
-                BinaryResult(Binary(binary.type, binary.data))
-            }
-            v.instanceOf(context, bsonTypes.hexData) -> {
-                val binary = JsonReader(v.invokeMember("toExtendedJSON").toString()).readBinaryData()
-                BinaryResult(Binary(binary.type, binary.data))
-            }
-            v.isString -> StringResult(v.asString())
-            v.isBoolean -> BooleanResult(v.asBoolean())
-            v.fitsInInt() -> IntResult(v.asInt())
-            v.fitsInLong() -> LongResult(v.asLong())
-            v.fitsInFloat() -> FloatResult(v.asFloat())
-            v.fitsInDouble() -> DoubleResult(v.asDouble())
-            v.equalsTo(context, "undefined") -> VoidResult
-            v.isNull -> NullResult
-            v.isHostObject && v.asHostObject<Any?>() is Unit -> VoidResult
-            v.isHostObject && v.asHostObject<Any?>() is Document -> DocumentResult(v.asHostObject())
-            v.isHostObject && v.asHostObject<Any?>() is ObjectId -> ObjectIdResult(v.asHostObject())
-            v.isHostObject && v.asHostObject<Any?>() is UUID -> UUIDResult(v.asHostObject())
-            v.isHostObject && v.asHostObject<Any?>() is Date -> DateResult(v.asHostObject())
-            v.hasArrayElements() -> ArrayResult((0 until v.arraySize).map { extract(v.getArrayElement(it)).value })
-            v.canExecute() -> FunctionResult
-            v.hasMembers() -> DocumentResult(Document(v.memberKeys.associateWith { key -> extract(v[key]!!).value })) // todo: handle recursion
-            else -> throw IllegalArgumentException("unknown result: $v")
-        }
+        return converter.unwrapPromise(toShellResultFn.execute(rawValue))
     }
 
     fun eval(@Language("js") script: String, name: String): Value {
@@ -293,66 +158,10 @@ internal class MongoShellEvaluator(client: MongoClient, private val context: Mon
         }
     }
 
-    fun <T> toJsPromise(promise: Either<T>): Value {
-        return when (promise) {
-            is Right -> context.eval("(v) => new Promise(((resolve) => resolve(v)))", "resolved_promise_script").execute(toJs(promise.value))
-            is Left -> context.eval("(v) => new Promise(((_, reject) => reject(v)))", "rejected_promise_script").execute(promise.value)
-        }
-    }
-
     fun close() {
         context.close()
     }
-
-    fun toJs(o: Any?): Any? {
-        return when (o) {
-            is Iterable<*> -> toJs(o)
-            is Array<*> -> toJs(o)
-            is Map<*, *> -> toJs(o)
-            Unit -> context.eval("undefined")
-            else -> o
-        }
-    }
-
-    private fun toJs(map: Map<*, *>): Value {
-        @Suppress("JSPrimitiveTypeWrapperUsage")
-        val jsMap = context.eval("new Object()")
-        for ((key, value) in map.entries) {
-            jsMap.putMember(key as String, toJs(value))
-        }
-        return jsMap
-    }
-
-    private fun toJs(list: Iterable<Any?>): Value {
-        val array = context.eval("[]")
-        list.forEachIndexed { index, v ->
-            array.setArrayElement(index.toLong(), toJs(v))
-        }
-        return array
-    }
-
-    private fun toJs(list: Array<*>): Value {
-        val array = context.eval("[]")
-        list.forEachIndexed { index, v ->
-            array.setArrayElement(index.toLong(), toJs(v))
-        }
-        return array
-    }
 }
-
-private data class BsonTypes(
-        val maxKey: Value,
-        val minKey: Value,
-        val objectId: Value,
-        val numberDecimal: Value,
-        val numberInt: Value,
-        val timestamp: Value,
-        val code: Value,
-        val dbRef: Value,
-        val bsonSymbol: Value,
-        val numberLong: Value,
-        val binData: Value,
-        val hexData: Value)
 
 /**
  * yyyy-MM-dd['T'HH:mm:ss.SSS['Z'|+HH:MM:ss]]

--- a/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/MongoShellEvaluator.kt
+++ b/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/MongoShellEvaluator.kt
@@ -32,7 +32,7 @@ import java.util.concurrent.ExecutionException
 import java.util.concurrent.TimeUnit
 import java.util.regex.Pattern
 
-internal class MongoShellContext(client: MongoClient) {
+internal class MongoShellEvaluator(client: MongoClient) {
     private var ctx: Context? = Context.create()
     private val serviceProvider = JavaServiceProvider(client, this)
     private val shellEvaluator: Value

--- a/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/result/Cursor.kt
+++ b/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/result/Cursor.kt
@@ -1,12 +1,12 @@
 package com.mongodb.mongosh.result
 
-import com.mongodb.mongosh.MongoShellContext
+import com.mongodb.mongosh.MongoShellEvaluator
 import org.graalvm.polyglot.Value
 
-open class Cursor<out T> internal constructor(protected var cursor: Value?, private var context: MongoShellContext?) : Iterator<T> {
+open class Cursor<out T> internal constructor(protected var cursor: Value?, private var evaluator: MongoShellEvaluator?) : Iterator<T> {
     fun _asPrintable(): String {
-        val (cursor, context) = checkClosed()
-        return context.extract(context.toShellResult(cursor).getMember("printable"))._asPrintable()
+        val (cursor, evaluator) = checkClosed()
+        return evaluator.extract(evaluator.toShellResult(cursor).getMember("printable"))._asPrintable()
     }
 
     override fun hasNext(): Boolean {
@@ -15,22 +15,22 @@ open class Cursor<out T> internal constructor(protected var cursor: Value?, priv
     }
 
     override fun next(): T {
-        val (cursor, context) = checkClosed()
+        val (cursor, evaluator) = checkClosed()
         if (!hasNext()) throw NoSuchElementException()
-        return context.extract(cursor.invokeMember("next")).value as T
+        return evaluator.extract(cursor.invokeMember("next")).value as T
     }
 
     fun close() {
         val (c, _) = checkClosed()
         c.invokeMember("close")
         cursor = null
-        context = null
+        evaluator = null
     }
 
-    internal fun checkClosed(): Pair<Value, MongoShellContext> {
+    internal fun checkClosed(): Pair<Value, MongoShellEvaluator> {
         val cursor = this.cursor
-        val context = this.context
-        if (cursor == null || context == null) throw IllegalStateException("Cursor has already been closed")
-        return cursor to context
+        val evaluator = this.evaluator
+        if (cursor == null || evaluator == null) throw IllegalStateException("Cursor has already been closed")
+        return cursor to evaluator
     }
 }

--- a/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/result/FindCursor.kt
+++ b/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/result/FindCursor.kt
@@ -1,9 +1,9 @@
 package com.mongodb.mongosh.result
 
-import com.mongodb.mongosh.MongoShellEvaluator
+import com.mongodb.mongosh.MongoShellConverter
 import org.graalvm.polyglot.Value
 
-class FindCursor<out T> internal constructor(cursor: Value?, evaluator: MongoShellEvaluator?) : Cursor<T>(cursor, evaluator) {
+class FindCursor<out T> internal constructor(cursor: Value?, converter: MongoShellConverter) : Cursor<T>(cursor, converter) {
     fun batchSize(size: Int) {
         val (cursor, _) = checkClosed()
         cursor.invokeMember("batchSize", size)

--- a/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/result/FindCursor.kt
+++ b/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/result/FindCursor.kt
@@ -1,9 +1,9 @@
 package com.mongodb.mongosh.result
 
-import com.mongodb.mongosh.MongoShellContext
+import com.mongodb.mongosh.MongoShellEvaluator
 import org.graalvm.polyglot.Value
 
-class FindCursor<out T> internal constructor(cursor: Value?, context: MongoShellContext?) : Cursor<T>(cursor, context) {
+class FindCursor<out T> internal constructor(cursor: Value?, evaluator: MongoShellEvaluator?) : Cursor<T>(cursor, evaluator) {
     fun batchSize(size: Int) {
         val (cursor, _) = checkClosed()
         cursor.invokeMember("batchSize", size)

--- a/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/service/BaseMongoIterableHelper.kt
+++ b/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/service/BaseMongoIterableHelper.kt
@@ -1,22 +1,24 @@
 package com.mongodb.mongosh.service
 
-import com.mongodb.*
+import com.mongodb.CursorType
+import com.mongodb.ReadPreference
+import com.mongodb.TagSet
 import com.mongodb.client.AggregateIterable
 import com.mongodb.client.FindIterable
 import com.mongodb.client.MongoDatabase
 import com.mongodb.client.MongoIterable
-import com.mongodb.mongosh.MongoShellEvaluator
+import com.mongodb.mongosh.MongoShellConverter
 import org.bson.Document
 import org.graalvm.polyglot.Value
 
-internal abstract class BaseMongoIterableHelper<T : MongoIterable<*>>(val iterable: T, protected val evaluator: MongoShellEvaluator, protected val options: Document?) {
+internal abstract class BaseMongoIterableHelper<T : MongoIterable<*>>(val iterable: T, protected val converter: MongoShellConverter, protected val options: Document?) {
     abstract val converters: Map<String, (T, Any?) -> Either<T>>
     abstract val defaultConverter: (T, String, Any?) -> Either<T>
 
     fun map(function: Value): BaseMongoIterableHelper<*> {
         return helper(iterable.map { v ->
-            evaluator.extract(function.execute(evaluator.toJs(v))).value
-        }, evaluator)
+            converter.toJava(function.execute(converter.toJs(v))).value
+        }, converter)
     }
 
     fun itcount(): Int {
@@ -53,8 +55,8 @@ internal abstract class BaseMongoIterableHelper<T : MongoIterable<*>>(val iterab
 }
 
 internal class MongoIterableHelper(iterable: MongoIterable<*>,
-                                   evaluator: MongoShellEvaluator,
-                                   options: Document?) : BaseMongoIterableHelper<MongoIterable<*>>(iterable, evaluator, options) {
+                                   converter: MongoShellConverter,
+                                   options: Document?) : BaseMongoIterableHelper<MongoIterable<*>>(iterable, converter, options) {
     override val converters = iterableConverters
     override val defaultConverter = unrecognizedField<MongoIterable<*>>("iterable options")
 }
@@ -64,10 +66,10 @@ internal data class AggregateCreateOptions(val db: MongoDatabase,
                                            val pipeline: List<Document>)
 
 internal class AggregateIterableHelper(iterable: AggregateIterable<*>,
-                                       evaluator: MongoShellEvaluator,
+                                       converter: MongoShellConverter,
                                        options: Document?,
                                        private val createOptions: AggregateCreateOptions?)
-    : BaseMongoIterableHelper<AggregateIterable<out Any?>>(iterable, evaluator, options) {
+    : BaseMongoIterableHelper<AggregateIterable<out Any?>>(iterable, converter, options) {
     override val converters = aggregateConverters
     override val defaultConverter = aggregateDefaultConverter
 
@@ -89,7 +91,7 @@ internal class AggregateIterableHelper(iterable: AggregateIterable<*>,
         else createOptions.db.withReadPreference(ReadPreference.valueOf(v, tags))
         val newCreateOptions = createOptions.copy(db = newDb)
         val newIterable = aggregate(options, newCreateOptions)
-        return AggregateIterableHelper(newIterable, evaluator, options, newCreateOptions)
+        return AggregateIterableHelper(newIterable, converter, options, newCreateOptions)
     }
 
     override fun maxTimeMS(v: Long) = set("maxTimeMS", v)
@@ -123,10 +125,10 @@ internal data class FindCreateOptions(val db: MongoDatabase,
                                       val find: Document)
 
 internal class FindIterableHelper(iterable: FindIterable<out Any?>,
-                                  evaluator: MongoShellEvaluator,
+                                  converter: MongoShellConverter,
                                   options: Document?,
                                   private val createOptions: FindCreateOptions?)
-    : BaseMongoIterableHelper<FindIterable<out Any?>>(iterable, evaluator, options) {
+    : BaseMongoIterableHelper<FindIterable<out Any?>>(iterable, converter, options) {
     override val converters = findConverters
     override val defaultConverter = findDefaultConverter
 
@@ -137,7 +139,7 @@ internal class FindIterableHelper(iterable: FindIterable<out Any?>,
         else createOptions.db.withReadPreference(ReadPreference.valueOf(v, tags))
         val newCreateOptions = createOptions.copy(db = newDb)
         val newIterable = find(options, newCreateOptions)
-        return FindIterableHelper(newIterable, evaluator, options, newCreateOptions)
+        return FindIterableHelper(newIterable, converter, options, newCreateOptions)
     }
 
     override fun allowPartialResults() = set("allowPartialResults", true)
@@ -163,10 +165,10 @@ internal class FindIterableHelper(iterable: FindIterable<out Any?>,
     }
 }
 
-internal fun helper(iterable: MongoIterable<out Any?>, evaluator: MongoShellEvaluator): BaseMongoIterableHelper<*> {
+internal fun helper(iterable: MongoIterable<out Any?>, converter: MongoShellConverter): BaseMongoIterableHelper<*> {
     return when (iterable) {
-        is FindIterable -> FindIterableHelper(iterable, evaluator, null, null)
-        is AggregateIterable -> AggregateIterableHelper(iterable, evaluator, null, null)
-        else -> MongoIterableHelper(iterable, evaluator, null)
+        is FindIterable -> FindIterableHelper(iterable, converter, null, null)
+        is AggregateIterable -> AggregateIterableHelper(iterable, converter, null, null)
+        else -> MongoIterableHelper(iterable, converter, null)
     }
 }

--- a/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/service/Cursor.kt
+++ b/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/service/Cursor.kt
@@ -1,13 +1,13 @@
 package com.mongodb.mongosh.service
 
 import com.mongodb.client.MongoCursor
-import com.mongodb.mongosh.MongoShellEvaluator
+import com.mongodb.mongosh.MongoShellConverter
 import com.mongodb.mongosh.result.DocumentResult
 import org.bson.Document
 import org.graalvm.polyglot.HostAccess
 import org.graalvm.polyglot.Value
 
-internal class Cursor(private var helper: BaseMongoIterableHelper<*>, private val evaluator: MongoShellEvaluator) : ServiceProviderCursor {
+internal class Cursor(private var helper: BaseMongoIterableHelper<*>, private val converter: MongoShellConverter) : ServiceProviderCursor {
     private var iterator: MongoCursor<out Any?>? = null
     private var closed = false
 
@@ -75,7 +75,7 @@ internal class Cursor(private var helper: BaseMongoIterableHelper<*>, private va
         if (!v.hasMembers()) {
             throw IllegalArgumentException("Expected one argument of type object. Got: $v")
         }
-        val collation = toDocument(evaluator, v)
+        val collation = toDocument(converter, v)
         helper.collation(collation)
         return this
     }
@@ -96,7 +96,7 @@ internal class Cursor(private var helper: BaseMongoIterableHelper<*>, private va
     @HostAccess.Export
     override fun explain(verbosity: String?): Any? {
         checkQueryNotExecuted()
-        return evaluator.toJs(helper.explain(verbosity))
+        return converter.toJs(helper.explain(verbosity))
     }
 
     @HostAccess.Export
@@ -105,7 +105,7 @@ internal class Cursor(private var helper: BaseMongoIterableHelper<*>, private va
             throw IllegalArgumentException("Expected one argument of type function. Got: $func")
         }
         getOrCreateIterator().forEach { v ->
-            func.execute(evaluator.toJs(v))
+            func.execute(converter.toJs(v))
         }
     }
 
@@ -121,7 +121,7 @@ internal class Cursor(private var helper: BaseMongoIterableHelper<*>, private va
         if (v.isString) {
             helper.hint(v.asString())
         } else if (v.hasMembers()) {
-            helper.hint(toDocument(evaluator, v))
+            helper.hint(toDocument(converter, v))
         }
         return this
     }
@@ -160,7 +160,7 @@ internal class Cursor(private var helper: BaseMongoIterableHelper<*>, private va
         if (!v.hasMembers()) {
             throw IllegalArgumentException("Expected one argument of type object. Got: $v")
         }
-        helper.max(toDocument(evaluator, v))
+        helper.max(toDocument(converter, v))
         return this
     }
 
@@ -181,7 +181,7 @@ internal class Cursor(private var helper: BaseMongoIterableHelper<*>, private va
         if (!v.hasMembers()) {
             throw IllegalArgumentException("Expected one argument of type object. Got: $v")
         }
-        helper.min(toDocument(evaluator, v))
+        helper.min(toDocument(converter, v))
         return this
     }
 
@@ -191,7 +191,7 @@ internal class Cursor(private var helper: BaseMongoIterableHelper<*>, private va
     @HostAccess.Export
     override fun project(v: Value): ServiceProviderCursor {
         checkQueryNotExecuted()
-        helper.projection(toDocument(evaluator, v))
+        helper.projection(toDocument(converter, v))
         return this
     }
 
@@ -228,22 +228,22 @@ internal class Cursor(private var helper: BaseMongoIterableHelper<*>, private va
     @HostAccess.Export
     override fun sort(spec: Value): Cursor {
         checkQueryNotExecuted()
-        helper.sort(toDocument(evaluator, spec))
+        helper.sort(toDocument(converter, spec))
         return this
     }
 
     @HostAccess.Export
     override fun toArray(): Any? {
         checkQueryNotExecuted()
-        return evaluator.toJs(helper.toArray())
+        return converter.toJs(helper.toArray())
     }
 
     private fun checkQueryNotExecuted() {
         check(iterator == null) { "query already executed" }
     }
 
-    private fun toDocument(evaluator: MongoShellEvaluator, map: Value?): Document {
+    private fun toDocument(converter: MongoShellConverter, map: Value?): Document {
         return if (map == null || map.isNull) Document()
-        else (evaluator.extract(map) as DocumentResult).value
+        else (converter.toJava(map) as DocumentResult).value
     }
 }

--- a/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/service/Cursor.kt
+++ b/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/service/Cursor.kt
@@ -1,13 +1,13 @@
 package com.mongodb.mongosh.service
 
 import com.mongodb.client.MongoCursor
-import com.mongodb.mongosh.MongoShellContext
+import com.mongodb.mongosh.MongoShellEvaluator
 import com.mongodb.mongosh.result.DocumentResult
 import org.bson.Document
 import org.graalvm.polyglot.HostAccess
 import org.graalvm.polyglot.Value
 
-internal class Cursor(private var helper: BaseMongoIterableHelper<*>, private val context: MongoShellContext) : ServiceProviderCursor {
+internal class Cursor(private var helper: BaseMongoIterableHelper<*>, private val evaluator: MongoShellEvaluator) : ServiceProviderCursor {
     private var iterator: MongoCursor<out Any?>? = null
     private var closed = false
 
@@ -75,7 +75,7 @@ internal class Cursor(private var helper: BaseMongoIterableHelper<*>, private va
         if (!v.hasMembers()) {
             throw IllegalArgumentException("Expected one argument of type object. Got: $v")
         }
-        val collation = toDocument(context, v)
+        val collation = toDocument(evaluator, v)
         helper.collation(collation)
         return this
     }
@@ -96,7 +96,7 @@ internal class Cursor(private var helper: BaseMongoIterableHelper<*>, private va
     @HostAccess.Export
     override fun explain(verbosity: String?): Any? {
         checkQueryNotExecuted()
-        return context.toJs(helper.explain(verbosity))
+        return evaluator.toJs(helper.explain(verbosity))
     }
 
     @HostAccess.Export
@@ -105,7 +105,7 @@ internal class Cursor(private var helper: BaseMongoIterableHelper<*>, private va
             throw IllegalArgumentException("Expected one argument of type function. Got: $func")
         }
         getOrCreateIterator().forEach { v ->
-            func.execute(context.toJs(v))
+            func.execute(evaluator.toJs(v))
         }
     }
 
@@ -121,7 +121,7 @@ internal class Cursor(private var helper: BaseMongoIterableHelper<*>, private va
         if (v.isString) {
             helper.hint(v.asString())
         } else if (v.hasMembers()) {
-            helper.hint(toDocument(context, v))
+            helper.hint(toDocument(evaluator, v))
         }
         return this
     }
@@ -160,7 +160,7 @@ internal class Cursor(private var helper: BaseMongoIterableHelper<*>, private va
         if (!v.hasMembers()) {
             throw IllegalArgumentException("Expected one argument of type object. Got: $v")
         }
-        helper.max(toDocument(context, v))
+        helper.max(toDocument(evaluator, v))
         return this
     }
 
@@ -181,7 +181,7 @@ internal class Cursor(private var helper: BaseMongoIterableHelper<*>, private va
         if (!v.hasMembers()) {
             throw IllegalArgumentException("Expected one argument of type object. Got: $v")
         }
-        helper.min(toDocument(context, v))
+        helper.min(toDocument(evaluator, v))
         return this
     }
 
@@ -191,7 +191,7 @@ internal class Cursor(private var helper: BaseMongoIterableHelper<*>, private va
     @HostAccess.Export
     override fun project(v: Value): ServiceProviderCursor {
         checkQueryNotExecuted()
-        helper.projection(toDocument(context, v))
+        helper.projection(toDocument(evaluator, v))
         return this
     }
 
@@ -228,22 +228,22 @@ internal class Cursor(private var helper: BaseMongoIterableHelper<*>, private va
     @HostAccess.Export
     override fun sort(spec: Value): Cursor {
         checkQueryNotExecuted()
-        helper.sort(toDocument(context, spec))
+        helper.sort(toDocument(evaluator, spec))
         return this
     }
 
     @HostAccess.Export
     override fun toArray(): Any? {
         checkQueryNotExecuted()
-        return context.toJs(helper.toArray())
+        return evaluator.toJs(helper.toArray())
     }
 
     private fun checkQueryNotExecuted() {
         check(iterator == null) { "query already executed" }
     }
 
-    private fun toDocument(context: MongoShellContext, map: Value?): Document {
+    private fun toDocument(evaluator: MongoShellEvaluator, map: Value?): Document {
         return if (map == null || map.isNull) Document()
-        else (context.extract(map) as DocumentResult).value
+        else (evaluator.extract(map) as DocumentResult).value
     }
 }

--- a/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/service/JavaServiceProvider.kt
+++ b/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/service/JavaServiceProvider.kt
@@ -4,7 +4,7 @@ import com.mongodb.client.MongoClient
 import com.mongodb.client.MongoDatabase
 import com.mongodb.client.model.*
 import com.mongodb.client.result.UpdateResult
-import com.mongodb.mongosh.MongoShellContext
+import com.mongodb.mongosh.MongoShellEvaluator
 import com.mongodb.mongosh.result.ArrayResult
 import com.mongodb.mongosh.result.CommandException
 import com.mongodb.mongosh.result.DocumentResult
@@ -13,7 +13,7 @@ import org.graalvm.polyglot.HostAccess
 import org.graalvm.polyglot.Value
 
 @Suppress("NAME_SHADOWING")
-internal class JavaServiceProvider(private val client: MongoClient, private val context: MongoShellContext) : ReadableServiceProvider, WritableServiceProvider, AdminServiceProvider {
+internal class JavaServiceProvider(private val client: MongoClient, private val evaluator: MongoShellEvaluator) : ReadableServiceProvider, WritableServiceProvider, AdminServiceProvider {
 
     @JvmField
     @HostAccess.Export
@@ -340,7 +340,7 @@ internal class JavaServiceProvider(private val client: MongoClient, private val 
         val db = getDatabase(database, dbOptions).getOrThrow()
         val createOptions = AggregateCreateOptions(db, collection, pipeline.filterIsInstance<Document>())
         val opt = options ?: Document()
-        return Cursor(AggregateIterableHelper(aggregate(opt, createOptions), context, opt, createOptions), context)
+        return Cursor(AggregateIterableHelper(aggregate(opt, createOptions), evaluator, opt, createOptions), evaluator)
     }
 
     @HostAccess.Export
@@ -352,7 +352,7 @@ internal class JavaServiceProvider(private val client: MongoClient, private val 
         val db = getDatabase(database, dbOptions).getOrThrow()
         val createOptions = AggregateCreateOptions(db, null, pipeline.filterIsInstance<Document>())
         val opt = options ?: Document()
-        return Cursor(AggregateIterableHelper(aggregate(opt, createOptions), context, opt, createOptions), context)
+        return Cursor(AggregateIterableHelper(aggregate(opt, createOptions), evaluator, opt, createOptions), evaluator)
     }
 
     @HostAccess.Export
@@ -401,7 +401,7 @@ internal class JavaServiceProvider(private val client: MongoClient, private val 
         val db = client.getDatabase(database)
         val createOptions = FindCreateOptions(db, collection, filter ?: Document())
         val opt = options ?: Document()
-        return Cursor(FindIterableHelper(find(opt, createOptions), context, opt, createOptions), context)
+        return Cursor(FindIterableHelper(find(opt, createOptions), evaluator, opt, createOptions), evaluator)
     }
 
     private fun toDocument(value: Value?, fieldName: String): Document? {
@@ -409,7 +409,7 @@ internal class JavaServiceProvider(private val client: MongoClient, private val 
         if (!value.hasMembers()) {
             throw IllegalArgumentException("$fieldName should be an object: $value")
         }
-        return (context.extract(value) as DocumentResult).value
+        return (evaluator.extract(value) as DocumentResult).value
     }
 
     private fun toList(value: Value?, fieldName: String): List<Any?>? {
@@ -417,7 +417,7 @@ internal class JavaServiceProvider(private val client: MongoClient, private val 
         if (!value.hasArrayElements()) {
             throw IllegalArgumentException("$fieldName should be a list: $value")
         }
-        return (context.extract(value) as ArrayResult).value
+        return (evaluator.extract(value) as ArrayResult).value
     }
 
     @HostAccess.Export
@@ -552,7 +552,7 @@ internal class JavaServiceProvider(private val client: MongoClient, private val 
     override fun dropIndexes(database: String, collection: String, indexes: Value?, options: Value?): Value = promise<Any?> {
         val indexes = if (indexes != null && !indexes.isNull) indexes else throw IllegalArgumentException("Indexes parameter must not be null")
         val indexesList = if (indexes.hasArrayElements()) toList(indexes, "indexes")!!
-        else listOf(context.extract(indexes).value)
+        else listOf(evaluator.extract(indexes).value)
         getDatabase(database, null).map { db ->
             val coll = db.getCollection(collection)
             indexesList.forEach { index ->
@@ -589,6 +589,6 @@ internal class JavaServiceProvider(private val client: MongoClient, private val 
     }
 
     private fun <T> promise(block: () -> Either<T>): Value {
-        return context.toJsPromise(block())
+        return evaluator.toJsPromise(block())
     }
 }

--- a/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/util.kt
+++ b/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/util.kt
@@ -1,0 +1,23 @@
+@file:Suppress("NOTHING_TO_INLINE")
+
+package com.mongodb.mongosh
+
+import org.graalvm.polyglot.Value
+import org.intellij.lang.annotations.Language
+
+
+internal inline operator fun Value.get(identifier: String): Value? {
+    return getMember(identifier)
+}
+
+internal inline fun Value.instanceOf(context: MongoShellContext, @Language("js") clazz: String): Boolean {
+    return context.eval("(x) => x instanceof $clazz", "instance_of_script").execute(this).asBoolean()
+}
+
+internal inline fun Value.instanceOf(context: MongoShellContext, clazz: Value?): Boolean {
+    return clazz != null && context.eval("(o, clazz) => o instanceof clazz", "instance_of_class_script").execute(this, clazz).asBoolean()
+}
+
+internal inline fun Value.equalsTo(context: MongoShellContext, value: String): Boolean {
+    return context.eval("(x) => x === $value", "equals_script").execute(this).asBoolean()
+}


### PR DESCRIPTION
I split `MongoShellContext` into smaller parts:
* `MongoShellContext` now contains only GraalVM context and code for creating JS functions
* `MongoShellConverter` knows how to convert JS <-> Java values
* `ConsoleLogSupport` initializes console.log function 
* `MongoShellEvaluator` instantiates shell evaluator and shell internal state + add some constructors like ISODate