### PR TITLE
refactor(node-runtime-worker-thread): Use Compass service provider to correctly resolve unsupported shell api methods

### DIFF
--- a/packages/node-runtime-worker-thread/src/worker-runtime.ts
+++ b/packages/node-runtime-worker-thread/src/worker-runtime.ts
@@ -8,7 +8,7 @@ import {
   MongoClientOptions,
   ServiceProvider
 } from '@mongosh/service-provider-core';
-import { CliServiceProvider } from '@mongosh/service-provider-server';
+import { CompassServiceProvider } from '@mongosh/service-provider-server';
 import { exposeAll, createCaller } from './rpc';
 import { serializeEvaluationResult } from './serializer';
 
@@ -43,8 +43,16 @@ export type WorkerRuntime = Runtime & {
 };
 
 const workerRuntime: WorkerRuntime = {
-  async init(uri, driverOptions = {}, cliOptions = {}) {
-    provider = await CliServiceProvider.connect(uri, driverOptions, cliOptions);
+  async init(
+    uri: string,
+    driverOptions: MongoClientOptions = {},
+    cliOptions: { nodb?: boolean } = {}
+  ) {
+    provider = await CompassServiceProvider.connect(
+      uri,
+      driverOptions,
+      cliOptions
+    );
     runtime = new ElectronRuntime(
       provider /** , TODO: `messageBus` support for telemetry in a separate ticket */
     );

--- a/packages/service-provider-server/src/cli-service-provider.ts
+++ b/packages/service-provider-server/src/cli-service-provider.ts
@@ -169,6 +169,7 @@ class CliServiceProvider extends ServiceProviderCore implements ServiceProvider 
    * @returns {Promise} The promise with cli service provider.
    */
   static async connect(
+    this: typeof CliServiceProvider,
     uri: string,
     driverOptions: MongoClientOptions = {},
     cliOptions: { nodb?: boolean } = {}
@@ -183,7 +184,7 @@ class CliServiceProvider extends ServiceProviderCore implements ServiceProvider 
       ) :
       new MongoClient(connectionString.toString(), clientOptions);
 
-    return new CliServiceProvider(mongoClient, clientOptions, connectionString);
+    return new this(mongoClient, clientOptions, connectionString);
   }
 
   public readonly platform: ReplPlatform;

--- a/packages/service-provider-server/src/compass/compass-service-provider.ts
+++ b/packages/service-provider-server/src/compass/compass-service-provider.ts
@@ -1,6 +1,6 @@
 import CliServiceProvider from '../cli-service-provider';
-import { MongoClient, MongoClientOptions } from 'mongodb';
-import { ConnectionString, ReplPlatform } from '@mongosh/service-provider-core';
+import { MongoClient } from 'mongodb';
+import { ConnectionString, ReplPlatform, MongoClientOptions } from '@mongosh/service-provider-core';
 
 interface DataService {
   client: {


### PR DESCRIPTION
Tiny fix for unsupported shell apis to reject correctly:

<img width="789" alt="Screenshot 2021-02-01 at 12 42 42" src="https://user-images.githubusercontent.com/5036933/106455091-01016600-648c-11eb-8947-0ee662db96e6.png">
