### PR TITLE
chore(build): ensure git 2.24 is installed in centos MONGOSH-505

### DIFF
--- a/packages/build/src/npm-packages.ts
+++ b/packages/build/src/npm-packages.ts
@@ -10,14 +10,6 @@ export function bumpNpmPackages(version: string): void {
     return;
   }
 
-  execFileSync('git', ['--version'], { stdio: 'inherit' });
-  try {
-    const execa = require('execa');
-    execa('git', ['--version']);
-  } catch (e) {
-    console.warn('Could not use execa directly for debugging...');
-  }
-
   console.info(`mongosh: Bumping package versions to ${version}`);
   execFileSync(LERNA_BIN, [
     'version',

--- a/scripts/docker/centos7-build.Dockerfile
+++ b/scripts/docker/centos7-build.Dockerfile
@@ -2,8 +2,12 @@ FROM centos:7
 
 RUN yum install -y centos-release-scl epel-release
 RUN yum repolist
-RUN yum install -y python3 devtoolset-8 git cmake
+RUN yum install -y python3 devtoolset-8 cmake
 RUN scl enable devtoolset-8 bash
+
+# Add Git from IUS repo as CentOS has git 1.8.3.1 by default (lerna requires 2.+)
+RUN yum install -y https://repo.ius.io/ius-release-el7.rpm
+RUN yum install -y git224
 
 # Add Node.js
 RUN curl -sL https://rpm.nodesource.com/setup_14.x | bash -
@@ -15,6 +19,6 @@ RUN curl -L https://github.com/mozilla/sccache/releases/download/0.2.13/sccache-
 ENV CC="sccache gcc"
 ENV CXX="sccache g++"
 
-RUN bash -c 'source /opt/rh/devtoolset-8/enable && g++ --version'
+RUN bash -c 'source /opt/rh/devtoolset-8/enable && g++ --version && git --version'
 
 ENTRYPOINT [ "bash" ]

--- a/scripts/docker/centos7-package.Dockerfile
+++ b/scripts/docker/centos7-package.Dockerfile
@@ -4,6 +4,10 @@ RUN yum install -y centos-release-scl epel-release
 RUN yum repolist
 RUN yum install -y python3 rpm-build dpkg-devel dpkg-dev
 
+# Add Git from IUS repo as CentOS has git 1.8.3.1 by default (lerna requires 2.+)
+RUN yum install -y https://repo.ius.io/ius-release-el7.rpm
+RUN yum install -y git224
+
 # Add Node.js
 RUN curl -sL https://rpm.nodesource.com/setup_14.x | bash -
 RUN yum install -y nodejs


### PR DESCRIPTION
Adapted the CentOS docker images to include git 2.24. By default, CentOS comes with git v1.8.3.1 which is way too old for `lerna` to be able to bump the package versions.

It went undetected, as we only bump the version when we tag a commit.