### PR TITLE
fix(service-provider-core, browser-repl): Make ConnectionString compatible with browser environment

### DIFF
--- a/packages/browser-repl/.storybook/webpack.config.js
+++ b/packages/browser-repl/.storybook/webpack.config.js
@@ -3,6 +3,10 @@ const webpackBaseConfig = require('../config/webpack.config.base');
 module.exports = ({ config }) => {
   config.module.rules = webpackBaseConfig.module.rules;
   config.resolve.extensions = webpackBaseConfig.resolve.extensions;
+  config.resolve.alias = {
+    ...webpackBaseConfig.resolve.alias,
+    ...config.resolve.alias
+  };
   config.externals = {...config.externals || {}, fs: 'none'};
   return config;
 };

--- a/packages/browser-repl/config/empty.js
+++ b/packages/browser-repl/config/empty.js
@@ -1,0 +1,1 @@
+module.exports = {};

--- a/packages/browser-repl/config/webpack.config.base.js
+++ b/packages/browser-repl/config/webpack.config.base.js
@@ -1,7 +1,13 @@
+const path = require('path');
+
 module.exports = {
   stats: 'errors-only',
   resolve: {
-    extensions: ['.tsx', '.ts', '.jsx', '.js', '.less']
+    extensions: ['.tsx', '.ts', '.jsx', '.js', '.less'],
+    alias: {
+      // imports in service-provider-core that can break the browser build
+      'whatwg-url': path.resolve(__dirname, 'empty.js'),
+    }
   },
   module: {
     rules: [

--- a/packages/service-provider-core/src/connection-string.ts
+++ b/packages/service-provider-core/src/connection-string.ts
@@ -63,8 +63,9 @@ export class ConnectionString extends URLWithoutHost {
     let authString = '';
     if (typeof username === 'string') authString += username;
     if (typeof password === 'string') authString += `:${password}`;
+    if (authString) authString += '@';
 
-    super(`${protocol.toLowerCase()}://${authString}@${DUMMY_HOSTNAME}${rest}`);
+    super(`${protocol.toLowerCase()}://${authString}${DUMMY_HOSTNAME}${rest}`);
     this._hosts = hosts.split(',');
 
     if (this.isSRV && this.hosts.length !== 1) {

--- a/packages/service-provider-core/src/whatwg-url.ts
+++ b/packages/service-provider-core/src/whatwg-url.ts
@@ -2,24 +2,40 @@
 // And, because it's so much fun, it also doesn't have TextEncoder/TextDecoder,
 // so we need to (crudely) polyfill that as well in order to use that
 // pure-JS implementation.
-if (typeof require('util').TextDecoder !== 'function' || typeof require('util').TextEncoder !== 'function') {
+if (
+  typeof require('util').TextDecoder !== 'function' ||
+  typeof require('util').TextEncoder !== 'function'
+) {
   Object.assign(require('util'), textEncodingPolyfill());
 }
 
+// Easiest way to get global `this` (either `global` in Node or `window` in
+// browser) in any environment
+//
+// eslint-disable-next-line no-new-func
+const _global = new Function('return this')();
+
+// URL has to be defined dynamically to allow browser environments get rid of
+// the polyfill that can potentially break them, even when not used
 let URL: typeof import('url').URL;
 
-// Easiest way to get global `this` in any environment
-// eslint-disable-next-line no-new-func
-const globalThis = new Function('return this')();
-
-// Dynamically requiring URL should allow us to skip imports that potentially
-// can break browser runtimes
-if ('URL' in globalThis) {
-  URL = globalThis.URL;
+// URL should be available in global scope both in Node >= 10 and in browser
+// (this also means that electron renderer should have it available one way or
+// another)
+if ('URL' in _global) {
+  URL = _global.URL;
 } else {
-  URL = require('url').URL ?? require('whatwg-url').URL;
+  // java-shell js runtime (and older Node versions, but we don't support those)
+  // doesn't have URL available so we fallback to the `whatwg-url` polyfill.
+  //
+  // WARN: this polyfill is not supported in browser environment and even just
+  // importing it can break the browser runtime from time to time, if you are
+  // using `service-provider-core` in browser environment, make sure that this
+  // import does not actually import the library
+  URL = require('whatwg-url').URL;
 }
 
+// Basic encoder/decoder polyfill for java-shell environment (see above)
 function textEncodingPolyfill(): any {
   class TextEncoder {
     encode(string: string): Uint8Array {


### PR DESCRIPTION
Fixes a few issues with `service-provider-core` compatibility with the browser environment:

- Makes `url` and `whatwg-url` an "optional" import so `browser-repl` can ignore them and removes it from the `browser-repl` build by aliasing library to an empty module
- Fixes serialization issue with auth string occuring due to the browser URL behavior. Having a rouge `@` in the hosthame when username/password are not provided was causing `ConnectionString.clone` to basically produce a different url when no credentials were passed