### PR TITLE
fix(build): fix markBumpedFilesAsAssumeUnchanged file location

### DIFF
--- a/packages/build/src/npm-packages.spec.ts
+++ b/packages/build/src/npm-packages.spec.ts
@@ -59,6 +59,11 @@ describe('npm-packages', () => {
         ['version', '0.7.0', '--no-changelog', '--no-push', '--exact', '--no-git-tag-version', '--force-publish', '--yes'],
         sinon.match.any
       );
+      expect(spawnSync).to.have.been.calledWith(
+        'git',
+        ['status', '--porcelain'],
+        sinon.match.any
+      );
     });
   });
 

--- a/packages/build/src/npm-packages.spec.ts
+++ b/packages/build/src/npm-packages.spec.ts
@@ -6,7 +6,8 @@ import {
   listNpmPackages,
   markBumpedFilesAsAssumeUnchanged,
   publishNpmPackages,
-  spawnSync
+  spawnSync,
+  LernaPackageDescription
 } from './npm-packages';
 
 
@@ -167,16 +168,16 @@ describe('npm-packages', () => {
   });
 
   describe('markBumpedFilesAsAssumeUnchanged', () => {
-    let packages: { name: string; version: string }[];
+    let packages: LernaPackageDescription[];
     let expectedFiles: string[];
     let spawnSync: SinonStub;
 
     beforeEach(() => {
       expectedFiles = ['lerna.json'];
       packages = listNpmPackages();
-      packages.forEach(({ name }) => {
-        expectedFiles.push(`packages/${name}/package.json`);
-        expectedFiles.push(`packages/${name}/package-lock.json`);
+      packages.forEach(({ location }) => {
+        expectedFiles.push(`${location}/package.json`);
+        expectedFiles.push(`${location}/package-lock.json`);
       });
 
       spawnSync = sinon.stub();

--- a/packages/build/src/npm-packages.spec.ts
+++ b/packages/build/src/npm-packages.spec.ts
@@ -173,11 +173,13 @@ describe('npm-packages', () => {
     let spawnSync: SinonStub;
 
     beforeEach(() => {
-      expectedFiles = ['lerna.json'];
+      expectedFiles = [
+        path.resolve(__dirname, '..', '..', '..', 'lerna.json')
+      ];
       packages = listNpmPackages();
       packages.forEach(({ location }) => {
-        expectedFiles.push(`${location}/package.json`);
-        expectedFiles.push(`${location}/package-lock.json`);
+        expectedFiles.push(path.resolve(location, 'package.json'));
+        expectedFiles.push(path.resolve(location, 'package-lock.json'));
       });
 
       spawnSync = sinon.stub();

--- a/packages/build/src/npm-packages.ts
+++ b/packages/build/src/npm-packages.ts
@@ -53,6 +53,11 @@ export function bumpNpmPackages(
     cwd: PROJECT_ROOT,
     encoding: 'utf8'
   });
+  spawnSyncFn('git', ['status', '--porcelain'], {
+    stdio: 'inherit',
+    cwd: PROJECT_ROOT,
+    encoding: 'utf8'
+  });
 }
 
 export function publishNpmPackages(

--- a/packages/build/src/npm-packages.ts
+++ b/packages/build/src/npm-packages.ts
@@ -6,6 +6,13 @@ const PLACEHOLDER_VERSION = '0.0.0-dev.0';
 const PROJECT_ROOT = path.resolve(__dirname, '..', '..', '..');
 const LERNA_BIN = path.resolve(PROJECT_ROOT, 'node_modules', '.bin', 'lerna');
 
+export interface LernaPackageDescription {
+  name: string;
+  version: string;
+  private: boolean;
+  location: string;
+}
+
 export function spawnSync(command: string, args: string[], options: SpawnSyncOptionsWithStringEncoding): SpawnSyncReturns<string> {
   const result = spawn.sync(command, args, options);
   if (result.error) {
@@ -88,11 +95,12 @@ export function publishNpmPackages(
   }
 }
 
-export function listNpmPackages(): { name: string; version: string }[] {
+export function listNpmPackages(): LernaPackageDescription[] {
   const lernaListOutput = spawnSync(
     LERNA_BIN, [
       'list',
       '--json',
+      '--all'
     ],
     {
       cwd: PROJECT_ROOT,
@@ -104,15 +112,16 @@ export function listNpmPackages(): { name: string; version: string }[] {
 }
 
 export function markBumpedFilesAsAssumeUnchanged(
-  packages: { name: string }[], assumeUnchanged: boolean,
+  packages: LernaPackageDescription[],
+  assumeUnchanged: boolean,
   spawnSyncFn: typeof spawnSync = spawnSync
 ): void {
   const filesToAssume = [
     'lerna.json'
   ];
-  packages.forEach(({ name }) => {
-    filesToAssume.push(`packages/${name}/package.json`);
-    filesToAssume.push(`packages/${name}/package-lock.json`);
+  packages.forEach(({ location }) => {
+    filesToAssume.push(`${location}/package.json`);
+    filesToAssume.push(`${location}/package-lock.json`);
   });
 
   filesToAssume.forEach(f => {

--- a/packages/build/src/npm-packages.ts
+++ b/packages/build/src/npm-packages.ts
@@ -117,11 +117,11 @@ export function markBumpedFilesAsAssumeUnchanged(
   spawnSyncFn: typeof spawnSync = spawnSync
 ): void {
   const filesToAssume = [
-    'lerna.json'
+    path.resolve(PROJECT_ROOT, 'lerna.json')
   ];
   packages.forEach(({ location }) => {
-    filesToAssume.push(`${location}/package.json`);
-    filesToAssume.push(`${location}/package-lock.json`);
+    filesToAssume.push(path.resolve(location, 'package.json'));
+    filesToAssume.push(path.resolve(location, 'package-lock.json'));
   });
 
   filesToAssume.forEach(f => {


### PR DESCRIPTION
`name` would be the package name, e.g. `@mongosh/build`, which would
not be present in that form on the file system.

We also need to use `lerna list --all`, since otherwise private
packages are not included.