### PR TITLE
chore(test): do not fail tests if cleaning up fake homedir fails

### DIFF
--- a/packages/cli-repl/test/e2e.spec.ts
+++ b/packages/cli-repl/test/e2e.spec.ts
@@ -415,7 +415,13 @@ describe('e2e', function() {
 
     afterEach(async() => {
       await TestShell.killall();
-      await promisify(rimraf)(homedir);
+      try {
+        await promisify(rimraf)(homedir);
+      } catch (err) {
+        // On Windows in CI, this can fail with EPERM for some reason.
+        // If it does, just log the error instead of failing all tests.
+        console.error('Could not remove fake home directory:', err);
+      }
     });
 
     describe('config file', async() => {


### PR DESCRIPTION
Example failure: https://evergreen.mongodb.com/task/mongosh_win32_test_m42x_win_7ec01ec01310c9270e83925c4bc782c9a1882427_20_11_26_12_29_44