### PR TITLE
chore(test): increase test coverage for async-rewriter

### DIFF
--- a/packages/async-rewriter/src/async-writer-babel.spec.ts
+++ b/packages/async-rewriter/src/async-writer-babel.spec.ts
@@ -5,9 +5,10 @@ import traverse from '@babel/traverse';
 
 const signatures = require('../test/shell-api-signatures');
 
-import AsyncWriter, { checkHasAsyncChild } from './async-writer-babel';
+import AsyncWriter, { assertUnreachable, checkHasAsyncChild } from './async-writer-babel';
 import SymbolTable from './symbol-table';
 import { AsyncRewriterErrors } from './error-codes';
+import { MongoshInternalError, MongoshInvalidInputError, MongoshUnimplementedError } from '@mongosh/errors';
 
 const skipPath = (p): any => {
   expect(Object.keys(p)).to.deep.equal([ 'type', 'returnsPromise', 'returnType', 'path' ]);
@@ -76,6 +77,16 @@ describe('checkHasAsyncChild', () => {
         }
       }
     })).to.equal(false);
+  });
+});
+describe('assertUnreachable', () => {
+  it('throws an error containing the type that failed', () => {
+    try {
+      assertUnreachable('AnExpression' as never);
+    } catch (e) {
+      expect(e).to.be.instanceOf(MongoshInternalError);
+      expect(e.message).to.contain('type AnExpression unhandled');
+    }
   });
 });
 describe('async-writer-babel', () => {
@@ -851,7 +862,7 @@ return (names.length); })()`);
         db: signatures.Database,
       });
     });
-    describe('with known type', () => {
+    describe('with known simple type', () => {
       before(() => {
         input = '[db]';
         ast = writer.getTransform(input).ast;
@@ -875,6 +886,43 @@ return (names.length); })()`);
         traverse(ast, {
           Identifier(path) {
             expect(path.node['shellType']).to.deep.equal(signatures.Database);
+            done();
+          }
+        });
+      });
+    });
+    describe('with known function return type', () => {
+      before(() => {
+        input = '[function callMe() { return db; }]';
+        ast = writer.getTransform(input).ast;
+      });
+      it('compiles correctly', () => {
+        expect(compileCheckScopes(writer, input)).to.equal('[function callMe() {\n  return db;\n}];');
+      });
+      it('decorates array', (done) => {
+        traverse(ast, {
+          ArrayExpression(path) {
+            expect(path.node['shellType']).to.include({
+              type: 'array',
+              hasAsyncChild: true
+            });
+            expect(path.node['shellType'].attributes['0']).to.include({
+              type: 'function',
+              returnsPromise: false
+            });
+            expect(path.node['shellType'].attributes['0'].returnType).to.deep.equal(signatures.Database);
+            done();
+          }
+        });
+      });
+      it('decorates element', (done) => {
+        traverse(ast, {
+          FunctionExpression(path) {
+            expect(path.node['shellType']).to.include({
+              type: 'function',
+              returnsPromise: false
+            });
+            expect(path.node['shellType'].returnType).to.deep.equal(signatures.Database);
             done();
           }
         });
@@ -1665,6 +1713,22 @@ function f() {
             });
             it('final symbol table state updated', () => {
               expect(spy.scopeAt(1).x).to.deep.equal({ type: 'object', hasAsyncChild: false, attributes: { y: { type: 'unknown', attributes: {} } } });
+            });
+          });
+          describe('this expressions', () => {
+            before(() => {
+              spy = sinon.spy(new SymbolTable([{ db: signatures.Database }, {}], signatures));
+              writer = new AsyncWriter(signatures, spy);
+            });
+            it('fails on nested expressions', () => {
+              input = 'class TestClass { testFn() { this.nested.whatever = bla } }';
+              try {
+                compileCheckScopes(writer, input);
+              } catch (e) {
+                expect(e).to.be.instanceOf(MongoshUnimplementedError);
+                return;
+              }
+              expect.fail('expected error');
             });
           });
           describe('with string index', () => {
@@ -3013,6 +3077,17 @@ class Test {
       expect(call.args[1].type).to.equal('Test');
       expect(skipPath(call.args[1].attributes.regularFn)).to.deep.equal(type.returnType.attributes.regularFn);
       expect(skipPath(call.args[1].attributes.awaitFn)).to.deep.equal(type.returnType.attributes.awaitFn);
+    });
+    it('throws when passing an async type', () => {
+      const code = 'new Whatever(db)';
+      try {
+        compileCheckScopes(writer, code);
+      } catch (e) {
+        expect(e).to.be.instanceOf(MongoshInvalidInputError);
+        expect(e.message).to.contain('Argument in position 0 is now an asynchronous function');
+        return;
+      }
+      expect.fail('expected error');
     });
   });
   describe('branching', () => {

--- a/packages/async-rewriter/src/async-writer-babel.spec.ts
+++ b/packages/async-rewriter/src/async-writer-babel.spec.ts
@@ -160,6 +160,26 @@ class Test {
 
 ;`);
     });
+    it('compiles forEach with top-level variable calling a function and returning', () => {
+      const code = `
+var names = ['Angela', 'Barack', 'Charles'];
+function insertDoc(name) {
+  db.coll.insertOne({ name });
+}
+names.forEach(n => insertDoc(n));
+(names.length);
+`;
+      expect(writer.process(code)).to.equal(`(async () => { void (names = ['Angela', 'Barack', 'Charles']);
+
+insertDoc=async function insertDoc(name) {
+  await db.coll.insertOne({
+    name
+  });
+}
+
+await toIterator(names).forEach(async n => await insertDoc(n));
+return (names.length); })()`);
+    });
   });
   describe('MemberExpression', () => {
     describe('with Identifier lhs', () => {

--- a/packages/async-rewriter/src/async-writer-babel.ts
+++ b/packages/async-rewriter/src/async-writer-babel.ts
@@ -764,15 +764,15 @@ export default class AsyncWriter {
    * Returns translated code.
    * @param {string} code - string to compile.
    */
-  compile(code): string {
+  compile(code: string): string {
     return this.getTransform(code).code;
   }
 
   /**
    * Returns translated code.
-   * @param {string} code - string to compile.
+   * @param code - string to compile.
    */
-  process(code): string {
+  process(code: string): string {
     const input = this.compile(code);
     return processTopLevelAwait(input) || input;
   }

--- a/packages/async-rewriter/src/async-writer-babel.ts
+++ b/packages/async-rewriter/src/async-writer-babel.ts
@@ -17,7 +17,10 @@ const debug = (str, type?, indent?): void => {
   // console.log(str);
 };
 
-function assertUnreachable(type?: never): never {
+/**
+ * Exported for testing
+ */
+export function assertUnreachable(type?: never): never {
   throw new MongoshInternalError(`type ${type} unhandled`);
 }
 
@@ -113,13 +116,7 @@ var TypeInferenceVisitor: Visitor = { /* eslint no-var:0 */
       }
       if (path.node.object.type === 'ThisExpression') {
         const classPath = path.findParent((p) => p.isClassDeclaration());
-        if (!classPath) {
-          throw new MongoshUnimplementedError('Unable to handle \'this\' keyword outside of method definition of class declaration', AsyncRewriterErrors.UsedThisOutsideOfMethodOfClassDeclaration);
-        }
         const methodPath = path.findParent((p) => p.isMethod()) as babel.NodePath<babel.types.ClassMethod>;
-        if (!methodPath) {
-          throw new MongoshUnimplementedError('Unable to handle \'this\' keyword outside of method definition');
-        }
         // if not within constructor
         if (methodPath.node.kind !== 'constructor' && classPath.node['shellType'].returnType.attributes[rhs] === 'unset') {
           throw new MongoshInvalidInputError(`Unable to use attribute ${rhs} because it's not defined yet`, AsyncRewriterErrors.UsedMemberInClassBeforeDefinition);
@@ -304,13 +301,10 @@ var TypeInferenceVisitor: Visitor = { /* eslint no-var:0 */
             const id = tyTS as babel.types.Identifier;
             state.symbols.updateAttribute(id.name, attrs, sType);
           } else if (lhsNode.type === 'ThisExpression') {
-            const classPath = path.findParent((p) => p.isClassDeclaration());
-            if (!classPath) {
-              throw new MongoshUnimplementedError('Unable to handle \'this\' keyword outside of method definition of class declaration', AsyncRewriterErrors.UsedThisOutsideOfMethodOfClassDeclaration);
-            }
             if (attrs.length > 1) {
               throw new MongoshUnimplementedError('Unable to handle nested assignment to \'this\' keyword', AsyncRewriterErrors.NestedThisAssignment);
             }
+            const classPath = path.findParent((p) => p.isClassDeclaration());
             if (classPath.node['shellType'].returnType.type === 'unknown') {
               classPath.node['shellType'].returnType.type = 'object';
             }

--- a/packages/async-rewriter/src/await.spec.ts
+++ b/packages/async-rewriter/src/await.spec.ts
@@ -1,0 +1,139 @@
+import { expect } from 'chai';
+import processTopLevelAwait from './await';
+
+describe('await', () => {
+  context('does not do anything', () => {
+    it('if there is no await inside', () => {
+      const code = `
+var someCode = "a string";
+callingSomeFunctions();
+// with comments
+someCode
+`;
+      expect(processTopLevelAwait(code)).to.equal(null);
+    });
+
+    it('if there is a return statement present', () => {
+      const code = `
+var someVar = "test value";
+return someVar;
+`;
+      expect(processTopLevelAwait(code)).to.equal(null);
+    });
+  });
+
+  // note: all other tests have to include an await call!
+  context('processes variable declarations', () => {
+    it('single', () => {
+      const code = `
+var someVar = "test value";
+await db.coll.insertOne({ someVar });
+`;
+      expect(processTopLevelAwait(code)).to.equal(`(async () => { 
+void (someVar = "test value");
+return (await db.coll.insertOne({ someVar }));
+ })()`);
+    });
+
+    it('multiple', () => {
+      const code = `
+var someVar = "test value", anotherVar;
+await db.coll.insertOne({ someVar });
+`;
+      expect(processTopLevelAwait(code)).to.equal(`(async () => { 
+void ( (someVar = "test value"), (anotherVar=undefined));
+return (await db.coll.insertOne({ someVar }));
+ })()`);
+    });
+
+    it('lets and consts', () => {
+      const code = `
+let someVar = "test value";
+const anotherVar = "has value";
+await db.coll.insertOne({ someVar });
+`;
+      expect(processTopLevelAwait(code)).to.equal(`(async () => { 
+void (someVar = "test value");
+void (anotherVar = "has value");
+return (await db.coll.insertOne({ someVar }));
+ })()`);
+    });
+
+    it('hoisted vars but not let', () => {
+      const code = `
+if (callMeMaybe) {
+  var ringRing = "hey, it's me!";
+  let bingBing = "c'est moi!";
+  const bongBong = "hola, como estas?";
+}
+function call() {
+  var thisIsNested;
+}
+await db.coll.insertOne({});
+`;
+      expect(processTopLevelAwait(code)).to.equal(`(async () => { 
+if (callMeMaybe) {
+  void (ringRing = "hey, it's me!");
+  let bingBing = "c'est moi!";
+  const bongBong = "hola, como estas?";
+}
+call=function call() {
+  var thisIsNested;
+}
+return (await db.coll.insertOne({}));
+ })()`);
+    });
+  });
+
+  it('processes function declarations', () => {
+    const code = `
+await callingTheFunc();
+async function callingTheFunc() {
+  return await db.coll.insertOne({});
+}
+`;
+    expect(processTopLevelAwait(code)).to.equal(`(async () => { 
+await callingTheFunc();
+callingTheFunc=async function callingTheFunc() {
+  return await db.coll.insertOne({});
+}
+ })()`);
+  });
+
+  context('processes for-of statements', () => {
+    it('checks for direct await', () => {
+      const code = `
+for await (const c of names) {
+  const otherName = c;
+}
+`;
+      expect(processTopLevelAwait(code)).to.equal(`(async () => { 
+for await (const c of names) {
+  const otherName = c;
+}
+ })()`);
+    });
+
+    it('checks for await inside loop', () => {
+      const code = `
+for (const c of names) {
+  await db.coll.insertOne({ name: c });
+}
+`;
+      expect(processTopLevelAwait(code)).to.equal(`(async () => { 
+for (const c of names) {
+  await db.coll.insertOne({ name: c });
+}
+ })()`);
+    });
+
+    it('checks for return inside loop', () => {
+      const code = `
+for (const c of names) {
+  return db.coll.insertOne({ name: c });
+}
+`;
+      expect(processTopLevelAwait(code)).to.equal(null);
+    });
+  });
+});

--- a/packages/async-rewriter/src/await.ts
+++ b/packages/async-rewriter/src/await.ts
@@ -79,7 +79,7 @@ for (const nodeType of Object.keys(walk.base)) {
   };
 }
 
-function processTopLevelAwait(src): null | string {
+function processTopLevelAwait(src: string): null | string {
   const wrapped = `(async () => { ${src} })()`;
   const wrappedArray = wrapped.split('');
   let root;
@@ -92,17 +92,17 @@ function processTopLevelAwait(src): null | string {
   const state = {
     body,
     ancestors: [],
-    replace(from, to, str): void {
+    replace(from: number, to: number, str: string): void {
       for (let i = from; i < to; i++) {
         wrappedArray[i] = '';
       }
       if (from === to) str += wrappedArray[from];
       wrappedArray[from] = str;
     },
-    prepend(node, str): void {
+    prepend(node, str: string): void {
       wrappedArray[node.start] = str + wrappedArray[node.start];
     },
-    append(node, str): void {
+    append(node, str: string): void {
       wrappedArray[node.end - 1] += str;
     },
     containsAwait: false,

--- a/packages/async-rewriter/src/symbol-table.spec.ts
+++ b/packages/async-rewriter/src/symbol-table.spec.ts
@@ -1,3 +1,4 @@
+import { MongoshInternalError } from '@mongosh/errors';
 import { expect } from 'chai';
 import SymbolTable, { addApi } from './symbol-table';
 const s = require('../test/shell-api-signatures');
@@ -107,6 +108,20 @@ describe('SymbolTable', () => {
       expect(copy2).to.deep.equal(st);
       expect(copy2.lookup('typeWithPath').path === st.lookup('typeWithPath').path).to.be.true;
       expect(copy2.lookup('typeWithPath').attributes === st.lookup('typeWithPath').attributes).to.be.false;
+    });
+    it('throws an exception of copy symbol fails', () => {
+      const replacer = st.replacer;
+      st.replacer = () => { return undefined; };
+      try {
+        st.deepCopy();
+      } catch (e) {
+        expect(e).to.be.instanceOf(MongoshInternalError);
+        expect(e.message).to.contain('Internal error occurred for copying symbol');
+        return;
+      } finally {
+        st.replacer = replacer;
+      }
+      expect.fail('expected error');
     });
   });
   describe('#lookup', () => {
@@ -327,6 +342,20 @@ describe('SymbolTable', () => {
         });
       });
     });
+    it('fails on different stack heights', () => {
+      const st = new SymbolTable([{}], {});
+      const alternatives = [
+        new SymbolTable([{}, { myVar: myType }], {})
+      ];
+      try {
+        st.compareSymbolTables(alternatives);
+      } catch (e) {
+        expect(e).to.be.instanceOf(MongoshInternalError);
+        expect(e.message).to.contain('Could not compare scopes');
+        return;
+      }
+      expect.fail('expected error');
+    });
   });
   describe('#updateAttribute', () => {
     describe('all sub types exist', () => {
@@ -398,6 +427,15 @@ describe('SymbolTable', () => {
         st.revertState();
         expect(st.scopeAt(1)).to.deep.equal({});
       });
+    });
+  });
+  describe('#print/#printSymbol', () => {
+    const st = new SymbolTable([{
+      a: { type: 'object', attributes: {} },
+      a1: { type: 'object', attributes: {} },
+    }], {});
+    it('works without error', () => {
+      st.print();
     });
   });
 });

--- a/packages/async-rewriter/src/symbol-table.spec.ts
+++ b/packages/async-rewriter/src/symbol-table.spec.ts
@@ -87,6 +87,23 @@ describe('SymbolTable', () => {
         { type: 'same', attributes: {} },
       )).to.be.false;
     });
+    it('throws an exception if comparison fails', () => {
+      const replacer = st.replacer;
+      st.replacer = () => { throw new Error('crap'); };
+      try {
+        st.compareTypes(
+          { type: 'same', attributes: { missing: true } },
+          { type: 'same', attributes: {} },
+        );
+      } catch (e) {
+        expect(e).to.be.instanceOf(MongoshInternalError);
+        expect(e.message).to.contain('Internal error occurred for comparing symbols');
+        return;
+      } finally {
+        st.replacer = replacer;
+      }
+      expect.fail('expected error');
+    });
   });
   describe('#deepCopy', () => {
     const st = new SymbolTable([{}], {});
@@ -109,7 +126,7 @@ describe('SymbolTable', () => {
       expect(copy2.lookup('typeWithPath').path === st.lookup('typeWithPath').path).to.be.true;
       expect(copy2.lookup('typeWithPath').attributes === st.lookup('typeWithPath').attributes).to.be.false;
     });
-    it('throws an exception of copy symbol fails', () => {
+    it('throws an exception if copy symbol fails', () => {
       const replacer = st.replacer;
       st.replacer = () => { return undefined; };
       try {

--- a/packages/async-rewriter/src/symbol-table.ts
+++ b/packages/async-rewriter/src/symbol-table.ts
@@ -69,7 +69,7 @@ export default class SymbolTable {
     this.pushScope();
   }
 
-  public replacer(k, v): any {
+  public replacer(k: string, v: any): any {
     if (k === 'path') return undefined;
     return v;
   }
@@ -93,21 +93,15 @@ export default class SymbolTable {
    * Do not deep copy path attributes as they must stay as references to the AST.
    */
   public deepCopy(): SymbolTable {
-    const newStack = [];
-    this.scopeStack.forEach(oldScope => {
-      const newScope = {};
-      Object.keys(oldScope).forEach(key => {
-        newScope[key] = this.deepCopySymbol(oldScope[key]);
-        if ('path' in oldScope[key]) {
-          newScope[key].path = oldScope[key].path;
-        }
-      });
-      newStack.push(newScope);
-    });
+    const newStack = this.deepCopyStack();
     return new SymbolTable(newStack, this.signatures);
   }
 
   public saveState(): void {
+    this.savedState = this.deepCopyStack();
+  }
+
+  private deepCopyStack(): object[] {
     const newStack = [];
     this.scopeStack.forEach(oldScope => {
       const newScope = {};
@@ -119,7 +113,7 @@ export default class SymbolTable {
       });
       newStack.push(newScope);
     });
-    this.savedState = newStack;
+    return newStack;
   }
 
   public revertState(): void {


### PR DESCRIPTION
This covers edge cases and removes essentially duplicate code to increase coverage for `async-rewriter`.

![image](https://user-images.githubusercontent.com/4354632/101753488-fbfae880-3ad2-11eb-9679-3c69e080265b.png)
