### PR TITLE
test(connectivity-tests): Add connectivity tests for atlas and data lake MONGOSH-419

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -181,6 +181,10 @@ functions:
             --rm -v $PWD:/tmp/build ubuntu18.04-xvfb \
             -c 'cd /tmp/build && ./testing/test-vscode.sh'
   test_connectivity:
+    - command: expansions.write
+      params:
+        file: tmp/expansions.yaml
+        redacted: true
     - command: shell.exec
       params:
         working_dir: src

--- a/packages/connectivity-tests/test/all.sh
+++ b/packages/connectivity-tests/test/all.sh
@@ -15,17 +15,6 @@ git clone git@github.com:mongodb-js/devtools-docker-test-envs.git test-envs
 cd test-envs
 git checkout de257688e6b7ce265a70bf75c7127c6da0bf2cf0
 
-# To avoid printing secrets to logs
-set +x
-eval $(
-    node "${MONGOSH_ROOT_DIR}/scripts/print-expansions.js" \
-    connectivity_test_data_lake_hostname \
-    connectivity_test_atlas_hostname \
-    connectivity_test_atlas_username \
-    connectivity_test_atlas_password
-)
-set -x
-
 source "$CONNECTIVITY_TEST_SOURCE_DIR/ldap.sh"
 source "$CONNECTIVITY_TEST_SOURCE_DIR/localhost.sh"
 source "$CONNECTIVITY_TEST_SOURCE_DIR/atlas.sh"

--- a/packages/connectivity-tests/test/all.sh
+++ b/packages/connectivity-tests/test/all.sh
@@ -17,7 +17,13 @@ git checkout de257688e6b7ce265a70bf75c7127c6da0bf2cf0
 
 # To avoid printing secrets to logs
 set +x
-eval $(node "$MONGOSH_ROOT_DIR/scripts/print-expansions.js")
+eval $(
+    node "${MONGOSH_ROOT_DIR}/scripts/print-expansions.js" \
+    connectivity_test_data_lake_hostname \
+    connectivity_test_atlas_hostname \
+    connectivity_test_atlas_username \
+    connectivity_test_atlas_password
+)
 set -x
 
 source "$CONNECTIVITY_TEST_SOURCE_DIR/ldap.sh"

--- a/packages/connectivity-tests/test/all.sh
+++ b/packages/connectivity-tests/test/all.sh
@@ -15,5 +15,11 @@ git clone git@github.com:mongodb-js/devtools-docker-test-envs.git test-envs
 cd test-envs
 git checkout de257688e6b7ce265a70bf75c7127c6da0bf2cf0
 
+# To avoid printing secrets to logs
+set +x
+eval $(node "$MONGOSH_ROOT_DIR/scripts/print-expansions.js")
+set -x
+
 source "$CONNECTIVITY_TEST_SOURCE_DIR/ldap.sh"
 source "$CONNECTIVITY_TEST_SOURCE_DIR/localhost.sh"
+source "$CONNECTIVITY_TEST_SOURCE_DIR/atlas.sh"

--- a/packages/connectivity-tests/test/atlas.sh
+++ b/packages/connectivity-tests/test/atlas.sh
@@ -1,0 +1,124 @@
+#!/bin/bash
+set -e
+# To avoid username and password variables showing up in the logs
+set +x
+
+USERNAME="${CONNECTIVITY_TEST_ATLAS_USERNAME}"
+PASSWORD="${CONNECTIVITY_TEST_ATLAS_PASSWORD}"
+HOSTNAME="${CONNECTIVITY_TEST_ATLAS_HOSTNAME}"
+DATA_LAKE_HOSTNAME="${CONNECTIVITY_TEST_DATA_LAKE_HOSTNAME}"
+
+if
+  [[ -z "${USERNAME}" ]] ||
+    [[ -z "${PASSWORD}" ]] ||
+    [[ -z "${HOSTNAME}" ]] ||
+    [[ -z "${DATA_LAKE_HOSTNAME}" ]]
+then
+  echo "Atlas credentials are not provided"
+  exit 0
+fi
+
+FAILED=no
+
+CONNECTION_STATUS_COMMAND='db.runCommand({ connectionStatus: 1 }).authInfo.authenticatedUsers'
+CONNECTION_STATUS_CHECK_STRING="user: '${USERNAME}'"
+
+function check_failed() {
+  if [[ $FAILED != no ]]; then
+    printf "FAILED:\n"
+    printf "  ${FAILED}\n"
+    exit 1
+  else
+    printf "OK\n"
+  fi
+}
+
+function test_connection_string() {
+  printf "test_connection_string ... "
+
+  CONNECTION_STRING="mongodb+srv://${USERNAME}:${PASSWORD}@${HOSTNAME}/admin"
+
+  echo "${CONNECTION_STATUS_COMMAND}" | mongosh "${CONNECTION_STRING}" |
+    grep -Fq "${CONNECTION_STATUS_CHECK_STRING}" ||
+    FAILED="Can't connect to Atlas using connection string with username and password"
+
+  check_failed
+}
+
+function test_atlas_in_logs() {
+  printf "test_atlas_in_logs ... "
+
+  CONNECTION_STRING="mongodb+srv://${USERNAME}:${PASSWORD}@${HOSTNAME}/admin"
+  LOG_ID=$(echo "exit" | mongosh "${CONNECTION_STRING}" | sed -n -e 's/Current Mongosh Log ID: //p')
+  LOG_PATH="${HOME}/.mongodb/mongosh/${LOG_ID}_log"
+
+  cat "${LOG_PATH}" | grep -Fq '\"is_atlas\":true' ||
+    FAILED="Can't find Atlas mention in the logs"
+
+  check_failed
+}
+
+function test_credentials_masking() {
+  printf "test_credentials_masking ... "
+
+  CONNECTION_STRING="mongodb+srv://${USERNAME}:${PASSWORD}@${HOSTNAME}/admin"
+  MASKED_CREDENTIALS_STRING="mongodb+srv://<credentials>@${HOSTNAME}/admin"
+
+  echo "${CONNECTION_STATUS_COMMAND}" | mongosh "${CONNECTION_STRING}" |
+    grep -Fq "${MASKED_CREDENTIALS_STRING}" ||
+    FAILED="When connecting, credentials are not masked in the connection string"
+
+  check_failed
+}
+
+function test_cli_args() {
+  printf "test_cli_args ... "
+
+  CONNECTION_STRING="mongodb+srv://${HOSTNAME}/admin"
+
+  echo "${CONNECTION_STATUS_COMMAND}" |
+    mongosh "${CONNECTION_STRING}" --username "${USERNAME}" --password "${PASSWORD}" |
+    grep -Fq "${CONNECTION_STATUS_CHECK_STRING}" ||
+    FAILED="Can't connect to Atlas using connection string and username and password arguments"
+
+  check_failed
+}
+
+function test_password_prompt() {
+  printf "test_password_prompt ... "
+
+  CONNECTION_STRING="mongodb+srv://${HOSTNAME}/admin"
+
+  echo -e "${PASSWORD}\n${CONNECTION_STATUS_COMMAND}" |
+    mongosh "${CONNECTION_STRING}" --username "aaaaaa${USERNAME}" |
+    grep -Fq "${CONNECTION_STATUS_CHECK_STRING}" ||
+    FAILED="Can't connect to Atlas using password prompt"
+
+  check_failed
+}
+
+function test_data_lake() {
+  printf "test_data_lake ... "
+
+  CONNECTION_STRING="mongodb://${DATA_LAKE_HOSTNAME}/admin"
+
+  echo "${CONNECTION_STATUS_COMMAND}" |
+    mongosh "${CONNECTION_STRING}" \
+      --tls \
+      --authenticationDatabase admin \
+      --username "${USERNAME}" \
+      --password "${PASSWORD}" |
+    grep -Fq "${CONNECTION_STATUS_CHECK_STRING}" ||
+    FAILED="Can't connect to Data Lake using connection string with username and password"
+
+  check_failed
+}
+
+test_connection_string
+test_atlas_in_logs
+test_credentials_masking
+test_cli_args
+test_password_prompt
+test_data_lake
+
+echo "All Atlas tests are passing"

--- a/packages/connectivity-tests/test/atlas.sh
+++ b/packages/connectivity-tests/test/atlas.sh
@@ -15,7 +15,12 @@ if
     [[ -z "${DATA_LAKE_HOSTNAME}" ]]
 then
   echo "Atlas credentials are not provided"
-  exit 0
+
+  if [[ -z "${IS_CI}" ]] || [[ -z "${CI}" ]]; then
+    exit 1
+  else
+    exit 0
+  fi
 fi
 
 FAILED=no

--- a/scripts/print-expansions.js
+++ b/scripts/print-expansions.js
@@ -11,6 +11,8 @@ const os = require('os');
  * we don't getting logging of our keys in Evergreen.
  */
 const printExpansions = () => {
+  const filter = process.argv.slice(2);
+
   if (!process.env.EVERGREEN_EXPANSIONS_PATH) {
     return;
   }
@@ -32,6 +34,7 @@ const printExpansions = () => {
 
   console.log(
     Object.keys(expansions)
+      .filter((expansion) => filter.length === 0 || filter.includes(expansion))
       .map((key) => `${key.toUpperCase()}="${expansions[key]}"`)
       .join('\n')
   );

--- a/scripts/print-expansions.js
+++ b/scripts/print-expansions.js
@@ -1,0 +1,40 @@
+/* istanbul ignore file */
+
+'use strict';
+const YAML = require('yaml');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+/**
+ * Imports expansions written to disk to the process env so
+ * we don't getting logging of our keys in Evergreen.
+ */
+const printExpansions = () => {
+  if (!process.env.EVERGREEN_EXPANSIONS_PATH) {
+    return;
+  }
+
+  const expansionsPath = path.resolve(process.env.EVERGREEN_EXPANSIONS_PATH);
+
+  if (!fs.existsSync(expansionsPath)) {
+    console.error({
+      platform: os.platform(),
+      cwd: process.cwd(),
+      expansionsPath
+    });
+
+    throw new Error(`printExpansions failed: file ${expansionsPath} not found`);
+  }
+
+  const data = fs.readFileSync(expansionsPath, 'utf8');
+  const expansions = YAML.parse(data);
+
+  console.log(
+    Object.keys(expansions)
+      .map((key) => `${key.toUpperCase()}="${expansions[key]}"`)
+      .join('\n')
+  );
+};
+
+printExpansions();


### PR DESCRIPTION
This PR adds the following tests for remote servers following the mongosh test matrix

- [x] Connecting to Atlas with connection string works
- [x] `mongosh` logs have `is_atlas` set to `true`
- [x] `mongosh` masks credentials in CLI output
- [x] Connecting to Atlas with cli args works
- [x] Connecting to Atlas with password prompt works
- [x] Connecting to Data Lake works

All secrets are added in evergreen config, hopefully everything is wired up together correctly 🤞 