### PR TITLE
Revert "feat(build): exclude mongocryptd from packaging (#591)"

### DIFF
--- a/config/build.conf.js
+++ b/config/build.conf.js
@@ -114,7 +114,7 @@ module.exports = {
           rpmIdentifier: 'ASL 2.0'
         }
       },
-      /*{
+      {
         sourceFilePath: MONGOCRYPTD_PATH,
         category: 'libexec',
         license: {
@@ -124,13 +124,13 @@ module.exports = {
           debIdentifier: 'Proprietary',
           rpmIdentifier: 'Proprietary'
         }
-      }*/
+      }
     ],
     otherDocFilePaths: [
-      /*{
+      {
         sourceFilePath: path.resolve(__dirname, '..', 'packaging', 'README'),
         packagedFilePath: 'README'
-      },*/
+      },
       {
         sourceFilePath: path.resolve(__dirname, '..', 'THIRD_PARTY_NOTICES.md'),
         packagedFilePath: 'THIRD_PARTY_NOTICES'


### PR DESCRIPTION
This reverts commit a83b40fd2d4b8f2485dc17175f656a5d77017e68.

(To be merged after the 0.7.0 release is done.)