### PR TITLE
chore(cli-repl): add FLE option integration test

### DIFF
--- a/packages/cli-repl/src/smoke-tests.spec.ts
+++ b/packages/cli-repl/src/smoke-tests.spec.ts
@@ -1,23 +1,10 @@
 import { runSmokeTests } from './';
 import path from 'path';
-import { startTestServer, ensureMongodAvailable } from '../../../testing/integration-testing-hooks';
+import { startTestServer, useBinaryPath } from '../../../testing/integration-testing-hooks';
 
 describe('smoke tests', () => {
   const testServer = startTestServer('shared');
-
-  let pathBefore;
-  before(async() => {
-    // The smoke tests want mongocryptd to be in the path. We may need to add
-    // the directory of the downloaded mongod in order to be able to use it.
-    pathBefore = process.env.PATH;
-    const extraPath = await ensureMongodAvailable();
-    if (extraPath !== null) {
-      process.env.PATH += path.delimiter + extraPath;
-    }
-  });
-  after(() => {
-    process.env.PATH = pathBefore;
-  });
+  useBinaryPath(testServer); // Get mongocryptd in the PATH for this test
 
   it('self-test passes', async() => {
     // Use ts-node to run the .ts files directly so nyc can pick them up for

--- a/packages/cli-repl/test/e2e-fle.spec.ts
+++ b/packages/cli-repl/test/e2e-fle.spec.ts
@@ -1,6 +1,6 @@
 import { MongoClient } from 'mongodb';
 import { TestShell } from './test-shell';
-import { startTestServer, useBinaryPath } from '../../../testing/integration-testing-hooks';
+import { startTestServer, useBinaryPath, skipIfServerVersion } from '../../../testing/integration-testing-hooks';
 import { makeFakeHTTPServer, fakeAWSHandlers } from '../../../testing/fake-kms';
 import { once } from 'events';
 import { serialize } from 'v8';
@@ -9,6 +9,7 @@ import path from 'path';
 
 describe('FLE tests', () => {
   const testServer = startTestServer('shared');
+  skipIfServerVersion(testServer, '< 4.2'); // FLE only available on 4.2+
   useBinaryPath(testServer); // Get mongocryptd in the PATH for this test
   let kmsServer: ReturnType<typeof makeFakeHTTPServer>;
   let dbname: string;

--- a/packages/cli-repl/test/e2e-fle.spec.ts
+++ b/packages/cli-repl/test/e2e-fle.spec.ts
@@ -1,0 +1,81 @@
+import { MongoClient } from 'mongodb';
+import { TestShell } from './test-shell';
+import { startTestServer, useBinaryPath } from '../../../testing/integration-testing-hooks';
+import { makeFakeHTTPServer, fakeAWSHandlers } from '../../../testing/fake-kms';
+import { once } from 'events';
+import { serialize } from 'v8';
+import { inspect } from 'util';
+import path from 'path';
+
+describe('FLE tests', () => {
+  const testServer = startTestServer('shared');
+  useBinaryPath(testServer); // Get mongocryptd in the PATH for this test
+  let kmsServer: ReturnType<typeof makeFakeHTTPServer>;
+  let dbname: string;
+
+  before(async() => {
+    kmsServer = makeFakeHTTPServer(fakeAWSHandlers);
+    kmsServer.listen(0);
+    await once(kmsServer, 'listening');
+  });
+  after(() => {
+    kmsServer.close();
+  });
+  beforeEach(() => {
+    kmsServer.requests = [];
+    dbname = `test-${Date.now()}`;
+  });
+  afterEach(async() => {
+    const client = await MongoClient.connect(await testServer.connectionString(), {});
+    await client.db(dbname).dropDatabase();
+    await client.close();
+    await TestShell.killall();
+  });
+
+  it('passes through command line options', async() => {
+    const accessKeyId = 'SxHpYMUtB1CEVg9tX0N1';
+    const secretAccessKey = '44mjXTk34uMUmORma3w1viIAx4RCUv78bzwDY0R7';
+    const shell = TestShell.start({
+      args: [
+        `--awsAccessKeyId=${accessKeyId}`,
+        `--awsSecretAccessKey=${secretAccessKey}`,
+        `--keyVaultNamespace=${dbname}.keyVault`,
+        await testServer.connectionString()
+      ],
+      env: {
+        ...process.env,
+        NODE_OPTIONS: '--require ./redirect-network-io.js',
+        REDIRECT_NETWORK_SOURCES: serialize(fakeAWSHandlers.map(({ host }) => host)).toString('base64'),
+        REDIRECT_NETWORK_TARGET: `localhost:${(kmsServer.address() as any).port}`,
+      },
+      cwd: path.join(__dirname, 'fixtures')
+    });
+
+    await shell.executeLine(`use ${dbname}`);
+    await shell.executeLine(`db.keyVault.insertOne({
+      _id: UUID("e7b4abe7-ff70-48c3-9d3a-3526e18c2646"),
+      keyMaterial: new Binary(Buffer.from("010202007888b7b9089f9cf816059c4c02edf139d50227528b2a74a5c9910c89095d45a9d10133bd4c047f2ba610d7ad4efcc945f863000000c23081bf06092a864886f70d010706a081b13081ae0201003081a806092a864886f70d010701301e060960864801650304012e3011040cf406b9ccb00f83dd632e76e9020110807b9c2b3a676746e10486ec64468d45ec89cac30f59812b711fc24530188166c481f4f4ab376c258f8f54affdc8523468fdd07b84e77b21a14008a23fb6d111c05eb4287b7b973f3a60d5c7d87074119b424477366cbe72c31da8fc76b8f72e31f609c3b423c599d3e4a59c21e4a0fe227ebe1aa53038cb94f79c457b", "hex"), 0),
+      creationDate: ISODate('2021-02-10T15:51:00.567Z'),
+      updateDate: ISODate('2021-02-10T15:51:00.567Z'),
+      status: 0,
+      masterKey: {
+        provider: 'aws',
+        region: 'us-east-2',
+        key: 'arn:aws:kms:us-east-2:398471984214:key/174b7c1d-3651-4517-7521-21988befd8cb'
+      }
+    })`);
+    await shell.executeLine(`db.data.insertOne({
+      _id: ObjectId("602400ec9933cbed7fa92a1c"),
+      taxid: new Binary(Buffer.from("02e7b4abe7ff7048c39d3a3526e18c264602846f122fa8c1ae1b8aff3dc7c20a8a3dbc95541e8d0d75cb8daf0b7e3137d553a788ccb62e31fed2da98ea3a596972c6dc7c17bbe6f9a9edc3a7f3e2ad96a819", "hex"), 6)
+    });`);
+    // This will try to automatically decrypt the data, but it will not succeed.
+    // That does not matter here -- we're just checking that the HTTP requests
+    // made were successful.
+    await shell.executeLine('db.data.find();');
+
+    // The actual assertion here:
+    if (!kmsServer.requests.some(req => req.headers.authorization.includes(accessKeyId))) {
+      throw new Error(`Missed expected request to AWS\nShell output:\n${shell.output}\nRequests:\n${kmsServer.requests.map(req => inspect(req.headers))}`);
+    }
+  });
+});

--- a/packages/cli-repl/test/fixtures/redirect-network-io.js
+++ b/packages/cli-repl/test/fixtures/redirect-network-io.js
@@ -1,0 +1,37 @@
+// eslint-disable-next-line strict
+'use strict';
+const tls = require('tls');
+const net = require('net');
+const v8 = require('v8');
+
+const sources = v8.deserialize(Buffer.from(process.env.REDIRECT_NETWORK_SOURCES, 'base64'));
+const target = process.env.REDIRECT_NETWORK_TARGET.split(':');
+
+for (const mod of [ tls, net ]) {
+  const originalConnect = mod.connect;
+  mod.connect = (...args) => {
+    // Signatures:
+    // connect(opts, cb)
+    // connect(path, cb)
+    // connect(port[, host][, cb])
+    // connect(path[, options][, cb])
+    // connect(port[, host][, options][, cb])
+    if (typeof args[0] === 'number' && typeof args[1] === 'string') {
+      const hostport = { host: args[1], port: args[0] };
+      if (typeof args[2] === 'object') {
+        args.splice(0, 2);
+        args[0] = { ...args[0], ...hostport };
+      } else {
+        args.splice(0, 2, hostport);
+      }
+    }
+
+    const host = args[0].host;
+    if (host !== undefined && sources.some(source => source.test(host))) {
+      args[0].host = target[0];
+      args[0].port = +target[1];
+      return net.connect(...args);
+    }
+    return originalConnect(...args);
+  };
+}

--- a/testing/fake-kms.ts
+++ b/testing/fake-kms.ts
@@ -4,13 +4,41 @@ import http from 'http';
 // Exact values specified by RFC6749 ;)
 const oauthToken = { access_token: '2YotnFZFEjr1zCsicMWpAA', expires_in: 3600 };
 
+type RequestData = { url: string, body: string };
+type HandlerFunction = (data: RequestData) => any;
+type HandlerList = { host: RegExp, handler: HandlerFunction }[];
+type Duplex = NodeJS.ReadableStream & NodeJS.WritableStream;
+
 // Return a Duplex stream that behaves like an HTTP stream, with the 'server'
 // being provided by the handler function in this case (which is expected
 // to return JSON).
-type RequestData = { url: string, body: string };
-function makeFakeHTTP(handler: (data: RequestData) => any): NodeJS.ReadableStream & NodeJS.WritableStream {
+export function makeFakeHTTPConnection(handlerList: HandlerList): Duplex {
   const { socket1, socket2 } = new DuplexPair();
-  const httpServer = http.createServer((req, res) => {
+  const server = makeFakeHTTPServer(handlerList);
+  server.emit('connection', socket2);
+  return socket1;
+}
+
+type FakeHTTPServer = http.Server & { requests: http.IncomingMessage[] };
+export function makeFakeHTTPServer(handlerList: HandlerList): FakeHTTPServer {
+  const server = http.createServer((req, res) => {
+    (server as FakeHTTPServer).requests.push(req);
+    let handler: HandlerFunction | undefined;
+    const host = req.headers['host'];
+    for (const potentialHandler of handlerList) {
+      if (potentialHandler.host.test(host)) {
+        handler = potentialHandler.handler;
+        break;
+      }
+    }
+    if (!handler) {
+      res.writeHead(404, {
+        'Content-Type': 'text/plain'
+      });
+      res.end(`Host ${host} not found`);
+      return;
+    }
+
     let body = '';
     req.setEncoding('utf8').on('data', chunk => { body += chunk; });
     req.on('end', () => {
@@ -20,56 +48,55 @@ function makeFakeHTTP(handler: (data: RequestData) => any): NodeJS.ReadableStrea
       res.end(JSON.stringify(handler({ url: req.url, body })));
     });
   });
-  httpServer.emit('connection', socket2);
-  return socket1;
+  return Object.assign(server, { requests: [] });
 }
 
-export function fakeAWSKMS(): NodeJS.ReadableStream & NodeJS.WritableStream {
-  return makeFakeHTTP(({ body }) => {
-    const request = JSON.parse(body);
-    let response;
-    if (request.KeyId && request.Plaintext) {
-      // Famously "unbreakable" base64 encryption ;) We use this to forward
-      // both KeyId and Plaintext so that they are available for generating
-      // the decryption response, which also provides the KeyId and Plaintext
-      // based on the CiphertextBlob alone.
-      const CiphertextBlob = Buffer.from(request.KeyId + '\0' + request.Plaintext).toString('base64')
-      return {
-        CiphertextBlob,
-        EncryptionAlgorithm: 'SYMMETRIC_DEFAULT',
-        KeyId: request.KeyId
-      };
-    } else {
-      const [ KeyId, Plaintext ] = Buffer.from(request.CiphertextBlob, 'base64').toString().split('\0');
-      return {
-        Plaintext,
-        EncryptionAlgorithm: 'SYMMETRIC_DEFAULT',
-        KeyId
-      };
-    }
-  });
+export const fakeAWSHandlers: HandlerList = [
+  { host: /\.amazonaws\.com$/, handler: awsHandler },
+  { host: /\.microsoftonline.com$|\.azure.net$/, handler: azureHandler },
+  { host: /\.googleapis.com$/, handler: gcpHandler }
+];
+
+function awsHandler({ body }: RequestData): any {
+  const request = JSON.parse(body);
+  let response;
+  if (request.KeyId && request.Plaintext) {
+    // Famously "unbreakable" base64 encryption ;) We use this to forward
+    // both KeyId and Plaintext so that they are available for generating
+    // the decryption response, which also provides the KeyId and Plaintext
+    // based on the CiphertextBlob alone.
+    const CiphertextBlob = Buffer.from(request.KeyId + '\0' + request.Plaintext).toString('base64')
+    return {
+      CiphertextBlob,
+      EncryptionAlgorithm: 'SYMMETRIC_DEFAULT',
+      KeyId: request.KeyId
+    };
+  } else {
+    const [ KeyId, Plaintext ] = Buffer.from(request.CiphertextBlob, 'base64').toString().split('\0');
+    return {
+      Plaintext,
+      EncryptionAlgorithm: 'SYMMETRIC_DEFAULT',
+      KeyId
+    };
+  }
 }
 
-export function fakeAzureKMS(): NodeJS.ReadableStream & NodeJS.WritableStream {
-  return makeFakeHTTP(({ body, url }) => {
-    if (url.endsWith('/token')) {
-      return oauthToken;
-    } else if (url.match(/\/(un)?wrapkey/)) {
-      // Just act as if this was encrypted.
-      return { value: JSON.parse(body).value };
-    }
-  });
+function azureHandler({ body, url }: RequestData): any {
+  if (url.endsWith('/token')) {
+    return oauthToken;
+  } else if (url.match(/\/(un)?wrapkey/)) {
+    // Just act as if this was encrypted.
+    return { value: JSON.parse(body).value };
+  }
 }
 
-export function fakeGCPKMS(): NodeJS.ReadableStream & NodeJS.WritableStream {
-  return makeFakeHTTP(({ body, url }) => {
-    if (url.endsWith('/token')) {
-      return oauthToken;
-    } else if (url.endsWith(':encrypt')) {
-      // Here we also just perform noop encryption.
-      return { ciphertext: JSON.parse(body).plaintext };
-    } else if (url.endsWith(':decrypt')) {
-      return { plaintext: JSON.parse(body).ciphertext };
-    }
-  });
+function gcpHandler({ body, url }: RequestData): any {
+  if (url.endsWith('/token')) {
+    return oauthToken;
+  } else if (url.endsWith(':encrypt')) {
+    // Here we also just perform noop encryption.
+    return { ciphertext: JSON.parse(body).plaintext };
+  } else if (url.endsWith(':decrypt')) {
+    return { plaintext: JSON.parse(body).ciphertext };
+  }
 }


### PR DESCRIPTION
Add integration tests for the AWS-related FLE command line options.
This involves:

- The fake KMS HTTP services can now be spun up as actual HTTP servers
- We inject a script into the target process that redirects network
  connections to such HTTP servers
- We provide a utility method for adding the downloaded mongodb
  package’s binary path to the PATH environment variable, so that
  tests that use it can access `mongocryptd`
- We insert fake data into a test database that the driver will attempt
  to decrypt (but fail), and make a request to the fake AWS KMS
  server in the process that we take as validation that the AWS
  options were correctly passed.