### PR TITLE
chore(ci): move powershell scripts into dedicated files

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -67,22 +67,15 @@ variables:
         npm run test-e2e-ci
 
   - &compile_and_upload_artifact_win
-    command: shell.exec
+    command: subprocess.exec
     params:
       working_dir: src
-      shell: powershell
-      script: |
-        $Env:NODE_JS_VERSION = "${node_js_version}"
-        $ErrorActionPreference = "Stop"
-        .\.evergreen\SetupEnv
-        node --version
-        npm --version
-        $Env:PUPPETEER_SKIP_CHROMIUM_DOWNLOAD = "true"
-        $Env:EVERGREEN_EXPANSIONS_PATH = $(Join-Path -Path '..' -ChildPath 'tmp/expansions.yaml' -Resolve)
-        npm run evergreen-release package
-        $Env:MONGOSH_TEST_EXECUTABLE_PATH = $(Join-Path -Path '.' -ChildPath 'dist/mongosh.exe' -Resolve)
-        echo "$Env:MONGOSH_TEST_EXECUTABLE_PATH"
-        npm run test-e2e-ci
+      binary: powershell
+      args:
+        - .\.evergreen\CompileAndUpload
+      env:
+        NODE_JS_VERSION: ${node_js_version}
+        PUPPETEER_SKIP_CHROMIUM_DOWNLOAD: "true"
 
 # Functions are any command that can be run.
 # Variables ending with _win do the same thing as their non-suffixed counterparts
@@ -114,13 +107,14 @@ functions:
           export NODE_JS_VERSION=${node_js_version}
           source .evergreen/.install_node
   install_win:
-    - command: shell.exec
+    - command: subprocess.exec
       params:
         working_dir: src
-        shell: powershell
-        script: |
-          $Env:NODE_JS_VERSION = "${node_js_version}"
-          .\.evergreen\InstallNode
+        binary: powershell
+        args:
+          - .\.evergreen\InstallNode
+        env:
+          NODE_JS_VERSION: ${node_js_version}
   check:
     - command: shell.exec
       params:
@@ -131,14 +125,14 @@ functions:
           source .evergreen/.setup_env
           npm run check-ci
   check_win:
-    - command: shell.exec
+    - command: subprocess.exec
       params:
         working_dir: src
-        shell: powershell
-        script: |
-          $Env:NODE_JS_VERSION = "${node_js_version}"
-          .\.evergreen\SetupEnv
-          npm run check-ci
+        binary: powershell
+        args:
+          - .\.evergreen\Check
+        env:
+          NODE_JS_VERSION: ${node_js_version}
   test:
     - command: expansions.write
       params:
@@ -159,16 +153,14 @@ functions:
       params:
         file: tmp\expansions.yaml
         redacted: true
-    - command: shell.exec
+    - command: subprocess.exec
       params:
         working_dir: src
-        shell: powershell
-        script: |
-          $ErrorActionPreference = "Stop"
-          $Env:NODE_JS_VERSION = "${node_js_version}"
-          .\.evergreen\SetupEnv
-          $Env:EVERGREEN_EXPANSIONS_PATH = $(Join-Path -Path '..' -ChildPath 'tmp/expansions.yaml' -Resolve)
-          npm run test-ci
+        binary: powershell
+        args:
+          - .\.evergreen\Test
+        env:
+          NODE_JS_VERSION: ${node_js_version}
   test_vscode:
     - command: shell.exec
       params:

--- a/.evergreen/Check.ps1
+++ b/.evergreen/Check.ps1
@@ -1,0 +1,5 @@
+$ErrorActionPreference = "Stop"
+
+.\.evergreen\SetupEnv
+
+npm run check-ci

--- a/.evergreen/CompileAndUpload.ps1
+++ b/.evergreen/CompileAndUpload.ps1
@@ -1,0 +1,11 @@
+$ErrorActionPreference = "Stop"
+
+.\.evergreen\SetupEnv
+$Env:EVERGREEN_EXPANSIONS_PATH = $(Join-Path -Path '..' -ChildPath 'tmp/expansions.yaml' -Resolve)
+
+npm run evergreen-release package
+
+$Env:MONGOSH_TEST_EXECUTABLE_PATH = $(Join-Path -Path '.' -ChildPath 'dist/mongosh.exe' -Resolve)
+echo "$Env:MONGOSH_TEST_EXECUTABLE_PATH"
+
+npm run test-e2e-ci

--- a/.evergreen/InstallNode.ps1
+++ b/.evergreen/InstallNode.ps1
@@ -1,3 +1,5 @@
+$ErrorActionPreference = "Stop"
+
 $version = "$Env:NODE_JS_VERSION"
 $url = "https://nodejs.org/download/release/v$version/node-v$version-win-x64.zip"
 $filename = "node.zip"

--- a/.evergreen/SetupEnv.ps1
+++ b/.evergreen/SetupEnv.ps1
@@ -1,3 +1,5 @@
+$ErrorActionPreference = "Stop"
+
 $version = "$Env:NODE_JS_VERSION"
 $Env:PATH = "$PSScriptRoot\node-v$version-win-x64;C:\Python39\Scripts;C:\Python39;C:\Program Files\Git\mingw32\libexec\git-core;C:\cmake\bin\;$Env:PATH"
 

--- a/.evergreen/Test.ps1
+++ b/.evergreen/Test.ps1
@@ -1,0 +1,6 @@
+$ErrorActionPreference = "Stop"
+
+.\.evergreen\SetupEnv
+$Env:EVERGREEN_EXPANSIONS_PATH = $(Join-Path -Path '..' -ChildPath 'tmp/expansions.yaml' -Resolve)
+
+npm run test-ci


### PR DESCRIPTION
I noticed due to some other build failures that the scripts we were executing inside powershell do not fail as expected.

Code declared in a `shell.exec` step is piped into the powershell executable via stdin (see https://github.com/evergreen-ci/evergreen/blob/master/agent/command/shell.go#L137). This treats every line completely separate in powershell and powershell will always continue execution. A failing line is disregarded (regardless of `$ErrorActionPreference`).

The scripts are now moved to dedicated `.ps1` files and are started using `subprocess.exec`.