### PR TITLE
fix(shell-api): use readPref for runCommand if explicitly set MONGOSH-508

### DIFF
--- a/packages/cli-repl/test/e2e-direct.spec.ts
+++ b/packages/cli-repl/test/e2e-direct.spec.ts
@@ -1,5 +1,6 @@
 import { startTestCluster } from '../../../testing/integration-testing-hooks';
 import { eventually } from './helpers';
+import { expect } from 'chai';
 import { TestShell } from './test-shell';
 
 describe('e2e direct connection', () => {
@@ -94,6 +95,14 @@ describe('e2e direct connection', () => {
           await shell.executeLine('db.runCommand({ listCollections: 1 })');
           shell.assertContainsOutput("name: 'system.version'");
         });
+
+        it('lists collections and dbs using show by default', async() => {
+          const shell = TestShell.start({ args: [`${await rs1.connectionString()}`] });
+          await shell.waitForPrompt();
+          await shell.executeLine('use admin');
+          expect(await shell.executeLine('show collections')).to.include('system.version');
+          expect(await shell.executeLine('show dbs')).to.include('admin');
+        });
       });
 
       context('connecting to primary', () => {
@@ -121,6 +130,14 @@ describe('e2e direct connection', () => {
           shell.assertContainsOutput('ismaster: true');
           shell.assertContainsOutput(`me: '${await rs0.hostport()}'`);
           shell.assertContainsOutput(`setName: '${replSetId}'`);
+        });
+
+        it('lists collections and dbs using show by default', async() => {
+          const shell = TestShell.start({ args: [`${await rs1.connectionString()}`] });
+          await shell.waitForPrompt();
+          await shell.executeLine('use admin');
+          expect(await shell.executeLine('show collections')).to.include('system.version');
+          expect(await shell.executeLine('show dbs')).to.include('admin');
         });
       });
     });

--- a/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/service/AdminServiceProvider.kt
+++ b/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/service/AdminServiceProvider.kt
@@ -6,7 +6,7 @@ import org.graalvm.polyglot.Value
  * see service-provider-core/src/admin.ts
  */
 internal interface AdminServiceProvider {
-    fun listDatabases(database: String): Value
+    fun listDatabases(database: String, options: Value?): Value
     fun getNewConnection(uri: String, options: Value?): Value
     fun getConnectionInfo(): Value
     fun authenticate(authDoc: Value): Value

--- a/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/service/JavaServiceProvider.kt
+++ b/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/service/JavaServiceProvider.kt
@@ -438,7 +438,7 @@ internal class JavaServiceProvider(private val client: MongoClient,
     }
 
     @HostAccess.Export
-    override fun listDatabases(database: String): Value = promise {
+    override fun listDatabases(database: String, options: Value?): Value = promise {
         Right(mapOf("databases" to client.listDatabases()))
     }
 

--- a/packages/service-provider-core/src/admin.ts
+++ b/packages/service-provider-core/src/admin.ts
@@ -48,6 +48,11 @@ export default interface Admin {
   getNewConnection(uri: string, options: MongoClientOptions): Promise<any>; // returns the ServiceProvider instance
 
   /**
+   * Return the URI for the current connection, if this ServiceProvider is connected.
+   */
+  getURI(): string | undefined;
+
+  /**
    * Return connection info
    */
   getConnectionInfo(): Promise<Document>;

--- a/packages/service-provider-core/src/admin.ts
+++ b/packages/service-provider-core/src/admin.ts
@@ -8,7 +8,8 @@ import type {
   CreateCollectionOptions,
   ClientSession,
   DbOptions,
-  ClientSessionOptions
+  ClientSessionOptions,
+  ListDatabasesOptions
 } from './all-transport-types';
 import type { bson as BSON } from './index';
 import { ReplPlatform } from './platform';
@@ -37,7 +38,7 @@ export default interface Admin {
    *
    * @returns {Promise} The promise of command Documents.
    */
-  listDatabases(database: string): Promise<Document>;
+  listDatabases(database: string, options?: ListDatabasesOptions): Promise<Document>;
 
   /**
    * create a new service provider with a new connection.

--- a/packages/service-provider-server/src/cli-service-provider.integration.spec.ts
+++ b/packages/service-provider-server/src/cli-service-provider.integration.spec.ts
@@ -686,4 +686,10 @@ describe('CliServiceProvider [integration]', function() {
       expect(serviceProvider.driverMetadata.driver.name).to.equal('nodejs');
     });
   });
+
+  describe('#getURI', () => {
+    it('returns the current URI', () => {
+      expect(serviceProvider.getURI()).to.equal(connectionString + '/');
+    });
+  });
 });

--- a/packages/service-provider-server/src/cli-service-provider.ts
+++ b/packages/service-provider-server/src/cli-service-provider.ts
@@ -841,8 +841,9 @@ class CliServiceProvider extends ServiceProviderCore implements ServiceProvider 
    *
    * @returns {Promise} The promise of command results.
    */
-  listDatabases(database: string): Promise<Document> {
-    return this.db(database).admin().listDatabases(this.baseCmdOptions as ListDatabasesOptions);
+  listDatabases(database: string, options: ListDatabasesOptions = {}): Promise<Document> {
+    options = { ...this.baseCmdOptions, ...options };
+    return this.db(database).admin().listDatabases(options);
   }
 
   /**

--- a/packages/service-provider-server/src/cli-service-provider.ts
+++ b/packages/service-provider-server/src/cli-service-provider.ts
@@ -1156,6 +1156,10 @@ class CliServiceProvider extends ServiceProviderCore implements ServiceProvider 
   getRawClient(): MongoClient {
     return this.mongoClient;
   }
+
+  getURI(): string | undefined {
+    return this.uri?.href;
+  }
 }
 
 export default CliServiceProvider;

--- a/packages/shell-api/src/database.ts
+++ b/packages/shell-api/src/database.ts
@@ -141,8 +141,8 @@ export default class Database extends ShellApiClass {
     ) || [];
   }
 
-  async _getCollectionNames(): Promise<string[]> {
-    const infos = await this._listCollections({}, { nameOnly: true });
+  async _getCollectionNames(options?: ListCollectionsOptions): Promise<string[]> {
+    const infos = await this._listCollections({}, { ...options, nameOnly: true });
     this._cachedCollectionNames = infos.map((collection: any) => collection.name);
     return this._cachedCollectionNames;
   }

--- a/packages/shell-api/src/mongo.spec.ts
+++ b/packages/shell-api/src/mongo.spec.ts
@@ -116,14 +116,16 @@ describe('Mongo', () => {
         describe(t, () => {
           it('calls database.getCollectionNames', async() => {
             const expectedResult = ['a', 'b'];
-            database.getCollectionNames.resolves(expectedResult);
+            database._getCollectionNames.resolves(expectedResult);
             await mongo.show(t);
-            expect(database.getCollectionNames).to.have.been.calledWith();
+            expect(database._getCollectionNames).to.have.been.calledWith({
+              readPreference: 'primaryPreferred'
+            });
           });
 
           it('returns ShowCollectionsResult CommandResult', async() => {
             const expectedResult = ['a', 'b'];
-            database.getCollectionNames.resolves(expectedResult);
+            database._getCollectionNames.resolves(expectedResult);
             const result = await mongo.show(t);
             expect(result.value).to.deep.equal(expectedResult);
             expect(result.type).to.equal('ShowCollectionsResult');
@@ -131,7 +133,7 @@ describe('Mongo', () => {
 
           it('throws if database.getCollectionNames rejects', async() => {
             const expectedError = new Error();
-            database.getCollectionNames.rejects(expectedError);
+            database._getCollectionNames.rejects(expectedError);
             const catchedError = await mongo.show(t)
               .catch(e => e);
             expect(catchedError).to.equal(expectedError);

--- a/packages/shell-api/src/mongo.ts
+++ b/packages/shell-api/src/mongo.ts
@@ -145,12 +145,12 @@ export default class Mongo extends ShellApiClass {
 
   @returnsPromise
   async show(cmd: string, arg?: string): Promise<CommandResult> {
-    this._internalState.messageBus.emit( 'mongosh:show', { method: `show ${cmd}` });
+    this._internalState.messageBus.emit('mongosh:show', { method: `show ${cmd}` });
 
     switch (cmd) {
       case 'databases':
       case 'dbs':
-        const result = await this._serviceProvider.listDatabases('admin');
+        const result = await this._serviceProvider.listDatabases('admin', { readPreference: 'primaryPreferred' });
         if (!('databases' in result)) {
           const err = new MongoshRuntimeError('Got invalid result from "listDatabases"', CommonErrors.CommandFailed);
           this._internalState.messageBus.emit('mongosh:error', err);
@@ -160,7 +160,7 @@ export default class Mongo extends ShellApiClass {
         return new CommandResult('ShowDatabasesResult', result.databases);
       case 'collections':
       case 'tables':
-        const collectionNames = await this._internalState.currentDb.getCollectionNames();
+        const collectionNames = await this._internalState.currentDb._getCollectionNames({ readPreference: 'primaryPreferred' });
         return new CommandResult('ShowCollectionsResult', collectionNames);
       case 'profile':
         const sysprof = this._internalState.currentDb.getCollection('system.profile');


### PR DESCRIPTION
##### fix(shell-api): use readPref for runCommand if explicitly set MONGOSH-508

If `readPreference` has been explicitly set, either through
a) the connection string or b) by using `setReadPref()`,
then pass it for `db.runCommand()` as well.

The reason we’re not always using it is that the driver will
report it back to use as `primary` by default, which would then
break `db.runCommand()` for almost all calls when we’re connected
to a secondary.

As part of this, update the default `Mongo` instance to also
report the connection string, like a programmatically created `Mongo`
instance would (and like it worked in the old shell).
(Also addresses MONGOSH-557)

Refs: https://docs.google.com/document/d/10FTlhliWtg_XquUGbEmZQ7ccUiImMLlBT5Qlm2O1ZxI/edit?pli=1

##### fix(shell-api): use primaryPreferred for `show` commands

People don’t necessarily expect `show` to follow the same rules as
other shell calls, and expect it to work even when connected to a
secondary. Use `primaryPreferred` as the read preference for
`show db`/`show collections` to address this.
(This is a deviation from the old shell’s behavior.)
