### PR TITLE
fix(cli-repl): wait for output drain before exiting

### DIFF
--- a/packages/cli-repl/src/mongosh-repl.ts
+++ b/packages/cli-repl/src/mongosh-repl.ts
@@ -17,6 +17,7 @@ import clr, { StyleDefinition } from './clr';
 import { TELEMETRY_GREETING_MESSAGE, MONGOSH_WIKI } from './constants';
 import { promisify } from 'util';
 import askpassword from 'askpassword';
+import { once } from 'events';
 
 export type MongoshCliOptions = ShellCliOptions & {
   redactInfo?: boolean;
@@ -297,6 +298,9 @@ class MongoshNodeRepl {
       this._runtimeState = null;
       rs.repl.close();
       await rs.internalState.close(true);
+      if (this.output.writableLength > 0) {
+        await once(this.output, 'drain');
+      }
     }
   }
 }


### PR DESCRIPTION
We’re explicitly calling `process.exit()` in the CLI repl once the
REPL has been closed, stops all asynchronous operations, including
writing to asynchronous stdio streams.

We should at least wait until all currently pending output has been
written to stdout before doing so. This seems fix a problem that
I cannot reproduce locally, but @gribnoysup can. :)