### PR TITLE
feat: control iteration batch size + add 'Type "it"' prompt MONGOSH-361

### DIFF
--- a/packages/browser-repl/src/components/types/cursor-iteration-result-output.tsx
+++ b/packages/browser-repl/src/components/types/cursor-iteration-result-output.tsx
@@ -8,7 +8,7 @@ export interface Document {
 }
 
 interface CursorIterationResultOutputProps {
-  value: Document[];
+  value: Document[] & { cursorHasMore: boolean };
 }
 
 export class CursorIterationResultOutput extends Component<CursorIterationResultOutputProps> {
@@ -17,11 +17,17 @@ export class CursorIterationResultOutput extends Component<CursorIterationResult
   };
 
   render(): JSX.Element {
-    if (this.props.value.length) {
-      return <div>{this.props.value.map(this.renderDocument)}</div>;
+    if (!this.props.value.length) {
+      return <div>{i18n.__('shell-api.classes.Cursor.iteration.no-cursor')}</div>;
     }
 
-    return <div>{i18n.__('shell-api.classes.Cursor.iteration.no-cursor')}</div>;
+    const more = this.props.value.cursorHasMore ?
+      (<pre>{i18n.__('shell-api.classes.Cursor.iteration.type-it-for-more')}</pre>) :
+      '';
+    return (<div>
+      {this.props.value.map(this.renderDocument)}
+      {more}
+    </div>);
   }
 
   renderDocument = (document: Document, i: number): JSX.Element => {

--- a/packages/browser-repl/src/components/types/cursor-output.spec.tsx
+++ b/packages/browser-repl/src/components/types/cursor-output.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import { expect } from '../../../testing/chai';
-import { shallow } from '../../../testing/enzyme';
+import { shallow, mount } from '../../../testing/enzyme';
 
 import { CursorOutput } from './cursor-output';
 import { CursorIterationResultOutput } from './cursor-iteration-result-output';
@@ -20,30 +20,21 @@ describe('CursorOutput', () => {
     expect(wrapper.find(CursorIterationResultOutput).prop('value')).to.deep.equal(docs);
   });
 
-  context('when value contains more than 20 docs', () => {
+  context('when value has more elements available', () => {
     it('prompts to type "it"', () => {
-      const docs = new Array(21).fill({});
-      const wrapper = shallow(<CursorOutput value={docs} />);
+      const docs = Object.assign([{}], { cursorHasMore: true });
+      const wrapper = mount(<CursorOutput value={docs} />);
 
-      expect(wrapper.text()).to.contain('Type "it" for more');
+      expect(wrapper.find(CursorIterationResultOutput).text()).to.contain('Type "it" for more');
     });
   });
 
-  context('when value contains 20 docs', () => {
-    it('prompts to type "it"', () => {
-      const docs = new Array(20).fill({});
-      const wrapper = shallow(<CursorOutput value={docs} />);
-
-      expect(wrapper.text()).to.contain('Type "it" for more');
-    });
-  });
-
-  context('when value contains less than 20 docs', () => {
+  context('when value does not have more elements available', () => {
     it('does not prompt to type "it"', () => {
-      const docs = new Array(1).fill({});
-      const wrapper = shallow(<CursorOutput value={docs} />);
+      const docs = Object.assign([{}], { cursorHasMore: false });
+      const wrapper = mount(<CursorOutput value={docs} />);
 
-      expect(wrapper.text()).not.to.contain('Type "it" for more');
+      expect(wrapper.find(CursorIterationResultOutput).text()).not.to.contain('Type "it" for more');
     });
   });
 });

--- a/packages/browser-repl/src/components/types/cursor-output.tsx
+++ b/packages/browser-repl/src/components/types/cursor-output.tsx
@@ -1,13 +1,10 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import i18n from '@mongosh/i18n';
 import { CursorIterationResultOutput, Document } from './cursor-iteration-result-output';
 
 interface CursorOutputProps {
-  value: Document[];
+  value: Document[] & { cursorHasMore: boolean };
 }
-
-const MAX_DOCUMENT_PER_ITERATION = 20;
 
 export class CursorOutput extends Component<CursorOutputProps> {
   static propTypes = {
@@ -19,13 +16,7 @@ export class CursorOutput extends Component<CursorOutputProps> {
       return <pre/>;
     }
 
-    const more = this.props.value.length < MAX_DOCUMENT_PER_ITERATION ? '' :
-      (<pre>{i18n.__('shell-api.classes.Cursor.iteration.type-it-for-more')}</pre>);
-
-    return (<div>
-      <CursorIterationResultOutput value={this.props.value} />
-      {more}
-    </div>);
+    return <CursorIterationResultOutput value={this.props.value} />;
   }
 }
 

--- a/packages/cli-repl/src/cli-repl.spec.ts
+++ b/packages/cli-repl/src/cli-repl.spec.ts
@@ -239,7 +239,7 @@ describe('CliRepl', () => {
       input.write('use clirepltest\n');
       await waitEval(cliRepl.bus);
 
-      input.write(`for (let i = 0; i < 100; i++) { \
+      input.write(`for (let i = 0; i < 35; i++) { \
         db.coll.insertOne({ index: i }); \
       }
 `);
@@ -251,6 +251,7 @@ describe('CliRepl', () => {
       await waitEval(cliRepl.bus);
       expect(output).to.include('index: 10');
       expect(output).not.to.include('index: 30');
+      expect(output).to.include('Type "it" for more');
 
       // Print it again -- no change until iterated.
       output = '';
@@ -265,6 +266,7 @@ describe('CliRepl', () => {
       await waitEval(cliRepl.bus);
       expect(output).not.to.include('index: 10');
       expect(output).to.include('index: 30');
+      expect(output).not.to.include('Type "it" for more');
 
       // Still not iterating implicitly when we're printing the cursor itself.
       output = '';

--- a/packages/cli-repl/src/format-output.spec.ts
+++ b/packages/cli-repl/src/format-output.spec.ts
@@ -31,7 +31,7 @@ for (const colors of [ false, true ]) {
       context('when the Cursor is not empty', () => {
         it('returns the inspection', () => {
           const output = stripAnsiColors(format({
-            value: [{ doc: 1 }, { doc: 2 }],
+            value: Object.assign([{ doc: 1 }, { doc: 2 }], { cursorHasMore: true }),
             type: 'Cursor'
           }));
 
@@ -43,7 +43,7 @@ for (const colors of [ false, true ]) {
       context('when the Cursor is empty', () => {
         it('returns an empty string', () => {
           const output = stripAnsiColors(format({
-            value: [],
+            value: Object.assign([], { cursorHasMore: false }),
             type: 'Cursor'
           }));
 
@@ -56,19 +56,33 @@ for (const colors of [ false, true ]) {
       context('when the CursorIterationResult is not empty', () => {
         it('returns the inspection', () => {
           const output = stripAnsiColors(format({
-            value: [{ doc: 1 }, { doc: 2 }],
+            value: Object.assign([{ doc: 1 }, { doc: 2 }], { cursorHasMore: true }),
             type: 'CursorIterationResult'
           }));
 
           expect(output).to.include('doc: 1');
           expect(output).to.include('doc: 2');
+          expect(output).to.include('Type "it" for more');
+        });
+      });
+
+      context('when the CursorIterationResult is not empty but exhausted', () => {
+        it('returns the inspection', () => {
+          const output = stripAnsiColors(format({
+            value: Object.assign([{ doc: 1 }, { doc: 2 }], { cursorHasMore: false }),
+            type: 'CursorIterationResult'
+          }));
+
+          expect(output).to.include('doc: 1');
+          expect(output).to.include('doc: 2');
+          expect(output).not.to.include('Type "it" for more');
         });
       });
 
       context('when the CursorIterationResult is empty', () => {
         it('returns "no cursor"', () => {
           const output = stripAnsiColors(format({
-            value: [],
+            value: Object.assign([], { cursorHasMore: false }),
             type: 'CursorIterationResult'
           }));
 

--- a/packages/cli-repl/src/format-output.ts
+++ b/packages/cli-repl/src/format-output.ts
@@ -6,7 +6,7 @@ import i18n from '@mongosh/i18n';
 import util from 'util';
 import stripAnsi from 'strip-ansi';
 import clr from './clr';
-import type { HelpProperties } from '@mongosh/shell-api';
+import { HelpProperties } from '@mongosh/shell-api';
 
 type EvaluationResult = {
   value: any;
@@ -172,7 +172,7 @@ function formatCursor(value: any, options: FormatOptions): any {
     return '';
   }
 
-  return inspect(value, options);
+  return formatCursorIterationResult(value, options);
 }
 
 function formatCursorIterationResult(value: any, options: FormatOptions): any {
@@ -180,7 +180,11 @@ function formatCursorIterationResult(value: any, options: FormatOptions): any {
     return i18n.__('shell-api.classes.Cursor.iteration.no-cursor');
   }
 
-  return inspect(value, options);
+  let ret = inspect(value, options);
+  if (value.cursorHasMore) {
+    ret += '\n' + i18n.__('shell-api.classes.Cursor.iteration.type-it-for-more');
+  }
+  return ret;
 }
 
 function formatHelp(value: HelpProperties, options: FormatOptions): string {

--- a/packages/i18n/src/locales/en_US.ts
+++ b/packages/i18n/src/locales/en_US.ts
@@ -211,6 +211,10 @@ const translations: Catalog = {
             },
             pretty: {
               description: 'Deprecated. The shell provides auto-formatting so this method is no longer useful'
+            },
+            batchSize: {
+              description: 'Specifies the number of documents that mongosh displays at once.',
+              example: 'db.collection.aggregate(pipeline, options).batchSize(10)'
             }
           }
         }
@@ -654,6 +658,10 @@ const translations: Catalog = {
             },
             isExhausted: {
               description: 'This method is deprecated because because after closing a cursor, the remaining documents in the batch are no longer accessible. If you want to see if the cursor is closed use cursor.isClosed. If you want to see if there are documents left in the batch, use cursor.tryNext. This is a breaking change'
+            },
+            batchSize: {
+              description: 'Specifies the number of documents that mongosh displays at once.',
+              example: 'db.collection.aggregate(pipeline, options).batchSize(10)'
             }
           }
         }
@@ -677,9 +685,9 @@ const translations: Catalog = {
               example: 'db.collection.find(query, projection).allowPartialResults()'
             },
             batchSize: {
-              link: '',
-              description: 'Specifies the number of documents to return in each batch of the response from the MongoDB instance. In most cases, modifying the batch size will not affect the user or the application, as the mongo shell and most drivers return results as if MongoDB returned a single batch.',
-              example: 'db.collection.find(query, projection).'
+              link: 'https://docs.mongodb.com/manual/reference/method/cursor.batchSize',
+              description: 'Specifies the number of documents to return in each batch of the response from the MongoDB instance. In most cases, modifying the batch size will not affect the user or the application, as the mongo shell and most drivers return results as if MongoDB returned a single batch. This also specifies how many entries mongosh displays at once.',
+              example: 'db.collection.find(query, projection).batchSize(10)'
             },
             close: {
               link: 'https://docs.mongodb.com/manual/reference/method/cursor.close',

--- a/packages/shell-api/src/aggregation-cursor.spec.ts
+++ b/packages/shell-api/src/aggregation-cursor.spec.ts
@@ -214,6 +214,13 @@ describe('AggregationCursor', () => {
         expect(result1).to.not.deep.equal(result3);
         expect(i).to.equal(40);
       });
+
+      it('lets .batchSize() control the output length', async() => {
+        shellApiCursor.batchSize(10);
+        const result = (await toShellResult(shellApiCursor)).printable;
+        expect(i).to.equal(10);
+        expect(result.length).to.equal(10);
+      });
     });
   });
 });

--- a/packages/shell-api/src/aggregation-cursor.ts
+++ b/packages/shell-api/src/aggregation-cursor.ts
@@ -124,7 +124,6 @@ export default class AggregationCursor extends ShellApiClass {
   @returnType('AggregationCursor')
   batchSize(size: number): AggregationCursor {
     this._batchSize = size;
-    this._cursor.batchSize(size);
     return this;
   }
 }

--- a/packages/shell-api/src/aggregation-cursor.ts
+++ b/packages/shell-api/src/aggregation-cursor.ts
@@ -124,6 +124,7 @@ export default class AggregationCursor extends ShellApiClass {
   @returnType('AggregationCursor')
   batchSize(size: number): AggregationCursor {
     this._batchSize = size;
+    this._cursor.batchSize(size);
     return this;
   }
 }

--- a/packages/shell-api/src/change-stream-cursor.spec.ts
+++ b/packages/shell-api/src/change-stream-cursor.spec.ts
@@ -94,6 +94,16 @@ describe('ChangeStreamCursor', () => {
       expect(spCursor.next.calledWith()).to.equal(true);
       expect(warnSpy.calledOnce).to.equal(true);
     });
+    it('lets .batchSize() control iteration batch size', async() => {
+      const cursor2 = new ChangeStreamCursor({
+        tryNext: sinon.stub().resolves({ doc: 1 })
+      } as any, 'source', {
+        _internalState: {}
+      } as Mongo);
+      cursor2.batchSize(3);
+      const results = await cursor2._it();
+      expect(results).to.deep.equal([{ doc: 1 }, { doc: 1 }, { doc: 1 }]);
+    });
   });
   describe('integration', () => {
     const [ srv0 ] = startTestCluster(['--replicaset'] );

--- a/packages/shell-api/src/change-stream-cursor.ts
+++ b/packages/shell-api/src/change-stream-cursor.ts
@@ -11,7 +11,7 @@ import {
   ResumeToken
 } from '@mongosh/service-provider-core';
 import { CursorIterationResult } from './result';
-import { asPrintable } from './enums';
+import { asPrintable, DEFAULT_BATCH_SIZE } from './enums';
 import {
   MongoshInvalidInputError,
   MongoshRuntimeError,
@@ -28,6 +28,8 @@ export default class ChangeStreamCursor extends ShellApiClass {
   _cursor: ChangeStream;
   _currentIterationResult: CursorIterationResult | null = null;
   _on: string;
+  _batchSize = DEFAULT_BATCH_SIZE;
+
   constructor(cursor: ChangeStream, on: string, mongo: Mongo) {
     super();
     this._cursor = cursor;
@@ -40,7 +42,7 @@ export default class ChangeStreamCursor extends ShellApiClass {
       throw new MongoshRuntimeError('ChangeStreamCursor is closed');
     }
     const result = this._currentIterationResult = new CursorIterationResult();
-    return iterate(result, this._cursor);
+    return iterate(result, this._cursor, this._batchSize);
   }
 
   /**
@@ -127,6 +129,12 @@ export default class ChangeStreamCursor extends ShellApiClass {
 
   @returnType('ChangeStreamCursor')
   pretty(): ChangeStreamCursor {
+    return this;
+  }
+
+  @returnType('ChangeStreamCursor')
+  batchSize(size: number): ChangeStreamCursor {
+    this._batchSize = size;
     return this;
   }
 }

--- a/packages/shell-api/src/cursor.spec.ts
+++ b/packages/shell-api/src/cursor.spec.ts
@@ -41,7 +41,8 @@ describe('Cursor', () => {
     beforeEach(() => {
       wrappee = {
         map: sinon.spy(),
-        closed: true
+        closed: true,
+        bufferedCount() { return 0; }
       };
       cursor = new Cursor({
         _serviceProvider: { platform: ReplPlatform.CLI }

--- a/packages/shell-api/src/cursor.spec.ts
+++ b/packages/shell-api/src/cursor.spec.ts
@@ -728,6 +728,9 @@ describe('Cursor', () => {
             if (prop === 'tryNext') {
               return async() => ({ key: i++ });
             }
+            if (prop === 'batchSize') {
+              return () => {};
+            }
             return (target as any)[prop];
           }
         });
@@ -743,6 +746,13 @@ describe('Cursor', () => {
         const result3 = (await toShellResult(shellApiCursor)).printable;
         expect(result1).to.not.deep.equal(result3);
         expect(i).to.equal(40);
+      });
+
+      it('lets .batchSize() control the output length', async() => {
+        shellApiCursor.batchSize(10);
+        const result = (await toShellResult(shellApiCursor)).printable;
+        expect(i).to.equal(10);
+        expect(result.length).to.equal(10);
       });
     });
   });

--- a/packages/shell-api/src/cursor.ts
+++ b/packages/shell-api/src/cursor.ts
@@ -11,7 +11,8 @@ import {
 import {
   ServerVersions,
   asPrintable,
-  CURSOR_FLAGS
+  CURSOR_FLAGS,
+  DEFAULT_BATCH_SIZE
 } from './enums';
 import {
   FindCursor as ServiceProviderCursor,
@@ -35,6 +36,7 @@ export default class Cursor extends ShellApiClass {
   _cursor: ServiceProviderCursor;
   _currentIterationResult: CursorIterationResult | null = null;
   _tailable = false;
+  _batchSize = DEFAULT_BATCH_SIZE;
 
   constructor(mongo: Mongo, cursor: ServiceProviderCursor) {
     super();
@@ -51,7 +53,9 @@ export default class Cursor extends ShellApiClass {
 
   async _it(): Promise<CursorIterationResult> {
     const results = this._currentIterationResult = new CursorIterationResult();
-    return iterate(results, this._cursor);
+    await iterate(results, this._cursor, this._batchSize);
+    results.hasMore = !this.isExhausted();
+    return results;
   }
 
   /**
@@ -90,6 +94,7 @@ export default class Cursor extends ShellApiClass {
 
   @returnType('Cursor')
   batchSize(size: number): Cursor {
+    this._batchSize = size;
     this._cursor.batchSize(size);
     return this;
   }

--- a/packages/shell-api/src/enums.ts
+++ b/packages/shell-api/src/enums.ts
@@ -30,3 +30,4 @@ export const asPrintable = Symbol.for('@@mongosh.asPrintable');
 export const namespaceInfo = Symbol.for('@@mongosh.namespaceInfo');
 
 export const ADMIN_DB = 'admin';
+export const DEFAULT_BATCH_SIZE = 20;

--- a/packages/shell-api/src/helpers.ts
+++ b/packages/shell-api/src/helpers.ts
@@ -504,14 +504,18 @@ export function addHiddenDataProperty(target: object, key: string|symbol, value:
   });
 }
 
-export async function iterate(results: CursorIterationResult, cursor: FindCursor | SPAggregationCursor | ChangeStream ): Promise<CursorIterationResult> {
+export async function iterate(
+  results: CursorIterationResult,
+  cursor: FindCursor | SPAggregationCursor | ChangeStream,
+  batchSize: number): Promise<CursorIterationResult> {
   if (cursor.closed) {
     return results;
   }
 
-  for (let i = 0; i < 20; i++) {
+  for (let i = 0; i < batchSize; i++) {
     const doc = await cursor.tryNext();
     if (doc === null) {
+      results.hasMore = false;
       break;
     }
 

--- a/packages/shell-api/src/result.spec.ts
+++ b/packages/shell-api/src/result.spec.ts
@@ -119,7 +119,8 @@ describe('Results', () => {
     });
   });
   describe('CursorIterationResult', () => {
-    const r = new results.CursorIterationResult(1, 2, 3) as ShellApiInterface;
+    const r = new results.CursorIterationResult() as ShellApiInterface;
+    r.push(1, 2, 3);
     it('superclass attributes set', () => {
       expect(r.length).to.equal(3);
     });

--- a/packages/shell-api/src/result.ts
+++ b/packages/shell-api/src/result.ts
@@ -112,9 +112,17 @@ export class DeleteResult extends ShellApiClass {
 @shellApiClassDefault
 export class CursorIterationResult extends Array {
   [shellApiType]: string;
+  hasMore: boolean;
 
-  constructor(...args: any[]) {
-    super(...args);
+  constructor() {
+    super();
+    this.hasMore = true; // filled by iterate() in helpers.ts or the _it() methods
     addHiddenDataProperty(this, shellApiType, 'CursorIterationResult');
+  }
+
+  [asPrintable]() {
+    const ret = [...this];
+    addHiddenDataProperty(ret, 'cursorHasMore', this.hasMore);
+    return ret;
   }
 }


### PR DESCRIPTION
Make the iteration batch size for cursors controllable through
`.batchSize()` (the ticket suggested using `DBQuery.shellBatchSize`
for this, like the old shell did, but we’ve deprecated that and
are already explicitly telling users to use `.batchSize()` instead)
and print `Type "it" for more` in the shell when the current cursor
is iterable.