### PR TITLE
MONGOSH-565: Tweaked copy for docs link

### DIFF
--- a/packages/i18n/src/locales/en_US.ts
+++ b/packages/i18n/src/locales/en_US.ts
@@ -65,7 +65,7 @@ const translations: Catalog = {
       enabledTelemetry: 'Telemetry is now enabled.',
       disabledTelemetry: 'Telemetry is now disabled.',
       wiki: {
-        info: 'For more information about mongosh, please see our docs:',
+        info: 'For mongosh info see:',
         link: 'https://docs.mongodb.com/mongodb-shell/'
       }
     },


### PR DESCRIPTION
As suggested in MONGOSH-565, this PR makes the copy for the docs message/link shorter.

This is what it looks like with this change:
![image](https://user-images.githubusercontent.com/761042/107615919-50deea80-6c4d-11eb-8441-5b3ff2b69489.png)
