### PR TITLE
fix(node-runtime-worker-thread): Expose getShellPrompt method on the childProcessRuntime

### DIFF
--- a/packages/node-runtime-worker-thread/src/index.spec.ts
+++ b/packages/node-runtime-worker-thread/src/index.spec.ts
@@ -71,6 +71,19 @@ describe('WorkerRuntime', () => {
     });
   });
 
+  describe('getShellPrompt', () => {
+    const testServer = startTestServer('shared');
+
+    it('should return prompt when connected to the server', async() => {
+      const runtime = new WorkerRuntime(await testServer.connectionString());
+      const result = await runtime.getShellPrompt();
+
+      expect(result).to.match(/>/);
+
+      await runtime.terminate();
+    });
+  });
+
   describe('setEvaluationListener', () => {
     it('allows to set evaluation listener for runtime', async() => {
       const evalListener = {

--- a/packages/node-runtime-worker-thread/src/index.ts
+++ b/packages/node-runtime-worker-thread/src/index.ts
@@ -61,7 +61,13 @@ class WorkerRuntime implements Runtime {
     });
 
     this.childProcessRuntime = createCaller(
-      ['init', 'evaluate', 'getCompletions', 'setEvaluationListener'],
+      [
+        'init',
+        'evaluate',
+        'getCompletions',
+        'setEvaluationListener',
+        'getShellPrompt'
+      ],
       this.childProcess
     );
 


### PR DESCRIPTION
@mcasimir spotted that the prompt is missing while we were trying out the new runtime, this fixes the issue by actually making the method callable on the worker runtime