### PR TITLE
chore(test): test aggregate + explain behavior MONGOSH-203

### DIFF
--- a/packages/shell-api/src/integration.spec.ts
+++ b/packages/shell-api/src/integration.spec.ts
@@ -949,38 +949,72 @@ describe('Shell API (integration)', function() {
     });
 
     describe('aggregate', () => {
-      it('returns a cursor that has the explain as result of toShellResult', async() => {
-        const cursor = await collection.explain().aggregate([
-          { $match: {} }, { $skip: 1 }, { $limit: 1 }
-        ]);
-        const result = await toShellResult(cursor);
-        expect(result.printable).to.include.all.keys([
-          'ok',
-          'stages',
-          'serverInfo'
-        ]);
-        expect(result.printable.stages[0].$cursor).to.include.all.keys([
-          'queryPlanner'
-        ]);
-        expect(result.printable.stages[0].$cursor).to.not.include.any.keys([
-          'executionStats'
-        ]);
+      describe('up to server 4.4', () => {
+        skipIfServerVersion(testServer, '>= 4.5');
+        it('returns a cursor that has the explain as result of toShellResult', async() => {
+          const cursor = await collection.explain().aggregate([
+            { $match: {} }, { $skip: 1 }, { $limit: 1 }
+          ]);
+          const result = await toShellResult(cursor);
+          expect(result.printable).to.include.all.keys([
+            'ok',
+            'stages',
+            'serverInfo'
+          ]);
+          expect(result.printable.stages[0].$cursor).to.include.all.keys([
+            'queryPlanner'
+          ]);
+          expect(result.printable.stages[0].$cursor).to.not.include.any.keys([
+            'executionStats'
+          ]);
+        });
+
+        it('includes executionStats when requested', async() => {
+          const cursor = await collection.explain('executionStats').aggregate([
+            { $match: {} }, { $skip: 1 }, { $limit: 1 }
+          ]);
+          const result = await toShellResult(cursor);
+          expect(result.printable).to.include.all.keys([
+            'ok',
+            'stages',
+            'serverInfo'
+          ]);
+          expect(result.printable.stages[0].$cursor).to.include.all.keys([
+            'queryPlanner',
+            'executionStats'
+          ]);
+        });
       });
 
-      it('includes executionStats when requested', async() => {
-        const cursor = await collection.explain('executionStats').aggregate([
-          { $match: {} }, { $skip: 1 }, { $limit: 1 }
-        ]);
-        const result = await toShellResult(cursor);
-        expect(result.printable).to.include.all.keys([
-          'ok',
-          'stages',
-          'serverInfo'
-        ]);
-        expect(result.printable.stages[0].$cursor).to.include.all.keys([
-          'queryPlanner',
-          'executionStats'
-        ]);
+      describe('after server 4.4', () => {
+        skipIfServerVersion(testServer, '<= 4.4');
+        it('returns a cursor that has the explain as result of toShellResult', async() => {
+          const cursor = await collection.explain().aggregate([
+            { $match: {} }, { $skip: 1 }, { $limit: 1 }
+          ]);
+          const result = await toShellResult(cursor);
+          expect(result.printable).to.include.all.keys([
+            'ok',
+            'serverInfo',
+            'queryPlanner'
+          ]);
+          expect(result.printable).to.not.include.any.keys([
+            'executionStats'
+          ]);
+        });
+
+        it('includes executionStats when requested', async() => {
+          const cursor = await collection.explain('executionStats').aggregate([
+            { $match: {} }, { $skip: 1 }, { $limit: 1 }
+          ]);
+          const result = await toShellResult(cursor);
+          expect(result.printable).to.include.all.keys([
+            'ok',
+            'serverInfo',
+            'queryPlanner',
+            'executionStats'
+          ]);
+        });
       });
     });
   });


### PR DESCRIPTION
The references bug has been resolved, this just adds unit tests
(in particular, actually tests explaining `.aggregate()` calls
instead of duplicating the test for `.find()`).