### PR TITLE
fix(compass-shell): Do not add authMechanismProperties when not present

### DIFF
--- a/packages/compass-shell/src/modules/adapt-driver-v36-connection-params.js
+++ b/packages/compass-shell/src/modules/adapt-driver-v36-connection-params.js
@@ -57,16 +57,15 @@ function extractGssapiServiceName(oldDriverUrl, newDriverOptions) {
   const uri = new ConnectionString(oldDriverUrl);
 
   const gssapiServiceName = uri.searchParams.get('gssapiServiceName');
+
   uri.searchParams.delete('gssapiServiceName');
 
-  return [
-    uri.toString(),
-    {
-      ...newDriverOptions,
-      authMechanismProperties: {
-        ...newDriverOptions.authMechanismProperties,
-        gssapiServiceName
-      }
-    }
-  ];
+  if (gssapiServiceName) {
+    newDriverOptions.authMechanismProperties = {
+      ...newDriverOptions.authMechanismProperties,
+      gssapiServiceName,
+    };
+  }
+
+  return [uri.toString(), newDriverOptions];
 }

--- a/packages/compass-shell/src/modules/adapt-driver-v36-connection-params.spec.js
+++ b/packages/compass-shell/src/modules/adapt-driver-v36-connection-params.spec.js
@@ -109,4 +109,9 @@ describe('adaptDriverV36ConnectionParams', () => {
     expect(uri).to.equal(LOCALHOST);
     expect(options.authMechanismProperties.gssapiServiceName).to.equal('some-name');
   });
+
+  it("doesn't add authMechanismProperties if not present", () => {
+    const [, options] = adaptDriverV36ConnectionParams(LOCALHOST, {});
+    expect(options).to.not.have.property('authMechanismProperties');
+  });
 });


### PR DESCRIPTION
If options are added even when nothing was extracted from 3.6 options, mongodb driver would still try to use connection options and will not connect successfully