### PR TITLE
fix(shell-api): default to empty list for listCollections()

### DIFF
--- a/packages/shell-api/src/database.ts
+++ b/packages/shell-api/src/database.ts
@@ -136,7 +136,7 @@ export default class Database extends ShellApiClass {
       this._name,
       filter,
       { ...this._baseOptions, ...options }
-    );
+    ) || [];
   }
 
   async _getCollectionNames(): Promise<string[]> {


### PR DESCRIPTION
Based on seeing this output in CI, it seems reasonable to assume that
`listCollections().toArray()` can return `undefined`, even if the TypeScript
definitions don’t indicate that.

     [2021/01/18 10:13:20.959] (node:18714) UnhandledPromiseRejectionWarning: TypeError: Cannot read property 'map' of undefined
     [2021/01/18 10:13:20.959]     at Proxy._getCollectionNames (/data/mci/63c1249309c29dbf51f08a235fcdfa5e/src/packages/shell-api/src/database.ts:144:41)