### PR TITLE
chore(shell-api): refactor and test toIterator

### DIFF
--- a/config/eslintrc.base.js
+++ b/config/eslintrc.base.js
@@ -29,7 +29,8 @@ module.exports = {
     '@typescript-eslint/semi': [2, 'always'],
     'no-console': [1, { allow: ['warn', 'error', 'info'] }],
     'no-shadow': 0,
-    'no-use-before-define': 0
+    'no-use-before-define': 0,
+    'no-cond-assign': [2, 'except-parens']
   },
   overrides: [{
     files: ['**/*.js'],

--- a/packages/cli-repl/src/cli-repl.spec.ts
+++ b/packages/cli-repl/src/cli-repl.spec.ts
@@ -262,5 +262,29 @@ describe('CliRepl', () => {
       const [ err ] = await errored;
       expect(err.message).to.equal('The request was aborted by the user');
     });
+
+    it('allows .forEach with async code for cursors', async() => {
+      await cliRepl.start(await testServer.connectionString(), {});
+
+      input.write('use clirepltest\n');
+      await waitEval(cliRepl.bus);
+      input.write('db.test.insertMany([{a:2},{a:4},{a:6}])\n');
+      await waitEval(cliRepl.bus);
+      input.write('let cursor = db.test.find();\n');
+      await waitEval(cliRepl.bus);
+
+      const rewrittenPromise = once(cliRepl.bus, 'mongosh:rewritten-async-input');
+      input.write('cursor.forEach(doc => db.test.insertOne({ a: doc.a + 1 }))\n');
+      const [{ rewritten }] = await rewrittenPromise;
+      expect(rewritten).to.include('toIterator'); // Make sure we're testing the right thing
+      await waitEval(cliRepl.bus);
+
+      output = '';
+      input.write('db.test.find().sort({a:1}).map(doc => doc.a)\n');
+      await waitEval(cliRepl.bus);
+      expect(output).to.include('[ 2, 3, 4, 5, 6, 7 ]');
+
+      input.write('.exit\n');
+    });
   });
 });

--- a/packages/shell-api/src/aggregation-cursor.ts
+++ b/packages/shell-api/src/aggregation-cursor.ts
@@ -61,6 +61,13 @@ export default class AggregationCursor extends ShellApiClass {
     return this._cursor.tryNext();
   }
 
+  async* [Symbol.asyncIterator]() {
+    let doc;
+    while ((doc = await this.tryNext()) !== null) {
+      yield doc;
+    }
+  }
+
   isClosed(): boolean {
     return this._cursor.closed;
   }

--- a/packages/shell-api/src/change-stream-cursor.ts
+++ b/packages/shell-api/src/change-stream-cursor.ts
@@ -73,6 +73,13 @@ export default class ChangeStreamCursor extends ShellApiClass {
     return this._cursor.cursor.tryNext();
   }
 
+  async* [Symbol.asyncIterator]() {
+    let doc;
+    while ((doc = await this.tryNext()) !== null) {
+      yield doc;
+    }
+  }
+
   isClosed(): boolean {
     return this._cursor.closed;
   }

--- a/packages/shell-api/src/cursor.ts
+++ b/packages/shell-api/src/cursor.ts
@@ -168,6 +168,13 @@ export default class Cursor extends ShellApiClass {
     return this._cursor.tryNext();
   }
 
+  async* [Symbol.asyncIterator]() {
+    let doc;
+    while ((doc = await this.tryNext()) !== null) {
+      yield doc;
+    }
+  }
+
   @returnType('Cursor')
   hint(index: string): Cursor {
     this._cursor.hint(index);

--- a/packages/shell-api/src/toIterator.spec.ts
+++ b/packages/shell-api/src/toIterator.spec.ts
@@ -1,0 +1,34 @@
+import { Cursor, AggregationCursor, toIterator } from './index';
+import chai, { expect } from 'chai';
+import sinon from 'ts-sinon';
+import sinonChai from 'sinon-chai';
+chai.use(sinonChai);
+
+describe('toIterator', () => {
+  it('provides forEach for an array', async() => {
+    const iterator = sinon.spy();
+    const arr = [1, 2, 3];
+    await toIterator(arr).forEach(iterator);
+    expect(iterator).to.have.been.calledThrice;
+    expect(iterator).to.have.been.calledWith(1, 0, arr);
+    expect(iterator).to.have.been.calledWith(2, 1, arr);
+    expect(iterator).to.have.been.calledWith(3, 2, arr);
+  });
+
+  for (const Cls of [ Cursor, AggregationCursor ]) {
+    it(`provides forEach for ${cls.name}`, async() => {
+      const iterator = sinon.spy();
+      const tryNext = sinon.stub();
+      tryNext.onFirstCall().resolves({ a: 1 });
+      tryNext.onSecondCall().resolves({ a: 2 });
+      tryNext.onThirdCall().resolves(null);
+      const cursor = new Cls(null as any, { tryNext, closed: true } as any);
+      const asIterated = toIterator(cursor);
+      await asIterated.forEach(iterator);
+      expect(iterator).to.have.been.calledTwice;
+      expect(iterator).to.have.been.calledWith({ a: 1 }, 0, cursor);
+      expect(iterator).to.have.been.calledWith({ a: 2 }, 1, cursor);
+      expect((asIterated as any).isClosed()).to.equal(true);
+    });
+  }
+});

--- a/packages/shell-api/src/toIterator.spec.ts
+++ b/packages/shell-api/src/toIterator.spec.ts
@@ -16,7 +16,7 @@ describe('toIterator', () => {
   });
 
   for (const Cls of [ Cursor, AggregationCursor ]) {
-    it(`provides forEach for ${cls.name}`, async() => {
+    it(`provides forEach for ${Cls.name}`, async() => {
       const iterator = sinon.spy();
       const tryNext = sinon.stub();
       tryNext.onFirstCall().resolves({ a: 1 });

--- a/packages/shell-api/src/toIterator.ts
+++ b/packages/shell-api/src/toIterator.ts
@@ -1,15 +1,12 @@
 import {
   MongoshInvalidInputError
 } from '@mongosh/errors';
-import Cursor from './cursor';
 class Iterator {
-  iterable: Cursor | any[];
-  isCursor: boolean;
+  iterable: AsyncIterable<any> | Iterable<any>;
 
-  constructor(iterable: Cursor | any[]) {
+  constructor(iterable: AsyncIterable<any> | Iterable<any>) {
     this.iterable = iterable;
-    this.isCursor = this.iterable instanceof Cursor;
-    if (!this.isCursor && !Array.isArray(this.iterable)) {
+    if (!Array.isArray(iterable) && !(Symbol.iterator in iterable) && !(Symbol.asyncIterator in iterable)) {
       throw new MongoshInvalidInputError('Calling custom forEach method may not work as expected because callback is async. Try converting to array type before calling forEach.');
     }
     const proxy = new Proxy(this, {
@@ -22,23 +19,15 @@ class Iterator {
     });
     return proxy;
   }
-  async forEach(func: (...args: any[]) => void | Promise<void>, thisArg: any) {
-    if (this.isCursor) {
-      const cursor = this.iterable as Cursor;
-      let doc = await cursor.tryNext();
-      while (doc !== null) {
-        await func(doc);
-        doc = await cursor.tryNext();
-      }
-    } else {
-      const arr = this.iterable as any[];
-      for (let i = 0; i < arr.length; i++) {
-        await func(arr[i], i, arr, thisArg);
-      }
+
+  async forEach(func: (...args: any[]) => void | Promise<void>, thisArg?: any) {
+    let i = 0;
+    for await (const value of this.iterable) {
+      await func.call(thisArg, value, i++, this.iterable);
     }
   }
 }
 
-export default (iterable: Cursor | any[]) => {
+export default (iterable: AsyncIterable<any> | Iterable<any>) => {
   return new Iterator(iterable);
 };


### PR DESCRIPTION
- Make all cursor types async iterables (this is just for us,
  the async rewriter does not support async iteration at this point)
- Use the same iteration in `toIterator` for all input types
- Add tests for `toIterator`
- Add an e2e test to cover this feature