### PR TITLE
chore(shell-evaluator): remove setEvaluationListener

### DIFF
--- a/.nycrc
+++ b/.nycrc
@@ -5,6 +5,7 @@
     "config",
     "**/*.d.ts",
     "**/*.spec.{ts,js,tsx,jsx,cjs,mjs}",
+    "**/test/**/*.{ts,js,tsx,jsx,cjs,mjs}",
     "**/*.config.{ts,js,tsx,jsx,cjs,mjs}",
     "**/lib/*.js"
   ]

--- a/packages/browser-runtime-core/src/open-context-runtime.ts
+++ b/packages/browser-runtime-core/src/open-context-runtime.ts
@@ -59,7 +59,8 @@ export class OpenContextRuntime implements Runtime {
 
   setEvaluationListener(listener: EvaluationListener): EvaluationListener | null {
     const prev = this.evaluationListener;
-    this.shellEvaluator.setEvaluationListener(listener);
+    this.evaluationListener = listener;
+    this.internalState.setEvaluationListener(listener);
     return prev;
   }
 }

--- a/packages/cli-repl/src/mongosh-repl.ts
+++ b/packages/cli-repl/src/mongosh-repl.ts
@@ -70,7 +70,7 @@ class MongoshNodeRepl {
   async start(serviceProvider: ServiceProvider): Promise<void> {
     const internalState = new ShellInternalState(serviceProvider, this.bus, this.shellCliOptions);
     const shellEvaluator = new ShellEvaluator(internalState);
-    shellEvaluator.setEvaluationListener(this);
+    internalState.setEvaluationListener(this);
     await internalState.fetchConnectionInfo();
 
     const mongodVersion = internalState.connectionInfo.buildInfo.version;

--- a/packages/shell-evaluator/src/shell-evaluator.ts
+++ b/packages/shell-evaluator/src/shell-evaluator.ts
@@ -28,10 +28,6 @@ class ShellEvaluator<EvaluationResultType = ShellResult> {
     this.internalState.asyncWriter.symbols.saveState();
   }
 
-  public setEvaluationListener(listener: EvaluationListener): void {
-    this.internalState.setEvaluationListener(listener);
-  }
-
   /**
    * Checks for linux-style commands then evaluates input using originalEval.
    *


### PR DESCRIPTION
Any user of `ShellEvaluator` already has access to the
`ShellInternalState` instance, and therefore doesn't need
a method for forwarding this.

As drive-by changes, fix a small inconsistency that @gribnoysup 
pointed out to me and update the .nycrc to exclude explicit
test directories from coverage.