### PR TITLE
fix(ci): rimraf mongosh install dir on ssh host

### DIFF
--- a/.evergreen/test-package-win32.sh
+++ b/.evergreen/test-package-win32.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 curl -sSfL "$ARTIFACT_URL" > mongosh.zip
 export ARTIFACT_PATH="$PWD/mongosh.zip"
-(cd /cygdrive/c/Program\ Files/ && mkdir mongosh && cd mongosh && unzip "$ARTIFACT_PATH" && chmod -v +x bin/*)
+(cd /cygdrive/c/Program\ Files/ && rm -rf mongosh && mkdir mongosh && cd mongosh && unzip "$ARTIFACT_PATH" && chmod -v +x bin/*)
 export PATH="/cygdrive/c/Program Files/mongosh/bin:$PATH"
 mongosh --smokeTests
+(cd /cygdrive/c/Program\ Files/ && rm -rf mongosh)


### PR DESCRIPTION
Apparently, spawn hosts are not particularly isolated either,
and can be re-used:

    [2021/02/03 12:00:30.604] + cd '/cygdrive/c/Program Files/'
    [2021/02/03 12:00:30.604] + mkdir mongosh
    [2021/02/03 12:00:30.618] Starting script on SSH host
    [2021/02/03 12:00:30.618] mkdir: cannot create directory 'mongosh': File exists
    [2021/02/03 12:00:30.618] Command failed: error waiting on process 'ee956461-7225-4eae-9dda-d9bb8237be7b': exit status 1
    [2021/02/03 12:00:30.619] Task completed - FAILURE.