### PR TITLE
feat: show Atlas Data Lake hint in prompt

### DIFF
--- a/packages/shell-api/src/shell-internal-state.ts
+++ b/packages/shell-api/src/shell-internal-state.ts
@@ -276,8 +276,10 @@ export default class ShellInternalState {
   }
 
   private getDefaultPromptPrefix(): string {
-    if (this.connectionInfo?.extraInfo?.is_enterprise
-      || this.connectionInfo?.buildInfo?.modules?.indexOf('enterprise') >= 0) {
+    const extraConnectionInfo = this.connectionInfo?.extraInfo;
+    if (extraConnectionInfo?.is_data_lake) {
+      return 'Atlas Data Lake ';
+    } else if (extraConnectionInfo?.is_enterprise || this.connectionInfo?.buildInfo?.modules?.indexOf('enterprise') >= 0) {
       return 'Enterprise ';
     }
     return '';


### PR DESCRIPTION
This augments the default shell prompt to show `Atlas Data Lake >` when connected to an ADL. This works like the `Enterprise` prefix.

![image](https://user-images.githubusercontent.com/4354632/104208605-f88bb180-5430-11eb-9be2-ad20c8fdc95e.png)
