### PR TITLE
chore(build): add way to write uploaded URL to file

### DIFF
--- a/config/build.conf.js
+++ b/config/build.conf.js
@@ -98,6 +98,7 @@ module.exports = {
     owner: 'mongodb-js',
     repo: 'mongosh'
   },
+  artifactUrlFile: process.env.ARTIFACT_URL_FILE,
   mongocryptdPath: MONGOCRYPTD_PATH,
   packageInformation: {
     binaries: [

--- a/packages/build/src/config.ts
+++ b/packages/build/src/config.ts
@@ -36,4 +36,5 @@ export default interface Config {
   isPatch?: boolean;
   mongocryptdPath: string;
   packageInformation?: PackageInformation;
+  artifactUrlFile?: string;
 }

--- a/packages/build/src/do-upload.ts
+++ b/packages/build/src/do-upload.ts
@@ -9,7 +9,7 @@ export default async function doUpload(
   githubRepo: GithubRepo,
   barque: Barque,
   tarballFile: TarballFile,
-  uploadToEvergreen: (artifact: string, awsKey: string, awsSecret: string, project: string, revision: string) => Promise<void>,
+  uploadToEvergreen: (artifact: string, awsKey: string, awsSecret: string, project: string, revision: string, artifactUrlFile?: string) => Promise<void>,
   uploadToDownloadCenter: (artifact: string, awsKey: string, awsSecret: string) => Promise<void>): Promise<void> {
   for (const key of [
     'evgAwsKey', 'evgAwsSecret', 'project', 'revision', 'downloadCenterAwsKey', 'downloadCenterAwsSecret'
@@ -25,7 +25,8 @@ export default async function doUpload(
     config.evgAwsKey as string,
     config.evgAwsSecret as string,
     config.project as string,
-    config.revision as string
+    config.revision as string,
+    config.artifactUrlFile
   );
   console.info('mongosh: internal release completed.');
 

--- a/packages/build/src/evergreen.ts
+++ b/packages/build/src/evergreen.ts
@@ -14,10 +14,18 @@ const BUCKET = 'mciuploads';
  * @param {string} artifact - The artifact.
  * @param {string} awsKey - The aws key.
  * @param {string} awsSecret - The aws secret.
+ * @param {string} revision - The patch/commit id.
+ * @param {string} artifactUrlFile - An optional path to a file for writing the artifact's URL.
  *
  * @returns {Promise} The promise.
  */
-async function uploadArtifactToEvergreen(artifact: string, awsKey: string, awsSecret: string, project: string, revision: string): Promise<void> {
+async function uploadArtifactToEvergreen(
+  artifact: string,
+  awsKey: string,
+  awsSecret: string,
+  project: string,
+  revision: string,
+  artifactUrlFile?: string): Promise<void> {
   const s3 = new S3({
     accessKeyId: awsKey,
     secretAccessKey: awsSecret
@@ -31,8 +39,13 @@ async function uploadArtifactToEvergreen(artifact: string, awsKey: string, awsSe
   };
 
   console.info(`mongosh: uploading ${artifact} to evergreen bucket:`, BUCKET, key);
-  console.info(`mongosh: artifact download url: https://s3.amazonaws.com/${BUCKET}/${key}`);
   await upload(uploadParams, s3);
+
+  const url = `https://s3.amazonaws.com/${BUCKET}/${key}`;
+  console.info(`mongosh: artifact download url: ${url}`);
+  if (artifactUrlFile) {
+    await fs.promises.writeFile(artifactUrlFile, url);
+  }
 }
 
 function getArtifactUrl(project: string, revision: string, artifact: string): string {

--- a/packages/build/src/redact-config.ts
+++ b/packages/build/src/redact-config.ts
@@ -18,6 +18,7 @@ export function redactConfig(config: Config): Partial<Config> {
     repo: config.repo,
     isPatch: config.isPatch,
     packageInformation: config.packageInformation,
-    mongocryptdPath: config.mongocryptdPath
+    mongocryptdPath: config.mongocryptdPath,
+    artifactUrlFile: config.artifactUrlFile
   };
 }


### PR DESCRIPTION
Add a way to write the S3 URL for an uploaded package to a specified
location on disk. This is useful for MONGOSH-506, because it makes it
possible to store that file in a location that evergreen can understand
on its own (i.e. it doesn't need to use JS code to figure out where
the artifact is stored) and use it as a pointer to the actual artifact
URL.