### PR TITLE
fix(service-provider-server): Specify types export in the package.json

### DIFF
--- a/packages/service-provider-server/package.json
+++ b/packages/service-provider-server/package.json
@@ -3,6 +3,7 @@
   "version": "0.6.1",
   "description": "MongoDB Shell Server Service Provider Package",
   "main": "lib/index.js",
+  "types": "lib/index.d.ts",
   "config": {
     "unsafe-perm": true
   },


### PR DESCRIPTION
Seems like typescript is not always able to pick up types of this package correctly without `types` being specified in `package.json`