### PR TITLE
feat(browser-runtime-electron): Allow to interrupt vm on sigint COMPASS-4513

### DIFF
--- a/packages/browser-runtime-electron/src/electron-interpreter-environment.ts
+++ b/packages/browser-runtime-electron/src/electron-interpreter-environment.ts
@@ -14,7 +14,7 @@ export class ElectronInterpreterEnvironment implements InterpreterEnvironment {
   }
 
   sloppyEval(code: string): ContextValue {
-    return vm.runInContext(code, this.context);
+    return vm.runInContext(code, this.context, { breakOnSigint: true });
   }
 
   getContextObject(): ContextValue {


### PR DESCRIPTION
`breakOnSigint` defaults to `true` in modern node version but is defaults to `false` in the older ones. This PR explicitly allows to interrupt vm for consistency