### PR TITLE
fix(compass-shell): Remove URL mock and move getConnectionOptions so that tests don't break

### DIFF
--- a/packages/compass-shell/test/setup.js
+++ b/packages/compass-shell/test/setup.js
@@ -6,13 +6,7 @@ const chai = require('chai');
 const chaiEnzyme = require('chai-enzyme');
 const sinonChai = require('sinon-chai');
 
-require('jsdom-global')('', {
-  beforeParse(win) {
-    win.URL = {
-      createObjectURL: () => {}
-    };
-  }
-});
+require('jsdom-global')('');
 
 global.sinon = require('sinon');
 global.expect = chai.expect;


### PR DESCRIPTION
`compass-shell` tests are currently failing on master due to `URL` mock and and `dataService` mocks being not up to date. This PR fixes the issue by removing URL mock that we don't really need anymore and restructuring runtime module so that un-mocked method is not reachable in tests (we are not testing it yet this is why I decided not to add it to the mocks yet)