### PR TITLE
chore(cli-repl): refactor smoke test skipping

### DIFF
--- a/packages/cli-repl/src/smoke-tests-fle.ts
+++ b/packages/cli-repl/src/smoke-tests-fle.ts
@@ -20,6 +20,11 @@ try {
 } catch(err) {
   console.log(err);
 }
+if (db.version().startsWith('4.0.')) {
+  // No FLE on mongod < 4.2
+  print('Test skipped')
+  process.exit(0)
+}
 
 const dbname = 'testdb_fle' + new Date().getTime();
 use(dbname);

--- a/packages/cli-repl/src/smoke-tests.spec.ts
+++ b/packages/cli-repl/src/smoke-tests.spec.ts
@@ -1,10 +1,9 @@
 import { runSmokeTests } from './';
 import path from 'path';
-import { startTestServer, ensureMongodAvailable, skipIfServerVersion } from '../../../testing/integration-testing-hooks';
+import { startTestServer, ensureMongodAvailable } from '../../../testing/integration-testing-hooks';
 
 describe('smoke tests', () => {
   const testServer = startTestServer('shared');
-  skipIfServerVersion(testServer, '< 4.2');
 
   let pathBefore;
   before(async() => {


### PR DESCRIPTION
Don’t skip fully for 4.0, and rather only skip the FLE test when
connected to a 4.0 server.