### PR TITLE
fix(shell-api): use redactPassword in rs/sh print methods

### DIFF
--- a/packages/shell-api/src/replica-set.ts
+++ b/packages/shell-api/src/replica-set.ts
@@ -12,7 +12,7 @@ import { asPrintable } from './enums';
 import { assertArgsDefined, assertArgsType } from './helpers';
 import { CommonErrors, MongoshDeprecatedError, MongoshInvalidInputError, MongoshRuntimeError } from '@mongosh/errors';
 import { CommandResult } from './result';
-
+import { redactPassword } from '@mongosh/history';
 
 @shellApiClassDefault
 @hasAsyncChild
@@ -252,7 +252,7 @@ export default class ReplicaSet extends ShellApiClass {
    * Internal method to determine what is printed for this class.
    */
   [asPrintable](): string {
-    return `ReplicaSet class connected to ${this._database._mongo._uri} via db ${this._database._name}`;
+    return `ReplicaSet class connected to ${redactPassword(this._database._mongo._uri)} via db ${this._database._name}`;
   }
 
   /**

--- a/packages/shell-api/src/shard.ts
+++ b/packages/shell-api/src/shard.ts
@@ -9,6 +9,7 @@ import type { Document } from '@mongosh/service-provider-core';
 import { assertArgsDefined, assertArgsType, getConfigDB, getPrintableShardStatus } from './helpers';
 import { ServerVersions, asPrintable } from './enums';
 import { CommandResult, UpdateResult } from './result';
+import { redactPassword } from '@mongosh/history';
 
 @shellApiClassDefault
 @hasAsyncChild
@@ -24,7 +25,7 @@ export default class Shard extends ShellApiClass {
    * Internal method to determine what is printed for this class.
    */
   [asPrintable](): string {
-    return `Shard class connected to ${this._database._mongo._uri} via db ${this._database._name}`;
+    return `Shard class connected to ${redactPassword(this._database._mongo._uri)} via db ${this._database._name}`;
   }
 
   /**


### PR DESCRIPTION
Do the same thing we do for printing `Mongo` and
`ClientEncryption` classes.