### PR TITLE
fix(browser-runtime-core): drop unused dependency on cli-repl package

### DIFF
--- a/packages/browser-runtime-core/package.json
+++ b/packages/browser-runtime-core/package.json
@@ -37,7 +37,6 @@
     "@babel/generator": "^7.9.4",
     "@babel/parser": "^7.9.4",
     "@mongosh/autocomplete": "^0.6.1",
-    "@mongosh/cli-repl": "^0.6.1",
     "@mongosh/service-provider-core": "^0.6.1",
     "@mongosh/shell-api": "^0.6.1",
     "@mongosh/shell-evaluator": "^0.6.1"


### PR DESCRIPTION
… because otherwise this makes installing the compass-shell in compass
fail because cli-repl requires Node.js 14 according to its package.json.