### PR TITLE
MONGOSH-478 - Pass session correctly to createIndexes

### DIFF
--- a/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/service/JavaServiceProvider.kt
+++ b/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/service/JavaServiceProvider.kt
@@ -536,11 +536,10 @@ internal class JavaServiceProvider(private val client: MongoClient,
     }
 
     @HostAccess.Export
-    override fun createIndexes(database: String, collection: String, indexSpecs: Value?, options: Value?, dbOptions: Value?): Value = promise<Any?> {
+    override fun createIndexes(database: String, collection: String, indexSpecs: Value?, options: Value?): Value = promise<Any?> {
         val indexSpecs = toList(indexSpecs, "indexSpecs") ?: emptyList()
-        val dbOptions = toDocument(dbOptions, "dbOptions")
         if (indexSpecs.any { it !is Document }) throw IllegalArgumentException("Index specs must be a list of documents. Got $indexSpecs")
-        getDatabase(database, dbOptions).flatMap { db ->
+        getDatabase(database, null).flatMap { db ->
             val convertedIndexes = indexSpecs.map { spec ->
                 convert(IndexModel(Document()), indexModelConverters, indexModelDefaultConverter, spec as Document)
             }

--- a/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/service/WritableServiceProvider.kt
+++ b/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/service/WritableServiceProvider.kt
@@ -25,7 +25,7 @@ internal interface WritableServiceProvider {
     fun save(database: String, collection: String, document: Value, options: Value?, dbOptions: Value?): Value
     fun remove(database: String, collection: String, query: Value, options: Value?, dbOptions: Value?): Value
     fun convertToCapped(database: String, collection: String, size: Number, options: Value?): Value
-    fun createIndexes(database: String, collection: String, indexSpecs: Value?, options: Value?, dbOptions: Value?): Value
+    fun createIndexes(database: String, collection: String, indexSpecs: Value?, options: Value?): Value
     fun dropIndexes(database: String, collection: String, indexes: Value?, options: Value?): Value
     fun reIndex(database: String, collection: String, options: Value?, dbOptions: Value?): Value
     fun dropCollection(database: String, collection: String, options: Value?): Value

--- a/packages/shell-api/src/collection.spec.ts
+++ b/packages/shell-api/src/collection.spec.ts
@@ -332,7 +332,8 @@ describe('Collection', () => {
           expect(serviceProvider.createIndexes).to.have.been.calledWith(
             'db1',
             'coll1',
-            [{ key: { x: 1 }, name: 'index-1' }]
+            [{ key: { x: 1 }, name: 'index-1' }],
+            { name: 'index-1' }
           );
         });
       });
@@ -375,7 +376,8 @@ describe('Collection', () => {
             expect(serviceProvider.createIndexes).to.have.been.calledWith(
               'db1',
               'coll1',
-              [{ key: { x: 1 }, name: 'index-1' }]
+              [{ key: { x: 1 }, name: 'index-1' }],
+              { name: 'index-1' }
             );
           });
         });
@@ -1232,13 +1234,13 @@ describe('Collection', () => {
     let internalSession: StubbedInstance<ServiceProviderSession>;
     const exceptions = {
       renameCollection: { a: ['name'] },
-      createIndexes: { a: [[]], i: 4 },
+      createIndexes: { a: [[]] },
       runCommand: { a: ['coll', {} ], m: 'runCommandWithCheck', i: 2 },
       findOne: { m: 'find' },
       insert: { m: 'insertMany' },
       update: { m: 'updateOne', i: 4 },
-      createIndex: { m: 'createIndexes', i: 2 },
-      ensureIndex: { m: 'createIndexes', i: 2 },
+      createIndex: { m: 'createIndexes' },
+      ensureIndex: { m: 'createIndexes' },
       getIndexSpecs: { m: 'getIndexes', i: 2 },
       getIndices: { m: 'getIndexes', i: 2 },
       getIndexKeys: { m: 'getIndexes', i: 2 },
@@ -1309,7 +1311,7 @@ describe('Collection', () => {
           } catch (e) {
             expect.fail(`Collection.${method} failed, error thrown ${e.message}`);
           }
-          expect(serviceProvider[method].calledOnce).to.equal(true, `expected ${method} to be called but it was not`);
+          expect(serviceProvider[method].calledOnce).to.equal(true, `expected sp.${method} to be called but it was not`);
           expect((serviceProvider[method].getCall(-1).args[3] as any).session).to.equal(internalSession);
         }
       }
@@ -1324,14 +1326,14 @@ describe('Collection', () => {
         } catch (e) {
           expect.fail(`${method} failed, error thrown ${e.message}`);
         }
-        expect(serviceProvider[customM].called).to.equal(true, `expecting ${customM} to be called but it was not`);
+        expect(serviceProvider[customM].called).to.equal(true, `expecting sp.${customM} to be called but it was not`);
         const call = serviceProvider[customM].getCall(-1).args[customI];
         if (Array.isArray(call)) {
           for (const k of call) {
-            expect(k.session).to.equal(internalSession);
+            expect(k.session).to.equal(internalSession, `method ${method} supposed to call sp.${customM} with options at arg ${customI}`);
           }
         } else {
-          expect(call.session).to.equal(internalSession);
+          expect(call.session).to.equal(internalSession, `method ${method} supposed to call sp.${customM} with options at arg ${customI}`);
         }
       }
     });

--- a/packages/shell-api/src/collection.ts
+++ b/packages/shell-api/src/collection.ts
@@ -969,7 +969,7 @@ export default class Collection extends ShellApiClass {
 
     this._emitCollectionApiCall('createIndexes', { specs });
 
-    return await this._mongo._serviceProvider.createIndexes(this._database._name, this._name, specs, {}, this._database._baseOptions);
+    return await this._mongo._serviceProvider.createIndexes(this._database._name, this._name, specs, { ...this._database._baseOptions, ...options });
   }
 
   /**
@@ -994,8 +994,8 @@ export default class Collection extends ShellApiClass {
     }
     this._emitCollectionApiCall('createIndex', { keys, options });
 
-    const spec = { ...this._database._baseOptions, ...options, key: keys };
-    return await this._mongo._serviceProvider.createIndexes(this._database._name, this._name, [spec], {}, this._database._baseOptions);
+    const spec = { key: keys, ...options }; // keep options for java
+    return await this._mongo._serviceProvider.createIndexes(this._database._name, this._name, [spec], { ...this._database._baseOptions, ...options });
   }
 
   /**
@@ -1020,8 +1020,8 @@ export default class Collection extends ShellApiClass {
     }
     this._emitCollectionApiCall('ensureIndex', { keys, options });
 
-    const spec = { ...this._database._baseOptions, ...options, key: keys };
-    return await this._mongo._serviceProvider.createIndexes(this._database._name, this._name, [spec], {}, this._database._baseOptions);
+    const spec = { key: keys, ...options };
+    return await this._mongo._serviceProvider.createIndexes(this._database._name, this._name, [spec], { ...this._database._baseOptions, ...options });
   }
 
   /**


### PR DESCRIPTION
The last argument to each serviceProvider method is generally DbOptions, which are database-wide options that need to be passed to the drivers `getDatabase` method. We currently don't have anything we set there, but it's likely we will in the future, so right now that argument is optional and left off in most cases. There was a bug where the createIndexes method was passing command options as database options, which would mean those options would be ignored.

Because the drivers can either accept options as part of the index specification or as a separate options object, we now pass both instead of only within the index spec.