### PR TITLE
fix(test): shut down TLS-based servers through the shell

### DIFF
--- a/packages/cli-repl/test/e2e-tls.spec.ts
+++ b/packages/cli-repl/test/e2e-tls.spec.ts
@@ -75,6 +75,7 @@ describe('e2e TLS', () => {
             '--tls', '--tlsCAFile', CA_CERT
           ]
         });
+        await shell.waitForPrompt();
         await shell.executeLine('db.shutdownServer({ force: true })');
         await TestShell.killall();
       });
@@ -179,6 +180,7 @@ describe('e2e TLS', () => {
             '--tlsCertificateKeyFile', CLIENT_CERT
           ]
         });
+        await shell.waitForPrompt();
         await shell.executeLine('db.shutdownServer({ force: true })');
         await TestShell.killall();
       });

--- a/packages/cli-repl/test/e2e-tls.spec.ts
+++ b/packages/cli-repl/test/e2e-tls.spec.ts
@@ -64,6 +64,21 @@ describe('e2e TLS', () => {
         serverTlsCertificateKeyFileOption, SERVER_KEY
       );
 
+      after(async() => {
+        // mlaunch has some trouble interpreting all the server options correctly,
+        // and subsequently can't connect to the server to find out if it's up,
+        // then thinks it isn't and doesn't shut it down cleanly. We shut it down
+        // here to work around that.
+        const shell = TestShell.start({ args:
+          [
+            await server.connectionString(),
+            '--tls', '--tlsCAFile', CA_CERT
+          ]
+        });
+        await shell.executeLine('db.shutdownServer({ force: true })');
+        await TestShell.killall();
+      });
+
       it('works with matching CA (args)', async() => {
         const shell = TestShell.start({
           args: [
@@ -155,6 +170,18 @@ describe('e2e TLS', () => {
         serverTlsCAFileOption, CA_CERT
       );
       const certUser = 'emailAddress=tester@example.com,CN=Wonderwoman,OU=DevTools Testers,O=MongoDB';
+
+      after(async() => {
+        const shell = TestShell.start({ args:
+          [
+            await server.connectionString(),
+            '--tls', '--tlsCAFile', CA_CERT,
+            '--tlsCertificateKeyFile', CLIENT_CERT
+          ]
+        });
+        await shell.executeLine('db.shutdownServer({ force: true })');
+        await TestShell.killall();
+      });
 
       it('can connect with cert to create user', async() => {
         const shell = TestShell.start({

--- a/packages/cli-repl/test/e2e-tls.spec.ts
+++ b/packages/cli-repl/test/e2e-tls.spec.ts
@@ -58,12 +58,6 @@ describe('e2e TLS', () => {
 
   function registerTlsTests({ tlsMode: serverTlsModeOption, tlsModeValue: serverTlsModeValue, tlsCertificateFile: serverTlsCertificateKeyFileOption, tlsCaFile: serverTlsCAFileOption }) {
     context('connecting without client cert', () => {
-      const server = startTestServer(
-        'not-shared', '--hostname', 'localhost',
-        serverTlsModeOption, serverTlsModeValue,
-        serverTlsCertificateKeyFileOption, SERVER_KEY
-      );
-
       after(async() => {
         // mlaunch has some trouble interpreting all the server options correctly,
         // and subsequently can't connect to the server to find out if it's up,
@@ -79,6 +73,12 @@ describe('e2e TLS', () => {
         await shell.executeLine('db.shutdownServer({ force: true })');
         await TestShell.killall();
       });
+
+      const server = startTestServer(
+        'not-shared', '--hostname', 'localhost',
+        serverTlsModeOption, serverTlsModeValue,
+        serverTlsCertificateKeyFileOption, SERVER_KEY
+      );
 
       it('works with matching CA (args)', async() => {
         const shell = TestShell.start({
@@ -164,14 +164,6 @@ describe('e2e TLS', () => {
     });
 
     context('connecting with client cert', () => {
-      const server = startTestServer(
-        'not-shared', '--hostname', 'localhost',
-        serverTlsModeOption, serverTlsModeValue,
-        serverTlsCertificateKeyFileOption, SERVER_KEY,
-        serverTlsCAFileOption, CA_CERT
-      );
-      const certUser = 'emailAddress=tester@example.com,CN=Wonderwoman,OU=DevTools Testers,O=MongoDB';
-
       after(async() => {
         const shell = TestShell.start({ args:
           [
@@ -184,6 +176,14 @@ describe('e2e TLS', () => {
         await shell.executeLine('db.shutdownServer({ force: true })');
         await TestShell.killall();
       });
+
+      const server = startTestServer(
+        'not-shared', '--hostname', 'localhost',
+        serverTlsModeOption, serverTlsModeValue,
+        serverTlsCertificateKeyFileOption, SERVER_KEY,
+        serverTlsCAFileOption, CA_CERT
+      );
+      const certUser = 'emailAddress=tester@example.com,CN=Wonderwoman,OU=DevTools Testers,O=MongoDB';
 
       it('can connect with cert to create user', async() => {
         const shell = TestShell.start({


### PR DESCRIPTION
See the comment in the test – hopefully, this lets CI finish
on Windows now.