### PR TITLE
[java-shell] Fix createIndexes. Core did not pass dbOptions as a last argument

### DIFF
--- a/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/service/JavaServiceProvider.kt
+++ b/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/service/JavaServiceProvider.kt
@@ -537,10 +537,11 @@ internal class JavaServiceProvider(private val client: MongoClient,
     }
 
     @HostAccess.Export
-    override fun createIndexes(database: String, collection: String, indexSpecs: Value?): Value = promise<Any?> {
+    override fun createIndexes(database: String, collection: String, indexSpecs: Value?, options: Value?, dbOptions: Value?): Value = promise<Any?> {
         val indexSpecs = toList(indexSpecs, "indexSpecs") ?: emptyList()
+        val dbOptions = toDocument(dbOptions, "dbOptions")
         if (indexSpecs.any { it !is Document }) throw IllegalArgumentException("Index specs must be a list of documents. Got $indexSpecs")
-        getDatabase(database, null).flatMap { db ->
+        getDatabase(database, dbOptions).flatMap { db ->
             val convertedIndexes = indexSpecs.map { spec ->
                 convert(IndexModel(Document()), indexModelConverters, indexModelDefaultConverter, spec as Document)
             }

--- a/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/service/WritableServiceProvider.kt
+++ b/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/service/WritableServiceProvider.kt
@@ -25,7 +25,7 @@ internal interface WritableServiceProvider {
     fun save(database: String, collection: String, document: Value, options: Value?, dbOptions: Value?): Value
     fun remove(database: String, collection: String, query: Value, options: Value?, dbOptions: Value?): Value
     fun convertToCapped(database: String, collection: String, size: Number, options: Value?): Value
-    fun createIndexes(database: String, collection: String, indexSpecs: Value?): Value
+    fun createIndexes(database: String, collection: String, indexSpecs: Value?, options: Value?, dbOptions: Value?): Value
     fun dropIndexes(database: String, collection: String, indexes: Value?, options: Value?): Value
     fun reIndex(database: String, collection: String, options: Value?, dbOptions: Value?): Value
     fun dropCollection(database: String, collection: String, options: Value?): Value

--- a/packages/java-shell/src/test/kotlin/com/mongodb/mongosh/CollectionTest.kt
+++ b/packages/java-shell/src/test/kotlin/com/mongodb/mongosh/CollectionTest.kt
@@ -22,6 +22,7 @@ class CollectionTest : ShellTestCase() {
     @Test fun testCountWithQuery()         = test()
     @Test fun testCountWithUnknownOption() = test()
     @Test fun testCreateIndex()            = test()
+    @Test fun testCreateIndexes()          = test()
     @Test fun testDeleteMany()             = test()
     @Test fun testDeleteOne()              = test()
     @Test fun testDistinct()               = test()

--- a/packages/java-shell/src/test/resources/collection/createIndex.expected.1.txt
+++ b/packages/java-shell/src/test/resources/collection/createIndex.expected.1.txt
@@ -1,2 +1,0 @@
-[ "category_1" ]
-[ { "v": 2, "key": { "_id": 1 }, "name": "_id_" }, { "v": 2, "key": { "category": 1 }, "name": "category_1", "collation": { "locale": "fr", "caseLevel": false, "caseFirst": "off", "strength": 3, "numericOrdering": false, "alternate": "non-ignorable", "maxVariable": "punct", "normalization": false, "backwards": false, "version": "57.1" } } ]

--- a/packages/java-shell/src/test/resources/collection/createIndex.expected.txt
+++ b/packages/java-shell/src/test/resources/collection/createIndex.expected.txt
@@ -1,2 +1,2 @@
 [ "category_1" ]
-[ { "v": 2, "key": { "_id": 1 }, "name": "_id_", "ns": "admin.coll" }, { "v": 2, "key": { "category": 1 }, "name": "category_1", "ns": "admin.coll", "collation": { "locale": "fr", "caseLevel": false, "caseFirst": "off", "strength": 3, "numericOrdering": false, "alternate": "non-ignorable", "maxVariable": "punct", "normalization": false, "backwards": false, "version": "57.1" } } ]
+"category_1"

--- a/packages/java-shell/src/test/resources/collection/createIndex.js
+++ b/packages/java-shell/src/test/resources/collection/createIndex.js
@@ -5,7 +5,7 @@ db.coll.insertOne({category: "cat2", v: 2});
 db.coll.insertOne({category: "cat2", v: 3});
 // command
 db.coll.createIndex({category: 1}, {collation: {locale: "fr"}});
-// command
+// command getArrayItem=1 extractProperty=name
 db.coll.getIndexes();
 // clear
 db.coll.drop();

--- a/packages/java-shell/src/test/resources/collection/createIndexes.expected.txt
+++ b/packages/java-shell/src/test/resources/collection/createIndexes.expected.txt
@@ -1,0 +1,3 @@
+[ "category_1", "title_1" ]
+"category_1"
+"title_1"

--- a/packages/java-shell/src/test/resources/collection/createIndexes.js
+++ b/packages/java-shell/src/test/resources/collection/createIndexes.js
@@ -1,0 +1,11 @@
+// before
+db.coll.deleteMany({});
+db.coll.insertMany([{category: "cat1", v: 1}, {category: "cat2", title: "t3", v: 2}, {category: "cat2", title: "t4", v: 3}]);
+// command
+db.coll.createIndexes([{"category": 1}, {"title": 1}], {collation: {locale: "fr", strength: 2}});
+// command getArrayItem=1 extractProperty=name
+db.coll.getIndexes();
+// command getArrayItem=2 extractProperty=name
+db.coll.getIndexes();
+// clear
+db.coll.drop();

--- a/packages/shell-api/src/collection.spec.ts
+++ b/packages/shell-api/src/collection.spec.ts
@@ -1181,7 +1181,7 @@ describe('Collection', () => {
     let internalSession: StubbedInstance<ServiceProviderSession>;
     const exceptions = {
       renameCollection: { a: ['name'] },
-      createIndexes: { a: [[]] },
+      createIndexes: { a: [[]], i: 4 },
       runCommand: { a: ['coll', {} ], m: 'runCommandWithCheck', i: 2 },
       findOne: { m: 'find' },
       insert: { m: 'insertMany' },

--- a/packages/shell-api/src/collection.ts
+++ b/packages/shell-api/src/collection.ts
@@ -973,7 +973,7 @@ export default class Collection extends ShellApiClass {
 
     this._emitCollectionApiCall('createIndexes', { specs });
 
-    return await this._mongo._serviceProvider.createIndexes(this._database._name, this._name, specs, this._database._baseOptions);
+    return await this._mongo._serviceProvider.createIndexes(this._database._name, this._name, specs, {}, this._database._baseOptions);
   }
 
   /**
@@ -999,7 +999,7 @@ export default class Collection extends ShellApiClass {
     this._emitCollectionApiCall('createIndex', { keys, options });
 
     const spec = { ...this._database._baseOptions, ...options, key: keys };
-    return await this._mongo._serviceProvider.createIndexes(this._database._name, this._name, [spec]);
+    return await this._mongo._serviceProvider.createIndexes(this._database._name, this._name, [spec], {}, this._database._baseOptions);
   }
 
   /**
@@ -1025,7 +1025,7 @@ export default class Collection extends ShellApiClass {
     this._emitCollectionApiCall('ensureIndex', { keys, options });
 
     const spec = { ...this._database._baseOptions, ...options, key: keys };
-    return await this._mongo._serviceProvider.createIndexes(this._database._name, this._name, [spec]);
+    return await this._mongo._serviceProvider.createIndexes(this._database._name, this._name, [spec], {}, this._database._baseOptions);
   }
 
   /**


### PR DESCRIPTION
Note that it contains a small change in core code in `collection.ts`.
`dbOptions` there were not passed as last argument to `serviceProvider.createIndexes` that caused `Arity error - expected: 3 actual: 4`