### PR TITLE
chore(test): verify that fle addon is available in executable

### DIFF
--- a/packages/cli-repl/test/e2e.spec.ts
+++ b/packages/cli-repl/test/e2e.spec.ts
@@ -164,6 +164,12 @@ describe('e2e', function() {
       shell.assertContainsOutput(expected);
     });
 
+    it('fle addon is available', async() => {
+      const result = await shell.executeLine(
+        '`<${typeof db._mongo._serviceProvider.fle.ClientEncryption}>`');
+      expect(result).to.include('<function>');
+    });
+
     describe('error formatting', () => {
       it('throws when a syntax error is encountered', async() => {
         await shell.executeLine('<x');


### PR DESCRIPTION
This ensures that the test-e2e runs in CI also check that the addon is
actually working in the compiled binary.