### PR TITLE
fix(cli-repl): set history limit to 1000

### DIFF
--- a/packages/cli-repl/src/async-repl.ts
+++ b/packages/cli-repl/src/async-repl.ts
@@ -1,4 +1,5 @@
 import type { REPLServer, ReplOptions } from 'repl';
+import type { ReadLineOptions } from 'readline';
 import { Recoverable, start as originalStart } from 'repl';
 import isRecoverableError from 'is-recoverable-error';
 import { promisify } from 'util';
@@ -12,7 +13,7 @@ type Mutable<T> = {
 export type OriginalEvalFunction = (input: string, context: any, filename: string) => Promise<any>;
 export type AsyncEvalFunction = (originalEval: OriginalEvalFunction, input: string, context: any, filename: string) => Promise<any>;
 
-export type AsyncREPLOptions = Omit<ReplOptions, 'eval'> & {
+export type AsyncREPLOptions = ReadLineOptions & Omit<ReplOptions, 'eval'> & {
   start?: typeof originalStart,
   wrapCallbackError?: (err: Error) => Error;
   asyncEval: AsyncEvalFunction;

--- a/packages/cli-repl/src/mongosh-repl.ts
+++ b/packages/cli-repl/src/mongosh-repl.ts
@@ -96,6 +96,7 @@ class MongoshNodeRepl implements EvaluationListener {
       breakEvalOnSigint: true,
       preview: false,
       asyncEval: this.eval.bind(this),
+      historySize: 1000, // Same as the old shell.
       wrapCallbackError:
         (err: Error) => Object.assign(new MongoshInternalError(err.message), { stack: err.stack }),
       ...this.nodeReplOptions


### PR DESCRIPTION
Instead of the default of 30. This matches the old shell:

https://github.com/mongodb/mongo/blob/c575750f73b7a490a60919777dc49c45ec4f2e0c/src/mongo/shell/linenoise.cpp#L144