### PR TITLE
chore(cli-repl): use separate tmpdir for userId persistence test

### DIFF
--- a/packages/cli-repl/src/cli-repl.spec.ts
+++ b/packages/cli-repl/src/cli-repl.spec.ts
@@ -1,9 +1,7 @@
 import { PassThrough, Duplex } from 'stream';
-import { promisify } from 'util';
 import path from 'path';
 import { promises as fs } from 'fs';
 import { once } from 'events';
-import rimraf from 'rimraf';
 import CliRepl, { CliReplOptions } from './cli-repl';
 import { startTestServer } from '../../../testing/integration-testing-hooks';
 import { expect, useTmpdir, waitEval, fakeTTYProps } from '../test/repl-helpers';
@@ -75,7 +73,6 @@ describe('CliRepl', () => {
     context('during startup', () => {
       it('persists userId', async() => {
         const userIds: string[] = [];
-        await promisify(rimraf)(tmpdir.path);
         for (let i = 0; i < 2; i++) {
           cliRepl = new CliRepl(cliReplOptions);
           cliRepl.bus.on('mongosh:new-user', userId => userIds.push(userId));

--- a/packages/cli-repl/test/repl-helpers.ts
+++ b/packages/cli-repl/test/repl-helpers.ts
@@ -22,7 +22,13 @@ function useTmpdir(): { readonly path: string } {
   });
 
   afterEach(async() => {
-    promisify(rimraf)(tmpdir);
+    try {
+      await promisify(rimraf)(tmpdir);
+    } catch (err) {
+      // On Windows in CI, this can fail with EPERM for some reason.
+      // If it does, just log the error instead of failing all tests.
+      console.error('Could not remove fake home directory:', err);
+    }
   });
 
   return {


### PR DESCRIPTION
With a similar purpose like https://github.com/mongodb-js/mongosh/pull/449.

Example failure: https://evergreen.mongodb.com/task/mongosh_win32_test_m42x_win_7ec01ec01310c9270e83925c4bc782c9a1882427_20_11_26_12_29_44