### PR TITLE
fix(service-provider-core): Default to direct connection to specified node MONGOSH-465

### DIFF
--- a/packages/cli-repl/test/e2e-direct.spec.ts
+++ b/packages/cli-repl/test/e2e-direct.spec.ts
@@ -1,0 +1,99 @@
+import { MongodSetup, startTestCluster } from '../../../testing/integration-testing-hooks';
+import { eventually } from './helpers';
+import { TestShell } from './test-shell';
+
+describe('e2e direct connection', () => {
+  afterEach(async() => await TestShell.killall());
+
+  context('to a replica set', async() => {
+    const replSetId = 'replset';
+    const [rs0, rs1, rs2] = startTestCluster(
+      ['--single', '--replSet', replSetId],
+      ['--single', '--replSet', replSetId],
+      ['--single', '--replSet', replSetId]
+    );
+
+    [ [rs0, 'rs0'], [rs1, 'rs1'], [rs2, 'rs2'] ].forEach((elem) => {
+      const server = elem[0] as MongodSetup;
+      const node = elem[1] as string;
+      it(`works when connecting to node ${node} of uninitialized set`, async() => {
+        const shell = TestShell.start({ args: [await server.connectionString()] });
+        await shell.waitForPrompt();
+        await shell.executeLine('db.isMaster()');
+        shell.assertContainsOutput('ismaster: false');
+        shell.assertNotContainsOutput(`setName: '${replSetId}'`);
+      });
+    });
+
+    it('allows to initialize the replica set', async() => {
+      const replSetConfig = {
+        _id: replSetId,
+        version: 1,
+        members: [
+          { _id: 0, host: await rs0.hostport(), priority: 1 },
+          { _id: 1, host: await rs1.hostport(), priority: 0 },
+          { _id: 2, host: await rs2.hostport(), priority: 0 },
+        ]
+      };
+
+      const shell = TestShell.start({ args: [await rs0.connectionString()] });
+      await shell.waitForPrompt();
+      await shell.executeLine(`rs.initiate(${JSON.stringify(replSetConfig)})`);
+      shell.assertContainsOutput('ok: 1');
+      await eventually(async() => {
+        await shell.executeLine('db.isMaster()');
+        shell.assertContainsOutput('ismaster: true');
+        shell.assertContainsOutput(`me: '${await rs0.hostport()}'`);
+        shell.assertContainsOutput(`setName: '${replSetId}'`);
+      });
+    });
+
+    context('connecting to secondary members directly', () => {
+      it('works when specifying a connection string', async() => {
+        const shell = TestShell.start({ args: [await rs1.connectionString()] });
+        await shell.waitForPrompt();
+        await shell.executeLine('db.isMaster()');
+        shell.assertContainsOutput('ismaster: false');
+        shell.assertContainsOutput(`me: '${await rs1.hostport()}'`);
+        shell.assertContainsOutput(`setName: '${replSetId}'`);
+      });
+
+      it('works when specifying just host and port', async() => {
+        const shell = TestShell.start({ args: [await rs1.hostport()] });
+        await shell.waitForPrompt();
+        await shell.executeLine('db.isMaster()');
+        shell.assertContainsOutput('ismaster: false');
+        shell.assertContainsOutput(`me: '${await rs1.hostport()}'`);
+        shell.assertContainsOutput(`setName: '${replSetId}'`);
+      });
+    });
+
+    context('connecting to primary', () => {
+      it('when specifying replicaSet', async() => {
+        const shell = TestShell.start({ args: [`${await rs1.connectionString()}?replicaSet=${replSetId}`] });
+        await shell.waitForPrompt();
+        await shell.executeLine('db.isMaster()');
+        shell.assertContainsOutput('ismaster: true');
+        shell.assertContainsOutput(`me: '${await rs0.hostport()}'`);
+        shell.assertContainsOutput(`setName: '${replSetId}'`);
+      });
+      it('when setting directConnection to false', async() => {
+        const shell = TestShell.start({ args: [`${await rs1.connectionString()}?directConnection=false`] });
+        await shell.waitForPrompt();
+        await shell.executeLine('db.isMaster()');
+        shell.assertContainsOutput('ismaster: true');
+        shell.assertContainsOutput(`me: '${await rs0.hostport()}'`);
+        shell.assertContainsOutput(`setName: '${replSetId}'`);
+      });
+      it('when specifying multiple seeds', async() => {
+        const connectionString = 'mongodb://' + await rs2.hostport() + ',' + await rs1.hostport() + ',' + await rs0.hostport();
+        const shell = TestShell.start({ args: [connectionString] });
+        await shell.waitForPrompt();
+        await shell.executeLine('db.isMaster()');
+        shell.assertContainsOutput('ismaster: true');
+        shell.assertContainsOutput(`me: '${await rs0.hostport()}'`);
+        shell.assertContainsOutput(`setName: '${replSetId}'`);
+      });
+    });
+  });
+});

--- a/packages/cli-repl/test/e2e-direct.spec.ts
+++ b/packages/cli-repl/test/e2e-direct.spec.ts
@@ -1,4 +1,4 @@
-import { MongodSetup, startTestCluster } from '../../../testing/integration-testing-hooks';
+import { startTestCluster } from '../../../testing/integration-testing-hooks';
 import { eventually } from './helpers';
 import { TestShell } from './test-shell';
 
@@ -13,10 +13,12 @@ describe('e2e direct connection', () => {
       ['--single', '--replSet', replSetId]
     );
 
-    [ [rs0, 'rs0'], [rs1, 'rs1'], [rs2, 'rs2'] ].forEach((elem) => {
-      const server = elem[0] as MongodSetup;
-      const node = elem[1] as string;
-      it(`works when connecting to node ${node} of uninitialized set`, async() => {
+    [
+      { server: rs0, name: 'rs0' },
+      { server: rs1, name: 'rs1' },
+      { server: rs2, name: 'rs2' }
+    ].forEach(({ server, name }) => {
+      it(`works when connecting to node ${name} of uninitialized set`, async() => {
         const shell = TestShell.start({ args: [await server.connectionString()] });
         await shell.waitForPrompt();
         await shell.executeLine('db.isMaster()');

--- a/packages/service-provider-core/src/uri-generator.spec.ts
+++ b/packages/service-provider-core/src/uri-generator.spec.ts
@@ -1,5 +1,4 @@
 import { CommonErrors, MongoshInvalidInputError } from '@mongosh/errors';
-import { fail } from 'assert';
 import { expect } from 'chai';
 import generateUri from './uri-generator';
 
@@ -8,34 +7,34 @@ describe('uri-generator.generate-uri', () => {
     const options = { _: [] };
 
     it('returns the default uri', () => {
-      expect(generateUri(options)).to.equal('mongodb://127.0.0.1:27017?directConnection=true');
+      expect(generateUri(options)).to.equal('mongodb://127.0.0.1:27017/?directConnection=true');
     });
   });
 
   context('when no URI is provided', () => {
     it('handles host', () => {
-      expect(generateUri({ _: [], host: 'localhost' })).to.equal('mongodb://localhost:27017?directConnection=true');
+      expect(generateUri({ _: [], host: 'localhost' })).to.equal('mongodb://localhost:27017/?directConnection=true');
     });
     it('handles port', () => {
-      expect(generateUri({ _: [], port: '27018' })).to.equal('mongodb://127.0.0.1:27018?directConnection=true');
+      expect(generateUri({ _: [], port: '27018' })).to.equal('mongodb://127.0.0.1:27018/?directConnection=true');
     });
     it('handles both host and port', () => {
-      expect(generateUri({ _: [], host: 'localhost', port: '27018' })).to.equal('mongodb://localhost:27018?directConnection=true');
+      expect(generateUri({ _: [], host: 'localhost', port: '27018' })).to.equal('mongodb://localhost:27018/?directConnection=true');
     });
     it('handles host with port included', () => {
-      expect(generateUri({ _: [], host: 'localhost:27018' })).to.equal('mongodb://localhost:27018?directConnection=true');
+      expect(generateUri({ _: [], host: 'localhost:27018' })).to.equal('mongodb://localhost:27018/?directConnection=true');
     });
     it('throws if host has port AND port set to other value', () => {
       try {
         generateUri({ _: [], host: 'localhost:27018', port: '27019' });
-        fail('expected error');
+        expect.fail('expected error');
       } catch (e) {
         expect(e).to.be.instanceOf(MongoshInvalidInputError);
         expect(e.code).to.equal(CommonErrors.InvalidArgument);
       }
     });
     it('handles host has port AND port set to equal value', () => {
-      expect(generateUri({ _: [], host: 'localhost:27018', port: '27018' })).to.equal('mongodb://localhost:27018?directConnection=true');
+      expect(generateUri({ _: [], host: 'localhost:27018', port: '27018' })).to.equal('mongodb://localhost:27018/?directConnection=true');
     });
   });
 
@@ -56,7 +55,7 @@ describe('uri-generator.generate-uri', () => {
         it('throws an exception', () => {
           try {
             generateUri(options);
-            fail('expected error');
+            expect.fail('expected error');
           } catch (e) {
             expect(e).to.be.instanceOf(MongoshInvalidInputError);
             expect(e.code).to.equal(CommonErrors.InvalidArgument);
@@ -71,7 +70,7 @@ describe('uri-generator.generate-uri', () => {
         it('throws an exception', () => {
           try {
             generateUri(options);
-            fail('expected error');
+            expect.fail('expected error');
           } catch (e) {
             expect(e.name).to.equal('MongoshInvalidInputError');
             expect(e.code).to.equal(CommonErrors.InvalidArgument);
@@ -82,10 +81,10 @@ describe('uri-generator.generate-uri', () => {
 
     context('when providing a URI with query parameters', () => {
       context('that do not conflict with directConnection', () => {
-        const uri = 'mongodb://192.0.0.1:27018/db?readPreference=primary';
+        const uri = 'mongodb://192.0.0.1:27018?readPreference=primary';
         const options = { _: [uri] };
         it('still includes directConnection', () => {
-          expect(generateUri(options)).to.equal('mongodb://192.0.0.1:27018/db?readPreference=primary&directConnection=true');
+          expect(generateUri(options)).to.equal('mongodb://192.0.0.1:27018/?readPreference=primary&directConnection=true');
         });
       });
 
@@ -107,7 +106,7 @@ describe('uri-generator.generate-uri', () => {
     });
 
     context('when providing a URI with SRV record', () => {
-      const uri = 'mongodb+srv://192.0.0.1:27018/db?readPreference=primary';
+      const uri = 'mongodb+srv://192.0.0.1:27018?readPreference=primary';
       const options = { _: [uri] };
       it('no directConnection is added', () => {
         expect(generateUri(options)).to.equal(uri);
@@ -149,7 +148,7 @@ describe('uri-generator.generate-uri', () => {
       it('throws an exception', () => {
         try {
           generateUri(options);
-          fail('expected error');
+          expect.fail('expected error');
         } catch (e) {
           expect(e).to.be.instanceOf(MongoshInvalidInputError);
           expect(e.code).to.equal(CommonErrors.InvalidArgument);
@@ -157,7 +156,25 @@ describe('uri-generator.generate-uri', () => {
       });
     });
 
-    context('when no additional options are provided', () => {
+    context('when no additional options are provided without db', () => {
+      const uri = '192.0.0.1:27018';
+      const options = { _: [uri] };
+
+      it('returns the uri with the scheme', () => {
+        expect(generateUri(options)).to.equal(`mongodb://${uri}/test?directConnection=true`);
+      });
+    });
+
+    context('when no additional options are provided with empty db', () => {
+      const uri = '192.0.0.1:27018/';
+      const options = { _: [uri] };
+
+      it('returns the uri with the scheme', () => {
+        expect(generateUri(options)).to.equal(`mongodb://${uri}test?directConnection=true`);
+      });
+    });
+
+    context('when no additional options are provided with db', () => {
       const uri = '192.0.0.1:27018/foo';
       const options = { _: [uri] };
 
@@ -174,7 +191,7 @@ describe('uri-generator.generate-uri', () => {
         it('throws an exception', () => {
           try {
             generateUri(options);
-            fail('expected error');
+            expect.fail('expected error');
           } catch (e) {
             expect(e).to.be.instanceOf(MongoshInvalidInputError);
             expect(e.code).to.equal(CommonErrors.InvalidArgument);
@@ -198,7 +215,7 @@ describe('uri-generator.generate-uri', () => {
         it('throws an exception', () => {
           try {
             generateUri(options);
-            fail('expected error');
+            expect.fail('expected error');
           } catch (e) {
             expect(e).to.be.instanceOf(MongoshInvalidInputError);
             expect(e.code).to.equal(CommonErrors.InvalidArgument);
@@ -222,7 +239,7 @@ describe('uri-generator.generate-uri', () => {
         it('throws an exception', () => {
           try {
             generateUri(options);
-            fail('expected error');
+            expect.fail('expected error');
           } catch (e) {
             expect(e).to.be.instanceOf(MongoshInvalidInputError);
             expect(e.code).to.equal(CommonErrors.InvalidArgument);
@@ -233,10 +250,10 @@ describe('uri-generator.generate-uri', () => {
 
     context('when providing a URI with query parameters', () => {
       context('that do not conflict with directConnection', () => {
-        const uri = '192.0.0.1:27018/db?readPreference=primary';
+        const uri = '192.0.0.1:27018?readPreference=primary';
         const options = { _: [uri] };
         it('still includes directConnection', () => {
-          expect(generateUri(options)).to.equal(`mongodb://${uri}&directConnection=true`);
+          expect(generateUri(options)).to.equal('mongodb://192.0.0.1:27018/?readPreference=primary&directConnection=true');
         });
       });
 
@@ -249,10 +266,10 @@ describe('uri-generator.generate-uri', () => {
       });
 
       context('including explicit directConnection', () => {
-        const uri = '192.0.0.1:27018/db?directConnection=false';
+        const uri = '192.0.0.1:27018?directConnection=false';
         const options = { _: [uri] };
         it('does not change the directConnection parameter', () => {
-          expect(generateUri(options)).to.equal(`mongodb://${uri}`);
+          expect(generateUri(options)).to.equal('mongodb://192.0.0.1:27018/?directConnection=false');
         });
       });
     });
@@ -266,12 +283,13 @@ describe('uri-generator.generate-uri', () => {
     it('returns the uri', () => {
       try {
         generateUri(options);
-        fail('expected error');
       } catch (e) {
         expect(e.message).to.contain('Invalid URI: /x');
         expect(e).to.be.instanceOf(MongoshInvalidInputError);
         expect(e.code).to.equal(CommonErrors.InvalidArgument);
+        return;
       }
+      expect.fail('expected error');
     });
   });
 });

--- a/packages/service-provider-core/src/uri-generator.ts
+++ b/packages/service-provider-core/src/uri-generator.ts
@@ -2,6 +2,7 @@
 
 import { CommonErrors, MongoshInvalidInputError } from '@mongosh/errors';
 import i18n from '@mongosh/i18n';
+import { URL } from 'url';
 import CliOptions from './cli-options';
 import { DEFAULT_DB } from './index';
 
@@ -107,13 +108,17 @@ function generateUri(options: CliOptions): string {
 
   // There is no URI provided, use default 127.0.0.1:27017
   if (!uri) {
-    return `${Scheme.Mongo}${generateHost(options)}:${generatePort(options)}`;
+    return `${Scheme.Mongo}${generateHost(options)}:${generatePort(options)}/?directConnection=true`;
   }
 
-  // A mongodb:// or mongodb+srv:// URI is provided, treat as correct.
-  if (uri.startsWith(Scheme.Mongo) || uri.startsWith(Scheme.MongoSrv)) {
+  // mongodb+srv:// URI is provided, treat as correct and immediately return
+  if (uri.startsWith(Scheme.MongoSrv)) {
     validateConflicts(options);
     return uri;
+  } else if (uri.startsWith(Scheme.Mongo)) {
+    // we need to figure out if we have to add the directConnection query parameter
+    validateConflicts(options);
+    return addDirectConnectionQueryParameterToMongoUriIfRequired(uri);
   }
 
   // Capture host, port and db from the string and generate a URI from
@@ -127,12 +132,12 @@ function generateUri(options: CliOptions): string {
 
   let host: string | undefined = parts[1];
   const port = parts[2];
-  let db = parts[3];
+  let dbAndQueryString = parts[3];
 
   // If there is no port and db, host becomes db if there is no
   // '.' in the string. (legacy shell behaviour)
-  if (!port && !db && host.indexOf('.') < 0) {
-    db = host;
+  if (!port && !dbAndQueryString && host.indexOf('.') < 0) {
+    dbAndQueryString = host;
     host = undefined;
   }
 
@@ -142,7 +147,61 @@ function generateUri(options: CliOptions): string {
     validateConflicts(options);
   }
 
-  return `${Scheme.Mongo}${host || generateHost(options)}:${port || generatePort(options)}/${db || DEFAULT_DB}`;
+  return `${Scheme.Mongo}${host || generateHost(options)}:${port || generatePort(options)}${getDbAndQueryStringWithDirectConnectionIfRequired(dbAndQueryString || DEFAULT_DB)}`;
+}
+
+/**
+ * Parses a given mongodb:// connection string and adds the `directConnection=true` query parameter if required.
+ * See: https://github.com/mongodb/specifications/blob/master/source/connection-string/connection-string-spec.rst#reference-implementation
+ * @param uri mongodb:// connection string
+ */
+function addDirectConnectionQueryParameterToMongoUriIfRequired(uri: string): string {
+  const uriNoScheme = uri.substr(Scheme.Mongo.length);
+
+  // Split URI at first "/"
+  let splitIndex = uriNoScheme.indexOf('/');
+  if (splitIndex < 0) {
+    // maybe there's a question mark as separator
+    splitIndex = uriNoScheme.indexOf('?');
+  }
+
+  const userAndHostInfo = splitIndex < 0 ? uriNoScheme : uriNoScheme.substr(0, splitIndex);
+  const authDbAndOptions = splitIndex < 0 || splitIndex === uriNoScheme.length - 1 ? '' : uriNoScheme.substr(splitIndex);
+
+  // Check user and host informatino part to extract only hosts
+  const atIndex = userAndHostInfo.lastIndexOf('@');
+  const hostInfo = atIndex < 0 ? userAndHostInfo : userAndHostInfo.substr(atIndex + 1);
+  if (hostInfo.indexOf(',') > -1) {
+    // multiple hosts, i.e. a seed list is present -> return original uri
+    return uri;
+  }
+
+  if (authDbAndOptions) {
+    // Check if a replicaSet or directConnection parameter is already present
+    return `mongodb://${userAndHostInfo}` + getDbAndQueryStringWithDirectConnectionIfRequired(authDbAndOptions);
+  }
+  return `${uri.endsWith('/') ? uri : uri + '/'}?directConnection=true`;
+}
+
+/**
+ * Takes the given URI path and query string representing the auth database and connection options
+ * and checks if a `directConnection=true` parameter should be added.
+ *
+ * The returned string always starts with a `/`.
+ *
+ * @param dbAndQueryString URI Path and Query String
+ */
+function getDbAndQueryStringWithDirectConnectionIfRequired(dbAndQueryString: string): string {
+  if (!dbAndQueryString.startsWith('/')) {
+    dbAndQueryString = '/' + dbAndQueryString;
+  }
+  const params = new URL(`mongodb://localhost${dbAndQueryString}`).searchParams;
+  if (params.has('replicaSet') || params.has('directConnection')) {
+    return dbAndQueryString;
+  }
+
+  const directConnQueryParam = (!params.entries().next().done ? '&' : '?') + 'directConnection=true';
+  return dbAndQueryString + directConnQueryParam;
 }
 
 export default generateUri;

--- a/packages/shell-api/src/mongo.spec.ts
+++ b/packages/shell-api/src/mongo.spec.ts
@@ -55,7 +55,7 @@ describe('Mongo', () => {
     describe('toShellResult', () => {
       const mongo = new Mongo({} as any, 'localhost:37017');
       it('value', async() => {
-        expect((await toShellResult(mongo)).printable).to.equal('mongodb://localhost:37017/test');
+        expect((await toShellResult(mongo)).printable).to.equal('mongodb://localhost:37017/test?directConnection=true');
       });
       it('type', async() => {
         expect((await toShellResult(mongo)).type).to.equal('Mongo');
@@ -548,7 +548,7 @@ describe('Mongo', () => {
         const expectedResult = { ChangeStreamCursor: 1 } as any;
         serviceProvider.watch.returns(expectedResult);
         const result = mongo.watch();
-        expect(result).to.deep.equal(new ChangeStreamCursor(expectedResult, 'mongodb://localhost/', mongo));
+        expect(result).to.deep.equal(new ChangeStreamCursor(expectedResult, 'mongodb://localhost/?directConnection=true', mongo));
         expect(mongo._internalState.currentCursor).to.equal(result);
       });
 

--- a/packages/shell-api/src/shell-api.spec.ts
+++ b/packages/shell-api/src/shell-api.spec.ts
@@ -127,7 +127,7 @@ describe('ShellApi', () => {
       it('returns a new Mongo object', async() => {
         const m = await internalState.shellApi.Mongo('localhost:27017');
         expect((await toShellResult(m)).type).to.equal('Mongo');
-        expect(m._uri).to.equal('mongodb://localhost:27017/test');
+        expect(m._uri).to.equal('mongodb://localhost:27017/test?directConnection=true');
       });
       it('fails for non-CLI', async() => {
         serviceProvider.platform = ReplPlatform.Browser;
@@ -140,11 +140,11 @@ describe('ShellApi', () => {
       });
       it('parses URI with mongodb://', async() => {
         const m = await internalState.shellApi.Mongo('mongodb://127.0.0.1:27017');
-        expect(m._uri).to.equal('mongodb://127.0.0.1:27017');
+        expect(m._uri).to.equal('mongodb://127.0.0.1:27017/?directConnection=true');
       });
       it('parses URI with just db', async() => {
         const m = await internalState.shellApi.Mongo('dbname');
-        expect(m._uri).to.equal('mongodb://127.0.0.1:27017/dbname');
+        expect(m._uri).to.equal('mongodb://127.0.0.1:27017/dbname?directConnection=true');
       });
     });
     describe('connect', () => {
@@ -152,7 +152,7 @@ describe('ShellApi', () => {
         serviceProvider.platform = ReplPlatform.CLI;
         const db = await internalState.shellApi.connect('localhost:27017', 'username', 'pwd');
         expect((await toShellResult(db)).type).to.equal('Database');
-        expect(db.getMongo()._uri).to.equal('mongodb://localhost:27017/test');
+        expect(db.getMongo()._uri).to.equal('mongodb://localhost:27017/test?directConnection=true');
       });
       it('fails with no arg', async() => {
         serviceProvider.platform = ReplPlatform.CLI;
@@ -236,7 +236,7 @@ describe('ShellApi', () => {
       it('returns a new Mongo object', async() => {
         const m = await internalState.context.Mongo('mongodb://127.0.0.1:27017');
         expect((await toShellResult(m)).type).to.equal('Mongo');
-        expect(m._uri).to.equal('mongodb://127.0.0.1:27017');
+        expect(m._uri).to.equal('mongodb://127.0.0.1:27017/?directConnection=true');
       });
       it('fails for non-CLI', async() => {
         serviceProvider.platform = ReplPlatform.Browser;
@@ -253,13 +253,13 @@ describe('ShellApi', () => {
         serviceProvider.platform = ReplPlatform.CLI;
         const db = await internalState.context.connect('mongodb://127.0.0.1:27017');
         expect((await toShellResult(db)).type).to.equal('Database');
-        expect(db.getMongo()._uri).to.equal('mongodb://127.0.0.1:27017');
+        expect(db.getMongo()._uri).to.equal('mongodb://127.0.0.1:27017/?directConnection=true');
       });
       it('handles username/pwd', async() => {
         serviceProvider.platform = ReplPlatform.CLI;
         const db = await internalState.context.connect('mongodb://127.0.0.1:27017', 'username', 'pwd');
         expect((await toShellResult(db)).type).to.equal('Database');
-        expect(db.getMongo()._uri).to.equal('mongodb://127.0.0.1:27017');
+        expect(db.getMongo()._uri).to.equal('mongodb://127.0.0.1:27017/?directConnection=true');
         expect(db.getMongo()._options).to.deep.equal({ auth: { username: 'username', password: 'pwd' } });
       });
     });


### PR DESCRIPTION
## Description
This fixes the breaking behavioral change when connecting to a specific node. The old shell directly connected to a node as specified whereas we so far tried to establish a connection to e.g. the primary node of a replica set.

The default behavior now is to add the `directConnection=true` query parameter to the connection string automatically _except_:
* the `replicaSet` query parameter is present in the connection string
* the connection string uses the `mongodb+srv://` scheme
* the connection string contains a seed list with multiple hosts