### PR TITLE
fix(compass-shell): Exclude deprecated driver 3.x options before passing them to the worker runtime

### DIFF
--- a/packages/compass-shell/electron/renderer/index.js
+++ b/packages/compass-shell/electron/renderer/index.js
@@ -61,8 +61,6 @@ render(CompassShellPlugin);
 const connectionOptions = {
   url: 'mongodb://localhost:27020/test?readPreference=primary&ssl=false',
   options: {
-    useUnifiedTopology: true,
-    connectWithNoPrimary: true,
     sslValidate: false,
   },
 };


### PR DESCRIPTION
As discussed in [this thread](https://mongodb.slack.com/archives/GJ2CBBY86/p1611321819035300), worker runtime uses mongodb driver 4, but the connection options are currently passed from mongodb driver 3, this causes some "deprecated param" issues while runtime is connecting. To work around the issue, this PR removes deprecated connection options before passing options to the runtime