### PR TITLE
fix: print AggregationCursor output correctly MONGOSH-562

### DIFF
--- a/packages/browser-repl/src/components/shell-output-line.tsx
+++ b/packages/browser-repl/src/components/shell-output-line.tsx
@@ -75,7 +75,7 @@ export class ShellOutputLine extends Component<ShellOutputLineProps> {
       return <ShowCollectionsOutput value={value} />;
     }
 
-    if (type === 'Cursor') {
+    if (type === 'Cursor' || type === 'AggregationCursor' || type === 'ChangeStreamCursor') {
       return <CursorOutput value={value} />;
     }
 

--- a/packages/browser-repl/src/components/shell-output-line.tsx
+++ b/packages/browser-repl/src/components/shell-output-line.tsx
@@ -75,7 +75,7 @@ export class ShellOutputLine extends Component<ShellOutputLineProps> {
       return <ShowCollectionsOutput value={value} />;
     }
 
-    if (type === 'Cursor' || type === 'AggregationCursor' || type === 'ChangeStreamCursor') {
+    if (type === 'Cursor' || type === 'AggregationCursor') {
       return <CursorOutput value={value} />;
     }
 

--- a/packages/cli-repl/src/format-output.ts
+++ b/packages/cli-repl/src/format-output.ts
@@ -28,10 +28,11 @@ type FormatOptions = {
  *
  * @returns {string} The output.
  */
+// eslint-disable-next-line complexity
 export default function formatOutput(evaluationResult: EvaluationResult, options: FormatOptions): string {
   const { value, type } = evaluationResult;
 
-  if (type === 'Cursor') {
+  if (type === 'Cursor' || type === 'AggregationCursor' || type === 'ChangeStreamCursor') {
     return formatCursor(value, options);
   }
 

--- a/packages/cli-repl/src/format-output.ts
+++ b/packages/cli-repl/src/format-output.ts
@@ -32,7 +32,7 @@ type FormatOptions = {
 export default function formatOutput(evaluationResult: EvaluationResult, options: FormatOptions): string {
   const { value, type } = evaluationResult;
 
-  if (type === 'Cursor' || type === 'AggregationCursor' || type === 'ChangeStreamCursor') {
+  if (type === 'Cursor' || type === 'AggregationCursor') {
     return formatCursor(value, options);
   }
 

--- a/packages/cli-repl/test/e2e.spec.ts
+++ b/packages/cli-repl/test/e2e.spec.ts
@@ -278,6 +278,27 @@ describe('e2e', function() {
       shell.assertNoErrors();
     });
 
+    it('allows to find documents using aggregate', async() => {
+      await shell.writeInputLine(`use ${dbName}`);
+
+      await db.collection('test').insertMany([
+        { doc: 1 },
+        { doc: 2 },
+        { doc: 3 }
+      ]);
+
+      await shell.writeInputLine('db.test.aggregate({ $match: {} })');
+
+      await eventually(() => {
+        shell.assertContainsOutput('doc: 1');
+        shell.assertContainsOutput('doc: 2');
+        shell.assertContainsOutput('doc: 3');
+      });
+      shell.assertNotContainsOutput('CursorIterationResult');
+
+      shell.assertNoErrors();
+    });
+
     it('allows collections with .', async() => {
       await shell.writeInputLine(`use ${dbName}`);
 

--- a/packages/shell-api/src/aggregation-cursor.spec.ts
+++ b/packages/shell-api/src/aggregation-cursor.spec.ts
@@ -38,7 +38,8 @@ describe('AggregationCursor', () => {
     beforeEach(() => {
       wrappee = {
         map: sinon.spy(),
-        closed: true
+        closed: true,
+        bufferedCount() { return 0; }
       };
       cursor = new AggregationCursor({
         _serviceProvider: { platform: ReplPlatform.CLI }

--- a/packages/shell-api/src/aggregation-cursor.ts
+++ b/packages/shell-api/src/aggregation-cursor.ts
@@ -33,7 +33,7 @@ export default class AggregationCursor extends ShellApiClass {
   async _it(): Promise<CursorIterationResult> {
     const results = this._currentIterationResult = new CursorIterationResult();
     await iterate(results, this._cursor, this._batchSize);
-    results.hasMore = !this.isExhausted();
+    results.cursorHasMore = !this.isExhausted();
     return results;
   }
 
@@ -75,7 +75,7 @@ export default class AggregationCursor extends ShellApiClass {
     return this._cursor.closed;
   }
 
-  async isExhausted(): Promise<boolean> {
+  isExhausted(): boolean {
     return this.isClosed() && this.objsLeftInBatch() === 0;
   }
 

--- a/packages/shell-api/src/change-stream-cursor.spec.ts
+++ b/packages/shell-api/src/change-stream-cursor.spec.ts
@@ -103,7 +103,7 @@ describe('ChangeStreamCursor', () => {
       } as Mongo);
       cursor2.batchSize(3);
       const results = await cursor2._it();
-      expect(results).to.deep.equal([{ doc: 1 }, { doc: 1 }, { doc: 1 }]);
+      expect(results.documents).to.deep.equal([{ doc: 1 }, { doc: 1 }, { doc: 1 }]);
     });
   });
   describe('integration', () => {
@@ -163,11 +163,11 @@ describe('ChangeStreamCursor', () => {
         const result = await ensureResult(
           100,
           async() => await cursor._it(),
-          (t) => (t.length > 0),
+          (t) => (t.documents.length > 0),
           '_it to return a batch');
-        expect(result).to.have.lengthOf(1);
-        expect(result[0].operationType).to.equal('insert');
-        expect(result[0].fullDocument.myDoc).to.equal(1);
+        expect(result.documents).to.have.lengthOf(1);
+        expect(result.documents[0].operationType).to.equal('insert');
+        expect(result.documents[0].fullDocument.myDoc).to.equal(1);
         await cursor.close();
       });
       it('async iteration iterates over the cursor', async() => {

--- a/packages/shell-api/src/cursor.ts
+++ b/packages/shell-api/src/cursor.ts
@@ -56,7 +56,7 @@ export default class Cursor extends ShellApiClass {
   async _it(): Promise<CursorIterationResult> {
     const results = this._currentIterationResult = new CursorIterationResult();
     await iterate(results, this._cursor, this._batchSize);
-    results.hasMore = !this.isExhausted();
+    results.cursorHasMore = !this.isExhausted();
     return results;
   }
 

--- a/packages/shell-api/src/helpers.ts
+++ b/packages/shell-api/src/helpers.ts
@@ -518,11 +518,11 @@ export async function iterate(
   for (let i = 0; i < batchSize; i++) {
     const doc = await cursor.tryNext();
     if (doc === null) {
-      results.hasMore = false;
+      results.cursorHasMore = false;
       break;
     }
 
-    results.push(doc);
+    results.documents.push(doc);
   }
 
   return results;

--- a/packages/shell-api/src/integration.spec.ts
+++ b/packages/shell-api/src/integration.spec.ts
@@ -133,9 +133,10 @@ describe('Shell API (integration)', function() {
         it('returns next batch of docs', async() => {
           collection.find({}, { _id: 0 });
           await shellApi.it();
-          expect(await shellApi.it()).to.deep.equal([{
-            doc: 21
-          }]);
+          expect({ ...await shellApi.it() }).to.deep.equal({
+            cursorHasMore: false,
+            documents: [{ doc: 21 }]
+          });
         });
       });
 

--- a/packages/shell-api/src/result.spec.ts
+++ b/packages/shell-api/src/result.spec.ts
@@ -120,9 +120,9 @@ describe('Results', () => {
   });
   describe('CursorIterationResult', () => {
     const r = new results.CursorIterationResult() as ShellApiInterface;
-    r.push(1, 2, 3);
+    r.documents.push(1, 2, 3);
     it('superclass attributes set', () => {
-      expect(r.length).to.equal(3);
+      expect(r.documents.length).to.equal(3);
     });
     it('toShellResult', async() => {
       expect(await toShellResult(r)).to.have.property(
@@ -131,7 +131,7 @@ describe('Results', () => {
       );
       expect(await toShellResult(r))
         .to.have.nested.property('printable.documents')
-        .deep.equal(JSON.parse(JSON.stringify(r)));
+        .deep.equal(JSON.parse(JSON.stringify(r.documents)));
     });
   });
 });

--- a/packages/shell-api/src/result.ts
+++ b/packages/shell-api/src/result.ts
@@ -1,6 +1,5 @@
 import { ShellApiClass, shellApiClassDefault } from './decorators';
 import { shellApiType, asPrintable } from './enums';
-import { addHiddenDataProperty } from './helpers';
 import { Document, ObjectIdType } from '@mongosh/service-provider-core';
 
 @shellApiClassDefault
@@ -108,28 +107,14 @@ export class DeleteResult extends ShellApiClass {
   }
 }
 
-class PrintableCursorIterationResult {
-  documents: Document[];
-  cursorHasMore: boolean;
-  constructor(cursor: CursorIterationResult) {
-    this.documents = [...cursor];
-    this.cursorHasMore = cursor.hasMore;
-  }
-}
-
-// NOTE: because this is inherited, the decorator does not add attributes. So no help() function.
 @shellApiClassDefault
-export class CursorIterationResult extends Array {
-  [shellApiType]: string;
-  hasMore: boolean;
+export class CursorIterationResult extends ShellApiClass {
+  cursorHasMore: boolean;
+  documents: Document[];
 
   constructor() {
     super();
-    this.hasMore = true; // filled by iterate() in helpers.ts or the _it() methods
-    addHiddenDataProperty(this, shellApiType, 'CursorIterationResult');
-  }
-
-  [asPrintable]() {
-    return new PrintableCursorIterationResult(this);
+    this.cursorHasMore = true; // filled by iterate() in helpers.ts or the _it() methods
+    this.documents = [];
   }
 }


### PR DESCRIPTION
Treat AggregationCursor instances like Cursor instances in the output
handling functions.

Simplify `CursorIterationResult` so that we don’t need a separate
class for its printable version, since it is already supposed
to be printable.