### PR TITLE
chore(ci): add FLE smoke test MONGOSH-543

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -181,6 +181,26 @@ functions:
           echo "$MONGOSH_TEST_EXECUTABLE_PATH"
           npm run test-e2e-ci
           }
+
+  write_preload_script:
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          set +x
+          cat <<PRELOAD_SCRIPT > preload.sh
+          echo "Preload script starting"
+          set -e
+          set -x
+          export ARTIFACT_URL=$(cat ../artifact-url.txt)
+          export IS_CI=1
+          set +x
+          export MONGOSH_SMOKE_TEST_SERVER="mongodb+srv://${connectivity_test_atlas_username}:${connectivity_test_atlas_password}@${connectivity_test_atlas_hostname}/"
+          echo "Preload script done"
+          set -x
+          PRELOAD_SCRIPT
   spawn_host:
     - command: host.create
       params:
@@ -223,7 +243,7 @@ functions:
           set -e
           set -x
           {
-          export ARTIFACT_URL="$(cat ../artifact-url.txt)"
+          . preload.sh
           ./scripts/docker/build.sh ${dockerfile}
           ./scripts/docker/run.sh ${dockerfile} --smokeTests
           }
@@ -236,7 +256,7 @@ functions:
           set -e
           set -x
           {
-          export ARTIFACT_URL="$(cat ../artifact-url.txt)"
+          . preload.sh
           curl -sSfL "$ARTIFACT_URL" > mongosh.zip
           unzip mongosh.zip
           ./bin/mongosh --smokeTests
@@ -291,6 +311,7 @@ functions:
 #   package_and_upload_artifact - Upload the release binary to S3.
 #   test_linux_artifact - Test that the built artifact works where we expect it to.
 #   release_publish - Publishes the npm packages and uploads the tarballs.
+#   pkg_test_* - Run tests on the release packages
 tasks:
   - name: check
     commands:
@@ -525,14 +546,7 @@ tasks:
       - func: get_artifact_url
         vars:
           source_build_variant: win32
-      - command: shell.exec
-        params:
-          working_dir: src
-          shell: bash
-          script: |
-            set -e
-            set -x
-            echo "export ARTIFACT_URL=$(cat ../artifact-url.txt)" >> preload.sh
+      - func: write_preload_script
       - func: spawn_host
         vars:
           distro: windows-64-vs2019-small
@@ -551,9 +565,24 @@ tasks:
       - func: get_artifact_url
         vars:
           source_build_variant: debian
+      - func: write_preload_script
       - func: test_artifact_docker
         vars:
           dockerfile: ubuntu16.04-deb
+  - name: pkg_test_docker_ubuntu1804
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_linux
+        variant: debian
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_build_variant: debian
+      - func: write_preload_script
+      - func: test_artifact_docker
+        vars:
+          dockerfile: ubuntu18.04-deb
   - name: pkg_test_docker_ubuntu2004
     tags: ["smoke-test"]
     depends_on:
@@ -564,6 +593,7 @@ tasks:
       - func: get_artifact_url
         vars:
           source_build_variant: debian
+      - func: write_preload_script
       - func: test_artifact_docker
         vars:
           dockerfile: ubuntu20.04-deb
@@ -577,6 +607,7 @@ tasks:
       - func: get_artifact_url
         vars:
           source_build_variant: rhel
+      - func: write_preload_script
       - func: test_artifact_docker
         vars:
           dockerfile: centos7-rpm
@@ -590,6 +621,7 @@ tasks:
       - func: get_artifact_url
         vars:
           source_build_variant: rhel
+      - func: write_preload_script
       - func: test_artifact_docker
         vars:
           dockerfile: centos8-rpm
@@ -603,6 +635,7 @@ tasks:
       - func: get_artifact_url
         vars:
           source_build_variant: darwin_codesign
+      - func: write_preload_script
       - func: test_artifact_macos
   - name: release_draft
     git_tag_only: true
@@ -708,6 +741,11 @@ buildvariants:
     run_on: ubuntu1604-small
     tasks:
       - name: test_linux_artifact
+  - name: ubuntu1804
+    display_name: "Ubuntu 18.04"
+    run_on: ubuntu1804-small
+    tasks:
+      - name: test_linux_artifact
   - name: ubuntu2004
     display_name: "Ubuntu 20.04"
     run_on: ubuntu2004-small
@@ -753,6 +791,7 @@ buildvariants:
       - name: pkg_test_docker_centos7
       - name: pkg_test_docker_centos8
       - name: pkg_test_docker_ubuntu1604
+      - name: pkg_test_docker_ubuntu1804
       - name: pkg_test_docker_ubuntu2004
   - name: pkg_smoke_tests_win32
     display_name: "package smoke tests (win32)"

--- a/.evergreen/package-and-upload-artifact.sh
+++ b/.evergreen/package-and-upload-artifact.sh
@@ -16,7 +16,8 @@ if [ "$(uname)" == Linux ]; then
     export DISTRO_ID_OVERRIDE=rhel70
   fi
   if [ "$BUILD_VARIANT" = debian ]; then
-    export DISTRO_ID_OVERRIDE=ubuntu1604
+    # We need ubuntu1804 in order for mongocryptd to work on ubuntu1804 and above.
+    export DISTRO_ID_OVERRIDE=ubuntu1804
   fi
   mkdir -p tmp
   cp "$(pwd)/../tmp/expansions.yaml" tmp/expansions.yaml

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,4 @@ tmp/expansions.yaml
 .evergreen/mongodb
 tmp/
 dist.tgz
+mongocryptd.pid

--- a/packages/cli-repl/src/run.ts
+++ b/packages/cli-repl/src/run.ts
@@ -14,7 +14,14 @@ import { generateUri } from '@mongosh/service-provider-server';
       // eslint-disable-next-line no-console
       console.log(version);
     } else if (options.smokeTests) {
-      await runSmokeTests(process.execPath);
+      const smokeTestServer = process.env.MONGOSH_SMOKE_TEST_SERVER;
+      if (process.execPath === process.argv[1]) {
+        // This is the compiled binary. Use only the path to it.
+        await runSmokeTests(smokeTestServer, process.execPath);
+      } else {
+        // This is not the compiled binary. Use node + this script.
+        await runSmokeTests(smokeTestServer, process.execPath, process.argv[1]);
+      }
     } else {
       let mongocryptdSpawnPath = null;
       if (process.execPath === process.argv[1]) {

--- a/packages/cli-repl/src/smoke-tests-fle.ts
+++ b/packages/cli-repl/src/smoke-tests-fle.ts
@@ -1,0 +1,87 @@
+// Test script that verifies that automatic encryption using mongocryptd
+// works when using the Mongo() object to construct the encryption key and
+// to create an auto-encryption-aware connection.
+
+export default String.raw `
+const assert = function(value, message) {
+  if (!value) {
+    console.error('assertion failed:', message);
+    unencryptedDb.dropDatabase();
+    process.exit(1);
+  }
+};
+try {
+  // The mongocryptd binary that we ship works on Ubuntu 18.04 and above,
+  // but not Ubuntu 16.04.
+  if (fs.readFileSync('/etc/issue', 'utf8').match(/Ubuntu 16/)) {
+    print('Test skipped')
+    process.exit(0);
+  }
+} catch(err) {
+  console.log(err);
+}
+
+const dbname = 'testdb_fle' + new Date().getTime();
+use(dbname);
+unencryptedDb = db;
+assert(db.getName() === dbname, 'db name must match');
+
+const local = { key: BinData(0, 'kh4Gv2N8qopZQMQYMEtww/AkPsIrXNmEMxTrs3tUoTQZbZu4msdRUaR8U5fXD7A7QXYHcEvuu4WctJLoT+NvvV3eeIg3MD+K8H9SR794m/safgRHdIfy6PD+rFpvmFbY') };
+
+const keyMongo = Mongo(db.getMongo()._uri, {
+  keyVaultNamespace: 'encryption.__keyVault',
+  kmsProvider: { local }
+});
+
+const keyVault = keyMongo.getKeyVault();
+const keyId = keyVault.createKey('local');
+sleep(100);
+
+const schemaMap = {};
+schemaMap[dbname + '.employees'] = {
+  bsonType: 'object',
+  properties: {
+    taxid: {
+      encrypt: {
+        keyId: [keyId],
+        bsonType: 'string',
+        algorithm: 'AEAD_AES_256_CBC_HMAC_SHA_512-Random'
+      }
+    }
+  }
+};
+
+console.log('Using schema map', schemaMap);
+
+const autoMongo = Mongo(db.getMongo()._uri, {
+  keyVaultNamespace: 'encryption.__keyVault',
+  kmsProvider: { local },
+  schemaMap
+});
+
+db = autoMongo.getDB(dbname);
+db.employees.insertOne({ taxid: 'abc' });
+
+// If there is some failure that is not related to the assert() calls, we still
+// want to make sure that we only print the success message if everything
+// has worked so far, because the shell keeps evaluating statements after errors.
+let verifiedEncrypted = false
+let verifiedUnencrypted = false
+{
+  const document = db.employees.find().toArray()[0];
+  console.log('auto-decrypted document', document);
+  verifiedEncrypted = document.taxid === 'abc';
+  assert(verifiedEncrypted, 'Must do automatic decryption');
+}
+db = unencryptedDb;
+{
+  const document = db.employees.find().toArray()[0];
+  console.log('non-decrypted document', document);
+  verifiedUnencrypted = document.taxid.constructor === Binary && document.taxid.sub_type === 6;
+  assert(verifiedUnencrypted, 'Must not do decryption without keys');
+}
+if (verifiedEncrypted && verifiedUnencrypted) {
+  print('Test succeeded')
+}
+db.dropDatabase();
+`;

--- a/packages/cli-repl/src/smoke-tests.spec.ts
+++ b/packages/cli-repl/src/smoke-tests.spec.ts
@@ -1,11 +1,30 @@
 import { runSmokeTests } from './';
 import path from 'path';
+import { startTestServer, ensureMongodAvailable, skipIfServerVersion } from '../../../testing/integration-testing-hooks';
 
 describe('smoke tests', () => {
+  const testServer = startTestServer('shared');
+  skipIfServerVersion(testServer, '< 4.2');
+
+  let pathBefore;
+  before(async() => {
+    // The smoke tests want mongocryptd to be in the path. We may need to add
+    // the directory of the downloaded mongod in order to be able to use it.
+    pathBefore = process.env.PATH;
+    const extraPath = await ensureMongodAvailable();
+    if (extraPath !== null) {
+      process.env.PATH += path.delimiter + extraPath;
+    }
+  });
+  after(() => {
+    process.env.PATH = pathBefore;
+  });
+
   it('self-test passes', async() => {
     // Use ts-node to run the .ts files directly so nyc can pick them up for
     // coverage.
     await runSmokeTests(
+      await testServer.connectionString(),
       process.execPath, '-r', 'ts-node/register', path.resolve(__dirname, 'run.ts')
     );
   });

--- a/packages/cli-repl/src/smoke-tests.ts
+++ b/packages/cli-repl/src/smoke-tests.ts
@@ -1,18 +1,30 @@
+/* eslint-disable no-console */
 import { spawn } from 'child_process';
 import assert from 'assert';
 import { once } from 'events';
+import { redactPassword } from '@mongosh/history';
+import fleSmokeTestScript from './smoke-tests-fle';
 
-// Run smoke tests on a executable, e.g. runSmokeTests("/path/to/mongosh.exe")
-// or runSmokeTests("/path/to/node", "packages/cli-repl/bin/mongosh.js").
-export async function runSmokeTests(executable: string, ...args: string[]): Promise<void> {
+// Run smoke tests on a executable, e.g.
+// runSmokeTests("mongodb://localhost", "/path/to/mongosh.exe") or
+// runSmokeTests(undefined, "/path/to/node", "packages/cli-repl/bin/mongosh.js").
+export async function runSmokeTests(smokeTestServer: string | undefined, executable: string, ...args: string[]): Promise<void> {
+  console.log('MONGOSH_SMOKE_TEST_SERVER set?', !!smokeTestServer);
+  if (process.env.IS_CI) {
+    assert(!!smokeTestServer, 'Make sure MONGOSH_SMOKE_TEST_SERVER is set in CI');
+  }
+
   for (const { input, output, testArgs } of [{
     input: 'print("He" + "llo" + " Wor" + "ld!")',
     output: /Hello World!/,
-    testArgs: ['--nodb']
-  }]) {
+    testArgs: ['--nodb'],
+  }].concat(smokeTestServer ? [{
+    input: fleSmokeTestScript,
+    output: /Test succeeded|Test skipped/,
+    testArgs: [smokeTestServer as string]
+  }] : [])) {
     await runSmokeTest(executable, [...args, ...testArgs], input, output);
   }
-  // eslint-disable-next-line no-console
   console.log('all tests passed');
 }
 
@@ -27,7 +39,7 @@ async function runSmokeTest(executable: string, args: string[], input: string, o
   try {
     assert.match(stdout, output);
   } catch (err) {
-    console.error({ input, output, stdout, executable, args });
+    console.error({ input, output, stdout, executable, args: args.map(redactPassword) });
     throw err;
   }
 }

--- a/packaging/deb-template/mongosh/DEBIAN/control
+++ b/packaging/deb-template/mongosh/DEBIAN/control
@@ -7,3 +7,5 @@ Installed-Size: {{size}}
 Maintainer: {{maintainer}}
 Homepage: {{homepage}}
 Description: {{description}}
+Depends: libc6 (>= 2.17)
+Recommends: libsasl2-2, libcurl4, libssl1.1

--- a/scripts/docker/run.sh
+++ b/scripts/docker/run.sh
@@ -7,4 +7,4 @@ if [ -t 0 ]; then # Check whether input is a TTY
 else
   DOCKER_FLAGS='-i'
 fi
-docker run --rm $DOCKER_FLAGS --network host "mongosh-${1}" ${@:2}
+docker run --rm $DOCKER_FLAGS -e MONGOSH_SMOKE_TEST_SERVER -e IS_CI --network host "mongosh-${1}" ${@:2}

--- a/scripts/docker/ubuntu16.04-deb.Dockerfile
+++ b/scripts/docker/ubuntu16.04-deb.Dockerfile
@@ -2,5 +2,7 @@ FROM ubuntu:16.04
 
 ARG artifact_url=""
 ADD ${artifact_url} /tmp
-RUN apt-get install -y --install-recommends /tmp/mongosh_*_amd64.deb
+RUN apt-get update
+RUN apt-get install -y /tmp/mongosh_*_amd64.deb
+RUN /usr/bin/mongosh --version
 ENTRYPOINT [ "mongosh" ]

--- a/scripts/docker/ubuntu18.04-deb.Dockerfile
+++ b/scripts/docker/ubuntu18.04-deb.Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:16.04
+FROM ubuntu:18.04
 
 ARG artifact_url=""
 ADD ${artifact_url} /tmp

--- a/scripts/docker/ubuntu18.04-deb.Dockerfile
+++ b/scripts/docker/ubuntu18.04-deb.Dockerfile
@@ -2,5 +2,8 @@ FROM ubuntu:18.04
 
 ARG artifact_url=""
 ADD ${artifact_url} /tmp
-RUN apt-get install -y --install-recommends /tmp/mongosh_*_amd64.deb
+RUN apt-get update
+RUN apt-get install -y /tmp/mongosh_*_amd64.deb
+RUN /usr/bin/mongosh --version
+RUN /usr/libexec/mongocryptd-mongosh --version
 ENTRYPOINT [ "mongosh" ]

--- a/scripts/docker/ubuntu20.04-deb.Dockerfile
+++ b/scripts/docker/ubuntu20.04-deb.Dockerfile
@@ -2,5 +2,8 @@ FROM ubuntu:20.04
 
 ARG artifact_url=""
 ADD ${artifact_url} /tmp
-RUN apt-get install -y --install-recommends /tmp/mongosh_*_amd64.deb
+RUN apt-get update
+RUN apt-get install -y /tmp/mongosh_*_amd64.deb
+RUN /usr/bin/mongosh --version
+RUN /usr/libexec/mongocryptd-mongosh --version
 ENTRYPOINT [ "mongosh" ]

--- a/scripts/docker/ubuntu20.04-deb.Dockerfile
+++ b/scripts/docker/ubuntu20.04-deb.Dockerfile
@@ -2,5 +2,5 @@ FROM ubuntu:20.04
 
 ARG artifact_url=""
 ADD ${artifact_url} /tmp
-RUN dpkg -i /tmp/mongosh_*_amd64.deb
+RUN apt-get install -y --install-recommends /tmp/mongosh_*_amd64.deb
 ENTRYPOINT [ "mongosh" ]


### PR DESCRIPTION
Run a FLE script that verifies that automatic FLE using mongocryptd
works. This uses the same endpoint as the connectivity tests.

This also involves changing the mongocryptd binary we use for .deb
packages: The one from Ubuntu 16.04 only works there, so we use
the one from Ubuntu 18.04 instead. Ubuntu 16.04 users will have
to install mongocryptd manually (unless we decide to offer multiple
.deb packages at some point).