### PR TITLE
chore(build): always bump package version number MONGOSH-505

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -21,6 +21,10 @@ functions:
       params:
         directory: src
   install:
+    - command: expansions.write
+      params:
+        file: tmp/expansions.yaml
+        redacted: true
     - command: shell.exec
       params:
         working_dir: src
@@ -28,6 +32,7 @@ functions:
         script: |
           export NODE_JS_VERSION=${node_js_version}
           source .evergreen/.install_node
+          npm run evergreen-release bump
   check:
     - command: shell.exec
       params:

--- a/packages/build/src/npm-packages.ts
+++ b/packages/build/src/npm-packages.ts
@@ -7,6 +7,7 @@ const LERNA_BIN = path.resolve(PROJECT_ROOT, 'node_modules', '.bin', 'lerna');
 
 export function bumpNpmPackages(version: string): void {
   if (!version || version === PLACEHOLDER_VERSION) {
+    console.info('mongosh: Not bumping package version, keeping at placeholder');
     return;
   }
 

--- a/packages/build/src/release.ts
+++ b/packages/build/src/release.ts
@@ -40,9 +40,9 @@ export default async function release(
     redactConfig(config)
   );
 
-  // updates the version of internal packages to reflect the tagged one
-  bumpNpmPackages(config.version);
   if (command === 'bump') {
+    // updates the version of internal packages to reflect the tagged one
+    bumpNpmPackages(config.version);
     return;
   }
 

--- a/scripts/evergreen-release.js
+++ b/scripts/evergreen-release.js
@@ -11,8 +11,8 @@ const config = require(path.join(__dirname, '..', 'config', 'build.conf.js'));
 const runRelease = async() => {
   const command = process.argv[2];
 
-  if (!['compile', 'package', 'upload', 'publish'].includes(command)) {
-    throw new Error('USAGE: npm run evergreen-release -- <compile|package|upload|publish>');
+  if (!['bump', 'compile', 'package', 'upload', 'publish'].includes(command)) {
+    throw new Error('USAGE: npm run evergreen-release -- <bump|compile|package|upload|publish>');
   }
 
   const cliBuildVariant =


### PR DESCRIPTION
Added a new "evergreen-release" command `bump` which just bumps the package.json versions to the potentially present tag version.

I chose to always bump the version now, as for example the E2E tests verify the version that is output by `mongosh --version`. To avoid any additional issues with the version, it's now always bumped. I left the explicit bump also in for the other commands to ensure any other potential changes to the version will always be forced correctly when releasing.