### PR TITLE
feat(shell-api): add/rename explicitEncryptionOnly option MONGOSH-590

### DIFF
--- a/packages/shell-api/src/field-level-encryption.spec.ts
+++ b/packages/shell-api/src/field-level-encryption.spec.ts
@@ -406,6 +406,24 @@ describe('Field Level Encryption', () => {
       // eslint-disable-next-line no-new
       new Mongo(internalState, 'localhost:27017', localKmsOptions);
     });
+    it('fails if both explicitEncryptionOnly and schemaMap are passed', () => {
+      const localKmsOptions: ClientSideFieldLevelEncryptionOptions = {
+        keyVaultNamespace: `${DB}.${COLL}`,
+        kmsProvider: {
+          local: {
+            key: new bson.Binary(Buffer.alloc(96).toString('base64'))
+          }
+        },
+        schemaMap: SCHEMA_MAP,
+        explicitEncryptionOnly: true
+      };
+      try {
+        void new Mongo(internalState, 'localhost:27017', localKmsOptions);
+      } catch (e) {
+        return expect(e.message).to.contain('explicitEncryptionOnly and schemaMap are mutually exclusive');
+      }
+      expect.fail('Expected error');
+    });
   });
   describe('KeyVault constructor', () => {
     beforeEach(() => {
@@ -505,7 +523,7 @@ srDVjIT3LsvTqw==`
         const mongo = new Mongo(internalState, uri, {
           keyVaultNamespace: `${dbname}.__keyVault`,
           kmsProvider: { [kmsName]: kms[kmsName] } as any,
-          bypassAutoEncryptionFully: true
+          explicitEncryptionOnly: true
         });
         await mongo.connect();
         internalState.mongos.push(mongo);

--- a/packages/shell-api/src/field-level-encryption.ts
+++ b/packages/shell-api/src/field-level-encryption.ts
@@ -39,7 +39,7 @@ export interface ClientSideFieldLevelEncryptionOptions {
   kmsProvider: ClientSideFieldLevelEncryptionKmsProvider,
   schemaMap?: Document,
   bypassAutoEncryption?: boolean;
-  bypassAutoEncryptionFully?: boolean;
+  explicitEncryptionOnly?: boolean;
 }
 
 @shellApiClassDefault

--- a/packages/shell-api/src/mongo.ts
+++ b/packages/shell-api/src/mongo.ts
@@ -62,7 +62,7 @@ export default class Mongo extends ShellApiClass {
   private _keyVault: KeyVault | undefined; // need to keep it around so that the ShellApi ClientEncryption class can access it
   private _clientEncryption: ClientEncryption | undefined;
   private _readPreferenceWasExplicitlyRequested = false;
-  private _bypassAutoEncryptionFully = false;
+  private _explicitEncryptionOnly = false;
 
   constructor(
     internalState: ShellInternalState,
@@ -80,10 +80,13 @@ export default class Mongo extends ShellApiClass {
     }
     this._readPreferenceWasExplicitlyRequested = /\breadPreference=/.test(this._uri);
     if (fleOptions) {
-      if (fleOptions.bypassAutoEncryptionFully !== undefined) {
+      if (fleOptions.explicitEncryptionOnly !== undefined) {
+        if (fleOptions.schemaMap !== undefined) {
+          throw new MongoshInvalidInputError('explicitEncryptionOnly and schemaMap are mutually exclusive', CommonErrors.InvalidArgument);
+        }
         fleOptions = { ...fleOptions };
-        this._bypassAutoEncryptionFully = !!fleOptions.bypassAutoEncryptionFully;
-        delete fleOptions.bypassAutoEncryptionFully;
+        this._explicitEncryptionOnly = !!fleOptions.explicitEncryptionOnly;
+        delete fleOptions.explicitEncryptionOnly;
       }
       this._fleOptions = processFLEOptions(fleOptions, this._serviceProvider);
       const { mongocryptdSpawnPath } = this._internalState;
@@ -120,7 +123,7 @@ export default class Mongo extends ShellApiClass {
     const mongoClientOptions: MongoClientOptions = user || pwd ? {
       auth: { username: user, password: pwd }
     } : {};
-    if (this._fleOptions && !this._bypassAutoEncryptionFully) {
+    if (this._fleOptions && !this._explicitEncryptionOnly) {
       mongoClientOptions.autoEncryption = this._fleOptions;
     }
     this._serviceProvider = await this._serviceProvider.getNewConnection(this._uri, mongoClientOptions);


### PR DESCRIPTION
Rename the previously introduced option with a better name, in order
to provide a good public API, and add a check that verifies that this
is not used in combination with `schemaMap` (because the options would
contradict each other).