### PR TITLE
fix(cli-repl): Catch output stream errors to avoid uncaught exceptions

### DIFF
--- a/packages/cli-repl/package-lock.json
+++ b/packages/cli-repl/package-lock.json
@@ -25,6 +25,21 @@
 			"integrity": "sha512-y9KJUf19SBowoaqhWdQNnErxFMNsKbuair2i3SGv5Su1ExLPAJz37iPXLHKIFQGYkHGxsSe45rNt8ZekXxJwUw==",
 			"dev": true
 		},
+		"@types/chai": {
+			"version": "4.2.14",
+			"resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.2.14.tgz",
+			"integrity": "sha512-G+ITQPXkwTrslfG5L/BksmbLUA0M1iybEsmCWPqzSxsRRhJZimBKJkoMi8fr/CPygPTj4zO5pJH7I2/cm9M7SQ==",
+			"dev": true
+		},
+		"@types/chai-as-promised": {
+			"version": "7.1.3",
+			"resolved": "https://registry.npmjs.org/@types/chai-as-promised/-/chai-as-promised-7.1.3.tgz",
+			"integrity": "sha512-FQnh1ohPXJELpKhzjuDkPLR2BZCAqed+a6xV4MI/T3XzHfd2FlarfUGUdZYgqYe8oxkYn0fchHEeHfHqdZ96sg==",
+			"dev": true,
+			"requires": {
+				"@types/chai": "*"
+			}
+		},
 		"@types/lodash": {
 			"version": "4.14.163",
 			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.163.tgz",
@@ -212,6 +227,14 @@
 				"is-retry-allowed": "^1.1.0"
 			}
 		},
+		"chai-as-promised": {
+			"version": "7.1.1",
+			"resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
+			"integrity": "sha512-azL6xMoi+uxu6z4rhWQ1jbdUhOMhis2PvscD/xjLqNMkv3BPPp2JyyuTHOrf9BOosGpNQ11v6BKv/g57RXbiaA==",
+			"requires": {
+				"check-error": "^1.0.2"
+			}
+		},
 		"chalk": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.0.tgz",
@@ -225,6 +248,11 @@
 			"version": "0.0.2",
 			"resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
 			"integrity": "sha1-wKHS86cJLgN3S/qD8UwPxXkKhmc="
+		},
+		"check-error": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/check-error/-/check-error-1.0.2.tgz",
+			"integrity": "sha1-V00xLt2Iu13YkS6Sht1sCu1KrII="
 		},
 		"color-convert": {
 			"version": "2.0.1",

--- a/packages/cli-repl/package.json
+++ b/packages/cli-repl/package.json
@@ -63,11 +63,13 @@
   "devDependencies": {
     "@types/analytics-node": "^3.1.3",
     "@types/ansi-escape-sequences": "^4.0.0",
+    "@types/chai-as-promised": "^7.1.3",
     "@types/lodash.set": "^4.3.6",
     "@types/minimist": "^1.2.0",
     "@types/node": "^14.14.5",
     "@types/pino": "^6.3.3",
     "@types/read": "^0.0.28",
-    "@types/text-table": "^0.2.1"
+    "@types/text-table": "^0.2.1",
+    "chai-as-promised": "^7.1.1"
   }
 }

--- a/packages/cli-repl/src/cli-repl.spec.ts
+++ b/packages/cli-repl/src/cli-repl.spec.ts
@@ -38,6 +38,24 @@ describe('CliRepl', () => {
     };
   });
 
+  context('with a broken output stream', () => {
+    beforeEach(async() => {
+      cliReplOptions.shellCliOptions = { nodb: true };
+      cliRepl = new CliRepl(cliReplOptions);
+      await cliRepl.start('', {});
+      cliReplOptions.output.end();
+    });
+
+    it("doesn't throw errors", (done) => {
+      const replCall = async() => {
+        input.write('21 + 13\n');
+        await waitEval(cliRepl.bus);
+      };
+
+      expect(replCall()).to.be.fulfilled.and.notify(done);
+    });
+  });
+
   context('with nodb', () => {
     beforeEach(() => {
       cliReplOptions.shellCliOptions = { nodb: true };

--- a/packages/cli-repl/src/cli-repl.ts
+++ b/packages/cli-repl/src/cli-repl.ts
@@ -63,6 +63,13 @@ class CliRepl {
       .on('update-config', (config: UserConfig) =>
         this.bus.emit('mongosh:update-user', config.userId, config.enableTelemetry));
 
+    // We can't really do anything meaningfull if the output stream is broken or
+    // closed. To avoid throwing an error while writing to it, let's send it to
+    // the telemetry instead
+    this.output.on('error', (err: Error) => {
+      this.bus.emit('mongosh:error', err);
+    });
+
     this.mongoshRepl = new MongoshNodeRepl({
       ...options,
       nodeReplOptions: options.nodeReplOptions ?? {

--- a/packages/cli-repl/test/repl-helpers.ts
+++ b/packages/cli-repl/test/repl-helpers.ts
@@ -6,7 +6,10 @@ import rimraf from 'rimraf';
 import chai, { expect } from 'chai';
 import sinon from 'ts-sinon';
 import sinonChai from 'sinon-chai';
+import chaiAsPromised from 'chai-as-promised';
+
 chai.use(sinonChai);
+chai.use(chaiAsPromised);
 
 // MongoshNodeRepl performs no I/O, so it's safe to assume that all operations
 // finish within a single nextTick/microtask cycle. We can use `setImmediate()`


### PR DESCRIPTION
To reproduce you can try doing something like `echo "print('Hello' + ' ' + 'World')" | mongosh --nodb | grep -q "Hello"` in your shell (at least this is a way to reproduce on macos). The reason for this is that `q` argument forces `grep` to exit as soon as the match is found, destroying the stream after it is done, causing shell to throw:

<img width="635" alt="image" src="https://user-images.githubusercontent.com/5036933/102507185-3ee52f00-4084-11eb-9173-e4330caea556.png">


The fix adds an 'error' listener to the passed output stream and reports caught issues to the telemetry