### PR TITLE
revert removing pino-pretty

### DIFF
--- a/packages/cli-repl/package-lock.json
+++ b/packages/cli-repl/package-lock.json
@@ -4,6 +4,12 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@hapi/bourne": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/@hapi/bourne/-/bourne-2.0.0.tgz",
+			"integrity": "sha512-WEezM1FWztfbzqIUbsDzFRVMxSoLy3HugVcux6KDDtTqzPsLE8NDRHfXvev66aH1i2oOKKar3/XDjbvh/OUBdg==",
+			"dev": true
+		},
 		"@segment/loosely-validate-event": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/@segment/loosely-validate-event/-/loosely-validate-event-2.0.0.tgz",
@@ -180,6 +186,70 @@
 				"color-convert": "^2.0.1"
 			}
 		},
+		"args": {
+			"version": "5.0.1",
+			"resolved": "https://registry.npmjs.org/args/-/args-5.0.1.tgz",
+			"integrity": "sha512-1kqmFCFsPffavQFGt8OxJdIcETti99kySRUPMpOhaGjL6mRJn8HFU1OxKY5bMqfZKUwTQc1mZkAjmGYaVOHFtQ==",
+			"dev": true,
+			"requires": {
+				"camelcase": "5.0.0",
+				"chalk": "2.4.2",
+				"leven": "2.1.0",
+				"mri": "1.1.4"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"dev": true,
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"dev": true,
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"color-convert": {
+					"version": "1.9.3",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+					"dev": true,
+					"requires": {
+						"color-name": "1.1.3"
+					}
+				},
+				"color-name": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
+					"dev": true
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0=",
+					"dev": true
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"dev": true,
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
 		"array-back": {
 			"version": "4.0.1",
 			"resolved": "https://registry.npmjs.org/array-back/-/array-back-4.0.1.tgz",
@@ -211,6 +281,12 @@
 			"requires": {
 				"is-retry-allowed": "^1.1.0"
 			}
+		},
+		"camelcase": {
+			"version": "5.0.0",
+			"resolved": "https://registry.npmjs.org/camelcase/-/camelcase-5.0.0.tgz",
+			"integrity": "sha512-faqwZqnWxbxn+F1d399ygeamQNy3lPp/H9H6rNrqYh4FSVCtcY+3cub1MxA8o9mDd55mM8Aghuu/kuyYA6VTsA==",
+			"dev": true
 		},
 		"chalk": {
 			"version": "4.1.0",
@@ -249,6 +325,12 @@
 			"resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
 			"integrity": "sha1-iNf/fsDfuG9xPch7u0LQRNPmxBs="
 		},
+		"dateformat": {
+			"version": "3.0.3",
+			"resolved": "https://registry.npmjs.org/dateformat/-/dateformat-3.0.3.tgz",
+			"integrity": "sha512-jyCETtSl3VMZMWeRo7iY1FL19ges1t55hMo5yaam4Jrsm5EPL89UQkoQRyiI+Yf4k8r2ZpdngkV8hr1lIdjb3Q==",
+			"dev": true
+		},
 		"debug": {
 			"version": "3.1.0",
 			"resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
@@ -284,6 +366,21 @@
 					}
 				}
 			}
+		},
+		"end-of-stream": {
+			"version": "1.4.4",
+			"resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+			"integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+			"dev": true,
+			"requires": {
+				"once": "^1.4.0"
+			}
+		},
+		"escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+			"dev": true
 		},
 		"fast-redact": {
 			"version": "2.0.0",
@@ -331,6 +428,12 @@
 			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.12.0.tgz",
 			"integrity": "sha1-5tnb5Xy+/mB1HwKvM2GVhwyQwB4="
 		},
+		"inherits": {
+			"version": "2.0.4",
+			"resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+			"integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+			"dev": true
+		},
 		"is-buffer": {
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
@@ -353,10 +456,28 @@
 			"resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
 			"integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg=="
 		},
+		"jmespath": {
+			"version": "0.15.0",
+			"resolved": "https://registry.npmjs.org/jmespath/-/jmespath-0.15.0.tgz",
+			"integrity": "sha1-o/Iiqarp+Wb10nx5ZRDigJF2Qhc=",
+			"dev": true
+		},
 		"join-component": {
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/join-component/-/join-component-1.1.0.tgz",
 			"integrity": "sha1-uEF7dQZho5K+4sJTfGiyqdSXfNU="
+		},
+		"joycon": {
+			"version": "2.2.5",
+			"resolved": "https://registry.npmjs.org/joycon/-/joycon-2.2.5.tgz",
+			"integrity": "sha512-YqvUxoOcVPnCp0VU1/56f+iKSdvIRJYPznH22BdXV3xMk75SFXhWeJkZ8C9XxUWt1b5x2X1SxuFygW1U0FmkEQ==",
+			"dev": true
+		},
+		"leven": {
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/leven/-/leven-2.1.0.tgz",
+			"integrity": "sha1-wuep93IJTe6dNCAq6KzORoeHVYA=",
+			"dev": true
 		},
 		"lodash": {
 			"version": "4.17.20",
@@ -425,6 +546,12 @@
 				"lodash": "^4.17.15"
 			}
 		},
+		"mri": {
+			"version": "1.1.4",
+			"resolved": "https://registry.npmjs.org/mri/-/mri-1.1.4.tgz",
+			"integrity": "sha512-6y7IjGPm8AzlvoUrwAaw1tLnUBudaS3752vcd8JtrpGGQn+rXIe63LFVHm/YMwtqAuh+LJPCFdlLYPWM1nYn6w==",
+			"dev": true
+		},
 		"ms": {
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
@@ -462,6 +589,15 @@
 				"nanoscheduler": "^1.0.2"
 			}
 		},
+		"once": {
+			"version": "1.4.0",
+			"resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+			"integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+			"dev": true,
+			"requires": {
+				"wrappy": "1"
+			}
+		},
 		"pino": {
 			"version": "5.17.0",
 			"resolved": "https://registry.npmjs.org/pino/-/pino-5.17.0.tgz",
@@ -473,6 +609,25 @@
 				"pino-std-serializers": "^2.4.2",
 				"quick-format-unescaped": "^3.0.3",
 				"sonic-boom": "^0.7.5"
+			}
+		},
+		"pino-pretty": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/pino-pretty/-/pino-pretty-4.3.0.tgz",
+			"integrity": "sha512-uEc9SUCCGVEs0goZvyznKXBHtI1PNjGgqHviJHxOCEFEWZN6Z/IQKv5pO9gSdm/b+WfX+/dfheWhtZUyScqjlQ==",
+			"dev": true,
+			"requires": {
+				"@hapi/bourne": "^2.0.0",
+				"args": "^5.0.1",
+				"chalk": "^4.0.0",
+				"dateformat": "^3.0.3",
+				"fast-safe-stringify": "^2.0.7",
+				"jmespath": "^0.15.0",
+				"joycon": "^2.2.5",
+				"pump": "^3.0.0",
+				"readable-stream": "^3.6.0",
+				"split2": "^3.1.1",
+				"strip-json-comments": "^3.1.1"
 			}
 		},
 		"pino-std-serializers": {
@@ -496,10 +651,31 @@
 				"semver": "^7.2.2"
 			}
 		},
+		"pump": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+			"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
+			"dev": true,
+			"requires": {
+				"end-of-stream": "^1.1.0",
+				"once": "^1.3.1"
+			}
+		},
 		"quick-format-unescaped": {
 			"version": "3.0.3",
 			"resolved": "https://registry.npmjs.org/quick-format-unescaped/-/quick-format-unescaped-3.0.3.tgz",
 			"integrity": "sha512-dy1yjycmn9blucmJLXOfZDx1ikZJUi6E8bBZLnhPG5gBrVhHXx2xVyqqgKBubVNEXmx51dBACMHpoMQK/N/AXQ=="
+		},
+		"readable-stream": {
+			"version": "3.6.0",
+			"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+			"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+			"dev": true,
+			"requires": {
+				"inherits": "^2.0.3",
+				"string_decoder": "^1.1.1",
+				"util-deprecate": "^1.0.1"
+			}
 		},
 		"remove-array-items": {
 			"version": "1.1.1",
@@ -510,6 +686,12 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/remove-trailing-slash/-/remove-trailing-slash-0.1.0.tgz",
 			"integrity": "sha1-FJjl3wmEwn5Jt26/Boh8otARUNI="
+		},
+		"safe-buffer": {
+			"version": "5.2.1",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+			"integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+			"dev": true
 		},
 		"semver": {
 			"version": "7.3.2",
@@ -525,6 +707,24 @@
 				"flatstr": "^1.0.12"
 			}
 		},
+		"split2": {
+			"version": "3.2.2",
+			"resolved": "https://registry.npmjs.org/split2/-/split2-3.2.2.tgz",
+			"integrity": "sha512-9NThjpgZnifTkJpzTZ7Eue85S49QwpNhZTq6GRJwObb6jnLFNGB7Qm73V5HewTROPyxD0C29xqmaI68bQtV+hg==",
+			"dev": true,
+			"requires": {
+				"readable-stream": "^3.0.0"
+			}
+		},
+		"string_decoder": {
+			"version": "1.3.0",
+			"resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.3.0.tgz",
+			"integrity": "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA==",
+			"dev": true,
+			"requires": {
+				"safe-buffer": "~5.2.0"
+			}
+		},
 		"strip-ansi": {
 			"version": "6.0.0",
 			"resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.0.tgz",
@@ -532,6 +732,12 @@
 			"requires": {
 				"ansi-regex": "^5.0.0"
 			}
+		},
+		"strip-json-comments": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-3.1.1.tgz",
+			"integrity": "sha512-6fPc+R4ihwqP6N/aIv2f1gMH8lOVtWQHoqC4yK6oSDVVocumAsfCqjkXnqiYMhmMwS/mEHLp7Vehlt3ql6lEig==",
+			"dev": true
 		},
 		"supports-color": {
 			"version": "7.2.0",
@@ -545,6 +751,18 @@
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
 			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+		},
+		"util-deprecate": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+			"integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+			"dev": true
+		},
+		"wrappy": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+			"dev": true
 		}
 	}
 }

--- a/packages/cli-repl/package.json
+++ b/packages/cli-repl/package.json
@@ -68,6 +68,7 @@
     "@types/node": "^14.14.5",
     "@types/pino": "^6.3.3",
     "@types/read": "^0.0.28",
-    "@types/text-table": "^0.2.1"
+    "@types/text-table": "^0.2.1",
+    "pino-pretty": "^4.3.0"
   }
 }


### PR DESCRIPTION
I can't run compile-exec anymore on master, I get:

```
node --version v14.15.1
mongosh: writing analytics template: /Users/anna/mongosh/packages/cli-repl/lib/analytics-config.js
mongosh: creating bundle: /Users/anna/mongosh/packages/cli-repl/dist/mongosh.js
🚨  /Users/anna/mongosh/packages/cli-repl/node_modules/pino-pretty/index.js: ENOENT: no such file or directory, open '/Users/anna/mongosh/packages/cli-repl/node_modules/pino-pretty/index.js'
Error: ENOENT: no such file or directory, open '/Users/anna/mongosh/packages/cli-repl/node_modules/pino-pretty/index.js'

/Users/anna/mongosh/scripts/compile-exec.js:21
  (err) => process.nextTick(() => { throw err; }));
                                    ^
{
  message: "ENOENT: no such file or directory, open '/Users/anna/mongosh/packages/cli-repl/node_modules/pino-pretty/index.js'",
  stack: "Error: ENOENT: no such file or directory, open '/Users/anna/mongosh/packages/cli-repl/node_modules/pino-pretty/index.js'",
  name: 'Error',
  errno: -2,
  code: 'ENOENT',
  syscall: 'open',
  path: '/Users/anna/mongosh/packages/cli-repl/node_modules/pino-pretty/index.js',
  fileName: '/Users/anna/mongosh/packages/cli-repl/node_modules/pino-pretty/index.js'
}
```