### PR TITLE
chore(service-provider-core): remove extra methods MONGOSH-451

### DIFF
--- a/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/service/AdminServiceProvider.kt
+++ b/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/service/AdminServiceProvider.kt
@@ -6,8 +6,6 @@ import org.graalvm.polyglot.Value
  * see service-provider-core/src/admin.ts
  */
 internal interface AdminServiceProvider {
-    fun buildInfo(): Value
-    fun getCmdLineOpts(): Value
     fun listDatabases(database: String): Value
     fun getNewConnection(uri: String, options: Value?): Value
     fun getConnectionInfo(): Value

--- a/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/service/JavaServiceProvider.kt
+++ b/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/service/JavaServiceProvider.kt
@@ -50,16 +50,6 @@ internal class JavaServiceProvider(private val client: MongoClient,
     }
 
     @HostAccess.Export
-    override fun buildInfo(): Value = promise<Any?> {
-        Left(NotImplementedError())
-    }
-
-    @HostAccess.Export
-    override fun getCmdLineOpts(): Value = promise<Any?> {
-        Left(NotImplementedError())
-    }
-
-    @HostAccess.Export
     override fun insertOne(database: String, collection: String, document: Value?, options: Value?, dbOptions: Value?): Value = promise {
         val document = toDocument(document, "document")
         val dbOptions = toDocument(dbOptions, "dbOptions")
@@ -492,11 +482,6 @@ internal class JavaServiceProvider(private val client: MongoClient,
     }
 
     @HostAccess.Export
-    override fun convertToCapped(database: String, collection: String, size: Number, options: Value?): Value = promise<Any?> {
-        Left(NotImplementedError())
-    }
-
-    @HostAccess.Export
     override fun createCollection(database: String, collection: String, options: Value?): Value = promise {
         val options = toDocument(options, "options") ?: Document()
         getDatabase(database, null).flatMap { db ->
@@ -549,29 +534,6 @@ internal class JavaServiceProvider(private val client: MongoClient,
                 db.getCollection(collection).createIndexes(indexes)
             }
         }
-    }
-
-    @HostAccess.Export
-    override fun dropIndexes(database: String, collection: String, indexes: Value?, options: Value?): Value = promise<Any?> {
-        val indexes = if (indexes != null && !indexes.isNull) indexes else throw IllegalArgumentException("Indexes parameter must not be null")
-        val indexesList = if (indexes.hasArrayElements()) toList(indexes, "indexes")!!
-        else listOf(converter.toJava(indexes).value)
-        getDatabase(database, null).map { db ->
-            val coll = db.getCollection(collection)
-            indexesList.forEach { index ->
-                when (index) {
-                    is String -> coll.dropIndex(index)
-                    is Document -> coll.dropIndex(index)
-                    else -> throw IllegalArgumentException("Unknown index specification $index")
-                }
-            }
-
-        }
-    }
-
-    @HostAccess.Export
-    override fun reIndex(database: String, collection: String, options: Value?, dbOptions: Value?): Value = promise<Any?> {
-        Left(NotImplementedError())
     }
 
     @HostAccess.Export

--- a/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/service/WritableServiceProvider.kt
+++ b/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/service/WritableServiceProvider.kt
@@ -24,10 +24,7 @@ internal interface WritableServiceProvider {
     fun updateOne(database: String, collection: String, filter: Value, update: Value, options: Value?, dbOptions: Value?): Value
     fun save(database: String, collection: String, document: Value, options: Value?, dbOptions: Value?): Value
     fun remove(database: String, collection: String, query: Value, options: Value?, dbOptions: Value?): Value
-    fun convertToCapped(database: String, collection: String, size: Number, options: Value?): Value
     fun createIndexes(database: String, collection: String, indexSpecs: Value?, options: Value?, dbOptions: Value?): Value
-    fun dropIndexes(database: String, collection: String, indexes: Value?, options: Value?): Value
-    fun reIndex(database: String, collection: String, options: Value?, dbOptions: Value?): Value
     fun dropCollection(database: String, collection: String, options: Value?): Value
     fun renameCollection(database: String, oldName: String, newName: String, options: Value?, dbOptions: Value?): Value
     fun initializeBulkOp(database: String, collection: String, ordered: Boolean, options: Value?, dbOptions: Value?): Value

--- a/packages/java-shell/src/test/resources/collection/dropIndex.expected.1.txt
+++ b/packages/java-shell/src/test/resources/collection/dropIndex.expected.1.txt
@@ -1,1 +1,3 @@
+{ "nIndexesWas": 3, "ok": 1 }
+{ "nIndexesWas": 2, "ok": 1 }
 [ { "v": 2, "key": { "_id": 1 }, "name": "_id_" } ]

--- a/packages/java-shell/src/test/resources/collection/dropIndex.expected.txt
+++ b/packages/java-shell/src/test/resources/collection/dropIndex.expected.txt
@@ -1,1 +1,3 @@
+{ "nIndexesWas": 3, "ok": 1 }
+{ "nIndexesWas": 2, "ok": 1 }
 [ { "v": 2, "key": { "_id": 1 }, "name": "_id_", "ns": "admin.coll" } ]

--- a/packages/java-shell/src/test/resources/collection/dropIndexes.expected.1.txt
+++ b/packages/java-shell/src/test/resources/collection/dropIndexes.expected.1.txt
@@ -1,1 +1,2 @@
+{ "nIndexesWas": 3, "ok": 1 }
 [ { "v": 2, "key": { "_id": 1 }, "name": "_id_" } ]

--- a/packages/java-shell/src/test/resources/collection/dropIndexes.expected.txt
+++ b/packages/java-shell/src/test/resources/collection/dropIndexes.expected.txt
@@ -1,1 +1,2 @@
+{ "nIndexesWas": 3, "ok": 1 }
 [ { "v": 2, "key": { "_id": 1 }, "name": "_id_", "ns": "admin.coll" } ]

--- a/packages/service-provider-core/src/admin.ts
+++ b/packages/service-provider-core/src/admin.ts
@@ -29,20 +29,6 @@ export default interface Admin {
    */
   bsonLibrary: any;
 
-   /**
-   * Returns buildInfo.
-   *
-   * @returns {Promise} buildInfo object.
-   */
-  buildInfo(): Promise<Document>;
-
-  /**
-   * Returns the cmdLineOpts.
-   *
-   * @returns {Promise} The server version.
-   */
-  getCmdLineOpts(): Promise<Document>;
-
   /**
    * list databases.
    *

--- a/packages/service-provider-core/src/writable.ts
+++ b/packages/service-provider-core/src/writable.ts
@@ -320,25 +320,6 @@ export default interface Writable {
     dbOptions?: DbOptions): Promise<DeleteResult>;
 
   /**
-   * Converts an existing, non-capped collection to
-   * a capped collection within the same database.
-   *
-   * @param {String} database - The db name.
-   * @param {String} collection - The collection name.
-   * @param {String} size - The maximum size, in bytes, for the capped collection.
-   * @param {CommandOptions} options - The command options
-   *
-   * @param dbOptions
-   * @return {Promise}
-   */
-  convertToCapped(
-    database: string,
-    collection: string,
-    size: number,
-    options?: RunCommandOptions,
-    dbOptions?: DbOptions): Promise<Document>;
-
-  /**
    * Adds new indexes to a collection.
    *
    * @param {String} database - The db name.
@@ -354,39 +335,6 @@ export default interface Writable {
     indexSpecs: Document[],
     options?: CreateIndexesOptions,
     dbOptions?: DbOptions): Promise<Document>;
-
-  /**
-   * Drop indexes for a collection.
-   *
-   * @param {String} database - The db name.
-   * @param {String} collection - The collection name.
-   * @param {string|string[]|Object|Object[]} indexes the indexes to be removed.
-   * @param {CommandOptions} commandOptions - The command options.
-   * @param {DbOptions} dbOptions - The database options
-   * @return {Promise}
-   */
-  dropIndexes(
-    database: string,
-    collection: string,
-    indexes: string|string[]|Document|Document[],
-    commandOptions?: RunCommandOptions,
-    dbOptions?: DbOptions): Promise<Document>;
-
-  /**
-   * Reindex all indexes on the collection.
-   *
-   * @param {String} database - The db name.
-   * @param {String} collection - The collection name.
-   * @param {CommandOptions} options - The command options.
-   * @param {DbOptions} dbOptions - The database options
-   * @return {Promise}
-   */
-  reIndex(
-    database: string,
-    collection: string,
-    options?: RunCommandOptions,
-    dbOptions?: DbOptions
-  ): Promise<Document>;
 
   /**
    * Drops a collection.

--- a/packages/service-provider-server/src/cli-service-provider.integration.spec.ts
+++ b/packages/service-provider-server/src/cli-service-provider.integration.spec.ts
@@ -392,20 +392,6 @@ describe('CliServiceProvider [integration]', function() {
     });
   });
 
-  describe('#buildInfo', () => {
-    context('when the filter is empty', () => {
-      let result;
-
-      beforeEach(async() => {
-        result = await serviceProvider.buildInfo();
-      });
-
-      it('returns a semver', () => {
-        expect(result.version).to.match(/^\d+.\d+/);
-      });
-    });
-  });
-
   describe('#dropDatabase', () => {
     context('when a database does not exist', () => {
       let result;
@@ -439,29 +425,6 @@ describe('CliServiceProvider [integration]', function() {
       it('deletes the database', async() => {
         expect(await dbExists()).to.be.false;
       });
-    });
-  });
-
-  describe('#convertToCapped', () => {
-    it('converts a collection to capped', async() => {
-      const collName = 'coll1';
-      const nativeCollection = db.collection(collName);
-
-      await db.createCollection(collName);
-
-      expect(
-        await nativeCollection.isCapped()
-      ).to.be.false;
-
-      await serviceProvider.convertToCapped(
-        dbName,
-        collName,
-        10000
-      );
-
-      expect(
-        await nativeCollection.isCapped()
-      ).to.be.true;
     });
   });
 
@@ -506,44 +469,6 @@ describe('CliServiceProvider [integration]', function() {
       expect(
         result.map((spec) => spec.key)
       ).to.deep.equal([{ _id: 1 }, { x: 1 }]);
-    });
-  });
-
-  describe('#dropIndexes', () => {
-    it('drop existing indexes', async() => {
-      const collName = 'coll1';
-      const nativeCollection = db.collection(collName);
-
-      await nativeCollection.createIndex({ x: 1 }, { name: 'index_1' });
-
-      expect(
-        await nativeCollection.indexExists('index_1')
-      ).to.be.true;
-
-      await serviceProvider.dropIndexes(
-        dbName,
-        collName,
-        'index_1'
-      );
-
-      expect(
-        await nativeCollection.indexExists('index_1')
-      ).to.be.false;
-    });
-
-    it('throws an error if index does not exist', async() => {
-      const collName = 'coll1';
-      await db.createCollection(collName);
-
-      let error;
-      await serviceProvider.dropIndexes(
-        dbName,
-        collName,
-        ['index_1']
-      ).catch(err => {error = err;});
-
-      expect(error.ok).to.equal(0);
-      expect(error.codeName).to.equal('IndexNotFound');
     });
   });
 
@@ -609,34 +534,6 @@ describe('CliServiceProvider [integration]', function() {
       ).to.deep.contain({
         name: 'coll2',
         type: 'collection'
-      });
-    });
-  });
-
-  describe('#reIndex', () => {
-    it('runs against the db', async() => {
-      const collName = 'coll1';
-      await db.createCollection(collName);
-
-      const result: any = await serviceProvider.reIndex(
-        dbName,
-        collName
-      );
-
-      expect(
-        result
-      ).to.deep.include({
-        nIndexesWas: 1,
-        nIndexes: 1,
-        ok: 1
-      });
-      expect(result.indexes.length).to.equal(1);
-      expect(result.indexes[0]).to.deep.include({
-        v: 2,
-        key: {
-          '_id': 1
-        },
-        name: '_id_'
       });
     });
   });

--- a/packages/service-provider-server/src/cli-service-provider.spec.ts
+++ b/packages/service-provider-server/src/cli-service-provider.spec.ts
@@ -465,91 +465,6 @@ describe('CliServiceProvider', () => {
     });
   });
 
-  describe('#buildInfo', () => {
-    let clientStub: StubbedInstance<MongoClient>;
-    let dbStub: StubbedInstance<Db>;
-
-    const buildInfoResult = {
-      version: '4.0.0',
-      gitVersion: 'a4b751dcf51dd249c5865812b390cfd1c0129c30',
-      javascriptEngine: 'mozjs',
-      versionArray: [4, 0, 0, 0],
-    };
-
-    beforeEach(() => {
-      dbStub = stubInterface<Db>();
-      clientStub = stubInterface<MongoClient>();
-      dbStub.command.resolves(buildInfoResult);
-      clientStub.db.returns(dbStub);
-      serviceProvider = new CliServiceProvider(clientStub);
-    });
-
-    it('executes the command against the admin database', async() => {
-      const cmd = { buildInfo: 1 };
-      const result = await serviceProvider.buildInfo();
-      expect(result).to.deep.equal(buildInfoResult);
-      expect(clientStub.db).to.have.been.calledWith('admin');
-      expect(dbStub.command).to.have.been.calledWith(cmd, DEFAULT_BASE_OPTS);
-    });
-  });
-
-  describe('#getCmdLineOpts', () => {
-    let dbStub: StubbedInstance<Db>;
-    let clientStub: StubbedInstance<MongoClient>;
-
-    const cmdLineOptsResult = {
-      argv: [
-        '/opt/mongodb-osx-x86_64-enterprise-3.6.3/bin/mongod',
-        '--dbpath=/Users/user/testdata'
-      ],
-      parsed: {
-        storage: {
-          dbPath: '/Users/user/testdata'
-        }
-      },
-      ok: 1
-    };
-
-    beforeEach(() => {
-      dbStub = stubInterface<Db>();
-      clientStub = stubInterface<MongoClient>();
-      dbStub.command.resolves(cmdLineOptsResult);
-      clientStub.db.returns(dbStub);
-      serviceProvider = new CliServiceProvider(clientStub);
-    });
-
-    it('executes getCmdLineOpts against an admin db', async() => {
-      const cmd = { getCmdLineOpts: 1 };
-      const result = await serviceProvider.getCmdLineOpts();
-      expect(result).to.deep.equal(cmdLineOptsResult);
-      expect(clientStub.db).to.have.been.calledWith('admin');
-      expect(dbStub.command).to.have.been.calledWith(cmd, DEFAULT_BASE_OPTS);
-    });
-  });
-
-  describe('#convertToCapped', () => {
-    let dbStub: StubbedInstance<Db>;
-    let clientStub: StubbedInstance<MongoClient>;
-
-    beforeEach(() => {
-      const result = { ok: 1 };
-
-      dbStub = stubInterface<Db>();
-      clientStub = stubInterface<MongoClient>();
-      dbStub.command.resolves(result);
-      clientStub.db.returns(dbStub);
-      serviceProvider = new CliServiceProvider(clientStub);
-    });
-
-    it('executes the command', async() => {
-      const cmd = { convertToCapped: 'coll1', size: 1000 };
-      const result = await serviceProvider.convertToCapped('db1', 'coll1', 1000);
-      expect(result).to.deep.equal({ ok: 1 });
-      expect(clientStub.db).to.have.been.calledWith('db1');
-      expect(dbStub.command).to.have.been.calledWith(cmd, DEFAULT_BASE_OPTS);
-    });
-  });
-
   describe('#createIndexes', () => {
     let indexSpecs;
     let nativeMethodResult;
@@ -611,28 +526,6 @@ describe('CliServiceProvider', () => {
     });
   });
 
-  describe('#dropIndexes', () => {
-    let dbStub: StubbedInstance<Db>;
-    let clientStub: StubbedInstance<MongoClient>;
-    const args = { dropIndexes: 'coll1', index: ['index-1'] };
-    const result = { ok: 1 };
-
-    beforeEach(() => {
-      dbStub = stubInterface<Db>();
-      clientStub = stubInterface<MongoClient>();
-      dbStub.command.resolves(result);
-      clientStub.db.returns(dbStub);
-      serviceProvider = new CliServiceProvider(clientStub);
-    });
-
-    it('executes the command', async() => {
-      const result = await serviceProvider.dropIndexes('db1', 'coll1', ['index-1']);
-      expect(result).to.deep.equal({ ok: 1 });
-      expect(dbStub.command).to.have.been.calledWith(args);
-      expect(clientStub.db).to.have.been.calledWith('db1');
-    });
-  });
-
   describe('#listCollections', () => {
     let dbStub: StubbedInstance<Db>;
     let clientStub: StubbedInstance<MongoClient>;
@@ -683,25 +576,6 @@ describe('CliServiceProvider', () => {
       const result = await serviceProvider.stats('db1', 'coll1', options);
       expect(result).to.deep.equal(expectedResult);
       expect(collectionStub.stats).to.have.been.calledWith(options);
-    });
-  });
-
-  describe('#reIndex', () => {
-    let dbStub: StubbedInstance<Db>;
-    let clientStub: StubbedInstance<MongoClient>;
-
-    beforeEach(() => {
-      dbStub = stubInterface<Db>();
-      clientStub = stubInterface<MongoClient>();
-      dbStub.command.resolves({ ok: 1 });
-      clientStub.db.returns(dbStub);
-      serviceProvider = new CliServiceProvider(clientStub);
-    });
-
-    it('executes the command against the database', async() => {
-      const result = await serviceProvider.reIndex('db1', 'coll1');
-      expect(result).to.deep.equal({ ok: 1 });
-      expect(dbStub.command).to.have.been.calledWith({ reIndex: 'coll1' });
     });
   });
 
@@ -762,37 +636,6 @@ describe('CliServiceProvider', () => {
     });
   });
 
-  describe('Throw error on ok: 0', () => {
-    let clientStub;
-    let dbStub;
-
-    beforeEach(() => {
-      dbStub = stubInterface<Db>();
-      clientStub = stubInterface<MongoClient>();
-      dbStub.command.resolves({ ok: 0 });
-      clientStub.db.returns(dbStub);
-      serviceProvider = new CliServiceProvider(clientStub);
-    });
-
-    afterEach(() => {
-      dbStub = null;
-      clientStub = null;
-      serviceProvider = null;
-    });
-
-    ['convertToCapped', 'buildInfo', 'getCmdLineOpts', 'dropIndexes', 'reIndex'].forEach((cmd) => {
-      it(cmd, async() => {
-        try {
-          await serviceProvider[cmd]('db', 'coll', 1);
-        } catch (e) {
-          expect(e.message).to.include(cmd);
-          expect(e.name).to.equal('MongoshCommandFailed');
-          return;
-        }
-        expect.fail(`Error not thrown for ok:0 on cmd ${cmd}`);
-      });
-    });
-  });
   describe('sessions', () => {
     let clientStub: StubbedInstance<MongoClient>;
     let serviceProvider: CliServiceProvider;

--- a/packages/service-provider-server/src/cli-service-provider.ts
+++ b/packages/service-provider-server/src/cli-service-provider.ts
@@ -191,12 +191,16 @@ class CliServiceProvider extends ServiceProviderCore implements ServiceProvider 
     topology: any;
     extraInfo: ConnectionInfo;
   }> {
-    const buildInfo = await this.buildInfo();
+    const buildInfo = await this.runCommandWithCheck('admin', {
+      buildInfo: 1
+    }, this.baseCmdOptions);
     const topology = await this.getTopology();
     const { version } = require('../package.json');
     let cmdLineOpts = null;
     try {
-      cmdLineOpts = await this.getCmdLineOpts();
+      cmdLineOpts = await this.runCommandWithCheck('admin', {
+        getCmdLineOpts: 1
+      }, this.baseCmdOptions);
       // eslint-disable-next-line no-empty
     } catch (e) {
     }
@@ -239,37 +243,6 @@ class CliServiceProvider extends ServiceProviderCore implements ServiceProvider 
     return await (this.db(database, dbOptions)
       .collection(collection) as any)
       .findAndModify(query, sort, update, options);
-  }
-
-  /**
-   * Converts an existing, non-capped collection to
-   * a capped collection within the same database.
-   *
-   * @param {String} database - The db name.
-   * @param {String} collection - The collection name.
-   * @param {String} size - The maximum size, in bytes, for the capped collection.
-   *
-   * @param options
-   * @param dbOptions
-   * @return {Promise}
-   */
-  async convertToCapped(
-    database: string,
-    collection: string,
-    size: number,
-    options: RunCommandOptions = {},
-    dbOptions?: DbOptions
-  ): Promise<Document> {
-    options = { ...this.baseCmdOptions, ...options };
-    return await this.runCommandWithCheck(
-      database,
-      {
-        convertToCapped: collection,
-        size: size
-      },
-      options,
-      dbOptions
-    );
   }
 
   /**
@@ -917,34 +890,6 @@ class CliServiceProvider extends ServiceProviderCore implements ServiceProvider 
   }
 
   /**
-   * Return buildInfo.
-   *
-   * @returns {Promise} buildInfo.
-   */
-  async buildInfo(): Promise<Document> {
-    const result: any = await this.runCommandWithCheck(
-      'admin',
-      {
-        buildInfo: 1
-      },
-      this.baseCmdOptions
-    );
-    return result;
-  }
-
-  /**
-   * Return cmdLineOpts.
-   *
-   * @returns {Promise} buildInfo.
-   */
-  async getCmdLineOpts(): Promise<Document> {
-    const result: any = await this.runCommandWithCheck(
-      'admin', { getCmdLineOpts: 1 }, this.baseCmdOptions
-    );
-    return result;
-  }
-
-  /**
    * Drop a database
    *
    * @param {String} db - The database name.
@@ -1014,30 +959,6 @@ class CliServiceProvider extends ServiceProviderCore implements ServiceProvider 
   }
 
   /**
-   * Drop indexes for a collection
-   *
-   * @param {string} database - the db name.
-   * @param {string} collection - the collection name.
-   * @param {(string|string[]|Document|Document[])} indexes - the indexes to be removed.
-   * @param {CommandOptions} [options] - The command options.
-   * @param {DbOptions} [dbOptions] - The database options.
-   *
-   * @returns {Promise<Document>}
-   */
-  async dropIndexes(
-    database: string,
-    collection: string,
-    indexes: string|string[]|Document|Document[],
-    options: RunCommandOptions = {},
-    dbOptions?: DbOptions): Promise<Document> {
-    options = { ...this.baseCmdOptions, ...options };
-    return await this.runCommandWithCheck(database, {
-      dropIndexes: collection,
-      index: indexes,
-    }, options, dbOptions);
-  }
-
-  /**
    * Returns an array of collection infos
    *
    * @param {String} database - The db name.
@@ -1077,27 +998,6 @@ class CliServiceProvider extends ServiceProviderCore implements ServiceProvider 
     return await this.db(database, dbOptions)
       .collection(collection)
       .stats(options as { scale: 1 });
-  }
-
-  /**
-   * Reindex all indexes on the collection.i
-   *
-   * @param {String} database - The db name.
-   * @param {String} collection - The collection name.
-   * @param {Object} options - The command options.
-   * @param {Object} dbOptions - The database options (i.e. readConcern, writeConcern. etc).
-   * @return {Promise}
-   */
-  async reIndex(
-    database: string,
-    collection: string,
-    options: RunCommandOptions = {},
-    dbOptions?: DbOptions
-  ): Promise<Document> {
-    options = { ...this.baseCmdOptions, ...options };
-    return await this.runCommandWithCheck(database, {
-      reIndex: collection
-    }, options, dbOptions);
   }
 
   /**

--- a/packages/shell-api/src/collection.spec.ts
+++ b/packages/shell-api/src/collection.spec.ts
@@ -293,15 +293,15 @@ describe('Collection', () => {
     });
 
     describe('convertToCapped', () => {
-      it('calls service provider convertToCapped', async() => {
-        serviceProvider.convertToCapped.resolves({ ok: 1 });
-
+      it('calls service provider runCommandWithCheck', async() => {
         const result = await collection.convertToCapped(1000);
 
-        expect(serviceProvider.convertToCapped).to.have.been.calledWith(
+        expect(serviceProvider.runCommandWithCheck).to.have.been.calledWith(
           'db1',
-          'coll1',
-          1000
+          {
+            convertToCapped: 'coll1',
+            size: 1000
+          }
         );
 
         expect(result).to.deep.equal({ ok: 1 });
@@ -449,7 +449,7 @@ describe('Collection', () => {
         let result;
         beforeEach(async() => {
           result = { nIndexesWas: 3, ok: 1 };
-          serviceProvider.dropIndexes.resolves(result);
+          serviceProvider.runCommandWithCheck.resolves(result);
         });
 
         it('returns the result of serviceProvider.dropIndexes', async() => {
@@ -468,7 +468,7 @@ describe('Collection', () => {
             name: 'MongoError'
           });
 
-          serviceProvider.dropIndexes.rejects(error);
+          serviceProvider.runCommandWithCheck.rejects(error);
         });
 
         it('returns the error as object', async() => {
@@ -485,7 +485,7 @@ describe('Collection', () => {
         let error;
         beforeEach(async() => {
           error = new Error('Some error');
-          serviceProvider.dropIndexes.rejects(new Error('Some error'));
+          serviceProvider.runCommandWithCheck.rejects(new Error('Some error'));
         });
 
         it('rejects with error', async() => {
@@ -501,7 +501,7 @@ describe('Collection', () => {
         let result;
         beforeEach(async() => {
           result = { nIndexesWas: 3, ok: 1 };
-          serviceProvider.dropIndexes.resolves(result);
+          serviceProvider.runCommandWithCheck.resolves(result);
         });
 
         it('returns the result of serviceProvider.dropIndexes', async() => {
@@ -552,16 +552,11 @@ describe('Collection', () => {
     });
 
     describe('reIndex', () => {
-      let result;
-
-      beforeEach(() => {
-        result = { ok: 1 };
-        serviceProvider.reIndex.resolves(result);
-      });
-
       it('returns the result of serviceProvider.dropIndexes', async() => {
-        expect(await collection.reIndex()).to.deep.equal(result);
-        expect(serviceProvider.reIndex).to.have.been.calledWith('db1', 'coll1');
+        expect(await collection.reIndex()).to.deep.equal({ ok: 1 });
+        expect(serviceProvider.runCommandWithCheck).to.have.been.calledWith('db1', {
+          reIndex: 'coll1'
+        });
       });
     });
 
@@ -1242,7 +1237,9 @@ describe('Collection', () => {
       getIndexSpecs: { m: 'getIndexes', i: 2 },
       getIndices: { m: 'getIndexes', i: 2 },
       getIndexKeys: { m: 'getIndexes', i: 2 },
-      dropIndex: { m: 'dropIndexes' },
+      dropIndex: { m: 'runCommandWithCheck', i: 2 },
+      dropIndexes: { m: 'runCommandWithCheck', i: 2 },
+      convertToCapped: { m: 'runCommandWithCheck', i: 2 },
       dataSize: { m: 'stats', i: 2 },
       storageSize: { m: 'stats', i: 2 },
       totalSize: { m: 'stats', i: 2 },
@@ -1265,7 +1262,7 @@ describe('Collection', () => {
       updateMany: { i: 4 },
       updateOne: { i: 4 },
       getIndexes: { i: 2 },
-      reIndex: { i: 2 },
+      reIndex: { m: 'runCommandWithCheck', i: 2 },
     };
     const ignore = [ 'getShardDistribution', 'stats', 'isCapped', 'save' ];
     const args = [ { query: {} }, {}, { out: 'coll' } ];

--- a/packages/shell-api/src/collection.ts
+++ b/packages/shell-api/src/collection.ts
@@ -934,10 +934,11 @@ export default class Collection extends ShellApiClass {
   @returnsPromise
   async convertToCapped(size: number): Promise<Document> {
     this._emitCollectionApiCall('convertToCapped', { size });
-    return await this._mongo._serviceProvider.convertToCapped(
-      this._database._name,
-      this._name,
-      size,
+    return await this._mongo._serviceProvider.runCommandWithCheck(
+      this._database._name, {
+        convertToCapped: this._name,
+        size
+      },
       this._database._baseOptions
     );
   }
@@ -1087,7 +1088,13 @@ export default class Collection extends ShellApiClass {
     assertArgsDefined(indexes);
     this._emitCollectionApiCall('dropIndexes', { indexes });
     try {
-      return await this._mongo._serviceProvider.dropIndexes(this._database._name, this._name, indexes, this._database._baseOptions);
+      return await this._mongo._serviceProvider.runCommandWithCheck(
+        this._database._name,
+        {
+          dropIndexes: this._name,
+          index: indexes,
+        },
+        this._database._baseOptions);
     } catch (error) {
       if (error.codeName === 'IndexNotFound') {
         return {
@@ -1121,7 +1128,13 @@ export default class Collection extends ShellApiClass {
     }
 
     try {
-      return await this._mongo._serviceProvider.dropIndexes(this._database._name, this._name, index, this._database._baseOptions);
+      return await this._mongo._serviceProvider.runCommandWithCheck(
+        this._database._name,
+        {
+          dropIndexes: this._name,
+          index,
+        },
+        this._database._baseOptions);
     } catch (error) {
       if (error.codeName === 'IndexNotFound') {
         return {
@@ -1162,7 +1175,9 @@ export default class Collection extends ShellApiClass {
   @returnsPromise
   async reIndex(): Promise<Document> {
     this._emitCollectionApiCall('reIndex');
-    return await this._mongo._serviceProvider.reIndex(this._database._name, this._name, this._database._baseOptions);
+    return await this._mongo._serviceProvider.runCommandWithCheck(this._database._name, {
+      reIndex: this._name
+    }, this._database._baseOptions);
   }
 
   /**

--- a/packages/shell-api/src/collection.ts
+++ b/packages/shell-api/src/collection.ts
@@ -1104,7 +1104,7 @@ export default class Collection extends ShellApiClass {
           (error.errmsg === 'invalid index name spec' || error.errmsg === undefined) &&
           Array.isArray(indexes) &&
           indexes.length > 0 &&
-          (await this._mongo._serverVersion()).match(/^4\.0\./)) {
+          (await this._database.version()).match(/^4\.0\./)) {
         const all = await Promise.all((indexes as string[]).map(index => this.dropIndexes(index)));
         const errored = all.find(result => !result.ok);
         if (errored) return errored;

--- a/packages/shell-api/src/database.ts
+++ b/packages/shell-api/src/database.ts
@@ -699,7 +699,7 @@ export default class Database extends ShellApiClass {
   }
 
   @returnsPromise
-  async version(): Promise<Document> {
+  async version(): Promise<string> {
     this._emitDatabaseApiCall('version', {});
     const info: Document = await this._runAdminCommand(
       {

--- a/packages/shell-api/src/integration.spec.ts
+++ b/packages/shell-api/src/integration.spec.ts
@@ -423,6 +423,14 @@ describe('Shell API (integration)', function() {
 
         expect(await getIndexNames(dbName, collectionName)).not.to.contain('index-1');
       });
+
+      it('removes indexes with an array argument', async() => {
+        expect(await getIndexNames(dbName, collectionName)).to.contain('index-1');
+
+        await collection.dropIndexes(['index-1']);
+
+        expect(await getIndexNames(dbName, collectionName)).not.to.contain('index-1');
+      });
     });
 
     describe('#reIndex', () => {

--- a/packages/shell-api/src/mongo.ts
+++ b/packages/shell-api/src/mongo.ts
@@ -37,7 +37,6 @@ export default class Mongo extends ShellApiClass {
   public _databases: Record<string, Database>;
   public _internalState: ShellInternalState;
   public _uri: string;
-  private _serverVersionCached: Promise<string> | null = null;
   private _options: Document;
 
   constructor(
@@ -237,12 +236,5 @@ export default class Mongo extends ShellApiClass {
     );
     this._internalState.currentCursor = cursor;
     return cursor;
-  }
-
-  _serverVersion(): Promise<string> {
-    this._serverVersionCached ??= (async() => {
-      return (await this._serviceProvider.runCommandWithCheck('admin', { buildInfo: 1 }, {})).version;
-    })();
-    return this._serverVersionCached;
   }
 }

--- a/packages/shell-api/src/mongo.ts
+++ b/packages/shell-api/src/mongo.ts
@@ -37,6 +37,7 @@ export default class Mongo extends ShellApiClass {
   public _databases: Record<string, Database>;
   public _internalState: ShellInternalState;
   public _uri: string;
+  private _serverVersionCached: Promise<string> | null = null;
   private _options: Document;
 
   constructor(
@@ -236,5 +237,12 @@ export default class Mongo extends ShellApiClass {
     );
     this._internalState.currentCursor = cursor;
     return cursor;
+  }
+
+  _serverVersion(): Promise<string> {
+    this._serverVersionCached ??= (async() => {
+      return (await this._serviceProvider.runCommandWithCheck('admin', { buildInfo: 1 }, {})).version;
+    })();
+    return this._serverVersionCached;
   }
 }


### PR DESCRIPTION
There are currently a few service provider methods (buildInfo,
getCmdLineOpts, dropIndexes, reIndex, convertToCapped)
that just do runCommand so those should not be in the SP API.