### PR TITLE
feat(shell-api,autocomplete): skip deprecated methods MONGOSH-509

### DIFF
--- a/packages/autocomplete/index.spec.ts
+++ b/packages/autocomplete/index.spec.ts
@@ -179,8 +179,11 @@ describe('completer.completer', () => {
 
     it('returns all suggestions', async() => {
       const i = 'db.';
-      const dbComplete = Object.keys(shellSignatures.Database.attributes as any);
-      const adjusted = dbComplete.map(c => `${i}${c}`);
+      const attr = shellSignatures.Database.attributes as any;
+      const dbComplete = Object.keys(attr);
+      const adjusted = dbComplete
+        .filter(c => !attr[c].deprecated)
+        .map(c => `${i}${c}`);
       expect(await completer(noParams, i)).to.deep.equal([adjusted, i]);
     });
 
@@ -221,7 +224,7 @@ describe('completer.completer', () => {
     it('returns all suggestions', async() => {
       const i = 'db.shipwrecks.';
       const collComplete = Object.keys(shellSignatures.Collection.attributes as any);
-      const adjusted = collComplete.filter(c => !['count', 'update', 'remove'].includes(c)).map(c => `${i}${c}`);
+      const adjusted = collComplete.filter(c => !['count', 'update', 'remove', 'insert', 'save'].includes(c)).map(c => `${i}${c}`);
 
       expect(await completer(sharded440, i)).to.deep.equal([adjusted, i]);
     });

--- a/packages/shell-api/src/aggregation-cursor.spec.ts
+++ b/packages/shell-api/src/aggregation-cursor.spec.ts
@@ -24,6 +24,7 @@ describe('AggregationCursor', () => {
       expect(signatures.AggregationCursor.attributes.map).to.deep.equal({
         type: 'function',
         returnsPromise: false,
+        deprecated: false,
         returnType: 'AggregationCursor',
         platforms: ALL_PLATFORMS,
         topologies: ALL_TOPOLOGIES,

--- a/packages/shell-api/src/bulk.spec.ts
+++ b/packages/shell-api/src/bulk.spec.ts
@@ -35,6 +35,7 @@ describe('Bulk API', () => {
         expect(signatures.Bulk.attributes.find).to.deep.equal({
           type: 'function',
           returnsPromise: false,
+          deprecated: false,
           returnType: 'BulkFindOp',
           platforms: ALL_PLATFORMS,
           topologies: ALL_TOPOLOGIES,
@@ -236,6 +237,7 @@ describe('Bulk API', () => {
         expect(signatures.BulkFindOp.attributes.hint).to.deep.equal({
           type: 'function',
           returnsPromise: false,
+          deprecated: false,
           returnType: 'BulkFindOp',
           platforms: ALL_PLATFORMS,
           topologies: ALL_TOPOLOGIES,

--- a/packages/shell-api/src/change-stream-cursor.spec.ts
+++ b/packages/shell-api/src/change-stream-cursor.spec.ts
@@ -30,6 +30,7 @@ describe('ChangeStreamCursor', () => {
       expect(signatures.ChangeStreamCursor.attributes.next).to.deep.equal({
         type: 'function',
         returnsPromise: true,
+        deprecated: false,
         returnType: { type: 'unknown', attributes: {} },
         platforms: ALL_PLATFORMS,
         topologies: ALL_TOPOLOGIES,

--- a/packages/shell-api/src/change-stream-cursor.ts
+++ b/packages/shell-api/src/change-stream-cursor.ts
@@ -3,7 +3,8 @@ import {
   returnsPromise,
   returnType,
   hasAsyncChild,
-  ShellApiClass
+  ShellApiClass,
+  deprecated
 } from './decorators';
 import {
   ChangeStream,
@@ -58,6 +59,7 @@ export default class ChangeStreamCursor extends ShellApiClass {
   }
 
   @returnsPromise
+  @deprecated
   async hasNext(): Promise<void> {
     printWarning(
       'If there are no documents in the batch, hasNext will block. Use tryNext if you want to check if there ' +

--- a/packages/shell-api/src/collection.spec.ts
+++ b/packages/shell-api/src/collection.spec.ts
@@ -40,6 +40,7 @@ describe('Collection', () => {
       expect(signatures.Collection.attributes.aggregate).to.deep.equal({
         type: 'function',
         returnsPromise: true,
+        deprecated: false,
         returnType: 'AggregationCursor',
         platforms: ALL_PLATFORMS,
         topologies: ALL_TOPOLOGIES,

--- a/packages/shell-api/src/collection.ts
+++ b/packages/shell-api/src/collection.ts
@@ -9,7 +9,8 @@ import {
   serverVersions,
   ShellApiClass,
   shellApiClassDefault,
-  topologies
+  topologies,
+  deprecated
 } from './decorators';
 import { ADMIN_DB, asPrintable, namespaceInfo, ServerVersions, Topologies } from './enums';
 import {
@@ -233,6 +234,7 @@ export default class Collection extends ShellApiClass {
    * @returns {Integer} The promise of the count.
    */
   @returnsPromise
+  @deprecated
   @serverVersions([ServerVersions.earliest, '4.0.0'])
   async count(query = {}, options: CountOptions = {}): Promise<number> {
     this._emitCollectionApiCall(
@@ -592,6 +594,8 @@ export default class Collection extends ShellApiClass {
    * @return {InsertManyResult}
    */
   @returnsPromise
+  @deprecated
+  @serverVersions([ServerVersions.earliest, '3.6.0'])
   async insert(docs: Document | Document[], options: BulkWriteOptions = {}): Promise<InsertManyResult> {
     printDeprecationWarning(
       'Collection.insert() is deprecated. Use insertOne, insertMany or bulkWrite.',
@@ -702,6 +706,7 @@ export default class Collection extends ShellApiClass {
    * @return {Promise}
    */
   @returnsPromise
+  @deprecated
   @serverVersions([ServerVersions.earliest, '3.2.0'])
   async remove(query: Document, options: boolean | RemoveShellOptions = {}): Promise<DeleteResult | Document> {
     printDeprecationWarning(
@@ -730,6 +735,7 @@ export default class Collection extends ShellApiClass {
   }
 
   @returnsPromise
+  @deprecated
   save(): Promise<void> {
     throw new MongoshInvalidInputError('Collection.save() is deprecated. Use insertOne, insertMany, updateOne or updateMany.');
   }
@@ -772,6 +778,7 @@ export default class Collection extends ShellApiClass {
   }
 
   @returnsPromise
+  @deprecated
   @serverVersions([ServerVersions.earliest, '3.2.0'])
   async update(filter: Document, update: Document, options: UpdateOptions & { multi?: boolean } = {}): Promise<UpdateResult | Document> {
     printDeprecationWarning(

--- a/packages/shell-api/src/cursor.spec.ts
+++ b/packages/shell-api/src/cursor.spec.ts
@@ -28,6 +28,7 @@ describe('Cursor', () => {
       expect(signatures.Cursor.attributes.map).to.deep.equal({
         type: 'function',
         returnsPromise: false,
+        deprecated: false,
         returnType: 'Cursor',
         platforms: ALL_PLATFORMS,
         topologies: ALL_TOPOLOGIES,

--- a/packages/shell-api/src/cursor.ts
+++ b/packages/shell-api/src/cursor.ts
@@ -6,7 +6,8 @@ import {
   serverVersions,
   ShellApiClass,
   shellApiClassDefault,
-  toShellResult
+  toShellResult,
+  deprecated
 } from './decorators';
 import {
   ServerVersions,
@@ -75,7 +76,6 @@ export default class Cursor extends ShellApiClass {
     if (optionFlagNumber === 4) {
       throw new MongoshUnimplementedError('the slaveOk option is not supported.', CommonErrors.NotImplemented);
     }
-
     const optionFlag: CursorFlag | undefined = (CURSOR_FLAGS as any)[optionFlagNumber];
 
     if (!optionFlag) {
@@ -340,6 +340,7 @@ export default class Cursor extends ShellApiClass {
     return this;
   }
 
+  @deprecated
   @serverVersions([ServerVersions.earliest, '4.0.0'])
   maxScan(): void {
     throw new MongoshDeprecatedError(

--- a/packages/shell-api/src/database.spec.ts
+++ b/packages/shell-api/src/database.spec.ts
@@ -81,6 +81,7 @@ describe('Database', () => {
       expect(signatures.Database.attributes.aggregate).to.deep.equal({
         type: 'function',
         returnsPromise: true,
+        deprecated: false,
         returnType: 'AggregationCursor',
         platforms: ALL_PLATFORMS,
         topologies: ALL_TOPOLOGIES,

--- a/packages/shell-api/src/database.ts
+++ b/packages/shell-api/src/database.ts
@@ -8,7 +8,8 @@ import {
   serverVersions,
   ShellApiClass,
   shellApiClassDefault,
-  topologies
+  topologies,
+  deprecated
 } from './decorators';
 import { ADMIN_DB, asPrintable, ServerVersions, Topologies } from './enums';
 import {
@@ -1024,14 +1025,17 @@ export default class Database extends ShellApiClass {
     return result.logComponentVerbosity;
   }
 
+  @deprecated
   cloneDatabase(): void {
     throw new MongoshDeprecatedError('`cloneDatabase()` was removed because it was deprecated in MongoDB 4.0');
   }
 
+  @deprecated
   cloneCollection(): void {
     throw new MongoshDeprecatedError('`cloneCollection()` was removed because it was deprecated in MongoDB 4.0');
   }
 
+  @deprecated
   copyDatabase(): void {
     throw new MongoshDeprecatedError('`copyDatabase()` was removed because it was deprecated in MongoDB 4.0');
   }
@@ -1248,6 +1252,7 @@ export default class Database extends ShellApiClass {
     return new CommandResult('StatsResult', result);
   }
 
+  @deprecated
   @returnsPromise
   async printSlaveReplicationInfo(): Promise<CommandResult> {
     throw new MongoshDeprecatedError('Method deprecated, use db.printSecondaryReplicationInfo instead');

--- a/packages/shell-api/src/deprecated.ts
+++ b/packages/shell-api/src/deprecated.ts
@@ -1,12 +1,14 @@
 import {
   ShellApiClass,
-  shellApiClassDefault
+  shellApiClassDefault,
+  classDeprecated
 } from './decorators';
 import { asPrintable } from './enums';
 import { MongoshDeprecatedError } from '@mongosh/errors';
 
 
 @shellApiClassDefault
+@classDeprecated
 class DeprecatedClass extends ShellApiClass {
   public name: string;
   constructor(name: string, alternatives: Record<string, string> = {}) {

--- a/packages/shell-api/src/explainable-cursor.spec.ts
+++ b/packages/shell-api/src/explainable-cursor.spec.ts
@@ -21,6 +21,7 @@ describe('ExplainableCursor', () => {
       expect(signatures.ExplainableCursor.attributes.map).to.deep.equal({
         type: 'function',
         returnsPromise: false,
+        deprecated: false,
         returnType: 'ExplainableCursor',
         platforms: ALL_PLATFORMS,
         topologies: ALL_TOPOLOGIES,

--- a/packages/shell-api/src/explainable.spec.ts
+++ b/packages/shell-api/src/explainable.spec.ts
@@ -28,6 +28,7 @@ describe('Explainable', () => {
       expect(signatures.Explainable.attributes.find).to.deep.equal({
         type: 'function',
         returnsPromise: false,
+        deprecated: false,
         returnType: 'ExplainableCursor',
         platforms: ALL_PLATFORMS,
         topologies: ALL_TOPOLOGIES,

--- a/packages/shell-api/src/field-level-encryption.spec.ts
+++ b/packages/shell-api/src/field-level-encryption.spec.ts
@@ -95,6 +95,7 @@ describe('Field Level Encryption', () => {
       expect(signatures.KeyVault.attributes.createKey).to.deep.equal({
         type: 'function',
         returnsPromise: true,
+        deprecated: false,
         returnType: { attributes: {}, type: 'unknown' },
         platforms: ALL_PLATFORMS,
         topologies: ALL_TOPOLOGIES,
@@ -103,6 +104,7 @@ describe('Field Level Encryption', () => {
       expect(signatures.ClientEncryption.attributes.encrypt).to.deep.equal({
         type: 'function',
         returnsPromise: true,
+        deprecated: false,
         returnType: { attributes: {}, type: 'unknown' },
         platforms: ALL_PLATFORMS,
         topologies: ALL_TOPOLOGIES,

--- a/packages/shell-api/src/index.ts
+++ b/packages/shell-api/src/index.ts
@@ -24,7 +24,8 @@ import {
   signatures,
   ShellResult,
   toShellResult,
-  getShellApiType
+  getShellApiType,
+  TypeSignature
 } from './decorators';
 import {
   Topologies,
@@ -60,5 +61,6 @@ export {
   toShellResult,
   getShellApiType,
   ShellResult,
-  ShellCliOptions
+  ShellCliOptions,
+  TypeSignature
 };

--- a/packages/shell-api/src/mongo.spec.ts
+++ b/packages/shell-api/src/mongo.spec.ts
@@ -41,6 +41,7 @@ describe('Mongo', () => {
       expect(signatures.Mongo.attributes.show).to.deep.equal({
         type: 'function',
         returnsPromise: true,
+        deprecated: false,
         returnType: { attributes: {}, type: 'unknown' },
         platforms: ALL_PLATFORMS,
         topologies: ALL_TOPOLOGIES,

--- a/packages/shell-api/src/mongo.ts
+++ b/packages/shell-api/src/mongo.ts
@@ -16,7 +16,8 @@ import {
   serverVersions,
   ShellApiClass,
   shellApiClassDefault,
-  topologies
+  topologies,
+  deprecated
 } from './decorators';
 import {
   ChangeStreamOptions,
@@ -260,10 +261,12 @@ export default class Mongo extends ShellApiClass {
     );
   }
 
+  @deprecated
   setSlaveOk(): void {
     throw new MongoshDeprecatedError('setSlaveOk is deprecated.');
   }
 
+  @deprecated
   setSecondaryOk(): void {
     throw new MongoshDeprecatedError('Setting secondaryOk is deprecated, use setReadPref instead');
   }

--- a/packages/shell-api/src/plan-cache.spec.ts
+++ b/packages/shell-api/src/plan-cache.spec.ts
@@ -22,6 +22,7 @@ describe('PlanCache', () => {
       expect(signatures.PlanCache.attributes.list).to.deep.equal({
         type: 'function',
         returnsPromise: true,
+        deprecated: false,
         returnType: { attributes: {}, type: 'unknown' },
         platforms: ALL_PLATFORMS,
         topologies: ALL_TOPOLOGIES,

--- a/packages/shell-api/src/plan-cache.ts
+++ b/packages/shell-api/src/plan-cache.ts
@@ -3,7 +3,8 @@ import {
   returnsPromise,
   serverVersions,
   ShellApiClass,
-  shellApiClassDefault
+  shellApiClassDefault,
+  deprecated
 } from './decorators';
 import { Document } from '@mongosh/service-provider-core';
 import Collection from './collection';
@@ -52,10 +53,12 @@ export default class PlanCache extends ShellApiClass {
     return await agg.toArray();
   }
 
+  @deprecated
   planCacheQueryShapes(): void {
     throw new MongoshDeprecatedError('PlanCache.listQueryShapes was deprecated, please use PlanCache.list instead');
   }
 
+  @deprecated
   getPlansByQuery(): void {
     throw new MongoshDeprecatedError('PlanCache.getPlansByQuery was deprecated, please use PlanCache.list instead');
   }

--- a/packages/shell-api/src/replica-set.spec.ts
+++ b/packages/shell-api/src/replica-set.spec.ts
@@ -44,6 +44,7 @@ describe('ReplicaSet', () => {
       expect(signatures.ReplicaSet.attributes.initiate).to.deep.equal({
         type: 'function',
         returnsPromise: true,
+        deprecated: false,
         returnType: { type: 'unknown', attributes: {} },
         platforms: ALL_PLATFORMS,
         topologies: ALL_TOPOLOGIES,

--- a/packages/shell-api/src/replica-set.ts
+++ b/packages/shell-api/src/replica-set.ts
@@ -3,7 +3,8 @@ import {
   shellApiClassDefault,
   hasAsyncChild,
   ShellApiClass,
-  returnsPromise
+  returnsPromise,
+  deprecated
 } from './decorators';
 import {
   Document
@@ -118,6 +119,7 @@ export default class ReplicaSet extends ShellApiClass {
     return this._database.printSecondaryReplicationInfo();
   }
 
+  @deprecated
   @returnsPromise
   async printSlaveReplicationInfo(): Promise<CommandResult> {
     throw new MongoshDeprecatedError('printSlaveReplicationInfo has been deprecated. Use printSecondaryReplicationInfo instead');

--- a/packages/shell-api/src/session.spec.ts
+++ b/packages/shell-api/src/session.spec.ts
@@ -35,6 +35,7 @@ describe('Session', () => {
       expect(signatures.Session.attributes.endSession).to.deep.equal({
         type: 'function',
         returnsPromise: true,
+        deprecated: false,
         returnType: { type: 'unknown', attributes: {} },
         platforms: ALL_PLATFORMS,
         topologies: ALL_TOPOLOGIES,

--- a/packages/shell-api/src/shard.spec.ts
+++ b/packages/shell-api/src/shard.spec.ts
@@ -33,6 +33,7 @@ describe('Shard', () => {
       expect(signatures.Shard.attributes.enableSharding).to.deep.equal({
         type: 'function',
         returnsPromise: true,
+        deprecated: false,
         returnType: { type: 'unknown', attributes: {} },
         platforms: ALL_PLATFORMS,
         topologies: ALL_TOPOLOGIES,

--- a/packages/shell-api/src/shell-api.spec.ts
+++ b/packages/shell-api/src/shell-api.spec.ts
@@ -37,6 +37,7 @@ describe('ShellApi', () => {
       expect(signatures.ShellApi.attributes.use).to.deep.equal({
         type: 'function',
         returnsPromise: false,
+        deprecated: false,
         returnType: { type: 'unknown', attributes: {} },
         platforms: ALL_PLATFORMS,
         topologies: ALL_TOPOLOGIES,
@@ -45,6 +46,7 @@ describe('ShellApi', () => {
       expect(signatures.ShellApi.attributes.show).to.deep.equal({
         type: 'function',
         returnsPromise: true,
+        deprecated: false,
         returnType: { type: 'unknown', attributes: {} },
         platforms: ALL_PLATFORMS,
         topologies: ALL_TOPOLOGIES,
@@ -53,6 +55,7 @@ describe('ShellApi', () => {
       expect(signatures.ShellApi.attributes.exit).to.deep.equal({
         type: 'function',
         returnsPromise: true,
+        deprecated: false,
         returnType: { type: 'unknown', attributes: {} },
         platforms: ALL_PLATFORMS,
         topologies: ALL_TOPOLOGIES,
@@ -61,6 +64,7 @@ describe('ShellApi', () => {
       expect(signatures.ShellApi.attributes.it).to.deep.equal({
         type: 'function',
         returnsPromise: true,
+        deprecated: false,
         returnType: { type: 'unknown', attributes: {} },
         platforms: ALL_PLATFORMS,
         topologies: ALL_TOPOLOGIES,
@@ -69,6 +73,7 @@ describe('ShellApi', () => {
       expect(signatures.ShellApi.attributes.print).to.deep.equal({
         type: 'function',
         returnsPromise: true,
+        deprecated: false,
         returnType: { type: 'unknown', attributes: {} },
         platforms: ALL_PLATFORMS,
         topologies: ALL_TOPOLOGIES,
@@ -77,6 +82,7 @@ describe('ShellApi', () => {
       expect(signatures.ShellApi.attributes.printjson).to.deep.equal({
         type: 'function',
         returnsPromise: true,
+        deprecated: false,
         returnType: { type: 'unknown', attributes: {} },
         platforms: ALL_PLATFORMS,
         topologies: ALL_TOPOLOGIES,
@@ -85,6 +91,7 @@ describe('ShellApi', () => {
       expect(signatures.ShellApi.attributes.sleep).to.deep.equal({
         type: 'function',
         returnsPromise: true,
+        deprecated: false,
         returnType: { type: 'unknown', attributes: {} },
         platforms: ALL_PLATFORMS,
         topologies: ALL_TOPOLOGIES,
@@ -93,6 +100,7 @@ describe('ShellApi', () => {
       expect(signatures.ShellApi.attributes.cls).to.deep.equal({
         type: 'function',
         returnsPromise: true,
+        deprecated: false,
         returnType: { type: 'unknown', attributes: {} },
         platforms: ALL_PLATFORMS,
         topologies: ALL_TOPOLOGIES,
@@ -101,6 +109,7 @@ describe('ShellApi', () => {
       expect(signatures.ShellApi.attributes.Mongo).to.deep.equal({
         type: 'function',
         returnsPromise: true,
+        deprecated: false,
         returnType: 'Mongo',
         platforms: [ ReplPlatform.CLI ],
         topologies: ALL_TOPOLOGIES,
@@ -109,6 +118,7 @@ describe('ShellApi', () => {
       expect(signatures.ShellApi.attributes.connect).to.deep.equal({
         type: 'function',
         returnsPromise: true,
+        deprecated: false,
         returnType: 'Database',
         platforms: [ ReplPlatform.CLI ],
         topologies: ALL_TOPOLOGIES,

--- a/packages/shell-api/src/shell-bson.ts
+++ b/packages/shell-api/src/shell-bson.ts
@@ -58,6 +58,7 @@ export default function constructShellBson(bson: typeof BSON): any {
   });
   // Symbol is deprecated
   (bson.BSONSymbol as any).prototype.serverVersions = [ ServerVersions.earliest, '1.6.0' ];
+  (bson.BSONSymbol as any).prototype.deprecated = true;
 
   const bsonPkg = {
     DBRef: function(namespace: string, oid: any, db?: string): any {


### PR DESCRIPTION
Mark methods as deprecated and skip them for autocompletion.