### PR TITLE
fix(shell-api): fix KeyVault.createKey signature MONGOSH-546

### DIFF
--- a/packages/shell-api/src/field-level-encryption.spec.ts
+++ b/packages/shell-api/src/field-level-encryption.spec.ts
@@ -184,33 +184,31 @@ describe('Field Level Encryption', () => {
       });
     });
     describe('createKey', () => {
-      it('calls createDataKey on libmongoc with string key', async() => {
+      it('calls createDataKey on libmongoc with no key for local', async() => {
         const raw = { result: 1 };
-        const kms = AWS_KMS.kmsProvider;
-        const masterkey = 'masterkey';
-        const keyaltname = ['keyaltname'];
+        const kms = 'local';
         libmongoc.createDataKey.resolves(raw);
-        const result = await keyVault.createKey(kms, masterkey, keyaltname);
-        expect(libmongoc.createDataKey).calledOnceWithExactly(kms, { masterKey: { key: masterkey }, keyAltNames: keyaltname });
+        const result = await keyVault.createKey('local');
+        expect(libmongoc.createDataKey).calledOnceWithExactly(kms, { masterKey: undefined });
         expect(result).to.deep.equal(raw);
       });
       it('calls createDataKey on libmongoc with doc key', async() => {
         const raw = { result: 1 };
         const kms = AWS_KMS.kmsProvider;
-        const masterkey = { docKey: 1 };
+        const masterKey = { region: 'us-east-1', key: 'masterkey' };
         const keyaltname = ['keyaltname'];
         libmongoc.createDataKey.resolves(raw);
-        const result = await keyVault.createKey(kms, masterkey, keyaltname);
-        expect(libmongoc.createDataKey).calledOnceWithExactly(kms, { masterKey: masterkey, keyAltNames: keyaltname });
+        const result = await keyVault.createKey(kms, masterKey, keyaltname);
+        expect(libmongoc.createDataKey).calledOnceWithExactly(kms, { masterKey, keyAltNames: keyaltname });
         expect(result).to.deep.equal(raw);
       });
       it('throw if failed', async() => {
         const kms = AWS_KMS.kmsProvider;
-        const masterkey = 'masterkey';
+        const masterKey = { region: 'us-east-1', key: 'masterkey' };
         const keyaltname = ['keyaltname'];
         const expectedError = new Error();
         libmongoc.createDataKey.rejects(expectedError);
-        const caughtError = await keyVault.createKey(kms, masterkey, keyaltname)
+        const caughtError = await keyVault.createKey(kms, masterKey, keyaltname)
           .catch(e => e);
         expect(caughtError).to.equal(expectedError);
       });

--- a/packages/shell-api/src/field-level-encryption.ts
+++ b/packages/shell-api/src/field-level-encryption.ts
@@ -120,17 +120,13 @@ export class KeyVault extends ShellApiClass {
   @returnsPromise
   createKey(
     kms: string | Document,
-    customMasterKey: string | Document, // doc defined here: https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/client-side-encryption.rst#masterkey
+    customMasterKey?: Document, // doc defined here: https://github.com/mongodb/specifications/blob/master/source/client-side-encryption/client-side-encryption.rst#masterkey
     keyAltName?: string[]
   ): Promise<Document> {
-    assertArgsDefined(kms, customMasterKey);
+    assertArgsDefined(kms);
     const options = {} as any;
 
-    if (typeof customMasterKey === 'string') {
-      options.masterKey = { key: customMasterKey };
-    } else {
-      options.masterKey = customMasterKey;
-    }
+    options.masterKey = customMasterKey;
     if (keyAltName) {
       options.keyAltNames = keyAltName;
     }


### PR DESCRIPTION
This was incorrect before (as mentioned in the ticket), but now
that we’ve updated `mongodb-client-encryption` this actually
becomes necessary, since no valid value for `masterKey` can
be specified when the kms is `local`.