### PR TITLE
fix(cli-repl): store files in APPDATA on Windows MONGOSH-230

### DIFF
--- a/packages/cli-repl/src/cli-repl.spec.ts
+++ b/packages/cli-repl/src/cli-repl.spec.ts
@@ -31,7 +31,10 @@ describe('CliRepl', () => {
       shellCliOptions: {},
       input: input,
       output: outputStream,
-      shellHomePath: tmpdir.path,
+      shellHomePaths: {
+        shellRoamingDataPath: tmpdir.path,
+        shellLocalDataPath: tmpdir.path,
+      },
       onExit: ((code: number) => {
         exitCode = code;
       }) as ((code: number) => never)
@@ -162,7 +165,8 @@ describe('CliRepl', () => {
           this.skip(); // TODO: Figure out why this doesn't work on Windows.
           return;
         }
-        cliReplOptions.shellHomePath = '/nonexistent/inaccesible';
+        cliReplOptions.shellHomePaths.shellRoamingDataPath = '/nonexistent/inaccesible';
+        cliReplOptions.shellHomePaths.shellLocalDataPath = '/nonexistent/inaccesible';
         cliRepl = new CliRepl(cliReplOptions);
         const onerror = once(cliRepl.bus, 'mongosh:error');
         try {

--- a/packages/cli-repl/src/config-directory.spec.ts
+++ b/packages/cli-repl/src/config-directory.spec.ts
@@ -22,7 +22,10 @@ describe('home directory management', () => {
 
   beforeEach(() => {
     base = path.resolve(__dirname, '..', '..', '..', 'tmp', 'test', `${Date.now()}`, `${Math.random()}`);
-    shellHomeDirectory = new ShellHomeDirectory(base);
+    shellHomeDirectory = new ShellHomeDirectory({
+      shellRoamingDataPath: base,
+      shellLocalDataPath: base
+    });
     manager = new ConfigManager(shellHomeDirectory);
     manager.on('error', onError = sinon.spy());
     manager.on('new-config', onNewConfig = sinon.spy());
@@ -48,7 +51,7 @@ describe('home directory management', () => {
     });
 
     it('provides a way to access subpaths', async() => {
-      const subpath = shellHomeDirectory.path('banana');
+      const subpath = shellHomeDirectory.localPath('banana');
       expect(subpath).to.equal(path.join(base, 'banana'));
     });
   });

--- a/packages/cli-repl/src/index.ts
+++ b/packages/cli-repl/src/index.ts
@@ -3,6 +3,7 @@ import parseCliArgs from './arg-parser';
 import mapCliToDriver from './arg-mapper';
 import clr from './clr';
 import { USAGE, TELEMETRY_GREETING_MESSAGE, MONGOSH_WIKI } from './constants';
+import { getStoragePaths } from './config-directory';
 
 export default CliRepl;
 
@@ -13,5 +14,6 @@ export {
   MONGOSH_WIKI,
   CliRepl,
   parseCliArgs,
-  mapCliToDriver
+  mapCliToDriver,
+  getStoragePaths
 };

--- a/packages/cli-repl/src/run.ts
+++ b/packages/cli-repl/src/run.ts
@@ -1,7 +1,5 @@
-import { CliRepl, parseCliArgs, mapCliToDriver, USAGE } from './index';
+import { CliRepl, parseCliArgs, mapCliToDriver, getStoragePaths, USAGE } from './index';
 import { generateUri } from '@mongosh/service-provider-server';
-import path from 'path';
-import os from 'os';
 
 (async() => {
   let repl;
@@ -31,12 +29,13 @@ import os from 'os';
       const driverOptions = await mapCliToDriver(options);
       const driverUri = generateUri(options);
       const appname = `${process.title} ${version}`;
+      const shellHomePaths = getStoragePaths();
       repl = new CliRepl({
         shellCliOptions: options,
         input: process.stdin,
         output: process.stdout,
         onExit: process.exit,
-        shellHomePath: path.join(os.homedir(), '.mongodb/mongosh/')
+        shellHomePaths: shellHomePaths
       });
       await repl.start(driverUri, { appName: appname, ...driverOptions });
     }


### PR DESCRIPTION
Store config and history in `%APPDATA%` on Windows, and the log
files in `%LOCALAPPDATA%` since roaming them is not meaningful.
The location for other OSes remains `~/.mongodb/mongosh`.