### PR TITLE
chore(cli-repl): fix createRole test case

### DIFF
--- a/packages/cli-repl/test/e2e-auth.spec.ts
+++ b/packages/cli-repl/test/e2e-auth.spec.ts
@@ -391,7 +391,7 @@ describe('Auth e2e', function() {
         it('all arguments', async() => {
           await shell.writeInputLine(`use ${dbName}`);
           await shell.writeInputLine(
-            `db.createRole({ role: "anna", privileges: ${JSON.stringify([examplePrivilege1])}, roles: ["dbAdmin"], authenticationRestrictions: [ { serverAddress: {}} ] })`
+            `db.createRole({ role: "anna", privileges: ${JSON.stringify([examplePrivilege1])}, roles: ["dbAdmin"], authenticationRestrictions: [ { serverAddress: [] } ] })`
           );
           await eventually(async() => {
             shell.assertContainsOutput('{ ok: 1 }');


### PR DESCRIPTION
The `createRole` command in the test case used a `serverAddress: {}` instead of `serverAddress: []` (see https://docs.mongodb.com/manual/reference/command/createRole/index.html#dbcmd.createRole).