### PR TITLE
deps(autocomplete): update mongodb-ace-autocompleter to 0.4.14

### DIFF
--- a/packages/autocomplete/index.spec.ts
+++ b/packages/autocomplete/index.spec.ts
@@ -1,4 +1,4 @@
-import completer from './';
+import completer, { BASE_COMPLETIONS } from './';
 import { signatures as shellSignatures, Topologies } from '@mongosh/shell-api';
 
 import { expect } from 'chai';
@@ -118,6 +118,25 @@ describe('completer.completer', () => {
   });
 
   context('datalake features', () => {
+    let origBaseCompletions: any[];
+    beforeEach(() => {
+      // Undo https://github.com/mongodb-js/ace-autocompleter/pull/65 for testing
+      // because it's the only DataLake-only feature.
+      origBaseCompletions = [...BASE_COMPLETIONS];
+      BASE_COMPLETIONS.push({
+        name: '$sql',
+        value: '$sql',
+        label: '$sql',
+        score: 1,
+        env: [ 'adl' ],
+        meta: 'stage',
+        version: '4.0.0'
+      });
+    });
+    afterEach(() => {
+      BASE_COMPLETIONS.splice(0, BASE_COMPLETIONS.length, ...origBaseCompletions);
+    });
+
     it('includes them when not connected', () => {
       const i = 'db.shipwrecks.aggregate([ { $sq';
       expect(completer(noParams, i)).to.deep.equal([

--- a/packages/autocomplete/index.ts
+++ b/packages/autocomplete/index.ts
@@ -23,11 +23,11 @@ export interface AutocompleteParameters {
   };
 }
 
-const BASE_COMPLETIONS = EXPRESSION_OPERATORS.concat(
+export const BASE_COMPLETIONS = EXPRESSION_OPERATORS.concat(
   CONVERSION_OPERATORS.concat(BSON_TYPES.concat(STAGE_OPERATORS)
   ));
 
-const MATCH_COMPLETIONS = QUERY_OPERATORS.concat(BSON_TYPES);
+export const MATCH_COMPLETIONS = QUERY_OPERATORS.concat(BSON_TYPES);
 
 /**
  * The project stage operator.

--- a/packages/autocomplete/package-lock.json
+++ b/packages/autocomplete/package-lock.json
@@ -606,9 +606,9 @@
 			}
 		},
 		"mongodb-ace-autocompleter": {
-			"version": "0.4.11",
-			"resolved": "https://registry.npmjs.org/mongodb-ace-autocompleter/-/mongodb-ace-autocompleter-0.4.11.tgz",
-			"integrity": "sha512-LlTsRj3RrEiFzxYeLTVcvlLCU0zNZXHt5jWe5/K88JP7/En47t0twuNjEtgZpm+jfpzp6hWztpo5oV/mX2/JWA==",
+			"version": "0.4.14",
+			"resolved": "https://registry.npmjs.org/mongodb-ace-autocompleter/-/mongodb-ace-autocompleter-0.4.14.tgz",
+			"integrity": "sha512-j49THhGVBCwTR0IP/98SrS4DftEi3bsFnQPJ6g/d3l0P6uaOLo4B4aIueVZz4gGFr/Mv1o2tJDLiBVdgCAbjVQ==",
 			"requires": {
 				"semver": "^7.1.1"
 			}

--- a/packages/autocomplete/package.json
+++ b/packages/autocomplete/package.json
@@ -29,7 +29,7 @@
   },
   "dependencies": {
     "@mongosh/shell-api": "^0.6.1",
-    "mongodb-ace-autocompleter": "^0.4.8",
+    "mongodb-ace-autocompleter": "^0.4.14",
     "semver": "^7.3.2"
   }
 }


### PR DESCRIPTION
As a minor part of MONGOSH-463 (mongodb 4.4 support).