### PR TITLE
MONGOSH-501 createIndex return index name

### DIFF
--- a/packages/service-provider-core/src/readable.ts
+++ b/packages/service-provider-core/src/readable.ts
@@ -152,7 +152,7 @@ export default interface Readable {
    *
    * @returns {Promise} The server version.
    */
-  getTopology(): any; // TODO: topology description is private, see NODE-2910
+  getTopology(): any;
 
   /**
    * Is the collection capped?

--- a/packages/service-provider-server/src/cli-service-provider.ts
+++ b/packages/service-provider-server/src/cli-service-provider.ts
@@ -277,7 +277,7 @@ class CliServiceProvider extends ServiceProviderCore implements ServiceProvider 
 
       // Ensure that we actually get a fresh database instance from the driver.
       returnNonCachedInstance: true
-    } as any; // Node 4.0 upgrade, see NODE-2931
+    } as any; // TODO: returnNonCachedInstance supported? see NODE-2931
 
     const db = this.mongoClient.db(name, optionsWithForceNewInstace);
     dbcache.set(key, db);

--- a/packages/shell-api/src/bulk.ts
+++ b/packages/shell-api/src/bulk.ts
@@ -29,7 +29,7 @@ export class BulkFindOp extends ShellApiClass {
     return 'BulkFindOp';
   }
 
-  // Blocked by NODE-2757
+  // Blocked by NODE-2757, bulk collation
   collation(): BulkFindOp {
     throw new MongoshUnimplementedError(
       'collation method on fluent Bulk API is not currently supported. ' +
@@ -40,7 +40,7 @@ export class BulkFindOp extends ShellApiClass {
     );
   }
 
-  // Blocked by NODE-2751
+  // Blocked by NODE-2751, bulk arrayFilters
   arrayFilters(): BulkFindOp {
     throw new MongoshUnimplementedError(
       'arrayFilters method on fluent Bulk API is not currently supported.',

--- a/packages/shell-api/src/integration.spec.ts
+++ b/packages/shell-api/src/integration.spec.ts
@@ -359,12 +359,32 @@ describe('Shell API (integration)', function() {
         });
       });
 
-      it('returns index name list', () => {
-        expect(result).to.equal(['index-1']);
+      it('returns index name', () => {
+        expect(result).to.equal('index-1');
       });
 
       it('creates the index', async() => {
         expect(await getIndexNames(dbName, collectionName)).to.contain('index-1');
+      });
+    });
+
+    describe.skip('createIndexes with multiple indexes', () => { // TODO: see NODE-2602 index names only
+      let result;
+
+      beforeEach(async() => {
+        await serviceProvider.createCollection(dbName, collectionName);
+        expect(await getIndexNames(dbName, collectionName)).not.to.contain('index-1');
+
+        result = await collection.createIndexes([{ x: 1 }, { y: 1 }]);
+      });
+
+      it('returns index name list', () => {
+        expect(result).to.equal(['x_1', 'y_1']);
+      });
+
+      it('creates the index', async() => {
+        expect(await getIndexNames(dbName, collectionName)).to.contain('x_1');
+        expect(await getIndexNames(dbName, collectionName)).to.contain('y_1');
       });
     });
 

--- a/packages/shell-api/src/integration.spec.ts
+++ b/packages/shell-api/src/integration.spec.ts
@@ -55,17 +55,11 @@ describe('Shell API (integration)', function() {
       { '_id': 5, 'item': 'jkl', 'price': 15, 'quantity': 15, 'type': 'electronics' }
     ]);
     expect(res.acknowledged).to.equal(true);
-    // TODO: createIndexes does not return full spec, see NODE-2602
-    // expect((await collection.createIndex({ item: 1 })).ok).to.equal(1);
-    // expect((await collection.createIndex({ item: 1, quantity: 1 })).ok).to.equal(1);
-    // expect((await collection.createIndex({ item: 1, price: 1 }, { partialFilterExpression: { price: { $gte: 10 } } })).ok).to.equal(1);
-    // expect((await collection.createIndex({ quantity: 1 })).ok).to.equal(1);
-    // expect((await collection.createIndex({ quantity: 1, type: 1 })).ok).to.equal(1);
-    await collection.createIndex({ item: 1 });
-    await collection.createIndex({ item: 1, quantity: 1 });
-    await collection.createIndex({ item: 1, price: 1 }, { partialFilterExpression: { price: { $gte: 10 } } });
-    await collection.createIndex({ quantity: 1 });
-    await collection.createIndex({ quantity: 1, type: 1 });
+    expect(await collection.createIndex({ item: 1 })).to.equal('item_1');
+    expect(await collection.createIndex({ item: 1, quantity: 1 })).to.not.be.undefined;
+    expect(await collection.createIndex({ item: 1, price: 1 }, { partialFilterExpression: { price: { $gte: 10 } } })).to.not.be.undefined;
+    expect(await collection.createIndex({ quantity: 1 })).to.not.be.undefined;
+    expect(await collection.createIndex({ quantity: 1, type: 1 })).to.not.be.undefined;
 
     await collection.find( { item: 'abc', price: { $gte: 10 } } ).toArray();
     await collection.find( { item: 'abc', price: { $gte: 5 } } ).toArray();
@@ -365,13 +359,8 @@ describe('Shell API (integration)', function() {
         });
       });
 
-      it.skip('returns creation result', () => { // TODO: Node 4.0 index doc not returned, see NODE-2602
-        expect(result).to.contain({
-          createdCollectionAutomatically: false,
-          numIndexesBefore: 1,
-          numIndexesAfter: 2,
-          ok: 1
-        });
+      it('returns index name list', () => {
+        expect(result).to.equal(['index-1']);
       });
 
       it('creates the index', async() => {


### PR DESCRIPTION
Due to the Node driver decision here: https://jira.mongodb.org/browse/NODE-2602 we need to update our code to expect only index names from createIndexes instead of the raw server result.