### PR TITLE
chore(test): add various more tests

### DIFF
--- a/.nycrc
+++ b/.nycrc
@@ -6,6 +6,7 @@
     "**/*.d.ts",
     "**/*.spec.{ts,js,tsx,jsx,cjs,mjs}",
     "**/test/**/*.{ts,js,tsx,jsx,cjs,mjs}",
+    "**/tmp/**/*.{ts,js,tsx,jsx,cjs,mjs}",
     "**/*.config.{ts,js,tsx,jsx,cjs,mjs}",
     "**/lib/*.js"
   ]

--- a/packages/build/src/generate-input.spec.ts
+++ b/packages/build/src/generate-input.spec.ts
@@ -1,0 +1,62 @@
+import { expect } from 'chai';
+import childProcess from 'child_process';
+import { promises as fs } from 'fs';
+import generateInput from './generate-input';
+import rimraf from 'rimraf';
+import path from 'path';
+import { promisify } from 'util';
+const execFile = promisify(childProcess.execFile);
+
+describe('input bundling', function() {
+  this.timeout(60_000);
+  const tmpdir = path.resolve(
+    __dirname, '..', '..', '..', 'tmp', `test-build-${Date.now()}-${Math.random()}`);
+
+  beforeEach(async() => {
+    await fs.mkdir(tmpdir, { recursive: true });
+  });
+
+  afterEach(async() => {
+    await promisify(rimraf)(tmpdir);
+  });
+
+  it('bundles input files together', async() => {
+    await fs.writeFile(path.join(tmpdir, 'a.js'), 'module.exports="works"');
+    await fs.writeFile(path.join(tmpdir, 'b.js'), `
+      console.log(JSON.stringify({
+        main: 'it ' + require("./a") + '!',
+        analytics: require("./analytics")
+      }));
+      `);
+    await generateInput(
+      path.join(tmpdir, 'b.js'),
+      path.join(tmpdir, 'compiled.js'),
+      path.join(tmpdir, 'analytics.js'),
+      '...segment-key...');
+    await fs.unlink(path.join(tmpdir, 'a.js'));
+    await fs.unlink(path.join(tmpdir, 'b.js'));
+    await fs.unlink(path.join(tmpdir, 'analytics.js'));
+    const { stdout } = await execFile(process.execPath, [path.join(tmpdir, 'compiled.js')]);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.main).to.equal('it works!');
+    expect(parsed.analytics.SEGMENT_API_KEY).to.equal('...segment-key...');
+  });
+
+  it('does not attempt to load ES6 modules because parcel cannot handle them properly', async() => {
+    const pkg = path.join(tmpdir, 'node_modules', 'some-fake-module');
+    await fs.mkdir(pkg, { recursive: true });
+    await fs.writeFile(path.join(pkg, 'package.json'), '{"main":"./cjs.js","module":"./esm.mjs"}');
+    await fs.writeFile(path.join(pkg, 'cjs.js'), 'module.exports = "cjs"');
+    await fs.writeFile(path.join(pkg, 'esm.mjs'), 'module.exports = "esm"');
+    await fs.writeFile(path.join(tmpdir, 'b.js'), `
+      console.log(require("some-fake-module"));
+      `);
+    await generateInput(
+      path.join(tmpdir, 'b.js'),
+      path.join(tmpdir, 'compiled.js'),
+      path.join(tmpdir, 'analytics.js'),
+      '...segment-key...');
+    const { stdout } = await execFile(process.execPath, [path.join(tmpdir, 'compiled.js')]);
+    expect(stdout.trim()).to.equal('cjs');
+  });
+});

--- a/packages/build/src/generate-input.ts
+++ b/packages/build/src/generate-input.ts
@@ -28,7 +28,8 @@ async function generateInput(input: string, execInput: string, analyticsConfig: 
     target: 'node',
     bundleNodeModules: true,
     sourceMaps: false,
-    logLevel: 3
+    logLevel: 3,
+    watch: false
   });
 
   // Sigh! Parcel does not understand that you can't just use an ES6 module file

--- a/packages/errors/index.spec.ts
+++ b/packages/errors/index.spec.ts
@@ -3,7 +3,8 @@ import {
   getScopeFromErrorCode,
   MongoshBaseError, MongoshInternalError,
   MongoshInvalidInputError, MongoshRuntimeError,
-  MongoshUnimplementedError
+  MongoshUnimplementedError, MongoshWarning, MongoshDeprecatedError,
+  MongoshCommandFailed
 } from './index';
 import { CommonErrors } from './lib';
 
@@ -70,5 +71,33 @@ describe('errors', () => {
     expect(errorWithCode.message).to.be.equal('[SHUPS-42] Something went wrong.');
     expect(errorWithCode.code).to.be.equal('SHUPS-42');
     expect(errorWithCode.scope).to.be.equal('SHUPS');
+  });
+  it('creates MongoshWarning', () => {
+    const errorNoCode = new MongoshWarning('Something went wrong.');
+    expect(errorNoCode).to.be.instanceOf(MongoshBaseError);
+    expect(errorNoCode.name).to.be.equal('MongoshWarning');
+    expect(errorNoCode.message).to.be.equal('Something went wrong.');
+    expect(errorNoCode.code).to.be.undefined;
+
+    const errorWithCode = new MongoshWarning('Something went wrong.', 'SHUPS-42');
+    expect(errorWithCode).to.be.instanceOf(MongoshBaseError);
+    expect(errorWithCode.name).to.be.equal('MongoshWarning');
+    expect(errorWithCode.message).to.be.equal('[SHUPS-42] Something went wrong.');
+    expect(errorWithCode.code).to.be.equal('SHUPS-42');
+    expect(errorWithCode.scope).to.be.equal('SHUPS');
+  });
+  it('creates MongoshDeprecatedError', () => {
+    const errorNoCode = new MongoshDeprecatedError('Something went wrong.');
+    expect(errorNoCode).to.be.instanceOf(MongoshBaseError);
+    expect(errorNoCode.name).to.be.equal('MongoshDeprecatedError');
+    expect(errorNoCode.message).to.be.equal('[COMMON-10003] Something went wrong.');
+    expect(errorNoCode.code).to.equal('COMMON-10003');
+  });
+  it('creates MongoshCommandFailed', () => {
+    const errorNoCode = new MongoshCommandFailed('Something went wrong.');
+    expect(errorNoCode).to.be.instanceOf(MongoshBaseError);
+    expect(errorNoCode.name).to.be.equal('MongoshCommandFailed');
+    expect(errorNoCode.message).to.be.equal("[COMMON-10004] Command Something went wrong. returned ok: 0. To see the raw results of the command, use 'runCommand' instead.");
+    expect(errorNoCode.code).to.equal('COMMON-10004');
   });
 });

--- a/packages/shell-api/src/change-stream-cursor.spec.ts
+++ b/packages/shell-api/src/change-stream-cursor.spec.ts
@@ -11,6 +11,7 @@ import Mongo from './mongo';
 import { ensureMaster, ensureResult } from '../../../testing/helpers';
 import Database from './database';
 import Collection from './collection';
+import { MongoshUnimplementedError } from '@mongosh/errors';
 
 describe('ChangeStreamCursor', () => {
   describe('help', () => {
@@ -264,6 +265,27 @@ describe('ChangeStreamCursor', () => {
           'itcount to return 1');
         expect(result).to.equal(1);
       });
+    });
+  });
+  describe('unsupported methods', () => {
+    let cursor;
+    beforeEach(() => {
+      cursor = new ChangeStreamCursor({} as ChangeStream, 'source', {} as Mongo);
+    });
+
+    for (const name of ['map', 'forEach', 'toArray', 'objsLeftInBatch']) {
+      // eslint-disable-next-line no-loop-func
+      it(`${name} fails`, () => {
+        expect(() => cursor[name]()).to.throw(MongoshUnimplementedError);
+      });
+    }
+    it('isExhausted fails', async() => {
+      try {
+        await cursor.isExhausted();
+        expect.fail('missed exception');
+      } catch (err) {
+        expect(err.name).to.equal('MongoshInvalidInputError');
+      }
     });
   });
 });

--- a/packages/shell-api/src/change-stream-cursor.ts
+++ b/packages/shell-api/src/change-stream-cursor.ts
@@ -85,7 +85,7 @@ export default class ChangeStreamCursor extends ShellApiClass {
   }
 
   @returnsPromise
-  async isExhausted(): Promise<boolean> {
+  isExhausted(): Promise<boolean> {
     throw new MongoshInvalidInputError('isExhausted is not implemented for ChangeStreams because after closing a cursor, the remaining documents in the batch are no longer accessible. If you want to see if the cursor is closed use isClosed. If you want to see if there are documents left in the batch, use tryNext.');
   }
 

--- a/packages/shell-api/src/collection.ts
+++ b/packages/shell-api/src/collection.ts
@@ -1514,14 +1514,16 @@ export default class Collection extends ShellApiClass {
     await Promise.all(collStats.map((extShardStats) => (
       (async(): Promise<void> => {
         // Extract and store only the relevant subset of the stats for this shard
-        const host = await config.getCollection('shards').findOne({ _id: extShardStats.shard });
+        const [ host, numChunks ] = await Promise.all([
+          config.getCollection('shards').findOne({ _id: extShardStats.shard }),
+          config.getCollection('chunks').countDocuments({ ns: extShardStats.ns, shard: extShardStats.shard })
+        ]);
         const shardStats = {
           shardId: extShardStats.shard,
           host: host !== null ? host.host : null,
           size: extShardStats.storageStats.size,
           count: extShardStats.storageStats.count,
-          numChunks:
-            await config.getCollection('chunks').countDocuments({ ns: extShardStats.ns, shard: extShardStats.shard }),
+          numChunks: numChunks,
           avgObjSize: extShardStats.storageStats.avgObjSize
         };
 

--- a/packages/shell-api/src/cursor.spec.ts
+++ b/packages/shell-api/src/cursor.spec.ts
@@ -204,6 +204,11 @@ describe('Cursor', () => {
         expect(await shellApiCursor.count()).to.equal(5);
         expect(spCursor.count).to.have.been.calledWith();
       });
+
+      it('is aliased by size()', async() => {
+        expect(await shellApiCursor.size()).to.equal(5);
+        expect(spCursor.count).to.have.been.calledWith();
+      });
     });
 
     describe('#hasNext', () => {
@@ -551,6 +556,12 @@ describe('Cursor', () => {
       it('fluidly adds the cursor flag', () => {
         expect(shellApiCursor.tailable()).to.equal(shellApiCursor);
         expect(spCursor.addCursorFlag).to.have.been.calledWith('tailable', true);
+      });
+
+      it('fluidly adds the awaitData flag', () => {
+        expect(shellApiCursor.tailable({ awaitData: true })).to.equal(shellApiCursor);
+        expect(spCursor.addCursorFlag).to.have.been.calledWith('tailable', true);
+        expect(spCursor.addCursorFlag).to.have.been.calledWith('awaitData', true);
       });
     });
 

--- a/packages/shell-api/src/mongo.spec.ts
+++ b/packages/shell-api/src/mongo.spec.ts
@@ -136,169 +136,176 @@ describe('Mongo', () => {
             expect(catchedError).to.equal(expectedError);
           });
         });
-        describe('users', () => {
-          it('calls database.getUsers', async() => {
-            const expectedResult = { ok: 1, users: [] };
-            database.getUsers.resolves(expectedResult);
-            await mongo.show('users');
-            expect(database.getUsers).to.have.been.calledWith(
+      });
+      describe('users', () => {
+        it('calls database.getUsers', async() => {
+          const expectedResult = { ok: 1, users: [] };
+          database.getUsers.resolves(expectedResult);
+          await mongo.show('users');
+          expect(database.getUsers).to.have.been.calledWith(
 
-            );
-          });
-
-          it('returns ShowResult CommandResult', async() => {
-            const expectedResult = { ok: 1, users: ['a', 'b'] };
-            database.getUsers.resolves(expectedResult);
-            const result = await mongo.show('users');
-            expect(result.value).to.deep.equal(expectedResult.users);
-            expect(result.type).to.equal('ShowResult');
-          });
-
-          it('throws if database.getUsers rejects', async() => {
-            const expectedError = new Error();
-            database.getUsers.rejects(expectedError);
-            const catchedError = await mongo.show('users')
-              .catch(e => e);
-            expect(catchedError).to.equal(expectedError);
-          });
+          );
         });
-        describe('roles', () => {
-          it('calls database.getRoles', async() => {
-            const expectedResult = { ok: 1, roles: [] };
-            database.getRoles.resolves(expectedResult);
-            await mongo.show('roles');
-            expect(database.getRoles).to.have.been.calledWith(
-              { showBuiltinRoles: true }
-            );
-          });
 
-          it('returns ShowResult CommandResult', async() => {
-            const expectedResult = { ok: 1, roles: ['a', 'b'] };
-            database.getRoles.resolves(expectedResult);
-            const result = await mongo.show('roles');
-            expect(result.value).to.deep.equal(expectedResult.roles);
-            expect(result.type).to.equal('ShowResult');
-          });
-
-          it('throws if database.getRoles rejects', async() => {
-            const expectedError = new Error();
-            database.getRoles.rejects(expectedError);
-            const catchedError = await mongo.show('roles')
-              .catch(e => e);
-            expect(catchedError).to.equal(expectedError);
-          });
+        it('returns ShowResult CommandResult', async() => {
+          const expectedResult = { ok: 1, users: ['a', 'b'] };
+          database.getUsers.resolves(expectedResult);
+          const result = await mongo.show('users');
+          expect(result.value).to.deep.equal(expectedResult.users);
+          expect(result.type).to.equal('ShowResult');
         });
-        describe('log', () => {
-          it('calls database.adminCommand without arg', async() => {
-            const expectedResult = { ok: 1, log: [] };
-            database.adminCommand.resolves(expectedResult);
-            await mongo.show('log');
-            expect(database.adminCommand).to.have.been.calledWith(
-              { getLog: 'global' }
-            );
-          });
-          it('calls database.adminCommand with arg', async() => {
-            const expectedResult = { ok: 1, log: [] };
-            database.adminCommand.resolves(expectedResult);
-            await mongo.show('log', 'other');
-            expect(database.adminCommand).to.have.been.calledWith(
-              { getLog: 'other' }
-            );
-          });
 
-          it('returns ShowResult CommandResult', async() => {
-            const expectedResult = { ok: 1, log: ['a', 'b'] };
-            database.adminCommand.resolves(expectedResult);
-            const result = await mongo.show('log');
-            expect(result.value).to.deep.equal(expectedResult.log);
-            expect(result.type).to.equal('ShowResult');
-          });
-
-          it('throws if database.adminCommand rejects', async() => {
-            const expectedError = new Error();
-            database.adminCommand.rejects(expectedError);
-            const catchedError = await mongo.show('log')
-              .catch(e => e);
-            expect(catchedError).to.equal(expectedError);
-          });
+        it('throws if database.getUsers rejects', async() => {
+          const expectedError = new Error();
+          database.getUsers.rejects(expectedError);
+          const catchedError = await mongo.show('users')
+            .catch(e => e);
+          expect(catchedError).to.equal(expectedError);
         });
-        describe('logs', () => {
-          it('calls database.adminCommand', async() => {
-            const expectedResult = { ok: 1, names: [] };
-            database.adminCommand.resolves(expectedResult);
-            await mongo.show('logs');
-            expect(database.adminCommand).to.have.been.calledWith(
-              { getLog: '*' }
-            );
-          });
-
-          it('returns ShowResult CommandResult', async() => {
-            const expectedResult = { ok: 1, names: ['a', 'b'] };
-            database.adminCommand.resolves(expectedResult);
-            const result = await mongo.show('logs');
-            expect(result.value).to.deep.equal(expectedResult.names);
-            expect(result.type).to.equal('ShowResult');
-          });
-
-          it('throws if database.adminCommand rejects', async() => {
-            const expectedError = new Error();
-            database.adminCommand.rejects(expectedError);
-            const catchedError = await mongo.show('logs')
-              .catch(e => e);
-            expect(catchedError).to.equal(expectedError);
-          });
+      });
+      describe('roles', () => {
+        it('calls database.getRoles', async() => {
+          const expectedResult = { ok: 1, roles: [] };
+          database.getRoles.resolves(expectedResult);
+          await mongo.show('roles');
+          expect(database.getRoles).to.have.been.calledWith(
+            { showBuiltinRoles: true }
+          );
         });
-        describe('profile', () => {
-          it('calls database.count but not find when count < 1', async() => {
-            const syscoll = stubInterface<Collection>();
-            database.getCollection.returns(syscoll);
-            syscoll.countDocuments.resolves(0);
-            syscoll.find.rejects(new Error());
-            const result = await mongo.show('profile');
-            expect(database.getCollection).to.have.been.calledWith('system.profile');
-            expect(syscoll.countDocuments).to.have.been.calledWith({});
-            expect(result.type).to.equal('ShowProfileResult');
-            expect(result.value).to.deep.equal({ count: 0 });
-          });
-          it('calls database.count and find when count > 0', async() => {
-            const expectedResult = [{ a: 'a' }, { b: 'b' }];
-            const syscoll = stubInterface<Collection>();
-            const cursor = stubInterface<Cursor>();
-            cursor.sort.returns(cursor);
-            cursor.limit.returns(cursor);
-            cursor.toArray.resolves(expectedResult);
-            database.getCollection.returns(syscoll);
-            syscoll.countDocuments.resolves(1);
-            syscoll.find.returns(cursor);
-            const result = await mongo.show('profile');
-            expect(database.getCollection).to.have.been.calledWith('system.profile');
-            expect(syscoll.countDocuments).to.have.been.calledWith({});
-            expect(cursor.sort).to.have.been.calledWith({ $natural: -1 });
-            expect(cursor.limit).to.have.been.calledWith(5);
-            expect(cursor.toArray).to.have.been.calledWith();
-            expect(result.type).to.equal('ShowProfileResult');
-            expect(result.value).to.deep.equal({ count: 1, result: expectedResult });
-          });
 
-          it('throws if collection.find throws', async() => {
-            const syscoll = stubInterface<Collection>();
-            database.getCollection.returns(syscoll);
-            syscoll.countDocuments.resolves(1);
-            const expectedError = new Error();
-            syscoll.find.throws(expectedError);
-            const catchedError = await mongo.show('profile')
-              .catch(e => e);
-            expect(catchedError).to.equal(expectedError);
-          });
-          it('throws if collection.countDocuments rejects', async() => {
-            const syscoll = stubInterface<Collection>();
-            database.getCollection.returns(syscoll);
-            const expectedError = new Error();
-            syscoll.countDocuments.rejects(expectedError);
-            const catchedError = await mongo.show('profile')
-              .catch(e => e);
-            expect(catchedError).to.equal(expectedError);
-          });
+        it('returns ShowResult CommandResult', async() => {
+          const expectedResult = { ok: 1, roles: ['a', 'b'] };
+          database.getRoles.resolves(expectedResult);
+          const result = await mongo.show('roles');
+          expect(result.value).to.deep.equal(expectedResult.roles);
+          expect(result.type).to.equal('ShowResult');
+        });
+
+        it('throws if database.getRoles rejects', async() => {
+          const expectedError = new Error();
+          database.getRoles.rejects(expectedError);
+          const catchedError = await mongo.show('roles')
+            .catch(e => e);
+          expect(catchedError).to.equal(expectedError);
+        });
+      });
+      describe('log', () => {
+        it('calls database.adminCommand without arg', async() => {
+          const expectedResult = { ok: 1, log: [] };
+          database.adminCommand.resolves(expectedResult);
+          await mongo.show('log');
+          expect(database.adminCommand).to.have.been.calledWith(
+            { getLog: 'global' }
+          );
+        });
+        it('calls database.adminCommand with arg', async() => {
+          const expectedResult = { ok: 1, log: [] };
+          database.adminCommand.resolves(expectedResult);
+          await mongo.show('log', 'other');
+          expect(database.adminCommand).to.have.been.calledWith(
+            { getLog: 'other' }
+          );
+        });
+
+        it('returns ShowResult CommandResult', async() => {
+          const expectedResult = { ok: 1, log: ['a', 'b'] };
+          database.adminCommand.resolves(expectedResult);
+          const result = await mongo.show('log');
+          expect(result.value).to.deep.equal(expectedResult.log);
+          expect(result.type).to.equal('ShowResult');
+        });
+
+        it('throws if database.adminCommand rejects', async() => {
+          const expectedError = new Error();
+          database.adminCommand.rejects(expectedError);
+          const catchedError = await mongo.show('log')
+            .catch(e => e);
+          expect(catchedError).to.equal(expectedError);
+        });
+      });
+      describe('logs', () => {
+        it('calls database.adminCommand', async() => {
+          const expectedResult = { ok: 1, names: [] };
+          database.adminCommand.resolves(expectedResult);
+          await mongo.show('logs');
+          expect(database.adminCommand).to.have.been.calledWith(
+            { getLog: '*' }
+          );
+        });
+
+        it('returns ShowResult CommandResult', async() => {
+          const expectedResult = { ok: 1, names: ['a', 'b'] };
+          database.adminCommand.resolves(expectedResult);
+          const result = await mongo.show('logs');
+          expect(result.value).to.deep.equal(expectedResult.names);
+          expect(result.type).to.equal('ShowResult');
+        });
+
+        it('throws if database.adminCommand rejects', async() => {
+          const expectedError = new Error();
+          database.adminCommand.rejects(expectedError);
+          const catchedError = await mongo.show('logs')
+            .catch(e => e);
+          expect(catchedError).to.equal(expectedError);
+        });
+      });
+      describe('profile', () => {
+        it('calls database.count but not find when count < 1', async() => {
+          const syscoll = stubInterface<Collection>();
+          database.getCollection.returns(syscoll);
+          syscoll.countDocuments.resolves(0);
+          syscoll.find.rejects(new Error());
+          const result = await mongo.show('profile');
+          expect(database.getCollection).to.have.been.calledWith('system.profile');
+          expect(syscoll.countDocuments).to.have.been.calledWith({});
+          expect(result.type).to.equal('ShowProfileResult');
+          expect(result.value).to.deep.equal({ count: 0 });
+        });
+        it('calls database.count and find when count > 0', async() => {
+          const expectedResult = [{ a: 'a' }, { b: 'b' }];
+          const syscoll = stubInterface<Collection>();
+          const cursor = stubInterface<Cursor>();
+          cursor.sort.returns(cursor);
+          cursor.limit.returns(cursor);
+          cursor.toArray.resolves(expectedResult);
+          database.getCollection.returns(syscoll);
+          syscoll.countDocuments.resolves(1);
+          syscoll.find.returns(cursor);
+          const result = await mongo.show('profile');
+          expect(database.getCollection).to.have.been.calledWith('system.profile');
+          expect(syscoll.countDocuments).to.have.been.calledWith({});
+          expect(cursor.sort).to.have.been.calledWith({ $natural: -1 });
+          expect(cursor.limit).to.have.been.calledWith(5);
+          expect(cursor.toArray).to.have.been.calledWith();
+          expect(result.type).to.equal('ShowProfileResult');
+          expect(result.value).to.deep.equal({ count: 1, result: expectedResult });
+        });
+
+        it('throws if collection.find throws', async() => {
+          const syscoll = stubInterface<Collection>();
+          database.getCollection.returns(syscoll);
+          syscoll.countDocuments.resolves(1);
+          const expectedError = new Error();
+          syscoll.find.throws(expectedError);
+          const catchedError = await mongo.show('profile')
+            .catch(e => e);
+          expect(catchedError).to.equal(expectedError);
+        });
+        it('throws if collection.countDocuments rejects', async() => {
+          const syscoll = stubInterface<Collection>();
+          database.getCollection.returns(syscoll);
+          const expectedError = new Error();
+          syscoll.countDocuments.rejects(expectedError);
+          const catchedError = await mongo.show('profile')
+            .catch(e => e);
+          expect(catchedError).to.equal(expectedError);
+        });
+      });
+      describe('invalid command', () => {
+        it('throws an error', async() => {
+          const caughtError = await mongo.show('aslkdjhekjghdskjhfds')
+            .catch(e => e);
+          expect(caughtError.name).to.equal('MongoshInvalidInputError');
         });
       });
     });
@@ -508,6 +515,13 @@ describe('Mongo', () => {
           expect(e.metadata?.driverCaused).to.equal(true);
           expect(e.metadata?.api).to.equal('Mongo.isCausalConsistency');
         }
+      });
+    });
+    describe('use', () => {
+      it('sets the current db', () => {
+        const msg = mongo.use('moo');
+        expect(msg).to.equal('switched to db moo');
+        expect(internalState.context.db.getName()).to.equal('moo');
       });
     });
     describe('deprecated mongo methods', () => {


### PR DESCRIPTION
This measured 95.0033 % line coverage on one run locally, so it
*technically* meets the acceptance criteria of MONGOSH-490,
but we’ll probably want to add a few more tests for wiggle room before
we bump the minimum coverage threshold :)

Current coverage report with this PR: [coverage.zip](https://github.com/mongodb-js/mongosh/files/5660758/coverage.zip)
