### PR TITLE
chore(shell-api): avoid using any to avoid circular references

### DIFF
--- a/packages/shell-api/src/bulk.ts
+++ b/packages/shell-api/src/bulk.ts
@@ -14,6 +14,7 @@ import { asPrintable } from './enums';
 import { blockedByDriverMetadata } from './error-codes';
 import { assertArgsDefined } from './helpers';
 import { BulkWriteResult } from './result';
+import type Collection from './collection';
 
 @shellApiClassDefault
 export class BulkFindOp extends ShellApiClass {
@@ -122,7 +123,7 @@ export class BulkFindOp extends ShellApiClass {
 @hasAsyncChild
 export default class Bulk extends ShellApiClass {
   _mongo: Mongo;
-  _collection: any; // to avoid circular ref
+  _collection: Collection;
   _batchCounts: any;
   _executed: boolean;
   _serviceProviderBulkOp: OrderedBulkOperation | UnorderedBulkOperation;

--- a/packages/shell-api/src/field-level-encryption.ts
+++ b/packages/shell-api/src/field-level-encryption.ts
@@ -35,7 +35,7 @@ declare interface localKms {
 }
 
 export interface ClientSideFieldLevelEncryptionOptions {
-  keyVaultClient?: any, /** This should be a Mongo class instance, but to avoid circular ref use any **/
+  keyVaultClient?: Mongo,
   keyVaultNamespace: string,
   kmsProvider: awsKms | localKms,
   schemaMap?: Document,


### PR DESCRIPTION
`import type` allows loading only the types without actually creating
circular dependencies between the files at runtime.