### PR TITLE
chore: update FLE API MONGOSH-540

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "posttest": "npm run clear-mlaunch",
     "posttest-ci": "npm run clear-mlaunch -- --killAllMongod",
     "posttest-e2e-ci": "npm run clear-mlaunch -- --killAllMongod",
-    "test": "rimraf .nyc_output && lerna exec --scope @mongosh/shell-api -- nyc --no-clean --cwd ../.. --reporter=none npm run test && npm run report-coverage",
+    "test": "rimraf .nyc_output && lerna exec -- nyc --no-clean --cwd ../.. --reporter=none npm run test && npm run report-coverage",
     "test-ci": "rimraf .nyc_output && lerna exec -- nyc --no-clean --cwd ../.. --reporter=none npm run test-ci && npm run report-coverage",
     "test-ci-nocoverage": "lerna exec -- npm run test-ci",
     "test-e2e": "lerna run --stream test-e2e",

--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "posttest": "npm run clear-mlaunch",
     "posttest-ci": "npm run clear-mlaunch -- --killAllMongod",
     "posttest-e2e-ci": "npm run clear-mlaunch -- --killAllMongod",
-    "test": "rimraf .nyc_output && lerna exec -- nyc --no-clean --cwd ../.. --reporter=none npm run test && npm run report-coverage",
+    "test": "rimraf .nyc_output && lerna exec --scope @mongosh/shell-api -- nyc --no-clean --cwd ../.. --reporter=none npm run test && npm run report-coverage",
     "test-ci": "rimraf .nyc_output && lerna exec -- nyc --no-clean --cwd ../.. --reporter=none npm run test-ci && npm run report-coverage",
     "test-ci-nocoverage": "lerna exec -- npm run test-ci",
     "test-e2e": "lerna run --stream test-e2e",

--- a/packages/cli-repl/src/smoke-tests-fle.ts
+++ b/packages/cli-repl/src/smoke-tests-fle.ts
@@ -26,7 +26,7 @@ use(dbname);
 unencryptedDb = db;
 assert(db.getName() === dbname, 'db name must match');
 
-const local = { key: BinData(0, 'kh4Gv2N8qopZQMQYMEtww/AkPsIrXNmEMxTrs3tUoTQZbZu4msdRUaR8U5fXD7A7QXYHcEvuu4WctJLoT+NvvV3eeIg3MD+K8H9SR794m/safgRHdIfy6PD+rFpvmFbY') };
+const local = { key: Buffer.from('kh4Gv2N8qopZQMQYMEtww/AkPsIrXNmEMxTrs3tUoTQZbZu4msdRUaR8U5fXD7A7QXYHcEvuu4WctJLoT+NvvV3eeIg3MD+K8H9SR794m/safgRHdIfy6PD+rFpvmFbY', 'base64') };
 
 const keyMongo = Mongo(db.getMongo()._uri, {
   keyVaultNamespace: 'encryption.__keyVault',

--- a/packages/service-provider-core/package-lock.json
+++ b/packages/service-provider-core/package-lock.json
@@ -311,9 +311,9 @@
       "integrity": "sha512-HC4ZG98ObbWGM3ikL3VfSvuug3iQVpA2kBob/MxK+mn2PNdVTvR5lShio+Ev1rDqODfq3ePcfO6prfi0agQp8g=="
     },
     "mongodb-client-encryption": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-1.2.0.tgz",
-      "integrity": "sha512-U3xnqrRr7DwHOFp2COFCY/nDeogpdF+PQ5Ea09tjCt/xv0FH33VjZNLe8de2S+eoSl2bzbomRE1W9FJp5idNRw==",
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-1.2.1.tgz",
+      "integrity": "sha512-FdAzufBIOEJqzF7TauWsNiSPhI7Zoumzj9ccUAKviurhenLhdcc3HIXyz7LSGKPqtwl1AlYMVwBWZ0jgja4/gQ==",
       "optional": true,
       "requires": {
         "bindings": "^1.5.0",

--- a/packages/service-provider-core/package-lock.json
+++ b/packages/service-provider-core/package-lock.json
@@ -35,10 +35,51 @@
         "@types/webidl-conversions": "*"
       }
     },
+    "ansi-regex": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "optional": true
+    },
+    "aproba": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/aproba/-/aproba-1.2.0.tgz",
+      "integrity": "sha512-Y9J6ZjXtoYh8RnXVCMOU/ttDmk1aBjunq9vO0ta5x85WDQiQfUF9sIPBITdbiiIVcBo03Hi3jMxigBtsddlXRw==",
+      "optional": true
+    },
+    "are-we-there-yet": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-1.1.5.tgz",
+      "integrity": "sha512-5hYdAkZlcG8tOLujVDTgCT+uPX0VnpAH28gWsLfzpXYm7wP6mp5Q/gYyR7YQ0cKVJcXJnl3j2kpBan13PtQf6w==",
+      "optional": true,
+      "requires": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^2.0.6"
+      }
+    },
     "base64-js": {
       "version": "1.5.1",
       "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
       "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
+    "bindings": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/bindings/-/bindings-1.5.0.tgz",
+      "integrity": "sha512-p2q/t/mhvuOj/UeLlV6566GD/guowlr0hHxClI0W9m7MWYkL1F0hLo+0Aexs9HSPCtR1SXQ0TD3MMKrXZajbiQ==",
+      "optional": true,
+      "requires": {
+        "file-uri-to-path": "1.0.0"
+      }
+    },
+    "bl": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
+      "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
+      "optional": true,
+      "requires": {
+        "readable-stream": "^2.3.5",
+        "safe-buffer": "^5.1.1"
+      }
     },
     "bson": {
       "version": "4.2.2",
@@ -57,15 +98,170 @@
         "ieee754": "^1.1.13"
       }
     },
+    "buffer-alloc": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
+      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
+      "optional": true,
+      "requires": {
+        "buffer-alloc-unsafe": "^1.1.0",
+        "buffer-fill": "^1.0.0"
+      }
+    },
+    "buffer-alloc-unsafe": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
+      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
+      "optional": true
+    },
+    "buffer-fill": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
+      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
+      "optional": true
+    },
+    "chownr": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/chownr/-/chownr-1.1.4.tgz",
+      "integrity": "sha512-jJ0bqzaylmJtVnNgzTeSOs8DPavpbYgEr/b0YL8/2GO3xJEhInFmhKMUnEJQjZumK7KXGFhUy89PrsJWlakBVg==",
+      "optional": true
+    },
+    "code-point-at": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/code-point-at/-/code-point-at-1.1.0.tgz",
+      "integrity": "sha1-DQcLTQQ6W+ozovGkDi7bPZpMz3c=",
+      "optional": true
+    },
+    "console-control-strings": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/console-control-strings/-/console-control-strings-1.1.0.tgz",
+      "integrity": "sha1-PXz0Rk22RG6mRL9LOVB/mFEAjo4=",
+      "optional": true
+    },
+    "core-util-is": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
+      "integrity": "sha1-tf1UIgqivFq1eqtxQMlAdUUDwac=",
+      "optional": true
+    },
+    "decompress-response": {
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
+      "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+      "optional": true,
+      "requires": {
+        "mimic-response": "^1.0.0"
+      }
+    },
+    "deep-extend": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
+      "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
+      "optional": true
+    },
+    "delegates": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delegates/-/delegates-1.0.0.tgz",
+      "integrity": "sha1-hMbhWbgZBP3KWaDvRM2HDTElD5o=",
+      "optional": true
+    },
     "denque": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/denque/-/denque-1.5.0.tgz",
       "integrity": "sha512-CYiCSgIF1p6EUByQPlGkKnP1M9g0ZV3qMIrqMqZqdwazygIA/YP2vrbcyl1h/WppKJTdl1F85cXIle+394iDAQ=="
     },
+    "detect-libc": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-1.0.3.tgz",
+      "integrity": "sha1-+hN8S9aY7fVc1c0CrFWfkaTEups=",
+      "optional": true
+    },
+    "end-of-stream": {
+      "version": "1.4.4",
+      "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.4.tgz",
+      "integrity": "sha512-+uw1inIHVPQoaVuHzRyXd21icM+cnt4CzD5rW+NC1wjOUSTOs+Te7FOv7AhN7vS9x/oIyhLP5PR1H+phQAHu5Q==",
+      "optional": true,
+      "requires": {
+        "once": "^1.4.0"
+      }
+    },
+    "expand-template": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
+      "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
+      "optional": true
+    },
+    "file-uri-to-path": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/file-uri-to-path/-/file-uri-to-path-1.0.0.tgz",
+      "integrity": "sha512-0Zt+s3L7Vf1biwWZ29aARiVYLx7iMGnEUl9x33fbB/j3jR81u/O2LbqK+Bm1CDSNDKVtJ/YjwY7TUd5SkeLQLw==",
+      "optional": true
+    },
+    "fs-constants": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs-constants/-/fs-constants-1.0.0.tgz",
+      "integrity": "sha512-y6OAwoSIf7FyjMIv94u+b5rdheZEjzR63GTyZJm5qh4Bi+2YgwLCcI/fPFZkL5PSixOt6ZNKm+w+Hfp/Bciwow==",
+      "optional": true
+    },
+    "gauge": {
+      "version": "2.7.4",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-2.7.4.tgz",
+      "integrity": "sha1-LANAXHU4w51+s3sxcCLjJfsBi/c=",
+      "optional": true,
+      "requires": {
+        "aproba": "^1.0.3",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.0",
+        "object-assign": "^4.1.0",
+        "signal-exit": "^3.0.0",
+        "string-width": "^1.0.1",
+        "strip-ansi": "^3.0.1",
+        "wide-align": "^1.1.0"
+      }
+    },
+    "github-from-package": {
+      "version": "0.0.0",
+      "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
+      "integrity": "sha1-l/tdlr/eiXMxPyDoKI75oWf6ZM4=",
+      "optional": true
+    },
+    "has-unicode": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/has-unicode/-/has-unicode-2.0.1.tgz",
+      "integrity": "sha1-4Ob+aijPUROIVeCG0Wkedx3iqLk=",
+      "optional": true
+    },
     "ieee754": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
       "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "optional": true
+    },
+    "ini": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/ini/-/ini-1.3.8.tgz",
+      "integrity": "sha512-JV/yugV2uzW5iMRSiZAyDtQd+nxtUnjeLt0acNdw98kKLrvuRVyB80tsREOE7yvGVgalhZ6RNXCmEHkUKBKxew==",
+      "optional": true
+    },
+    "is-fullwidth-code-point": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
+      "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
+      "optional": true,
+      "requires": {
+        "number-is-nan": "^1.0.0"
+      }
+    },
+    "isarray": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
+      "integrity": "sha1-u5NdSFgsuhaMBoNJV6VKPgcSTxE=",
+      "optional": true
     },
     "lodash.sortby": {
       "version": "4.7.0",
@@ -77,6 +273,27 @@
       "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
       "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
       "optional": true
+    },
+    "mimic-response": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
+      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "optional": true
+    },
+    "minimist": {
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+      "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
+      "optional": true
+    },
+    "mkdirp": {
+      "version": "0.5.5",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
+      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
+      "optional": true,
+      "requires": {
+        "minimist": "^1.2.5"
+      }
     },
     "mongodb": {
       "version": "4.0.0-beta.1",
@@ -93,10 +310,169 @@
       "resolved": "https://registry.npmjs.org/mongodb-build-info/-/mongodb-build-info-1.1.1.tgz",
       "integrity": "sha512-HC4ZG98ObbWGM3ikL3VfSvuug3iQVpA2kBob/MxK+mn2PNdVTvR5lShio+Ev1rDqODfq3ePcfO6prfi0agQp8g=="
     },
+    "mongodb-client-encryption": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-1.2.0.tgz",
+      "integrity": "sha512-U3xnqrRr7DwHOFp2COFCY/nDeogpdF+PQ5Ea09tjCt/xv0FH33VjZNLe8de2S+eoSl2bzbomRE1W9FJp5idNRw==",
+      "optional": true,
+      "requires": {
+        "bindings": "^1.5.0",
+        "bl": "^2.2.1",
+        "nan": "^2.14.0",
+        "prebuild-install": "5.3.0"
+      }
+    },
+    "nan": {
+      "version": "2.14.2",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.14.2.tgz",
+      "integrity": "sha512-M2ufzIiINKCuDfBSAUr1vWQ+vuVcA9kqx8JJUsbQi6yf1uGRyb7HfpdfUr5qLXf3B/t8dPvcjhKMmlfnP47EzQ==",
+      "optional": true
+    },
+    "napi-build-utils": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
+      "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==",
+      "optional": true
+    },
+    "node-abi": {
+      "version": "2.19.3",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.19.3.tgz",
+      "integrity": "sha512-9xZrlyfvKhWme2EXFKQhZRp1yNWT/uI1luYPr3sFl+H4keYY4xR+1jO7mvTTijIsHf1M+QDe9uWuKeEpLInIlg==",
+      "optional": true,
+      "requires": {
+        "semver": "^5.4.1"
+      }
+    },
+    "noop-logger": {
+      "version": "0.1.1",
+      "resolved": "https://registry.npmjs.org/noop-logger/-/noop-logger-0.1.1.tgz",
+      "integrity": "sha1-lKKxYzxPExdVMAfYlm/Q6EG2pMI=",
+      "optional": true
+    },
+    "npmlog": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-4.1.2.tgz",
+      "integrity": "sha512-2uUqazuKlTaSI/dC8AzicUck7+IrEaOnN/e0jd3Xtt1KcGpwx30v50mL7oPyr/h9bL3E4aZccVwpwP+5W9Vjkg==",
+      "optional": true,
+      "requires": {
+        "are-we-there-yet": "~1.1.2",
+        "console-control-strings": "~1.1.0",
+        "gauge": "~2.7.3",
+        "set-blocking": "~2.0.0"
+      }
+    },
+    "number-is-nan": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/number-is-nan/-/number-is-nan-1.0.1.tgz",
+      "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
+      "optional": true
+    },
+    "object-assign": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
+      "integrity": "sha1-IQmtx5ZYh8/AXLvUQsrIv7s2CGM=",
+      "optional": true
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "optional": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "os-homedir": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
+      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
+      "optional": true
+    },
+    "prebuild-install": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.0.tgz",
+      "integrity": "sha512-aaLVANlj4HgZweKttFNUVNRxDukytuIuxeK2boIMHjagNJCiVKWFsKF4tCE3ql3GbrD2tExPQ7/pwtEJcHNZeg==",
+      "optional": true,
+      "requires": {
+        "detect-libc": "^1.0.3",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.0",
+        "mkdirp": "^0.5.1",
+        "napi-build-utils": "^1.0.1",
+        "node-abi": "^2.7.0",
+        "noop-logger": "^0.1.1",
+        "npmlog": "^4.0.1",
+        "os-homedir": "^1.0.1",
+        "pump": "^2.0.1",
+        "rc": "^1.2.7",
+        "simple-get": "^2.7.0",
+        "tar-fs": "^1.13.0",
+        "tunnel-agent": "^0.6.0",
+        "which-pm-runs": "^1.0.0"
+      }
+    },
+    "process-nextick-args": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
+      "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
+      "optional": true
+    },
+    "pump": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
+      "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+      "optional": true,
+      "requires": {
+        "end-of-stream": "^1.1.0",
+        "once": "^1.3.1"
+      }
+    },
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
       "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+    },
+    "rc": {
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
+      "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
+      "optional": true,
+      "requires": {
+        "deep-extend": "^0.6.0",
+        "ini": "~1.3.0",
+        "minimist": "^1.2.0",
+        "strip-json-comments": "~2.0.1"
+      }
+    },
+    "readable-stream": {
+      "version": "2.3.7",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.7.tgz",
+      "integrity": "sha512-Ebho8K4jIbHAxnuxi7o42OrZgF/ZTNcsZj6nRKyUmkhLFq8CHItp/fy6hQZuZmP/n3yZ9VBUbp4zz/mX8hmYPw==",
+      "optional": true,
+      "requires": {
+        "core-util-is": "~1.0.0",
+        "inherits": "~2.0.3",
+        "isarray": "~1.0.0",
+        "process-nextick-args": "~2.0.0",
+        "safe-buffer": "~5.1.1",
+        "string_decoder": "~1.1.1",
+        "util-deprecate": "~1.0.1"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "optional": true
+        }
+      }
+    },
+    "safe-buffer": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.2.1.tgz",
+      "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==",
+      "optional": true
     },
     "saslprep": {
       "version": "1.0.3",
@@ -105,6 +481,41 @@
       "optional": true,
       "requires": {
         "sparse-bitfield": "^3.0.3"
+      }
+    },
+    "semver": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+      "integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ==",
+      "optional": true
+    },
+    "set-blocking": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/set-blocking/-/set-blocking-2.0.0.tgz",
+      "integrity": "sha1-BF+XgtARrppoA93TgrJDkrPYkPc=",
+      "optional": true
+    },
+    "signal-exit": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
+      "integrity": "sha512-VUJ49FC8U1OxwZLxIbTTrDvLnf/6TDgxZcK8wxR8zs13xpx7xbG60ndBlhNrFi2EMuFRoeDoJO7wthSLq42EjA==",
+      "optional": true
+    },
+    "simple-concat": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
+      "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
+      "optional": true
+    },
+    "simple-get": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
+      "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
+      "optional": true,
+      "requires": {
+        "decompress-response": "^3.3.0",
+        "once": "^1.3.1",
+        "simple-concat": "^1.0.0"
       }
     },
     "sparse-bitfield": {
@@ -116,6 +527,106 @@
         "memory-pager": "^1.0.2"
       }
     },
+    "string-width": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
+      "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
+      "optional": true,
+      "requires": {
+        "code-point-at": "^1.0.0",
+        "is-fullwidth-code-point": "^1.0.0",
+        "strip-ansi": "^3.0.0"
+      }
+    },
+    "string_decoder": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
+      "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
+      "optional": true,
+      "requires": {
+        "safe-buffer": "~5.1.0"
+      },
+      "dependencies": {
+        "safe-buffer": {
+          "version": "5.1.2",
+          "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+          "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
+          "optional": true
+        }
+      }
+    },
+    "strip-ansi": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
+      "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+      "optional": true,
+      "requires": {
+        "ansi-regex": "^2.0.0"
+      }
+    },
+    "strip-json-comments": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
+      "integrity": "sha1-PFMZQukIwml8DsNEhYwobHygpgo=",
+      "optional": true
+    },
+    "tar-fs": {
+      "version": "1.16.3",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.3.tgz",
+      "integrity": "sha512-NvCeXpYx7OsmOh8zIOP/ebG55zZmxLE0etfWRbWok+q2Qo8x/vOR/IJT1taADXPe+jsiu9axDb3X4B+iIgNlKw==",
+      "optional": true,
+      "requires": {
+        "chownr": "^1.0.1",
+        "mkdirp": "^0.5.1",
+        "pump": "^1.0.0",
+        "tar-stream": "^1.1.2"
+      },
+      "dependencies": {
+        "pump": {
+          "version": "1.0.3",
+          "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
+          "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
+          "optional": true,
+          "requires": {
+            "end-of-stream": "^1.1.0",
+            "once": "^1.3.1"
+          }
+        }
+      }
+    },
+    "tar-stream": {
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
+      "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
+      "optional": true,
+      "requires": {
+        "bl": "^1.0.0",
+        "buffer-alloc": "^1.2.0",
+        "end-of-stream": "^1.0.0",
+        "fs-constants": "^1.0.0",
+        "readable-stream": "^2.3.0",
+        "to-buffer": "^1.1.1",
+        "xtend": "^4.0.0"
+      },
+      "dependencies": {
+        "bl": {
+          "version": "1.2.3",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
+          "integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
+          "optional": true,
+          "requires": {
+            "readable-stream": "^2.3.5",
+            "safe-buffer": "^5.1.1"
+          }
+        }
+      }
+    },
+    "to-buffer": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
+      "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
+      "optional": true
+    },
     "tr46": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.0.2.tgz",
@@ -123,6 +634,21 @@
       "requires": {
         "punycode": "^2.1.1"
       }
+    },
+    "tunnel-agent": {
+      "version": "0.6.0",
+      "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
+      "integrity": "sha1-J6XeoGs2sEoKmWZ3SykIaPD8QP0=",
+      "optional": true,
+      "requires": {
+        "safe-buffer": "^5.0.1"
+      }
+    },
+    "util-deprecate": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
+      "integrity": "sha1-RQ1Nyfpw3nMnYvvS1KKJgUGaDM8=",
+      "optional": true
     },
     "webidl-conversions": {
       "version": "6.1.0",
@@ -138,6 +664,33 @@
         "tr46": "^2.0.2",
         "webidl-conversions": "^6.1.0"
       }
+    },
+    "which-pm-runs": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/which-pm-runs/-/which-pm-runs-1.0.0.tgz",
+      "integrity": "sha1-Zws6+8VS4LVd9rd4DKdGFfI60cs=",
+      "optional": true
+    },
+    "wide-align": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/wide-align/-/wide-align-1.1.3.tgz",
+      "integrity": "sha512-QGkOQc8XL6Bt5PwnsExKBPuMKBxnGxWWW3fU55Xt4feHozMUhdUMaBCk290qpm/wG5u/RSKzwdAC4i51YigihA==",
+      "optional": true,
+      "requires": {
+        "string-width": "^1.0.2 || 2"
+      }
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "optional": true
+    },
+    "xtend": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
+      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "optional": true
     }
   }
 }

--- a/packages/service-provider-core/package.json
+++ b/packages/service-provider-core/package.json
@@ -39,7 +39,7 @@
     "@types/whatwg-url": "^8.0.0"
   },
   "optionalDependencies": {
-    "mongodb-client-encryption": "^1.1.0"
+    "mongodb-client-encryption": "^1.2.1"
   },
   "dependency-check": {
     "entries": [

--- a/packages/service-provider-core/package.json
+++ b/packages/service-provider-core/package.json
@@ -38,6 +38,9 @@
     "@types/bl": "^2.1.0",
     "@types/whatwg-url": "^8.0.0"
   },
+  "optionalDependencies": {
+    "mongodb-client-encryption": "^1.1.0"
+  },
   "dependency-check": {
     "entries": [
       "src/**/*.js"

--- a/packages/service-provider-core/src/admin.ts
+++ b/packages/service-provider-core/src/admin.ts
@@ -13,6 +13,7 @@ import type {
 } from './all-transport-types';
 import type { bson as BSON } from './index';
 import { ReplPlatform } from './platform';
+import { FLE } from './all-fle-types';
 
 
 export default interface Admin {
@@ -105,5 +106,8 @@ export default interface Admin {
    */
   getRawClient(): any;
 
-  fle: any; // TODO: NODE-2989 Types for libmongoc
+  /**
+   * The FLE implementation for access to the client-side encryption API.
+   */
+  fle?: FLE | undefined;
 }

--- a/packages/service-provider-core/src/all-fle-types.ts
+++ b/packages/service-provider-core/src/all-fle-types.ts
@@ -1,0 +1,16 @@
+export type {
+  AWSEncryptionKeyOptions,
+  AzureEncryptionKeyOptions,
+  GCPEncryptionKeyOptions,
+  ClientEncryption,
+  ClientEncryptionCreateDataKeyCallback,
+  ClientEncryptionCreateDataKeyProviderOptions,
+  ClientEncryptionDataKeyProvider,
+  ClientEncryptionDecryptCallback,
+  ClientEncryptionEncryptCallback,
+  ClientEncryptionEncryptOptions,
+  ClientEncryptionOptions,
+  KMSProviders
+} from 'mongodb-client-encryption';
+
+export type FLE = typeof import('mongodb-client-encryption');

--- a/packages/service-provider-core/src/index.ts
+++ b/packages/service-provider-core/src/index.ts
@@ -24,6 +24,7 @@ import { bsonStringifiers } from './printable-bson';
 import ShellAuthOptions from './shell-auth-options';
 import { ConnectionString } from './connection-string';
 export * from './all-transport-types';
+export * from './all-fle-types';
 
 const bson = {
   ObjectId,

--- a/packages/service-provider-server/src/cli-service-provider.ts
+++ b/packages/service-provider-server/src/cli-service-provider.ts
@@ -73,7 +73,8 @@ import {
   ChangeStreamOptions,
   ChangeStream,
   bson as BSON,
-  ConnectionString
+  ConnectionString,
+  FLE
 } from '@mongosh/service-provider-core';
 
 import { MongoshCommandFailed, MongoshInternalError, MongoshRuntimeError } from '@mongosh/errors';
@@ -195,7 +196,7 @@ class CliServiceProvider extends ServiceProviderCore implements ServiceProvider 
   private currentClientOptions: MongoClientOptions;
   private dbcache: WeakMap<MongoClient, Map<string, Db>>;
   public baseCmdOptions: OperationOptions; // public for testing
-  public fle: any;
+  public fle: FLE | undefined;
 
   /**
    * Instantiate a new CliServiceProvider with the Node driver's connected

--- a/packages/shell-api/src/field-level-encryption.spec.ts
+++ b/packages/shell-api/src/field-level-encryption.spec.ts
@@ -1,10 +1,10 @@
 import { signatures, toShellResult } from './decorators';
 import { ALL_PLATFORMS, ALL_SERVER_VERSIONS, ALL_TOPOLOGIES } from './enums';
-import { KeyVault, ClientEncryption } from './field-level-encryption';
+import { KeyVault, ClientEncryption, ClientSideFieldLevelEncryptionOptions } from './field-level-encryption';
 import Mongo from './mongo';
 import { expect } from 'chai';
 import sinon, { StubbedInstance, stubInterface } from 'ts-sinon';
-import { ServiceProvider, bson, BinaryType } from '@mongosh/service-provider-core';
+import { ServiceProvider, bson, ClientEncryption as FLEClientEncryption } from '@mongosh/service-provider-core';
 import { EventEmitter } from 'events';
 import ShellInternalState from './shell-internal-state';
 import Database from './database';
@@ -41,29 +41,24 @@ const AWS_KMS = {
 
 const ALGO = 'AEAD_AES_256_CBC_HMAC_SHA_512-Deterministic';
 
-// TODO: see NODE-2989
-interface lmc {
-  encrypt(value: any, options: { keyId: BinaryType, keyAltName: string, algorithm: string }): Promise<void>;
-  decrypt(): Promise<any>;
-  createDataKey(): Promise<any>;
-}
-
 const RAW_CLIENT = { client: 1 } as any;
 
 describe('Field Level Encryption', () => {
   let sp: StubbedInstance<ServiceProvider>;
   let mongo: Mongo;
   let internalState: ShellInternalState;
-  let libmongoc: StubbedInstance<lmc>;
+  let libmongoc: StubbedInstance<FLEClientEncryption>;
   let clientEncryption: ClientEncryption;
   let keyVault: KeyVault;
   let clientEncryptionSpy;
   describe('Metadata', () => {
     before(() => {
-      libmongoc = stubInterface<lmc>();
+      libmongoc = stubInterface<FLEClientEncryption>();
       sp = stubInterface<ServiceProvider>();
       sp.bsonLibrary = bson;
-      sp.fle = { ClientEncryption: function() { return libmongoc; } };
+      sp.fle = {
+        ClientEncryption: function() { return libmongoc; }
+      } as any;
       sp.initialDb = 'test';
       internalState = new ShellInternalState(sp, stubInterface<EventEmitter>());
       internalState.currentDb = stubInterface<Database>();
@@ -119,7 +114,7 @@ describe('Field Level Encryption', () => {
   describe('commands', () => {
     beforeEach(() => {
       clientEncryptionSpy = sinon.spy();
-      libmongoc = stubInterface<lmc>();
+      libmongoc = stubInterface<FLEClientEncryption>();
       sp = stubInterface<ServiceProvider>();
       sp.getRawClient.returns(RAW_CLIENT);
       sp.bsonLibrary = bson;
@@ -128,7 +123,7 @@ describe('Field Level Encryption', () => {
           clientEncryptionSpy(...args);
           return libmongoc;
         }
-      };
+      } as any;
       sp.initialDb = 'test';
       internalState = new ShellInternalState(sp, stubInterface<EventEmitter>());
       internalState.currentDb = stubInterface<Database>();
@@ -189,26 +184,27 @@ describe('Field Level Encryption', () => {
         const kms = 'local';
         libmongoc.createDataKey.resolves(raw);
         const result = await keyVault.createKey('local');
-        expect(libmongoc.createDataKey).calledOnceWithExactly(kms, { masterKey: undefined });
+        expect(libmongoc.createDataKey).calledOnceWithExactly(kms, undefined);
         expect(result).to.deep.equal(raw);
       });
       it('calls createDataKey on libmongoc with doc key', async() => {
         const raw = { result: 1 };
-        const kms = AWS_KMS.kmsProvider;
         const masterKey = { region: 'us-east-1', key: 'masterkey' };
-        const keyaltname = ['keyaltname'];
+        const keyAltNames = ['keyaltname'];
         libmongoc.createDataKey.resolves(raw);
-        const result = await keyVault.createKey(kms, masterKey, keyaltname);
-        expect(libmongoc.createDataKey).calledOnceWithExactly(kms, { masterKey, keyAltNames: keyaltname });
+        const result = await keyVault.createKey('aws', {
+          masterKey,
+          keyAltNames
+        });
+        expect(libmongoc.createDataKey).calledOnceWithExactly('aws', { masterKey, keyAltNames });
         expect(result).to.deep.equal(raw);
       });
       it('throw if failed', async() => {
-        const kms = AWS_KMS.kmsProvider;
         const masterKey = { region: 'us-east-1', key: 'masterkey' };
-        const keyaltname = ['keyaltname'];
+        const keyAltNames = ['keyaltname'];
         const expectedError = new Error();
         libmongoc.createDataKey.rejects(expectedError);
-        const caughtError = await keyVault.createKey(kms, masterKey, keyaltname)
+        const caughtError = await keyVault.createKey('aws', { masterKey, keyAltNames })
           .catch(e => e);
         expect(caughtError).to.equal(expectedError);
       });
@@ -311,20 +307,20 @@ describe('Field Level Encryption', () => {
   });
   describe('Mongo constructor FLE options', () => {
     before(() => {
-      libmongoc = stubInterface<lmc>();
+      libmongoc = stubInterface<FLEClientEncryption>();
       sp = stubInterface<ServiceProvider>();
       sp.bsonLibrary = bson;
-      sp.fle = { ClientEncryption: function() { return libmongoc; } };
+      sp.fle = { ClientEncryption: function() { return libmongoc; } } as any;
       sp.initialDb = 'test';
       internalState = new ShellInternalState(sp, stubInterface<EventEmitter>());
       internalState.currentDb = stubInterface<Database>();
     });
     it('accepts the same local key twice', () => {
-      const localKmsOptions = {
+      const localKmsOptions: ClientSideFieldLevelEncryptionOptions = {
         keyVaultNamespace: `${DB}.${COLL}`,
         kmsProvider: {
           local: {
-            key: new bson.Binary(Buffer.alloc(96).toString('base64'))
+            key: Buffer.alloc(96).toString('base64')
           }
         },
         schemaMap: SCHEMA_MAP,

--- a/packages/shell-api/src/field-level-encryption.spec.ts
+++ b/packages/shell-api/src/field-level-encryption.spec.ts
@@ -1,3 +1,4 @@
+import { CommonErrors } from '@mongosh/errors';
 import { signatures, toShellResult } from './decorators';
 import { ALL_PLATFORMS, ALL_SERVER_VERSIONS, ALL_TOPOLOGIES } from './enums';
 import { KeyVault, ClientEncryption, ClientSideFieldLevelEncryptionOptions } from './field-level-encryption';
@@ -207,6 +208,16 @@ describe('Field Level Encryption', () => {
         const caughtError = await keyVault.createKey('aws', { masterKey, keyAltNames })
           .catch(e => e);
         expect(caughtError).to.equal(expectedError);
+      });
+      it('fails if it is handed 3 arguments', async() => {
+        try {
+          await keyVault.createKey('aws', null, ['oldAltNames']);
+        } catch (e) {
+          expect(e.message).to.contain('KeyVault.createKey requires 1 or 2 arguments');
+          expect(e.code).to.equal(CommonErrors.Deprecated);
+          return;
+        }
+        expect.fail('Expected error');
       });
     });
     describe('getKey', () => {

--- a/packages/shell-api/src/field-level-encryption.spec.ts
+++ b/packages/shell-api/src/field-level-encryption.spec.ts
@@ -320,7 +320,7 @@ describe('Field Level Encryption', () => {
         keyVaultNamespace: `${DB}.${COLL}`,
         kmsProvider: {
           local: {
-            key: Buffer.alloc(96).toString('base64')
+            key: new bson.Binary(Buffer.alloc(96).toString('base64'))
           }
         },
         schemaMap: SCHEMA_MAP,

--- a/packages/shell-api/src/field-level-encryption.ts
+++ b/packages/shell-api/src/field-level-encryption.ts
@@ -24,10 +24,16 @@ import { redactPassword } from '@mongosh/history';
 import type Mongo from './mongo';
 import { MongoshInvalidInputError, MongoshRuntimeError } from '@mongosh/errors';
 
+export type ClientSideFieldLevelEncryptionKmsProvider = Omit<KMSProviders, 'local'> & {
+  local?: {
+    key: Buffer | string | BinaryType;
+  }
+};
+
 export interface ClientSideFieldLevelEncryptionOptions {
   keyVaultClient?: Mongo,
   keyVaultNamespace: string,
-  kmsProvider: KMSProviders,
+  kmsProvider: ClientSideFieldLevelEncryptionKmsProvider,
   schemaMap?: Document,
   bypassAutoEncryption?: boolean;
 }

--- a/packages/shell-api/src/helpers.ts
+++ b/packages/shell-api/src/helpers.ts
@@ -618,29 +618,13 @@ export function processFLEOptions(fleOptions: ClientSideFieldLevelEncryptionOpti
       throw new MongoshInvalidInputError(`Unrecognized FLE Client Option ${k}`);
     }
   });
-  const autoEncryption = {
+  const autoEncryption: AutoEncryptionOptions = {
     keyVaultClient: fleOptions.keyVaultClient ?
       fleOptions.keyVaultClient._serviceProvider.getRawClient() :
       serviceProvider.getRawClient(),
     keyVaultNamespace: fleOptions.keyVaultNamespace,
     kmsProviders: { ...fleOptions.kmsProvider },
-  } as any;
-
-  if ('local' in autoEncryption.kmsProviders) {
-    if (autoEncryption.kmsProviders.local.key._bsontype !== 'Binary') {
-      throw new MongoshInvalidInputError('The key attribute of the local kms provider must be a BSON BinData or Binary type');
-    }
-    const rawBuff = autoEncryption.kmsProviders.local.key.value(true);
-    if (Buffer.isBuffer(rawBuff)) {
-      autoEncryption.kmsProviders.local = {
-        ...autoEncryption.kmsProviders.local,
-        key: rawBuff
-      };
-    } else {
-      // Future TODO: allow binary types that are not from a string
-      throw new MongoshInvalidInputError('key field of local kmsProvider must be a BinData type created from a base64 encoded string');
-    }
-  }
+  };
   if (fleOptions.schemaMap) {
     autoEncryption.schemaMap = fleOptions.schemaMap;
   }

--- a/packages/shell-api/src/helpers.ts
+++ b/packages/shell-api/src/helpers.ts
@@ -1,10 +1,4 @@
 /* eslint complexity: 0, no-use-before-define: 0 */
-/**
- * Helper method to adapt aggregation pipeline options.
- * This is here so that it's not visible to the user.
- *
- * @param options
- */
 import type {
   DbOptions,
   Document,
@@ -14,7 +8,8 @@ import type {
   FindAndModifyOptions,
   DeleteOptions,
   MapReduceOptions,
-  ChangeStream
+  ChangeStream,
+  KMSProviders
 } from '@mongosh/service-provider-core';
 import { CommonErrors, MongoshInvalidInputError, MongoshUnimplementedError } from '@mongosh/errors';
 import crypto from 'crypto';
@@ -22,10 +17,17 @@ import type Database from './database';
 import type Collection from './collection';
 import { CursorIterationResult } from './result';
 import { ShellApiErrors } from './error-codes';
-import { ReplPlatform, ServiceProvider } from '@mongosh/service-provider-core';
+import { BinaryType, ReplPlatform, ServiceProvider } from '@mongosh/service-provider-core';
 import { ClientSideFieldLevelEncryptionOptions } from './field-level-encryption';
 import { AutoEncryptionOptions } from 'mongodb';
 
+
+/**
+ * Helper method to adapt aggregation pipeline options.
+ * This is here so that it's not visible to the user.
+ *
+ * @param options
+ */
 export function adaptAggregateOptions(options: any = {}): {
   aggOptions: Document;
   dbOptions: DbOptions;
@@ -622,9 +624,26 @@ export function processFLEOptions(fleOptions: ClientSideFieldLevelEncryptionOpti
     keyVaultClient: fleOptions.keyVaultClient ?
       fleOptions.keyVaultClient._serviceProvider.getRawClient() :
       serviceProvider.getRawClient(),
-    keyVaultNamespace: fleOptions.keyVaultNamespace,
-    kmsProviders: { ...fleOptions.kmsProvider },
+    keyVaultNamespace: fleOptions.keyVaultNamespace
   };
+
+  const localKey = fleOptions.kmsProvider.local?.key;
+  if (localKey && (localKey as BinaryType)._bsontype === 'Binary') {
+    const rawBuff = (localKey as BinaryType).value(true);
+    if (Buffer.isBuffer(rawBuff)) {
+      autoEncryption.kmsProviders = {
+        ...fleOptions.kmsProvider,
+        local: {
+          key: rawBuff
+        }
+      };
+    } else {
+      throw new MongoshInvalidInputError('When specifying the key of a local KMS as BSON binary it must be constructed from a base64 encoded string');
+    }
+  } else {
+    autoEncryption.kmsProviders = { ...fleOptions.kmsProvider } as KMSProviders;
+  }
+
   if (fleOptions.schemaMap) {
     autoEncryption.schemaMap = fleOptions.schemaMap;
   }

--- a/packages/shell-api/src/shell-api.spec.ts
+++ b/packages/shell-api/src/shell-api.spec.ts
@@ -9,8 +9,6 @@ import Mongo from './mongo';
 import { ReplPlatform, ServiceProvider, bson, MongoClient } from '@mongosh/service-provider-core';
 import { EventEmitter } from 'events';
 import ShellInternalState, { EvaluationListener } from './shell-internal-state';
-import constructShellBson from './shell-bson';
-const shellBson = constructShellBson(bson);
 
 const b641234 = 'MTIzNA==';
 const schemaMap = {
@@ -218,7 +216,7 @@ describe('ShellApi', () => {
             keyVaultNamespace: 'encryption.dataKeys',
             kmsProvider: {
               local: {
-                key: shellBson.BinData(128, b641234)
+                key: Buffer.from(b641234, 'base64')
               }
             }
           });
@@ -257,7 +255,7 @@ describe('ShellApi', () => {
             keyVaultNamespace: 'encryption.dataKeys',
             kmsProvider: {
               local: {
-                key: shellBson.BinData(128, b641234)
+                key: Buffer.from(b641234, 'base64')
               }
             },
             keyVaultClient: mongo
@@ -281,7 +279,7 @@ describe('ShellApi', () => {
             keyVaultNamespace: 'encryption.dataKeys',
             kmsProvider: {
               local: {
-                key: shellBson.BinData(128, b641234)
+                key: Buffer.from(b641234, 'base64')
               }
             },
             keyVaultClient: m
@@ -343,7 +341,7 @@ describe('ShellApi', () => {
             keyVaultNamespace: 'encryption.dataKeys',
             kmsProvider: {
               local: {
-                key: shellBson.BinData(128, b641234)
+                key: Buffer.from(b641234, 'base64')
               }
             },
             schemaMap: schemaMap,


### PR DESCRIPTION
This PR includes the use of the types provided by `mongodb-client-encryption` as well as support of the new Azure and GCP KMS providers.