### PR TITLE
fix(compass-shell): Remove checkServerIdentity option that is incompatible with driver 4

### DIFF
--- a/packages/compass-shell/src/modules/runtime.js
+++ b/packages/compass-shell/src/modules/runtime.js
@@ -63,6 +63,13 @@ function reduceSetupRuntime(state, action) {
     delete connection.options.useUnifiedTopology;
     delete connection.options.connectWithNoPrimary;
     delete connection.options.useNewUrlParser;
+    // `true` is not a valid tls checkServerIdentity option that seems to break
+    // driver 4
+    //
+    // TODO(NODE-3061): Remove when fixed on driver side
+    if (connection.options.checkServerIdentity === true) {
+      delete connection.options.checkServerIdentity;
+    }
   }
 
   const runtime = shouldUseNewRuntime


### PR DESCRIPTION
Temporary workaround for NODE-3061