### PR TITLE
fix(cli-repl): merge Node.js REPL and mongosh autocompletion MONGOSH-164

### DIFF
--- a/packages/cli-repl/src/mongosh-repl.spec.ts
+++ b/packages/cli-repl/src/mongosh-repl.spec.ts
@@ -267,10 +267,31 @@ describe('MongoshNodeRepl', () => {
       expect(code).to.equal(0);
     });
 
-    it('autocompletes', async() => {
-      input.write('db.coll.\u0009\u0009'); // U+0009 is TAB
-      await tick();
-      expect(output).to.include('db.coll.updateOne');
+    context('autocompletion', () => {
+      it('autocompletes collection methods', async() => {
+        input.write('db.coll.\u0009\u0009'); // U+0009 is TAB
+        await tick();
+        expect(output).to.include('db.coll.updateOne');
+      });
+      it('autocompletes shell-api methods (once)', async() => {
+        input.write('slee\u0009\u0009'); // U+0009 is TAB
+        await tick();
+        expect(output).to.include('sleep');
+        expect(output).to.not.match(/sleep\s+sleep/);
+      });
+      it('autocompletes async shell api methods', async() => {
+        input.write('db.coll.find().\u0009\u0009'); // U+0009 is TAB
+        await tick();
+        expect(output).to.include('db.coll.find().close');
+      });
+      it('autocompletes local variables', async() => {
+        input.write('let somelongvariable = 0\n');
+        await tick();
+        output = '';
+        input.write('somelong\u0009\u0009'); // U+0009 is TAB
+        await tick();
+        expect(output).to.include('somelongvariable');
+      });
     });
   });
 

--- a/packages/cli-repl/src/mongosh-repl.spec.ts
+++ b/packages/cli-repl/src/mongosh-repl.spec.ts
@@ -274,10 +274,10 @@ describe('MongoshNodeRepl', () => {
         expect(output).to.include('db.coll.updateOne');
       });
       it('autocompletes shell-api methods (once)', async() => {
-        input.write('slee\u0009\u0009'); // U+0009 is TAB
+        input.write('vers\u0009\u0009'); // U+0009 is TAB
         await tick();
-        expect(output).to.include('sleep');
-        expect(output).to.not.match(/sleep\s+sleep/);
+        expect(output).to.include('version');
+        expect(output).to.not.match(/version\s+version/);
       });
       it('autocompletes async shell api methods', async() => {
         input.write('db.coll.find().\u0009\u0009'); // U+0009 is TAB

--- a/packages/cli-repl/src/mongosh-repl.ts
+++ b/packages/cli-repl/src/mongosh-repl.ts
@@ -15,7 +15,7 @@ import { LineByLineInput } from './line-by-line-input';
 import formatOutput, { formatError } from './format-output';
 import clr, { StyleDefinition } from './clr';
 import { TELEMETRY_GREETING_MESSAGE, MONGOSH_WIKI } from './constants';
-import { promisify } from 'util';
+import { promisify, callbackify } from 'util';
 import askpassword from 'askpassword';
 
 export type MongoshCliOptions = ShellCliOptions & {
@@ -41,6 +41,11 @@ type MongoshRuntimeState = {
   shellEvaluator: ShellEvaluator;
   internalState: ShellInternalState;
   repl: REPLServer;
+};
+
+// Utility, inverse of Readonly<T>
+type Mutable<T> = {
+  -readonly[P in keyof T]: T[P]
 };
 
 /**
@@ -83,7 +88,6 @@ class MongoshNodeRepl {
       output: this.output,
       prompt: '> ',
       writer: this.writer.bind(this),
-      completer: completer.bind(null, internalState.getAutocompleteParameters()),
       breakEvalOnSigint: true,
       preview: false,
       asyncEval: this.eval.bind(this),
@@ -91,11 +95,29 @@ class MongoshNodeRepl {
         (err: Error) => Object.assign(new MongoshInternalError(err.message), { stack: err.stack }),
       ...this.nodeReplOptions
     });
+
     this._runtimeState = {
       shellEvaluator,
       internalState,
       repl
     };
+
+    const origReplCompleter =
+      promisify(repl.completer.bind(repl)); // repl.completer is callback-style
+    const mongoshCompleter =
+      completer.bind(null, internalState.getAutocompleteParameters());
+    (repl as Mutable<typeof repl>).completer =
+      callbackify(async(text: string): Promise<[string[], string]> => {
+        // Merge the results from the repl completer and the mongosh completer.
+        const [ [replResults], [mongoshResults] ] = await Promise.all([
+          (async() => await origReplCompleter(text) || [[]])(),
+          (async() => await mongoshCompleter(text))()
+        ]);
+        // Remove duplicates, because shell API methods might otherwise show
+        // up in both completions.
+        const deduped = [...new Set([...replResults, ...mongoshResults])];
+        return [deduped, text];
+      });
 
     const originalDisplayPrompt = repl.displayPrompt.bind(repl);
 


### PR DESCRIPTION
Instead of replacing the Node.js REPL autocompletion function, use both
that and our own autocompletion and merge the results in order to
provide expected results to users.