### PR TITLE
chore(build): remove safeguard from testing MONGOSH-505

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -198,10 +198,8 @@ functions:
           source .evergreen/.setup_env
           export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD="true"
           echo "//registry.npmjs.org/:_authToken=${DEVTOOLSBOT_NPM_TOKEN}" > .npmrc
-          echo "PUBLISHING RELEASE"
+          npm run evergreen-release publish
           }
-        # TODO: move that back in once verified it works as expected
-        # npm run evergreen-release publish
   spawn_host:
     - command: host.create
       params:


### PR DESCRIPTION
This activates that a real publish is run on `release_publish`. Was disabled for testing the tagging behavior.

Evergreen is now configured properly so that when we tag a commit with a release tag it will also run `release_publish`.

So far this does not include separating the publishing from the rest, i.e. tagging with a release tag will still run the whole compile, package, etc. This is tracked by https://jira.mongodb.org/browse/MONGOSH-554