### PR TITLE
chore(shell-api): add FLE integration tests MONGOSH-496

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8712,6 +8712,15 @@
         "stream-shift": "^1.0.0"
       }
     },
+    "duplexpair": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/duplexpair/-/duplexpair-1.0.1.tgz",
+      "integrity": "sha512-xAJCL8UnXa+GyHIqSNUT9eiQSfGvSBPOZvAYN17ULwYBMady5Ek6Ghpuj4P6+ZGkjlmUFdTh9y+ejvKRl5rcRg==",
+      "dev": true,
+      "requires": {
+        "readable-stream": "^2.3.3"
+      }
+    },
     "ecc-jsbn": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",

--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "command-exists": "^1.2.9",
     "cross-env": "^6.0.3",
     "download": "^8.0.0",
+    "duplexpair": "^1.0.1",
     "electron-notarize": "mongodb-js/electron-notarize",
     "eslint": "^6.8.0",
     "eslint-config-mongodb-js": "^5.0.3",

--- a/packages/shell-api/src/field-level-encryption.ts
+++ b/packages/shell-api/src/field-level-encryption.ts
@@ -39,6 +39,7 @@ export interface ClientSideFieldLevelEncryptionOptions {
   kmsProvider: ClientSideFieldLevelEncryptionKmsProvider,
   schemaMap?: Document,
   bypassAutoEncryption?: boolean;
+  bypassAutoEncryptionFully?: boolean;
 }
 
 @shellApiClassDefault
@@ -60,8 +61,8 @@ export class ClientEncryption extends ShellApiClass {
     this._libmongocrypt = new fle.ClientEncryption(
       mongo._serviceProvider.getRawClient(),
       {
-        ...this._mongo._fleOptions
-      } as ClientEncryptionOptions
+        ...(this._mongo._fleOptions as ClientEncryptionOptions)
+      }
     );
   }
 

--- a/testing/fake-kms.ts
+++ b/testing/fake-kms.ts
@@ -1,0 +1,75 @@
+import DuplexPair from 'duplexpair';
+import http from 'http';
+
+// Exact values specified by RFC6749 ;)
+const oauthToken = { access_token: '2YotnFZFEjr1zCsicMWpAA', expires_in: 3600 };
+
+// Return a Duplex stream that behaves like an HTTP stream, with the 'server'
+// being provided by the handler function in this case (which is expected
+// to return JSON).
+type RequestData = { url: string, body: string };
+function makeFakeHTTP(handler: (data: RequestData) => any): NodeJS.ReadableStream & NodeJS.WritableStream {
+  const { socket1, socket2 } = new DuplexPair();
+  const httpServer = http.createServer((req, res) => {
+    let body = '';
+    req.setEncoding('utf8').on('data', chunk => { body += chunk; });
+    req.on('end', () => {
+      res.writeHead(200, {
+        'Content-Type': 'application/json'
+      });
+      res.end(JSON.stringify(handler({ url: req.url, body })));
+    });
+  });
+  httpServer.emit('connection', socket2);
+  return socket1;
+}
+
+export function fakeAWSKMS(): NodeJS.ReadableStream & NodeJS.WritableStream {
+  return makeFakeHTTP(({ body }) => {
+    const request = JSON.parse(body);
+    let response;
+    if (request.KeyId && request.Plaintext) {
+      // Famously "unbreakable" base64 encryption ;) We use this to forward
+      // both KeyId and Plaintext so that they are available for generating
+      // the decryption response, which also provides the KeyId and Plaintext
+      // based on the CiphertextBlob alone.
+      const CiphertextBlob = Buffer.from(request.KeyId + '\0' + request.Plaintext).toString('base64')
+      return {
+        CiphertextBlob,
+        EncryptionAlgorithm: 'SYMMETRIC_DEFAULT',
+        KeyId: request.KeyId
+      };
+    } else {
+      const [ KeyId, Plaintext ] = Buffer.from(request.CiphertextBlob, 'base64').toString().split('\0');
+      return {
+        Plaintext,
+        EncryptionAlgorithm: 'SYMMETRIC_DEFAULT',
+        KeyId
+      };
+    }
+  });
+}
+
+export function fakeAzureKMS(): NodeJS.ReadableStream & NodeJS.WritableStream {
+  return makeFakeHTTP(({ body, url }) => {
+    if (url.endsWith('/token')) {
+      return oauthToken;
+    } else if (url.match(/\/(un)?wrapkey/)) {
+      // Just act as if this was encrypted.
+      return { value: JSON.parse(body).value };
+    }
+  });
+}
+
+export function fakeGCPKMS(): NodeJS.ReadableStream & NodeJS.WritableStream {
+  return makeFakeHTTP(({ body, url }) => {
+    if (url.endsWith('/token')) {
+      return oauthToken;
+    } else if (url.endsWith(':encrypt')) {
+      // Here we also just perform noop encryption.
+      return { ciphertext: JSON.parse(body).plaintext };
+    } else if (url.endsWith(':decrypt')) {
+      return { plaintext: JSON.parse(body).ciphertext };
+    }
+  });
+}


### PR DESCRIPTION
(Blocked on #553, and thus still hitting a slightly moving target here)

Provide fake KMS services in order to test local, AWS, GCP and Azure
FLE integration.

Also introduce an undocumented (unless we want to document it)
`bypassAutoEncryptionFully` that lets us create `Mongo` objects
which do not try to perform automatic encryption themselves,
but which still provide working `.getClientEncryption()` and
`.getKeyVault()` methods (which is otherwise impossible).
