### PR TITLE
fix(build): ensure to check spawn result and assume files unchanged MONGOSH-521

### DIFF
--- a/packages/build/src/npm-packages.spec.ts
+++ b/packages/build/src/npm-packages.spec.ts
@@ -1,13 +1,52 @@
 import { expect } from 'chai';
-import { listNpmPackages } from './npm-packages';
+import sinon, { SinonStub } from 'sinon';
+import { listNpmPackages, markBumpedFilesAsAssumeUnchanged } from './npm-packages';
 
-describe('listNpmPackages', () => {
-  it('lists packages', () => {
-    const packages = listNpmPackages();
-    expect(packages.length).to.be.greaterThan(1);
-    for (const { name, version } of packages) {
-      expect(name).to.be.a('string');
-      expect(version).to.be.a('string');
-    }
+
+describe('npm-packages', () => {
+  describe('listNpmPackages', () => {
+    it('lists packages', () => {
+      const packages = listNpmPackages();
+      expect(packages.length).to.be.greaterThan(1);
+      for (const { name, version } of packages) {
+        expect(name).to.be.a('string');
+        expect(version).to.be.a('string');
+      }
+    });
+  });
+
+  describe('markBumpedFilesAsAssumeUnchanged', () => {
+    let packages: { name: string; version: string }[];
+    let expectedFiles: string[];
+    let spawnSync: SinonStub;
+
+    beforeEach(() => {
+      expectedFiles = ['.npmrc', 'lerna.json'];
+      packages = listNpmPackages();
+      packages.forEach(({ name }) => {
+        expectedFiles.push(`packages/${name}/package.json`);
+        expectedFiles.push(`packages/${name}/package-lock.json`);
+      });
+
+      spawnSync = sinon.stub();
+    });
+
+    it('marks files with --assume-unchanged', () => {
+      markBumpedFilesAsAssumeUnchanged(packages, true, spawnSync);
+      expectedFiles.forEach(f => {
+        expect(spawnSync).to.have.been.calledWith(
+          'git', ['update-index', '--assume-unchanged', f], sinon.match.any
+        );
+      });
+    });
+
+    it('marks files with --no-assume-unchanged', () => {
+      markBumpedFilesAsAssumeUnchanged(packages, false, spawnSync);
+      expectedFiles.forEach(f => {
+        expect(spawnSync).to.have.been.calledWith(
+          'git', ['update-index', '--no-assume-unchanged', f], sinon.match.any
+        );
+      });
+    });
   });
 });

--- a/packages/build/src/npm-packages.spec.ts
+++ b/packages/build/src/npm-packages.spec.ts
@@ -1,9 +1,35 @@
 import { expect } from 'chai';
 import sinon, { SinonStub } from 'sinon';
-import { listNpmPackages, markBumpedFilesAsAssumeUnchanged } from './npm-packages';
+import { listNpmPackages, markBumpedFilesAsAssumeUnchanged, spawnSync } from './npm-packages';
 
 
 describe('npm-packages', () => {
+  describe('spawnSync', () => {
+    it('works for a valid command', () => {
+      const result = spawnSync('bash', ['-c', 'echo -n works'], { encoding: 'utf8' });
+      expect(result.status).to.equal(0);
+      expect(result.stdout).to.equal('works');
+    });
+
+    it('throws on ENOENT error', () => {
+      try {
+        spawnSync('notaprogram', [], { encoding: 'utf8' });
+      } catch (e) {
+        return expect(e).to.not.be.undefined;
+      }
+      expect.fail('Expected error');
+    });
+
+    it('throws on non-zero exit code', () => {
+      try {
+        spawnSync('bash', ['-c', 'exit 1'], { encoding: 'utf8' });
+      } catch (e) {
+        return expect(e).to.not.be.undefined;
+      }
+      expect.fail('Expected error');
+    });
+  });
+
   describe('listNpmPackages', () => {
     it('lists packages', () => {
       const packages = listNpmPackages();

--- a/packages/build/src/npm-packages.spec.ts
+++ b/packages/build/src/npm-packages.spec.ts
@@ -1,6 +1,13 @@
 import { expect } from 'chai';
+import path from 'path';
 import sinon, { SinonStub } from 'sinon';
-import { listNpmPackages, markBumpedFilesAsAssumeUnchanged, spawnSync } from './npm-packages';
+import {
+  bumpNpmPackages,
+  listNpmPackages,
+  markBumpedFilesAsAssumeUnchanged,
+  publishNpmPackages,
+  spawnSync
+} from './npm-packages';
 
 
 describe('npm-packages', () => {
@@ -25,6 +32,124 @@ describe('npm-packages', () => {
         spawnSync('bash', ['-c', 'exit 1'], { encoding: 'utf8' });
       } catch (e) {
         return expect(e).to.not.be.undefined;
+      }
+      expect.fail('Expected error');
+    });
+  });
+
+  describe('bumpNpmPackages', () => {
+    let spawnSync: SinonStub;
+
+    beforeEach(() => {
+      spawnSync = sinon.stub();
+    });
+
+    it('does not do anything if no version or placeholder version is specified', () => {
+      bumpNpmPackages('', spawnSync);
+      bumpNpmPackages('0.0.0-dev.0', spawnSync);
+      expect(spawnSync).to.not.have.been.called;
+    });
+
+    it('calls lerna to bump package version', () => {
+      const lernaBin = path.resolve(__dirname, '..', '..', '..', 'node_modules', '.bin', 'lerna');
+      bumpNpmPackages('0.7.0', spawnSync);
+      expect(spawnSync).to.have.been.calledWith(
+        lernaBin,
+        ['version', '0.7.0', '--no-changelog', '--no-push', '--exact', '--no-git-tag-version', '--force-publish', '--yes'],
+        sinon.match.any
+      );
+    });
+  });
+
+  describe('publishNpmPackages', () => {
+    let listNpmPackages: SinonStub;
+    let markBumpedFilesAsAssumeUnchanged: SinonStub;
+    let spawnSync: SinonStub;
+
+    beforeEach(() => {
+      listNpmPackages = sinon.stub();
+      markBumpedFilesAsAssumeUnchanged = sinon.stub();
+      spawnSync = sinon.stub();
+    });
+
+    it('fails if packages have different versions', () => {
+      listNpmPackages.returns([
+        { name: 'packageA', version: '0.0.1' },
+        { name: 'packageB', version: '0.0.2' }
+      ]);
+      try {
+        publishNpmPackages(
+          listNpmPackages,
+          markBumpedFilesAsAssumeUnchanged,
+          spawnSync
+        );
+      } catch (e) {
+        expect(markBumpedFilesAsAssumeUnchanged).to.not.have.been.called;
+        expect(spawnSync).to.not.have.been.called;
+        return;
+      }
+      expect.fail('Expected error');
+    });
+
+    it('fails if packages have placeholder versions', () => {
+      listNpmPackages.returns([
+        { name: 'packageA', version: '0.0.0-dev.0' },
+        { name: 'packageB', version: '0.0.0-dev.0' }
+      ]);
+      try {
+        publishNpmPackages(
+          listNpmPackages,
+          markBumpedFilesAsAssumeUnchanged,
+          spawnSync
+        );
+      } catch (e) {
+        expect(markBumpedFilesAsAssumeUnchanged).to.not.have.been.called;
+        expect(spawnSync).to.not.have.been.called;
+        return;
+      }
+      expect.fail('Expected error');
+    });
+
+    it('calls lerna to publish packages for a real version', () => {
+      const lernaBin = path.resolve(__dirname, '..', '..', '..', 'node_modules', '.bin', 'lerna');
+      const packages = [
+        { name: 'packageA', version: '0.7.0' }
+      ];
+      listNpmPackages.returns(packages);
+
+      publishNpmPackages(
+        listNpmPackages,
+        markBumpedFilesAsAssumeUnchanged,
+        spawnSync
+      );
+
+      expect(markBumpedFilesAsAssumeUnchanged).to.have.been.calledWith(packages, true);
+      expect(spawnSync).to.have.been.calledWith(
+        lernaBin,
+        ['publish', 'from-package', '--no-changelog', '--no-push', '--exact', '--no-git-tag-version', '--force-publish', '--yes'],
+        sinon.match.any
+      );
+      expect(markBumpedFilesAsAssumeUnchanged).to.have.been.calledWith(packages, false);
+    });
+
+    it('reverts the assume unchanged even on spawn failure', () => {
+      const packages = [
+        { name: 'packageA', version: '0.7.0' }
+      ];
+      listNpmPackages.returns(packages);
+      spawnSync.throws(new Error('meeep'));
+
+      try {
+        publishNpmPackages(
+          listNpmPackages,
+          markBumpedFilesAsAssumeUnchanged,
+          spawnSync
+        );
+      } catch (e) {
+        expect(markBumpedFilesAsAssumeUnchanged).to.have.been.calledWith(packages, true);
+        expect(spawnSync).to.have.been.called;
+        expect(markBumpedFilesAsAssumeUnchanged).to.have.been.calledWith(packages, false);
+        return;
       }
       expect.fail('Expected error');
     });

--- a/packages/build/src/npm-packages.ts
+++ b/packages/build/src/npm-packages.ts
@@ -6,7 +6,7 @@ const PLACEHOLDER_VERSION = '0.0.0-dev.0';
 const PROJECT_ROOT = path.resolve(__dirname, '..', '..', '..');
 const LERNA_BIN = path.resolve(PROJECT_ROOT, 'node_modules', '.bin', 'lerna');
 
-function spawnSync(command: string, args: string[], options: SpawnSyncOptionsWithStringEncoding): SpawnSyncReturns<string> {
+export function spawnSync(command: string, args: string[], options: SpawnSyncOptionsWithStringEncoding): SpawnSyncReturns<string> {
   const result = spawn.sync(command, args, options);
   if (result.error) {
     console.error('spawn.sync returned error', result.error);


### PR DESCRIPTION
The underlying issue with our CI release pipeline is that we bump the version of the packages only in the CI environment. This leads to uncommitted changes in the git repository. The `lerna publish` command will fail in this case and the `--force-publish` option does not have any effect (see also https://github.com/lerna/lerna/issues/2550).

The alternative would be to do a dummy commit in the CI environment before publishing. I chose against this to at least keep consistency between the commit hash of the published package information and the tagged version. While we still knowingly have tagged versions without the package version being properly set.

This PR includes:
- uses a helper function to ensure spawn.sync calls throw if not successful
- before lerna publish marks known changed files as assume-unchanged and reverts after publish
