### PR TITLE
feat(autocomplete): autocomplete collection names MONGOSH-335

### DIFF
--- a/packages/autocomplete/index.spec.ts
+++ b/packages/autocomplete/index.spec.ts
@@ -44,26 +44,26 @@ const noParams = {
 
 describe('completer.completer', () => {
   context('when context is top level shell api', () => {
-    it('matches shell completions', () => {
+    it('matches shell completions', async() => {
       const i = 'u';
-      expect(completer(standalone440, i)).to.deep.equal([['use'], i]);
+      expect(await completer(standalone440, i)).to.deep.equal([['use'], i]);
     });
 
-    it('does not have a match', () => {
+    it('does not have a match', async() => {
       const i = 'ad';
-      expect(completer(standalone440, i)).to.deep.equal([[], i]);
+      expect(await completer(standalone440, i)).to.deep.equal([[], i]);
     });
 
-    it('is an exact match to one of shell completions', () => {
+    it('is an exact match to one of shell completions', async() => {
       const i = 'use';
-      expect(completer(standalone440, i)).to.deep.equal([[i], i]);
+      expect(await completer(standalone440, i)).to.deep.equal([[i], i]);
     });
   });
 
   context('when no version is passed to completer', () => {
-    it('matches all db completions', () => {
+    it('matches all db completions', async() => {
       const i = 'db.';
-      const c = completer(noParams, i);
+      const c = await completer(noParams, i);
       expect(c.length).to.equal(2);
       expect(c[1]).to.equal(i);
       expect(c[0]).to.include.members([
@@ -103,16 +103,16 @@ describe('completer.completer', () => {
       ]);
     });
 
-    it('does not have a match', () => {
+    it('does not have a match', async() => {
       const i = 'db.shipwrecks.aggregate([ { $so';
-      expect(completer(noParams, i)).to.deep.equal([
+      expect(await completer(noParams, i)).to.deep.equal([
         ['db.shipwrecks.aggregate([ { $sort',
           'db.shipwrecks.aggregate([ { $sortByCount'], i]);
     });
 
-    it('is an exact match to one of shell completions', () => {
+    it('is an exact match to one of shell completions', async() => {
       const i = 'db.bios.find({ field: { $exis';
-      expect(completer(noParams, i))
+      expect(await completer(noParams, i))
         .to.deep.equal([['db.bios.find({ field: { $exists'], i]);
     });
   });
@@ -137,23 +137,23 @@ describe('completer.completer', () => {
       BASE_COMPLETIONS.splice(0, BASE_COMPLETIONS.length, ...origBaseCompletions);
     });
 
-    it('includes them when not connected', () => {
+    it('includes them when not connected', async() => {
       const i = 'db.shipwrecks.aggregate([ { $sq';
-      expect(completer(noParams, i)).to.deep.equal([
+      expect(await completer(noParams, i)).to.deep.equal([
         ['db.shipwrecks.aggregate([ { $sqrt',
           'db.shipwrecks.aggregate([ { $sql'], i]);
     });
 
-    it('includes them when connected to DataLake', () => {
+    it('includes them when connected to DataLake', async() => {
       const i = 'db.shipwrecks.aggregate([ { $sq';
-      expect(completer(datalake440, i)).to.deep.equal([
+      expect(await completer(datalake440, i)).to.deep.equal([
         ['db.shipwrecks.aggregate([ { $sqrt',
           'db.shipwrecks.aggregate([ { $sql'], i]);
     });
 
-    it('does not include them when connected to a standalone node', () => {
+    it('does not include them when connected to a standalone node', async() => {
       const i = 'db.shipwrecks.aggregate([ { $sq';
-      expect(completer(standalone440, i)).to.deep.equal([
+      expect(await completer(standalone440, i)).to.deep.equal([
         ['db.shipwrecks.aggregate([ { $sqrt'], i]);
     });
   });
@@ -162,21 +162,21 @@ describe('completer.completer', () => {
     // this should eventually encompass tests for DATABASE commands and
     // COLLECTION names.
     // for now, this will only return the current input.
-    it('matches a database command', () => {
+    it('matches a database command', async() => {
       const i = 'db.agg';
-      expect(completer(standalone440, i)).to.deep.equal([['db.aggregate'], i]);
+      expect(await completer(standalone440, i)).to.deep.equal([['db.aggregate'], i]);
     });
 
-    it('returns all suggestions', () => {
+    it('returns all suggestions', async() => {
       const i = 'db.';
       const dbComplete = Object.keys(shellSignatures.Database.attributes as any);
       const adjusted = dbComplete.map(c => `${i}${c}`);
-      expect(completer(noParams, i)).to.deep.equal([adjusted, i]);
+      expect(await completer(noParams, i)).to.deep.equal([adjusted, i]);
     });
 
-    it('matches several suggestions', () => {
+    it('matches several suggestions', async() => {
       const i = 'db.get';
-      expect(completer(standalone440, i)[0]).to.include.members(
+      expect((await completer(standalone440, i))[0]).to.include.members(
         [
           'db.getCollectionNames',
           'db.getCollection',
@@ -185,34 +185,34 @@ describe('completer.completer', () => {
         ]);
     });
 
-    it('returns current input and no suggestions', () => {
+    it('returns current input and no suggestions', async() => {
       const i = 'db.shipw';
-      expect(completer(standalone440, i)).to.deep.equal([[], i]);
+      expect(await completer(standalone440, i)).to.deep.equal([[], i]);
     });
   });
 
   context('when context is collections', () => {
-    it('matches a collection command', () => {
+    it('matches a collection command', async() => {
       const i = 'db.shipwrecks.findAnd';
-      expect(completer(standalone440, i)).to.deep.equal([['db.shipwrecks.findAndModify'], i]);
+      expect(await completer(standalone440, i)).to.deep.equal([['db.shipwrecks.findAndModify'], i]);
     });
 
-    it('matches a collection command if part of an expression', () => {
+    it('matches a collection command if part of an expression', async() => {
       const i = 'var result = db.shipwrecks.findAnd';
-      expect(completer(standalone440, i)).to.deep.equal([['var result = db.shipwrecks.findAndModify'], i]);
+      expect(await completer(standalone440, i)).to.deep.equal([['var result = db.shipwrecks.findAndModify'], i]);
     });
 
-    it('returns all suggestions', () => {
+    it('returns all suggestions', async() => {
       const i = 'db.shipwrecks.';
       const collComplete = Object.keys(shellSignatures.Collection.attributes as any);
       const adjusted = collComplete.filter(c => !['count', 'update', 'remove'].includes(c)).map(c => `${i}${c}`);
 
-      expect(completer(sharded440, i)).to.deep.equal([adjusted, i]);
+      expect(await completer(sharded440, i)).to.deep.equal([adjusted, i]);
     });
 
-    it('matches several collection commands', () => {
+    it('matches several collection commands', async() => {
       const i = 'db.shipwrecks.find';
-      expect(completer(standalone440, i)).to.deep.equal([
+      expect(await completer(standalone440, i)).to.deep.equal([
         [
           'db.shipwrecks.find', 'db.shipwrecks.findAndModify',
           'db.shipwrecks.findOne', 'db.shipwrecks.findOneAndDelete',
@@ -220,35 +220,35 @@ describe('completer.completer', () => {
         ], i]);
     });
 
-    it('does not have a match', () => {
+    it('does not have a match', async() => {
       const i = 'db.shipwrecks.pr';
-      expect(completer(standalone440, i)).to.deep.equal([[], i]);
+      expect(await completer(standalone440, i)).to.deep.equal([[], i]);
     });
   });
 
   context('when context is collections and aggregation cursor', () => {
-    it('matches an aggregation cursor command', () => {
+    it('matches an aggregation cursor command', async() => {
       const i = 'db.shipwrecks.aggregate([{$sort: {feature_type: 1}}]).has';
-      expect(completer(standalone440, i)).to.deep.equal([
+      expect(await completer(standalone440, i)).to.deep.equal([
         ['db.shipwrecks.aggregate([{$sort: {feature_type: 1}}]).hasNext'], i]);
     });
 
-    it('returns all suggestions', () => {
+    it('returns all suggestions', async() => {
       const i = 'db.shipwrecks.aggregate([{$sort: {feature_type: 1}}]).';
       const aggCursorComplete = Object.keys(shellSignatures.AggregationCursor.attributes as any);
       const adjusted = aggCursorComplete.map(c => `${i}${c}`);
 
-      expect(completer(standalone440, i)).to.deep.equal([adjusted, i]);
+      expect(await completer(standalone440, i)).to.deep.equal([adjusted, i]);
     });
 
-    it('does not have a match', () => {
+    it('does not have a match', async() => {
       const i = 'db.shipwrecks.aggregate([{$sort: {feature_type: 1}}]).w';
-      expect(completer(standalone440, i)).to.deep.equal([[], i]);
+      expect(await completer(standalone440, i)).to.deep.equal([[], i]);
     });
 
-    it('has several matches', () => {
+    it('has several matches', async() => {
       const i = 'db.shipwrecks.aggregate([{$sort: {feature_type: 1}}]).i';
-      expect(completer(standalone440, i)).to.deep.equal([
+      expect(await completer(standalone440, i)).to.deep.equal([
         [
           'db.shipwrecks.aggregate([{$sort: {feature_type: 1}}]).isClosed',
           'db.shipwrecks.aggregate([{$sort: {feature_type: 1}}]).isExhausted',
@@ -258,29 +258,29 @@ describe('completer.completer', () => {
   });
 
   context('when context is aggregation query', () => {
-    it('has several matches', () => {
+    it('has several matches', async() => {
       const i = 'db.shipwrecks.aggregate([ { $so';
-      expect(completer(standalone440, i)).to.deep.equal([
+      expect(await completer(standalone440, i)).to.deep.equal([
         ['db.shipwrecks.aggregate([ { $sort',
           'db.shipwrecks.aggregate([ { $sortByCount'], i]);
     });
 
-    it('does not have a match', () => {
+    it('does not have a match', async() => {
       const i = 'db.shipwrecks.aggregate([ { $cat';
-      expect(completer(standalone440, i)).to.deep.equal([[], i]);
+      expect(await completer(standalone440, i)).to.deep.equal([[], i]);
     });
 
-    it('matches an aggregation stage', () => {
+    it('matches an aggregation stage', async() => {
       const i = 'db.shipwrecks.aggregate([ { $proj';
-      expect(completer(standalone440, i)).to.deep.equal([
+      expect(await completer(standalone440, i)).to.deep.equal([
         [ 'db.shipwrecks.aggregate([ { $project' ], i]);
     });
   });
 
   context('when context is a collection query', () => {
-    it('returns all suggestions', () => {
+    it('returns all suggestions', async() => {
       const i = 'db.shipwrecks.find({ ';
-      expect(completer(standalone440, i)[0]).to.include.members(
+      expect((await completer(standalone440, i))[0]).to.include.members(
         [ 'db.shipwrecks.find({ $all',
           'db.shipwrecks.find({ $and',
           'db.shipwrecks.find({ $bitsAllClear',
@@ -328,9 +328,9 @@ describe('completer.completer', () => {
           'db.shipwrecks.find({ RegExp' ]);
     });
 
-    it('has several matches', () => {
+    it('has several matches', async() => {
       const i = 'db.bios.find({ birth: { $g';
-      expect(completer(standalone440, i)).to.deep.equal([
+      expect(await completer(standalone440, i)).to.deep.equal([
         [
           'db.bios.find({ birth: { $geoIntersects',
           'db.bios.find({ birth: { $geoWithin',
@@ -339,26 +339,26 @@ describe('completer.completer', () => {
         ], i]);
     });
 
-    it('does not have a match', () => {
+    it('does not have a match', async() => {
       const i = 'db.bios.find({ field: { $cat';
-      expect(completer(standalone440, i)).to.deep.equal([[], i]);
+      expect(await completer(standalone440, i)).to.deep.equal([[], i]);
     });
 
-    it('matches an aggregation stage', () => {
+    it('matches an aggregation stage', async() => {
       const i = 'db.bios.find({ field: { $exis';
-      expect(completer(standalone440, i)).to.deep.equal([
+      expect(await completer(standalone440, i)).to.deep.equal([
         [ 'db.bios.find({ field: { $exists' ], i]);
     });
   });
 
   context('when context is collections and collection cursor', () => {
-    it('matches a collection cursor command', () => {
+    it('matches a collection cursor command', async() => {
       const i = 'db.shipwrecks.find({feature_type: "Wrecks - Visible"}).for';
-      expect(completer(standalone440, i)).to.deep.equal([
+      expect(await completer(standalone440, i)).to.deep.equal([
         ['db.shipwrecks.find({feature_type: "Wrecks - Visible"}).forEach'], i]);
     });
 
-    it('returns all suggestions running on 4.4.0 version', () => {
+    it('returns all suggestions running on 4.4.0 version', async() => {
       const i = 'db.shipwrecks.find({feature_type: "Wrecks - Visible"}).';
 
       const result = [
@@ -397,10 +397,10 @@ describe('completer.completer', () => {
         'db.shipwrecks.find({feature_type: \"Wrecks - Visible\"}).readConcern',
       ];
 
-      expect(completer(standalone440, i)[0]).to.include.members(result);
+      expect((await completer(standalone440, i))[0]).to.include.members(result);
     });
 
-    it('returns all suggestions matching 3.0.0 version', () => {
+    it('returns all suggestions matching 3.0.0 version', async() => {
       const i = 'db.shipwrecks.find({feature_type: "Wrecks - Visible"}).';
 
       const result = [
@@ -432,17 +432,17 @@ describe('completer.completer', () => {
         'db.shipwrecks.find({feature_type: \"Wrecks - Visible\"}).toArray',
       ];
 
-      expect(completer(standalone300, i)[0]).to.include.members(result);
+      expect((await completer(standalone300, i))[0]).to.include.members(result);
     });
 
-    it('does not have a match', () => {
+    it('does not have a match', async() => {
       const i = 'db.shipwrecks.find({feature_type: "Wrecks - Visible"}).gre';
-      expect(completer(standalone440, i)).to.deep.equal([[], i]);
+      expect(await completer(standalone440, i)).to.deep.equal([[], i]);
     });
 
-    it('has several matches', () => {
+    it('has several matches', async() => {
       const i = 'db.shipwrecks.find({feature_type: "Wrecks - Visible"}).cl';
-      expect(completer(standalone440, i)).to.deep.equal([
+      expect(await completer(standalone440, i)).to.deep.equal([
         [
           'db.shipwrecks.find({feature_type: "Wrecks - Visible"}).close'
         ], i]);

--- a/packages/autocomplete/index.spec.ts
+++ b/packages/autocomplete/index.spec.ts
@@ -3,13 +3,15 @@ import { signatures as shellSignatures, Topologies } from '@mongosh/shell-api';
 
 import { expect } from 'chai';
 
+let collections: string[];
 const standalone440 = {
   topology: () => Topologies.Standalone,
   connectionInfo: () => ({
     is_atlas: false,
     is_data_lake: false,
     server_version: '4.4.0'
-  })
+  }),
+  getCollectionCompletionsForCurrentDb: () => collections
 };
 const sharded440 = {
   topology: () => Topologies.Sharded,
@@ -17,7 +19,8 @@ const sharded440 = {
     is_atlas: false,
     is_data_lake: false,
     server_version: '4.4.0'
-  })
+  }),
+  getCollectionCompletionsForCurrentDb: () => collections
 };
 
 const standalone300 = {
@@ -26,7 +29,8 @@ const standalone300 = {
     is_atlas: false,
     is_data_lake: false,
     server_version: '3.0.0'
-  })
+  }),
+  getCollectionCompletionsForCurrentDb: () => collections
 };
 const datalake440 = {
   topology: () => Topologies.Sharded,
@@ -34,15 +38,21 @@ const datalake440 = {
     is_atlas: true,
     is_data_lake: true,
     server_version: '4.4.0'
-  })
+  }),
+  getCollectionCompletionsForCurrentDb: () => collections
 };
 
 const noParams = {
   topology: () => Topologies.Standalone,
-  connectionInfo: () => undefined
+  connectionInfo: () => undefined,
+  getCollectionCompletionsForCurrentDb: () => collections
 };
 
 describe('completer.completer', () => {
+  beforeEach(() => {
+    collections = [];
+  });
+
   context('when context is top level shell api', () => {
     it('matches shell completions', async() => {
       const i = 'u';
@@ -188,6 +198,12 @@ describe('completer.completer', () => {
     it('returns current input and no suggestions', async() => {
       const i = 'db.shipw';
       expect(await completer(standalone440, i)).to.deep.equal([[], i]);
+    });
+
+    it('includes collection names', async() => {
+      collections = ['shipwrecks'];
+      const i = 'db.shipw';
+      expect(await completer(standalone440, i)).to.deep.equal([['db.shipwrecks'], i]);
     });
   });
 

--- a/packages/autocomplete/index.ts
+++ b/packages/autocomplete/index.ts
@@ -47,7 +47,7 @@ const GROUP = '$group';
  *
  * @returns {array} Matching Completions, Current User Input.
  */
-function completer(params: AutocompleteParameters, line: string): [string[], string] {
+async function completer(params: AutocompleteParameters, line: string): Promise<[string[], string]> {
   const SHELL_COMPLETIONS = shellSignatures.ShellApi.attributes;
   const COLL_COMPLETIONS = shellSignatures.Collection.attributes;
   const DB_COMPLETIONS = shellSignatures.Database.attributes;

--- a/packages/autocomplete/index.ts
+++ b/packages/autocomplete/index.ts
@@ -20,7 +20,8 @@ export interface AutocompleteParameters {
     is_atlas: boolean;
     is_data_lake: boolean;
     server_version: string;
-  };
+  },
+  getCollectionCompletionsForCurrentDb: (collName: string) => string[] | Promise<string[]>;
 }
 
 export const BASE_COMPLETIONS = EXPRESSION_OPERATORS.concat(
@@ -67,6 +68,8 @@ async function completer(params: AutocompleteParameters, line: string): Promise<
     return [hits.length ? hits : [], line];
   } else if (firstLineEl.includes('db') && splitLine.length === 2) {
     const hits = filterShellAPI(params, DB_COMPLETIONS, elToComplete, splitLine);
+    const colls = await params.getCollectionCompletionsForCurrentDb(elToComplete.trim());
+    hits.push(...colls.map(coll => `${splitLine[0]}.${coll}`));
     return [hits.length ? hits : [], line];
   } else if (firstLineEl.includes('db') && splitLine.length > 2) {
     if (splitLine.length > 3) {

--- a/packages/browser-runtime-core/src/autocompleter/shell-api-autocompleter.spec.ts
+++ b/packages/browser-runtime-core/src/autocompleter/shell-api-autocompleter.spec.ts
@@ -8,7 +8,8 @@ const standalone440 = {
     is_atlas: false,
     is_data_lake: false,
     server_version: '4.4.0'
-  })
+  }),
+  getCollectionCompletionsForCurrentDb: () => ['bananas']
 };
 
 describe('Autocompleter', () => {
@@ -32,6 +33,14 @@ describe('Autocompleter', () => {
 
       expect(completions).to.deep.contain({
         completion: 'db.coll1.find'
+      });
+    });
+
+    it('returns collection names value with text after dot', async() => {
+      const completions = await autocompleter.getCompletions('db.b');
+
+      expect(completions).to.deep.contain({
+        completion: 'db.bananas'
       });
     });
   });

--- a/packages/browser-runtime-core/src/autocompleter/shell-api-autocompleter.ts
+++ b/packages/browser-runtime-core/src/autocompleter/shell-api-autocompleter.ts
@@ -1,5 +1,5 @@
 import cliReplCompleter, { AutocompleteParameters } from '@mongosh/autocomplete';
-import { Autocompleter, Completion } from './autocompleter';
+import type { Autocompleter, Completion } from './autocompleter';
 
 export class ShellApiAutocompleter implements Autocompleter {
   private parameters: AutocompleteParameters;
@@ -13,7 +13,7 @@ export class ShellApiAutocompleter implements Autocompleter {
       return [];
     }
 
-    const completions = cliReplCompleter(this.parameters, code);
+    const completions = await cliReplCompleter(this.parameters, code);
 
     if (!completions || !completions.length) {
       return [];

--- a/packages/cli-repl/src/mongosh-repl.ts
+++ b/packages/cli-repl/src/mongosh-repl.ts
@@ -127,6 +127,7 @@ class MongoshNodeRepl implements EvaluationListener {
           (async() => await origReplCompleter(text) || [[]])(),
           (async() => await mongoshCompleter(text))()
         ]);
+        this.bus.emit('mongosh:autocompletion-complete'); // For testing.
         // Remove duplicates, because shell API methods might otherwise show
         // up in both completions.
         const deduped = [...new Set([...replResults, ...mongoshResults])];

--- a/packages/cli-repl/test/repl-helpers.ts
+++ b/packages/cli-repl/test/repl-helpers.ts
@@ -53,6 +53,11 @@ async function waitEval(bus: MongoshBus) {
   await tick();
 }
 
+async function waitCompletion(bus: MongoshBus) {
+  await waitBus(bus, 'mongosh:autocompletion-complete');
+  await tick();
+}
+
 const fakeTTYProps = {
   isTTY: true,
   isRaw: true,
@@ -74,6 +79,7 @@ export {
   tick,
   waitBus,
   waitEval,
+  waitCompletion,
   fakeTTYProps,
   readReplLogfile
 };

--- a/packages/shell-api/src/integration.spec.ts
+++ b/packages/shell-api/src/integration.spec.ts
@@ -1708,12 +1708,22 @@ describe('Shell API (integration)', function() {
     });
 
     describe('getAutocompleteParameters', () => {
+      beforeEach(async() => {
+        // Make sure the collection is present so it is included in autocompletion.
+        await collection.insertOne({});
+        // Make sure 'database' is the current db in the eyes of the internal state object.
+        internalState.setDbFunc(database);
+      });
+
       it('returns information that is meaningful for autocompletion', async() => {
         const params = await internalState.getAutocompleteParameters();
         expect(params.topology()).to.equal(Topologies.Standalone);
         expect(params.connectionInfo().uri).to.equal(await testServer.connectionString());
         expect(params.connectionInfo().is_atlas).to.equal(false);
         expect(params.connectionInfo().is_localhost).to.equal(true);
+        expect(await database._getCollectionNames()).to.deep.equal(['docs']);
+        expect(await params.getCollectionCompletionsForCurrentDb('d')).to.deep.equal(['docs']);
+        expect(await params.getCollectionCompletionsForCurrentDb('e')).to.deep.equal([]);
       });
     });
   });

--- a/packages/shell-api/src/shell-internal-state.spec.ts
+++ b/packages/shell-api/src/shell-internal-state.spec.ts
@@ -46,8 +46,11 @@ describe('ShellInternalState', () => {
       expect(() => run('db = 42')).to.throw("[COMMON-10002] Cannot reassign 'db' to non-Database type");
     });
 
-    it('allows setting db to a db', async() => {
+    it('allows setting db to a db and causes prefetching', async() => {
+      serviceProvider.listCollections
+        .resolves([ { name: 'coll1' }, { name: 'coll2' } ]);
       expect(run('db = db.getSiblingDB("moo"); db.getName()')).to.equal('moo');
+      expect(serviceProvider.listCollections.calledWith('moo', {}, { nameOnly: true })).to.equal(true);
     });
   });
 });

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -64,6 +64,7 @@ export interface MongoshBusEventsMap {
   'mongosh:warn': (ev: ApiWarning) => void;
   'mongosh:closed': () => void; // For testing.
   'mongosh:eval-complete': () => void; // For testing.
+  'mongosh:autocompletion-complete': () => void; // For testing.
 }
 
 export interface MongoshBus {


### PR DESCRIPTION
Also implicitly address MONGOSH-291 by adding a 200ms timeout after
which cached results are used (which may seem either high or low,
so I’m happy to adjust it – see also the comment about that value).
