### PR TITLE
chore(ci): upload coverage tarball for CI runs

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -146,6 +146,16 @@ functions:
           export NODE_JS_VERSION=${node_js_version}
           source .evergreen/.setup_env
           npm run test-ci
+          tar cvzf coverage.tgz coverage
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/coverage.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/coverage-${build_variant}.tgz
+        bucket: mciuploads
+        permissions: public-read
+        content_type: application/x-gzip
   test_vscode:
     - command: shell.exec
       params:

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -146,6 +146,7 @@ functions:
           export NODE_JS_VERSION=${node_js_version}
           source .evergreen/.setup_env
           npm run test-ci
+          echo "Creating coverage tarball..."
           tar cvzf coverage.tgz coverage
     - command: s3.put
       params:

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -142,7 +142,6 @@ functions:
         working_dir: src
         shell: bash
         script: |
-          set -e
           export NODE_JS_VERSION=${node_js_version}
           source .evergreen/.setup_env
           (npm run test-ci && echo "success" && true) || (echo "failure" && false)

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -142,11 +142,14 @@ functions:
         working_dir: src
         shell: bash
         script: |
+          set -e
+          {
           export NODE_JS_VERSION=${node_js_version}
           source .evergreen/.setup_env
-          (npm run test-ci && echo "success" && true) || (echo "failure" && false)
+          npm run test-ci
           echo "Creating coverage tarball..."
           tar cvzf coverage.tgz coverage
+          }
     - command: s3.put
       params:
         aws_key: ${aws_key}

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -145,7 +145,7 @@ functions:
           set -e
           export NODE_JS_VERSION=${node_js_version}
           source .evergreen/.setup_env
-          npm run test-ci
+          (npm run test-ci && echo "success" && true) || (echo "failure" && false)
           echo "Creating coverage tarball..."
           tar cvzf coverage.tgz coverage
     - command: s3.put


### PR DESCRIPTION
Just realized that this is fairly easy to do, and this might be helpful
for us in figuring out where we could improve test coverage.