### PR TITLE
chore(ci): run tests against enterprise server versions

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14137,9 +14137,9 @@
       }
     },
     "mongodb-download-url": {
-      "version": "0.6.2",
-      "resolved": "https://registry.npmjs.org/mongodb-download-url/-/mongodb-download-url-0.6.2.tgz",
-      "integrity": "sha512-YLWy+FD9WUHPCEKwT0Ilsmk3TgcG1mF6AZP/VB2XuTBYMkQ6l62ikG1GjvrSmoxoxED7PxC3pZm7Yb7J/lbM8A==",
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/mongodb-download-url/-/mongodb-download-url-0.6.3.tgz",
+      "integrity": "sha512-H4+2Av9UgFTc4xA/isf99/aYj+R9B4oh6BxAyrHoxq0Cf5KR4VXdvpE2DtoDnpeFIesBqyeM9JmH13mmmWvEWg==",
       "dev": true,
       "requires": {
         "async": "^3.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -14137,9 +14137,9 @@
       }
     },
     "mongodb-download-url": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/mongodb-download-url/-/mongodb-download-url-0.6.1.tgz",
-      "integrity": "sha512-NVVMxgCAcSgd1cBT1qcoCMQMUptHk8BN/Zl9cLWYtuJwZrmkz1b8Njl0I2z6aEj0/yclKb2RZNBauPu4etysrw==",
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/mongodb-download-url/-/mongodb-download-url-0.6.2.tgz",
+      "integrity": "sha512-YLWy+FD9WUHPCEKwT0Ilsmk3TgcG1mF6AZP/VB2XuTBYMkQ6l62ikG1GjvrSmoxoxED7PxC3pZm7Yb7J/lbM8A==",
       "dev": true,
       "requires": {
         "async": "^3.1.0",
@@ -14158,9 +14158,9 @@
           "dev": true
         },
         "debug": {
-          "version": "4.2.0",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.2.0.tgz",
-          "integrity": "sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==",
+          "version": "4.3.1",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+          "integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
           "dev": true,
           "requires": {
             "ms": "2.1.2"

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "lerna": "^3.10.7",
     "mocha": "^7.1.2",
     "mongodb": "github:mongodb/node-mongodb-native#62717a1d",
-    "mongodb-download-url": "^0.6.1",
+    "mongodb-download-url": "^0.6.3",
     "mongodb-js-precommit": "^2.0.0",
     "node-codesign": "^0.3.2",
     "node-fetch": "^2.6.1",

--- a/packages/node-runtime-worker-thread/package.json
+++ b/packages/node-runtime-worker-thread/package.json
@@ -18,9 +18,9 @@
   },
   "scripts": {
     "pretest": "npm run webpack-build-dev -- --no-stats --no-devtool",
-    "test": "cross-env TS_NODE_PROJECT=./tsconfig.test.json mocha --timeout 15000 --colors -r ts-node/register \"./src/**/*.spec.ts\"",
+    "test": "cross-env TS_NODE_PROJECT=./tsconfig.test.json mocha -r \"../../scripts/import-expansions.js\" --timeout 15000 --colors -r ts-node/register \"./src/**/*.spec.ts\"",
     "pretest-ci": "npm run webpack-build -- --no-stats --no-devtool",
-    "test-ci": "cross-env TS_NODE_PROJECT=./tsconfig.test.json mocha --timeout 15000 -r ts-node/register \"./src/**/*.spec.ts\"",
+    "test-ci": "cross-env TS_NODE_PROJECT=./tsconfig.test.json mocha -r \"../../scripts/import-expansions.js\" --timeout 15000 -r ts-node/register \"./src/**/*.spec.ts\"",
     "lint": "eslint \"./src/**/*.{js,ts,tsx}\"",
     "check": "npm run lint",
     "webpack-build": "webpack --mode production",

--- a/testing/download-mongodb.ts
+++ b/testing/download-mongodb.ts
@@ -87,7 +87,7 @@ async function lookupDownloadUrl(versionInfo: VersionInfo, enterprise: boolean):
     downloadInfo = versionInfo.downloads
       .find((downloadInfo: DownloadInfo) =>
         downloadInfo.target === distro &&
-        downloadInfo.edition === (enterprise ? 'targeted' : 'enterprise') &&
+        downloadInfo.edition === (enterprise ? 'enterprise' : 'targeted') &&
         downloadInfo.arch === 'x86_64') as DownloadInfo;
   }
   return downloadInfo.archive.url;

--- a/testing/download-mongodb.ts
+++ b/testing/download-mongodb.ts
@@ -57,27 +57,29 @@ type FullJSON = {
 // On Linux, getting the exact download variant to pick is hard, so we still
 // use mongodb-download-url for that. For macOS, either would probably be fine.
 // TODO: upstream all of this into mongodb-download-url :(
-async function lookupDownloadUrl(versionInfo: VersionInfo): Promise<string> {
-  const knownDistroRegex = /^(?<name>rhel80|rhel7[0-9]|debian10)/;
+async function lookupDownloadUrl(versionInfo: VersionInfo, enterprise: boolean): Promise<string> {
+  const knownDistroRegex = /^(?<name>rhel80|rhel7[0-9]|debian10|ubuntu(?:\d+))/;
   const { version } = versionInfo;
   const distroId = process.env.DISTRO_ID || '';
   if ((process.platform === 'win32' && semver.lt(version, '4.4.0')) ||
       (process.platform === 'linux' && semver.lt(version, '4.2.0')) ||
       (process.platform !== 'win32' && !knownDistroRegex.test(distroId))) {
-    return (await promisify(getDownloadURL)({ version })).url;
+    return (await promisify(getDownloadURL)({ version, enterprise })).url;
   }
 
   let downloadInfo: DownloadInfo;
   if (process.platform === 'win32') {
     downloadInfo = versionInfo.downloads
       .find((downloadInfo: DownloadInfo) =>
-        downloadInfo.target === 'windows' && downloadInfo.edition === 'base') as DownloadInfo;
+        downloadInfo.target === 'windows' &&
+        downloadInfo.edition === (enterprise ? 'enterprise' : 'base')) as DownloadInfo;
   } else {
     let distro = distroId.match(knownDistroRegex)!.groups!.name;
     if (distro.match(/rhel7[0-9]/)) distro = 'rhel70';
     downloadInfo = versionInfo.downloads
       .find((downloadInfo: DownloadInfo) =>
-        downloadInfo.target === distro && downloadInfo.edition === 'targeted') as DownloadInfo;
+        downloadInfo.target === distro &&
+        downloadInfo.edition === (enterprise ? 'targeted' : 'enterprise')) as DownloadInfo;
   }
   return downloadInfo.archive.url;
 }
@@ -116,7 +118,7 @@ export async function downloadMongoDb(targetVersionSemverSpecifier = '*'): Promi
     .filter((info: VersionInfo) => semver.satisfies(info.version, targetVersionSemverSpecifier))
     .sort((a: VersionInfo, b: VersionInfo) => semver.rcompare(a.version, b.version));
   const versionInfo: VersionInfo = productionVersions[0];
-  return await doDownload(versionInfo.version, () => lookupDownloadUrl(versionInfo));
+  return await doDownload(versionInfo.version, () => lookupDownloadUrl(versionInfo, true));
 }
 
 const downloadPromises: Record<string, Promise<string>> = {};

--- a/testing/download-mongodb.ts
+++ b/testing/download-mongodb.ts
@@ -79,14 +79,16 @@ async function lookupDownloadUrl(versionInfo: VersionInfo, enterprise: boolean):
     downloadInfo = versionInfo.downloads
       .find((downloadInfo: DownloadInfo) =>
         downloadInfo.target === 'windows' &&
-        downloadInfo.edition === (enterprise ? 'enterprise' : 'base')) as DownloadInfo;
+        downloadInfo.edition === (enterprise ? 'enterprise' : 'base') &&
+        downloadInfo.arch === 'x86_64') as DownloadInfo;
   } else {
     let distro = distroId.match(knownDistroRegex)!.groups!.name;
     if (distro.match(/rhel7[0-9]/)) distro = 'rhel70';
     downloadInfo = versionInfo.downloads
       .find((downloadInfo: DownloadInfo) =>
         downloadInfo.target === distro &&
-        downloadInfo.edition === (enterprise ? 'targeted' : 'enterprise')) as DownloadInfo;
+        downloadInfo.edition === (enterprise ? 'targeted' : 'enterprise') &&
+        downloadInfo.arch === 'x86_64') as DownloadInfo;
   }
   return downloadInfo.archive.url;
 }

--- a/testing/download-mongodb.ts
+++ b/testing/download-mongodb.ts
@@ -64,7 +64,14 @@ async function lookupDownloadUrl(versionInfo: VersionInfo, enterprise: boolean):
   if ((process.platform === 'win32' && semver.lt(version, '4.4.0')) ||
       (process.platform === 'linux' && semver.lt(version, '4.2.0')) ||
       (process.platform !== 'win32' && !knownDistroRegex.test(distroId))) {
-    return (await promisify(getDownloadURL)({ version, enterprise })).url;
+    let { url } = (await promisify(getDownloadURL)({ version, enterprise }));
+    if (semver.gte(version, '4.2.0')) {
+      url = url.replace('mongodb-osx', 'mongodb-macos');
+    }
+    if (semver.lt(version, '4.2.0') && distroId) {
+      url = url.replace('enterprise-linux_64', `enterprise-${distroId.split('-')[0]}`);
+    }
+    return url;
   }
 
   let downloadInfo: DownloadInfo;


### PR DESCRIPTION
This is required for FLE testing and makes mongocryptd bundling easier.