### PR TITLE
fix(compass-shell): make max height 95% view height instead of 800 pixels COMPASS-4629

### DIFF
--- a/packages/compass-shell/src/components/compass-shell/compass-shell.jsx
+++ b/packages/compass-shell/src/components/compass-shell/compass-shell.jsx
@@ -141,7 +141,7 @@ export class CompassShell extends Component {
           }}
           id="content"
           minHeight={defaultShellHeightClosed}
-          maxHeight={800}
+          maxHeight="95vh"
           enable={{
             ...resizeableDirections,
             top: isExpanded


### PR DESCRIPTION
<img width="1033" alt="Screen Shot 2021-02-09 at 9 50 20 PM" src="https://user-images.githubusercontent.com/1791149/107427072-49babe00-6b21-11eb-9782-bcd69b3ae393.png">
