### PR TITLE
[java-shell] support dates without separators e.g. ISODate('20121219')

### DIFF
--- a/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/MongoShellEvaluator.kt
+++ b/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/MongoShellEvaluator.kt
@@ -8,7 +8,6 @@ import org.intellij.lang.annotations.Language
 import java.time.LocalDateTime
 import java.time.OffsetDateTime
 import java.time.ZoneOffset
-import java.time.format.DateTimeFormatter
 import java.time.format.DateTimeFormatterBuilder
 import java.time.temporal.ChronoField
 import java.time.temporal.TemporalAccessor
@@ -142,17 +141,27 @@ internal class MongoShellEvaluator(client: MongoClient, private val context: Mon
     }
 }
 
+private val COLON = DateTimeFormatterBuilder().appendLiteral(":").toFormatter()
+private val HYPHEN = DateTimeFormatterBuilder().appendLiteral("-").toFormatter()
+
 /**
  * yyyy-MM-dd['T'HH:mm:ss.SSS['Z'|+HH:MM:ss]]
  */
 private val DATE_FORMATTER = DateTimeFormatterBuilder()
-        .parseCaseInsensitive()
-        .append(DateTimeFormatter.ISO_LOCAL_DATE)
+        .appendValue(ChronoField.YEAR, 4)
+        .appendOptional(HYPHEN)
+        .appendValue(ChronoField.MONTH_OF_YEAR, 2)
+        .appendOptional(HYPHEN)
+        .appendValue(ChronoField.DAY_OF_MONTH, 2)
         .optionalStart()
         .appendLiteral('T')
-        .append(DateTimeFormatter.ISO_LOCAL_TIME)
+        .appendValue(ChronoField.HOUR_OF_DAY, 2)
+        .appendOptional(COLON)
+        .appendValue(ChronoField.MINUTE_OF_HOUR, 2)
         .optionalStart()
+        .appendOptional(COLON)
+        .appendValue(ChronoField.SECOND_OF_MINUTE, 2)
+        .optionalStart()
+        .appendFraction(ChronoField.NANO_OF_SECOND, 0, 9, true)
         .appendOffset("+HH:MM:ss", "Z")
-        .optionalEnd()
-        .optionalEnd()
         .toFormatter()

--- a/packages/java-shell/src/test/resources/literal/ISODate.expected.txt
+++ b/packages/java-shell/src/test/resources/literal/ISODate.expected.txt
@@ -8,3 +8,7 @@ LongResult: 1355875200000
 java.time.format.DateTimeParseException: Text '2012-12-19T14:00:00+14' could not be parsed, unparsed text found at index 19
 DateResult: { "$date" : 1355875200000}
 DateResult: { "$date" : 1355875200000}
+DateResult: { "$date" : 1355875200000}
+DateResult: { "$date" : 1355925905000}
+DateResult: { "$date" : 1355925905000}
+DateResult: { "$date" : 1355925905000}

--- a/packages/java-shell/src/test/resources/literal/ISODate.js
+++ b/packages/java-shell/src/test/resources/literal/ISODate.js
@@ -18,3 +18,11 @@ ISODate('2012-12-19T14:00:00+14')
 ISODate('2012-12-19T14:05:00+14:05')
 // command checkResultClass
 ISODate('2012-12-19T14:05:05+14:05:05')
+// command checkResultClass
+ISODate('20121219')
+// command checkResultClass
+ISODate('20121219T14:05:05')
+// command checkResultClass
+ISODate('20121219T140505')
+// command checkResultClass
+ISODate('2012-12-19T140505')


### PR DESCRIPTION
Issue in JDBC driver: https://github.com/DataGrip/mongo-jdbc-driver/issues/13