### PR TITLE
fix(async-rewriter): Ignore empty items in the arrays when traversing ast

### DIFF
--- a/packages/async-rewriter/src/async-writer-babel.spec.ts
+++ b/packages/async-rewriter/src/async-writer-babel.spec.ts
@@ -969,6 +969,15 @@ return (names.length); })()`);
         });
       });
     });
+    describe('with empty items in array', () => {
+      before(() => {
+        input = '[1,,3]';
+        ast = writer.getTransform(input).ast;
+      });
+      it('compiles correctly', () => {
+        expect(compileCheckScopes(writer, input)).to.equal('[1,, 3];');
+      });
+    });
   });
   describe('CallExpression', () => {
     describe('with unknown callee', () => {

--- a/packages/async-rewriter/src/async-writer-babel.ts
+++ b/packages/async-rewriter/src/async-writer-babel.ts
@@ -376,6 +376,9 @@ var TypeInferenceVisitor: Visitor = { /* eslint no-var:0 */
       const attributes = {};
       let hasAsyncChild = false;
       path.node.elements.forEach((n, i) => {
+        // skip empty items in array (e.g., [1, ,3])
+        //                                     ^ empty item
+        if (!n) return;
         attributes[i] = n['shellType'];
         if (attributes[i].hasAsyncChild || attributes[i].returnsPromise) {
           hasAsyncChild = true;


### PR DESCRIPTION
Tiny fix for async rewriter: it currently throws unexpectedly when array has holes. This PR fixes the issue by skipping them during AST traversal