### PR TITLE
fix(shell-api): support legacy explain verbosity values MONGOSH-204

### DIFF
--- a/packages/shell-api/src/aggregation-cursor.ts
+++ b/packages/shell-api/src/aggregation-cursor.ts
@@ -105,8 +105,10 @@ export default class AggregationCursor extends ShellApiClass {
   }
 
   @returnsPromise
-  explain(verbosity: ExplainVerbosityLike): Promise<any> {
-    verbosity = validateExplainableVerbosity(verbosity);
+  explain(verbosity?: ExplainVerbosityLike): Promise<any> {
+    if (verbosity !== undefined) {
+      verbosity = validateExplainableVerbosity(verbosity);
+    }
     return this._cursor.explain(verbosity);
   }
 

--- a/packages/shell-api/src/aggregation-cursor.ts
+++ b/packages/shell-api/src/aggregation-cursor.ts
@@ -14,7 +14,7 @@ import type {
 } from '@mongosh/service-provider-core';
 import { CursorIterationResult } from './result';
 import { asPrintable } from './enums';
-import { iterate } from './helpers';
+import { iterate, validateExplainableVerbosity } from './helpers';
 
 @shellApiClassDefault
 @hasAsyncChild
@@ -106,6 +106,7 @@ export default class AggregationCursor extends ShellApiClass {
 
   @returnsPromise
   explain(verbosity: ExplainVerbosityLike): Promise<any> {
+    verbosity = validateExplainableVerbosity(verbosity);
     return this._cursor.explain(verbosity);
   }
 

--- a/packages/shell-api/src/collection.spec.ts
+++ b/packages/shell-api/src/collection.spec.ts
@@ -1259,6 +1259,14 @@ describe('Collection', () => {
         expect(
           collection.explain('allPlansExecution')._verbosity
         ).to.equal('allPlansExecution');
+
+        expect(
+          collection.explain(true)._verbosity
+        ).to.equal('allPlansExecution');
+
+        expect(
+          collection.explain(false)._verbosity
+        ).to.equal('queryPlanner');
       });
 
       it('throws in case of non valid verbosity', () => {

--- a/packages/shell-api/src/collection.ts
+++ b/packages/shell-api/src/collection.ts
@@ -1294,7 +1294,7 @@ export default class Collection extends ShellApiClass {
 
   @returnType('Explainable')
   explain(verbosity = 'queryPlanner' as ExplainVerbosityLike): Explainable {
-    validateExplainableVerbosity(verbosity);
+    verbosity = validateExplainableVerbosity(verbosity);
     this._emitCollectionApiCall('explain', { verbosity });
     return new Explainable(this._mongo, this, verbosity);
   }

--- a/packages/shell-api/src/cursor.ts
+++ b/packages/shell-api/src/cursor.ts
@@ -23,7 +23,7 @@ import {
   ReadConcernLevelLike
 } from '@mongosh/service-provider-core';
 import { blockedByDriverMetadata } from './error-codes';
-import { iterate } from './helpers';
+import { iterate, validateExplainableVerbosity } from './helpers';
 import Mongo from './mongo';
 import { CursorIterationResult } from './result';
 import { printWarning } from './deprecation-warning';
@@ -124,7 +124,7 @@ export default class Cursor extends ShellApiClass {
     // TODO: @maurizio we should probably move this in the Explain class?
     // NOTE: the node driver always returns the full explain plan
     // for Cursor and the queryPlanner explain for AggregationCursor.
-
+    verbosity = validateExplainableVerbosity(verbosity);
     const fullExplain: any = await this._cursor.explain(verbosity);
 
     const explain: any = {

--- a/packages/shell-api/src/cursor.ts
+++ b/packages/shell-api/src/cursor.ts
@@ -120,11 +120,13 @@ export default class Cursor extends ShellApiClass {
   }
 
   @returnsPromise
-  async explain(verbosity: ExplainVerbosityLike): Promise<any> {
+  async explain(verbosity?: ExplainVerbosityLike): Promise<any> {
     // TODO: @maurizio we should probably move this in the Explain class?
     // NOTE: the node driver always returns the full explain plan
     // for Cursor and the queryPlanner explain for AggregationCursor.
-    verbosity = validateExplainableVerbosity(verbosity);
+    if (verbosity !== undefined) {
+      verbosity = validateExplainableVerbosity(verbosity);
+    }
     const fullExplain: any = await this._cursor.explain(verbosity);
 
     const explain: any = {

--- a/packages/shell-api/src/explainable.ts
+++ b/packages/shell-api/src/explainable.ts
@@ -60,7 +60,7 @@ export default class Explainable extends ShellApiClass {
   }
 
   setVerbosity(verbosity: ExplainVerbosityLike): void {
-    validateExplainableVerbosity(verbosity);
+    verbosity = validateExplainableVerbosity(verbosity);
     this._emitExplainableApiCall('setVerbosity', { verbosity });
     this._verbosity = verbosity;
   }

--- a/packages/shell-api/src/helpers.ts
+++ b/packages/shell-api/src/helpers.ts
@@ -47,7 +47,14 @@ export function adaptAggregateOptions(options: any = {}): {
   return { aggOptions, dbOptions, explain };
 }
 
-export function validateExplainableVerbosity(verbosity: ExplainVerbosityLike): void {
+export function validateExplainableVerbosity(verbosity: ExplainVerbosityLike): ExplainVerbosityLike & string {
+  // Legacy shell behavior.
+  if (verbosity === true) {
+    verbosity = 'allPlansExecution';
+  } else if (verbosity === false) {
+    verbosity = 'queryPlanner';
+  }
+
   const allowedVerbosity = [
     'queryPlanner',
     'executionStats',
@@ -60,6 +67,8 @@ export function validateExplainableVerbosity(verbosity: ExplainVerbosityLike): v
       CommonErrors.InvalidArgument
     );
   }
+
+  return verbosity;
 }
 
 export function assertArgsDefined(...args: any[]): void {


### PR DESCRIPTION
Do the same thing the old shell does. While the driver would also just
accept boolean values, we perform the mapping ourselves so that e.g.
`.getVerbosity()` still returns the mapped value (like the old shell).