### PR TITLE
feat(shell-api): support non-cursor explainable methods MONGOSH-185

### DIFF
--- a/packages/i18n/src/locales/en_US.ts
+++ b/packages/i18n/src/locales/en_US.ts
@@ -1207,6 +1207,36 @@ const translations: Catalog = {
               description: 'Returns information on the query plan.',
               example: 'db.coll.explain().find()'
             },
+            count: {
+              link: 'https://docs.mongodb.com/manual/reference/method/db.collection.explain',
+              description: 'Returns information on the query plan for db.collection.count().',
+              example: 'db.coll.explain().count()'
+            },
+            remove: {
+              link: 'https://docs.mongodb.com/manual/reference/method/db.collection.explain',
+              description: 'Returns information on the query plan for db.collection.remove().',
+              example: 'db.coll.explain().remove({})'
+            },
+            update: {
+              link: 'https://docs.mongodb.com/manual/reference/method/db.collection.explain',
+              description: 'Returns information on the query plan for db.collection.update().',
+              example: 'db.coll.explain().update({}, { $inc: ${ a: 1 } })'
+            },
+            distinct: {
+              link: 'https://docs.mongodb.com/manual/reference/method/db.collection.explain',
+              description: 'Returns information on the query plan for db.collection.distinct().',
+              example: 'db.coll.explain().distinct("_id")'
+            },
+            mapReduce: {
+              link: 'https://docs.mongodb.com/manual/reference/method/db.collection.explain',
+              description: 'Returns information on the query plan for db.collection.mapReduce().',
+              example: 'db.coll.explain().mapReduce(map, reduce, options)'
+            },
+            findAndModify: {
+              link: 'https://docs.mongodb.com/manual/reference/method/db.collection.explain',
+              description: 'Returns information on the query plan for db.collection.findAndModify().',
+              example: 'db.coll.explain().findAndModify({ query: { ... }, update: { ... } })'
+            },
             getCollection: {
               link: '',
               description: 'Returns the explainable collection.',

--- a/packages/service-provider-core/src/all-transport-types.ts
+++ b/packages/service-provider-core/src/all-transport-types.ts
@@ -41,6 +41,7 @@ export type {
   ListCollectionsOptions,
   ListDatabasesOptions,
   ListIndexesOptions,
+  MapReduceOptions,
   MongoClientOptions,
   OrderedBulkOperation,
   ReadConcern,

--- a/packages/shell-api/src/collection.spec.ts
+++ b/packages/shell-api/src/collection.spec.ts
@@ -395,32 +395,32 @@ describe('Collection', () => {
 
       it('calls deleteOne if justOne is passed as an argument', async() => {
         expect((await collection.remove({}, true)).deletedCount).to.equal(1);
-        expect(serviceProvider.deleteOne).to.have.been.calledWith('db1', 'coll1', {}, { justOne: true });
+        expect(serviceProvider.deleteOne).to.have.been.calledWith('db1', 'coll1', {}, {});
         expect(serviceProvider.deleteMany).to.not.have.been.called;
       });
 
       it('calls deleteOne if justOne is passed as an option', async() => {
         expect((await collection.remove({}, { justOne: true })).deletedCount).to.equal(1);
-        expect(serviceProvider.deleteOne).to.have.been.calledWith('db1', 'coll1', {}, { justOne: true });
+        expect(serviceProvider.deleteOne).to.have.been.calledWith('db1', 'coll1', {}, {});
         expect(serviceProvider.deleteMany).to.not.have.been.called;
       });
 
       it('calls deleteMany if !justOne is passed as an argument', async() => {
         expect((await collection.remove({}, false)).deletedCount).to.equal(2);
         expect(serviceProvider.deleteOne).to.not.have.been.called;
-        expect(serviceProvider.deleteMany).to.have.been.calledWith('db1', 'coll1', {}, { justOne: false });
+        expect(serviceProvider.deleteMany).to.have.been.calledWith('db1', 'coll1', {}, {});
       });
 
       it('calls deleteMany if !justOne is passed as an option', async() => {
         expect((await collection.remove({}, { justOne: false })).deletedCount).to.equal(2);
         expect(serviceProvider.deleteOne).to.not.have.been.called;
-        expect(serviceProvider.deleteMany).to.have.been.calledWith('db1', 'coll1', {}, { justOne: false });
+        expect(serviceProvider.deleteMany).to.have.been.calledWith('db1', 'coll1', {}, {});
       });
 
       it('calls deleteMany by default', async() => {
         expect((await collection.remove({})).deletedCount).to.equal(2);
         expect(serviceProvider.deleteOne).to.not.have.been.called;
-        expect(serviceProvider.deleteMany).to.have.been.calledWith('db1', 'coll1', {}, { justOne: false });
+        expect(serviceProvider.deleteMany).to.have.been.calledWith('db1', 'coll1', {}, {});
       });
     });
 

--- a/packages/shell-api/src/collection.ts
+++ b/packages/shell-api/src/collection.ts
@@ -709,9 +709,11 @@ export default class Collection extends ShellApiClass {
     );
     assertArgsDefined(query);
     const removeOptions = processRemoveOptions(options);
+    const method = removeOptions.justOne ? 'deleteOne' : 'deleteMany';
+    delete removeOptions.justOne;
 
     this._emitCollectionApiCall('remove', { query, removeOptions });
-    const result = await this._mongo._serviceProvider[removeOptions.justOne ? 'deleteOne' : 'deleteMany'](
+    const result = await this._mongo._serviceProvider[method](
       this._database._name,
       this._name,
       query,

--- a/packages/shell-api/src/explainable.ts
+++ b/packages/shell-api/src/explainable.ts
@@ -1,5 +1,5 @@
-import Collection from './collection';
-import Mongo from './mongo';
+import type Collection from './collection';
+import type Mongo from './mongo';
 import ExplainableCursor from './explainable-cursor';
 import {
   hasAsyncChild,
@@ -9,8 +9,21 @@ import {
   shellApiClassDefault
 } from './decorators';
 import { asPrintable } from './enums';
-import { validateExplainableVerbosity } from './helpers';
-import { Document, ExplainVerbosityLike } from '@mongosh/service-provider-core';
+import {
+  validateExplainableVerbosity,
+  processRemoveOptions,
+  RemoveShellOptions,
+  FindAndModifyMethodShellOptions,
+  processMapReduceOptions,
+  MapReduceShellOptions
+} from './helpers';
+import type {
+  Document,
+  ExplainVerbosityLike,
+  CountOptions,
+  DistinctOptions,
+  UpdateOptions
+} from '@mongosh/service-provider-core';
 
 @shellApiClassDefault
 @hasAsyncChild
@@ -83,5 +96,54 @@ export default class Explainable extends ShellApiClass {
     });
 
     return await cursor.explain(this._verbosity);
+  }
+
+  @returnsPromise
+  async count(query = {}, options: CountOptions = {}): Promise<Document> {
+    this._emitExplainableApiCall('count', { query, options });
+    // This is the only one that currently lacks explicit driver support.
+    return this._collection._database._runCommand({
+      explain: {
+        count: `${this._collection._database._name}.${this._collection._name}`,
+        query,
+        ...options
+      },
+      verbosity: this._verbosity
+    });
+  }
+
+  @returnsPromise
+  async distinct(field: string, query: Document, options: DistinctOptions = {}): Promise<Document> {
+    this._emitExplainableApiCall('distinct', { field, query, options });
+    return this._collection.distinct(field, query, { ...options, explain: this._verbosity });
+  }
+
+  @returnsPromise
+  async findAndModify(options: FindAndModifyMethodShellOptions): Promise<Document> {
+    this._emitExplainableApiCall('findAndModify', { options });
+    return this._collection.findAndModify({ ...options, explain: this._verbosity });
+  }
+
+  @returnsPromise
+  async remove(query: Document, options: boolean | RemoveShellOptions = {}): Promise<Document> {
+    this._emitExplainableApiCall('remove', { query, options });
+    options = { ...processRemoveOptions(options), explain: this._verbosity };
+    return this._collection.remove(query, options);
+  }
+
+  @returnsPromise
+  async update(filter: Document, update: Document, options: UpdateOptions = {}): Promise<Document> {
+    this._emitExplainableApiCall('update', { filter, update, options });
+    return this._collection.update(filter, update, { ...options, explain: this._verbosity });
+  }
+
+  @returnsPromise
+  async mapReduce(
+    map: Function | string,
+    reduce: Function | string,
+    optionsOrOutString: MapReduceShellOptions): Promise<Document> {
+    this._emitExplainableApiCall('mapReduce', { map, reduce, optionsOrOutString });
+    const options = { ...processMapReduceOptions(optionsOrOutString), explain: this._verbosity };
+    return this._collection.mapReduce(map, reduce, options);
   }
 }

--- a/packages/shell-api/src/explainable.ts
+++ b/packages/shell-api/src/explainable.ts
@@ -6,9 +6,10 @@ import {
   returnsPromise,
   returnType,
   ShellApiClass,
-  shellApiClassDefault
+  shellApiClassDefault,
+  serverVersions
 } from './decorators';
-import { asPrintable } from './enums';
+import { asPrintable, ServerVersions } from './enums';
 import {
   validateExplainableVerbosity,
   processRemoveOptions,
@@ -138,6 +139,7 @@ export default class Explainable extends ShellApiClass {
   }
 
   @returnsPromise
+  @serverVersions(['4.4.0', ServerVersions.latest])
   async mapReduce(
     map: Function | string,
     reduce: Function | string,

--- a/packages/shell-api/src/helpers.ts
+++ b/packages/shell-api/src/helpers.ts
@@ -11,7 +11,9 @@ import type {
   ExplainVerbosityLike,
   FindCursor,
   AggregationCursor as SPAggregationCursor,
-  FindAndModifyOptions
+  FindAndModifyOptions,
+  DeleteOptions,
+  MapReduceOptions
 } from '@mongosh/service-provider-core';
 import { CommonErrors, MongoshInvalidInputError } from '@mongosh/errors';
 import crypto from 'crypto';
@@ -517,6 +519,21 @@ export async function iterate(results: CursorIterationResult, cursor: FindCursor
   return results;
 }
 
+export type FindAndModifyMethodShellOptions = {
+  query?: Document;
+  sort?: Document | Document[];
+  update?: Document | Document[];
+  remove?: boolean;
+  new?: boolean;
+  fields?: Document;
+  upsert?: boolean;
+  bypassDocumentValidation?: boolean;
+  writeConcern?: Document;
+  collation?: Document;
+  arrayFilters?: Document[];
+  explain?: ExplainVerbosityLike;
+};
+
 export type FindAndModifyShellOptions = FindAndModifyOptions & {
   returnNewDocument?: boolean;
 };
@@ -538,3 +555,21 @@ export function processFindAndModifyOptions(options: FindAndModifyShellOptions):
   return options;
 }
 
+export type RemoveShellOptions = DeleteOptions & { justOne?: boolean };
+export function processRemoveOptions(options: boolean | RemoveShellOptions): RemoveShellOptions {
+  if (typeof options === 'boolean') {
+    return { justOne: options };
+  }
+  return { justOne: false, ...options };
+}
+
+export type MapReduceShellOptions = Document | string;
+export function processMapReduceOptions(optionsOrOutString: MapReduceShellOptions): MapReduceOptions {
+  if (typeof optionsOrOutString === 'string') {
+    return { out: optionsOrOutString } as any;
+  } else if (optionsOrOutString.out === undefined) {
+    throw new MongoshInvalidInputError('Missing \'out\' option', CommonErrors.InvalidArgument);
+  } else {
+    return optionsOrOutString;
+  }
+}

--- a/packages/shell-api/src/integration.spec.ts
+++ b/packages/shell-api/src/integration.spec.ts
@@ -1038,6 +1038,102 @@ describe('Shell API (integration)', function() {
         });
       });
     });
+
+    describe('count', () => {
+      it('provides explain information', async() => {
+        const explained = await collection.explain().count();
+        expect(explained).to.include.all.keys(['ok', 'serverInfo', 'queryPlanner']);
+        expect(explained).to.not.include.any.keys(['executionStats']);
+      });
+
+      it('includes executionStats when requested', async() => {
+        const explained = await collection.explain('executionStats').count();
+        expect(explained).to.include.all.keys(['ok', 'serverInfo', 'queryPlanner', 'executionStats']);
+      });
+    });
+
+    describe('distinct', () => {
+      it('provides explain information', async() => {
+        const explained = await collection.explain().distinct('_id');
+        expect(explained).to.include.all.keys(['ok', 'serverInfo', 'queryPlanner']);
+        expect(explained).to.not.include.any.keys(['executionStats']);
+      });
+
+      it('includes executionStats when requested', async() => {
+        const explained = await collection.explain('executionStats').distinct('_id');
+        expect(explained).to.include.all.keys(['ok', 'serverInfo', 'queryPlanner', 'executionStats']);
+      });
+    });
+
+    describe('findAndModify', () => {
+      it('provides explain information', async() => {
+        await collection.insertOne({});
+        const explained = await collection.explain()
+          .findAndModify({ query: {}, update: {} });
+        expect(explained).to.include.all.keys(['ok', 'serverInfo', 'queryPlanner']);
+        expect(explained).to.not.include.any.keys(['executionStats']);
+      });
+
+      it('includes executionStats when requested', async() => {
+        await collection.insertOne({});
+        const explained = await collection.explain('executionStats')
+          .findAndModify({ query: {}, update: {} });
+        expect(explained).to.include.all.keys(['ok', 'serverInfo', 'queryPlanner', 'executionStats']);
+      });
+    });
+
+    describe('remove', () => {
+      it('provides explain information', async() => {
+        const explained = await collection.explain().remove({ notfound: 1 });
+        expect(explained).to.include.all.keys(['ok', 'serverInfo', 'queryPlanner']);
+        expect(explained).to.not.include.any.keys(['executionStats']);
+      });
+
+      it('includes executionStats when requested', async() => {
+        const explained = await collection.explain('executionStats').remove({ notfound: 1 });
+        expect(explained).to.include.all.keys(['ok', 'serverInfo', 'queryPlanner', 'executionStats']);
+      });
+    });
+
+    describe('update', () => {
+      it('provides explain information', async() => {
+        const explained = await collection.explain()
+          .update({ notfound: 1 }, { $unset: { laksjdhkgh: '' } });
+        expect(explained).to.include.all.keys(['ok', 'serverInfo', 'queryPlanner']);
+        expect(explained).to.not.include.any.keys(['executionStats']);
+      });
+
+      it('includes executionStats when requested', async() => {
+        const explained = await collection.explain('executionStats')
+          .update({ notfound: 1 }, { $unset: { laksjdhkgh: '' } });
+        expect(explained).to.include.all.keys(['ok', 'serverInfo', 'queryPlanner', 'executionStats']);
+      });
+    });
+
+    describe('mapReduce', () => {
+      let mapFn;
+      let reduceFn;
+      beforeEach(async() => {
+        await loadMRExample(collection);
+        mapFn = compileExpr `function() {
+          emit(this.cust_id, this.price);
+        }`;
+        reduceFn = compileExpr `function(keyCustId, valuesPrices) {
+          return valuesPrices.reduce((s, t) => s + t);
+        }`;
+      });
+      it('provides explain information', async() => {
+        const explained = await collection.explain().mapReduce(mapFn, reduceFn, 'map_reduce_example');
+        expect(explained).to.include.all.keys(['ok', 'serverInfo', 'stages']);
+        expect(explained.stages[0].$cursor).to.include.all.keys(['queryPlanner']);
+      });
+
+      it('includes executionStats when requested', async() => {
+        const explained = await collection.explain('executionStats').mapReduce(mapFn, reduceFn, 'map_reduce_example');
+        expect(explained).to.include.all.keys(['ok', 'serverInfo', 'stages']);
+        expect(explained.stages[0].$cursor).to.include.all.keys(['queryPlanner', 'executionStats']);
+      });
+    });
   });
 
   describe('Bulk API', async() => {

--- a/packages/shell-api/src/integration.spec.ts
+++ b/packages/shell-api/src/integration.spec.ts
@@ -1111,6 +1111,8 @@ describe('Shell API (integration)', function() {
     });
 
     describe('mapReduce', () => {
+      skipIfServerVersion(testServer, '< 4.4');
+
       let mapFn;
       let reduceFn;
       beforeEach(async() => {

--- a/packages/shell-api/src/shard.ts
+++ b/packages/shell-api/src/shard.ts
@@ -225,7 +225,7 @@ export default class Shard extends ShellApiClass {
       { _id: 'autosplit' },
       { $set: { enabled: true } },
       { upsert: true, writeConcern: { w: 'majority', wtimeout: 30000 } }
-    );
+    ) as UpdateResult;
   }
 
   @returnsPromise
@@ -237,7 +237,7 @@ export default class Shard extends ShellApiClass {
       { _id: 'autosplit' },
       { $set: { enabled: false } },
       { upsert: true, writeConcern: { w: 'majority', wtimeout: 30000 } }
-    );
+    ) as UpdateResult;
   }
 
   @returnsPromise
@@ -296,7 +296,7 @@ export default class Shard extends ShellApiClass {
       { _id: ns },
       { $set: { 'noBalance': false } },
       { writeConcern: { w: 'majority', wtimeout: 60000 } }
-    );
+    ) as UpdateResult;
   }
 
   @returnsPromise
@@ -309,7 +309,7 @@ export default class Shard extends ShellApiClass {
       { _id: ns },
       { $set: { 'noBalance': true } },
       { writeConcern: { w: 'majority', wtimeout: 60000 } }
-    );
+    ) as UpdateResult;
   }
 
   @returnsPromise


### PR DESCRIPTION
Add `.explain()` support for non-cursor methods. In the process,
also fix up the options handling for `collection.remove()`, which
previously passed the `justOne` option to the driver instead of
handling it in mongosh (which was ignored by the driver).