### PR TITLE
fix(shell-api): catch Promise rejections caused by db switch

### DIFF
--- a/packages/shell-api/src/shell-internal-state.ts
+++ b/packages/shell-api/src/shell-internal-state.ts
@@ -126,8 +126,9 @@ export default class ShellInternalState {
     this.currentDb = newDb;
     this.context.rs = new ReplicaSet(this.currentDb);
     this.context.sh = new Shard(this.currentDb);
-    this.fetchConnectionInfo();
-    this.currentDb._getCollectionNames(); // Pre-fetch for autocompletion.
+    this.fetchConnectionInfo().catch(err => this.messageBus.emit('mongosh:error', err));
+    // Pre-fetch for autocompletion.
+    this.currentDb._getCollectionNames().catch(err => this.messageBus.emit('mongosh:error', err));
     return newDb;
   }
 


### PR DESCRIPTION
Make sure we’re not running into unhandled rejections when updating
information after a database switch.