### PR TITLE
feat(shell-api): add cls support MONGOSH-239

### DIFF
--- a/packages/browser-repl/src/components/shell.spec.tsx
+++ b/packages/browser-repl/src/components/shell.spec.tsx
@@ -367,6 +367,16 @@ describe('<Shell />', () => {
     ]);
   });
 
+  it('clears the current output when cls is used', () => {
+    wrapper.setState({ output: [
+      { format: 'input', value: 'some code' },
+      { format: 'output', value: 'some result' }
+    ] });
+
+    wrapper.instance().onClearCommand();
+
+    expect(onOutputChangedSpy).to.have.been.calledWith([]);
+  });
   describe('password prompt', () => {
     let pressKey: (key: string) => Promise<void>;
     beforeEach(() => {

--- a/packages/browser-repl/src/components/shell.tsx
+++ b/packages/browser-repl/src/components/shell.tsx
@@ -154,7 +154,7 @@ export class Shell extends Component<ShellProps, ShellState> {
     return output;
   }
 
-  private onClearCommand = (): void => {
+  onClearCommand = (): void => {
     const output: [] = [];
 
     Object.freeze(output);

--- a/packages/cli-repl/src/mongosh-repl.spec.ts
+++ b/packages/cli-repl/src/mongosh-repl.spec.ts
@@ -451,6 +451,20 @@ describe('MongoshNodeRepl', () => {
       expect(output).not.to.include('hello!');
       expect(output).to.include('ReferenceError');
     });
+
+    it('clears the console when console.clear() is used', async() => {
+      output = '';
+      input.write('console.clear()\n');
+      await tick();
+      expect(output).to.match(/\x1b\[[0-9]+J/); // 'CSI n J' is clear display
+    });
+
+    it('clears the console when cls is used', async() => {
+      output = '';
+      input.write('cls\n');
+      await tick();
+      expect(output).to.match(/\x1b\[[0-9]+J/); // 'CSI n J' is clear display
+    });
   });
 
   context('with somewhat unreachable history file', () => {

--- a/packages/i18n/src/locales/en_US.ts
+++ b/packages/i18n/src/locales/en_US.ts
@@ -133,6 +133,16 @@ const translations: Catalog = {
               description: 'Sleep for the specified number of milliseconds',
               link: 'https://docs.mongodb.com/manual/reference/method/sleep/',
               example: 'sleep(5000)'
+            },
+            cls: {
+              description: 'Clears the screen like console.clear()'
+            },
+            print: {
+              description: 'Prints the contents of an object to the output',
+              example: 'print({ some: "value" })'
+            },
+            printjson: {
+              description: 'Alias for print()'
             }
           }
         },

--- a/packages/shell-api/src/decorators.ts
+++ b/packages/shell-api/src/decorators.ts
@@ -305,6 +305,9 @@ export function topologies(topologiesArray: any[]): Function {
 export function returnsPromise(_target: any, _propertyKey: string, descriptor: PropertyDescriptor): void {
   descriptor.value.returnsPromise = true;
 }
+export function directShellCommand(_target: any, _propertyKey: string, descriptor: PropertyDescriptor): void {
+  descriptor.value.isDirectShellCommand = true;
+}
 export function returnType(type: string | TypeSignature): Function {
   return function(
     _target: any,

--- a/packages/shell-api/src/shell-api.spec.ts
+++ b/packages/shell-api/src/shell-api.spec.ts
@@ -48,6 +48,38 @@ describe('ShellApi', () => {
         topologies: ALL_TOPOLOGIES,
         serverVersions: ALL_SERVER_VERSIONS
       });
+      expect(signatures.ShellApi.attributes.print).to.deep.equal({
+        type: 'function',
+        returnsPromise: true,
+        returnType: { type: 'unknown', attributes: {} },
+        platforms: ALL_PLATFORMS,
+        topologies: ALL_TOPOLOGIES,
+        serverVersions: ALL_SERVER_VERSIONS
+      });
+      expect(signatures.ShellApi.attributes.printjson).to.deep.equal({
+        type: 'function',
+        returnsPromise: true,
+        returnType: { type: 'unknown', attributes: {} },
+        platforms: ALL_PLATFORMS,
+        topologies: ALL_TOPOLOGIES,
+        serverVersions: ALL_SERVER_VERSIONS
+      });
+      expect(signatures.ShellApi.attributes.sleep).to.deep.equal({
+        type: 'function',
+        returnsPromise: true,
+        returnType: { type: 'unknown', attributes: {} },
+        platforms: ALL_PLATFORMS,
+        topologies: ALL_TOPOLOGIES,
+        serverVersions: ALL_SERVER_VERSIONS
+      });
+      expect(signatures.ShellApi.attributes.cls).to.deep.equal({
+        type: 'function',
+        returnsPromise: true,
+        returnType: { type: 'unknown', attributes: {} },
+        platforms: ALL_PLATFORMS,
+        topologies: ALL_TOPOLOGIES,
+        serverVersions: ALL_SERVER_VERSIONS
+      });
       expect(signatures.ShellApi.attributes.Mongo).to.deep.equal({
         type: 'function',
         returnsPromise: true,
@@ -336,6 +368,13 @@ describe('ShellApi', () => {
         await internalState.context.sleep(50);
         const then = Date.now();
         expect(then - now).to.be.greaterThan(40);
+      });
+    });
+    describe('cls', () => {
+      it('clears the screen', async() => {
+        evaluationListener.onClearCommand.resolves();
+        await internalState.context.cls();
+        expect(evaluationListener.onClearCommand).to.have.been.calledWith();
       });
     });
   });


### PR DESCRIPTION
Add support for the `cls` (clear screen command) through using
`console.clear` in Node.js and using the existing method for the
browser REPL.

As drive-by cleanups:

- Move other global methods to the `ShellApi` class and document
  them accordingly
- Use decorators on the `ShellApi` methods that are exposed as
  bash-like commands instead of special-casing them in the
  shell-evaluator package.