### PR TITLE
feat(compass-shell): Connect appRegistry to worker runtime telemetry

### DIFF
--- a/packages/compass-shell/src/modules/runtime.js
+++ b/packages/compass-shell/src/modules/runtime.js
@@ -73,7 +73,8 @@ function reduceSetupRuntime(state, action) {
       {
         env: { ...process.env, ELECTRON_RUN_AS_NODE: 1 },
         serialization: 'advanced',
-      }
+      },
+      action.appRegistry
     )
     : new ElectronRuntime(
       CompassServiceProvider.fromDataService(action.dataService),


### PR DESCRIPTION
In #597 I forgot to actually pass the emitter to the runtime 😬