### PR TITLE
chore(build): decouple tasks from build variant names MONGOSH-534

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -140,13 +140,13 @@ functions:
         env:
           NODE_JS_VERSION: ${node_js_version}
           DISTRO_ID_OVERRIDE: ${distro_id}
-          BUILD_VARIANT: ${build_variant}
+          DISTRIBUTION_BUILD_VARIANT: ${distribution_build_variant}
     - command: s3.put
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
         local_file: src/artifact-url.txt
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/artifact-url-${build_variant}.txt
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/artifact-url-${distribution_build_variant}.txt
         bucket: mciuploads
         permissions: public-read
         content_type: application/x-gzip
@@ -156,7 +156,7 @@ functions:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
         local_file: artifact-url.txt
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/artifact-url-${source_build_variant}.txt
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/artifact-url-${source_distribution_build_variant}.txt
         bucket: mciuploads
   test_linux_artifact:
     - command: expansions.write
@@ -322,7 +322,10 @@ tasks:
       - func: check
         vars:
           node_js_version: "14.15.1"
+
+  # UNIT TESTS
   - name: test_m40x_n12
+    tags: ["unit-test"]
     commands:
       - func: checkout
       - func: install
@@ -334,6 +337,7 @@ tasks:
           node_js_version: "12.20.0"
           mongosh_skip_node_version_check: "1"
   - name: test_m42x_n12
+    tags: ["unit-test"]
     commands:
       - func: checkout
       - func: install
@@ -345,6 +349,7 @@ tasks:
           node_js_version: "12.20.0"
           mongosh_skip_node_version_check: "1"
   - name: test_m44x_n12
+    tags: ["unit-test"]
     commands:
       - func: checkout
       - func: install
@@ -356,6 +361,7 @@ tasks:
           node_js_version: "12.20.0"
           mongosh_skip_node_version_check: "1"
   - name: test_mlatest_n12
+    tags: ["unit-test", "mlatest"]
     commands:
       - func: checkout
       - func: install
@@ -367,6 +373,7 @@ tasks:
           node_js_version: "12.20.0"
           mongosh_skip_node_version_check: "1"
   - name: test_m40x_n14
+    tags: ["unit-test"]
     commands:
       - func: checkout
       - func: install
@@ -377,6 +384,7 @@ tasks:
           mongosh_server_test_version: "4.0.x"
           node_js_version: "14.15.1"
   - name: test_m42x_n14
+    tags: ["unit-test"]
     commands:
       - func: checkout
       - func: install
@@ -387,6 +395,7 @@ tasks:
           mongosh_server_test_version: "4.2.x"
           node_js_version: "14.15.1"
   - name: test_m44x_n14
+    tags: ["unit-test"]
     commands:
       - func: checkout
       - func: install
@@ -397,6 +406,7 @@ tasks:
           mongosh_server_test_version: "4.4.x"
           node_js_version: "14.15.1"
   - name: test_mlatest_n14
+    tags: ["unit-test", "mlatest"]
     commands:
       - func: checkout
       - func: install
@@ -406,6 +416,8 @@ tasks:
         vars:
           mongosh_server_test_version: "latest-alpha"
           node_js_version: "14.15.1"
+
+  # INTEGRATION TESTS
   - name: test_vscode
     tags: ["extra-integration-test"]
     commands:
@@ -431,28 +443,16 @@ tasks:
       - func: compile_artifact
         vars:
           node_js_version: "14.15.1"
+
+  # PACKAGING
   - name: package_and_upload_artifact_macos
     depends_on:
       - name: check
         variant: darwin
-      - name: test_m40x_n12
-        variant: darwin
-      - name: test_m42x_n12
-        variant: darwin
-      - name: test_m44x_n12
-        variant: darwin
-      # Revert the commit that commented this out after resolving
+      # Remove the !.mlatest when this issue is resolved
       # https://jira.mongodb.org/browse/MONGOSH-592
-      #- name: test_mlatest_n12
-      #  variant: darwin
-      - name: test_m40x_n14
+      - name: ".unit-test !.mlatest"
         variant: darwin
-      - name: test_m42x_n14
-        variant: darwin
-      - name: test_m44x_n14
-        variant: darwin
-      #- name: test_mlatest_n14
-      #  variant: darwin
       - name: compile_artifact
         variant: darwin
     commands:
@@ -463,25 +463,12 @@ tasks:
       - func: package_and_upload_artifact
         vars:
           node_js_version: "14.15.1"
+          distribution_build_variant: darwin
   - name: package_and_upload_artifact_linux
     depends_on:
       - name: check
         variant: linux
-      - name: test_m40x_n12
-        variant: linux
-      - name: test_m42x_n12
-        variant: linux
-      - name: test_m44x_n12
-        variant: linux
-      - name: test_mlatest_n12
-        variant: linux
-      - name: test_m40x_n14
-        variant: linux
-      - name: test_m42x_n14
-        variant: linux
-      - name: test_m44x_n14
-        variant: linux
-      - name: test_mlatest_n14
+      - name: ".unit-test"
         variant: linux
       - name: compile_artifact
         variant: linux_build
@@ -493,25 +480,46 @@ tasks:
       - func: package_and_upload_artifact
         vars:
           node_js_version: "14.15.1"
+          distribution_build_variant: linux
+  - name: package_and_upload_artifact_debian
+    depends_on:
+      - name: check
+        variant: linux
+      - name: ".unit-test"
+        variant: linux
+      - name: compile_artifact
+        variant: linux_build
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "14.15.1"
+      - func: package_and_upload_artifact
+        vars:
+          node_js_version: "14.15.1"
+          distribution_build_variant: debian
+  - name: package_and_upload_artifact_rhel
+    depends_on:
+      - name: check
+        variant: linux
+      - name: ".unit-test"
+        variant: linux
+      - name: compile_artifact
+        variant: linux_build
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "14.15.1"
+      - func: package_and_upload_artifact
+        vars:
+          node_js_version: "14.15.1"
+          distribution_build_variant: rhel
   - name: package_and_upload_artifact_win
     depends_on:
       - name: check
         variant: win32
-      - name: test_m40x_n12
-        variant: win32
-      - name: test_m42x_n12
-        variant: win32
-      - name: test_m44x_n12
-        variant: win32
-      - name: test_mlatest_n12
-        variant: win32
-      - name: test_m40x_n14
-        variant: win32
-      - name: test_m42x_n14
-        variant: win32
-      - name: test_m44x_n14
-        variant: win32
-      - name: test_mlatest_n14
+      - name: ".unit-test"
         variant: win32
       - name: compile_artifact
         variant: win32_build
@@ -523,6 +531,26 @@ tasks:
       - func: package_and_upload_artifact
         vars:
           node_js_version: "14.15.1"
+          distribution_build_variant: win32
+  - name: package_and_upload_artifact_winmsi
+    depends_on:
+      - name: check
+        variant: win32
+      - name: ".unit-test"
+        variant: win32
+      - name: compile_artifact
+        variant: win32_build
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "14.15.1"
+      - func: package_and_upload_artifact
+        vars:
+          node_js_version: "14.15.1"
+          distribution_build_variant: win32msi
+  
+  # VERIFICATION
   - name: test_linux_artifact
     depends_on:
       - name: package_and_upload_artifact_linux
@@ -530,7 +558,7 @@ tasks:
     commands:
       - func: get_artifact_url
         vars:
-          source_build_variant: linux
+          source_distribution_build_variant: linux
       - func: checkout
       - func: install
         vars:
@@ -538,6 +566,8 @@ tasks:
       - func: test_linux_artifact
         vars:
           node_js_version: "14.15.1"
+  
+  # SMOKE TESTS
   - name: pkg_test_ssh_win32
     tags: ["smoke-test"]
     depends_on:
@@ -547,7 +577,7 @@ tasks:
       - func: checkout
       - func: get_artifact_url
         vars:
-          source_build_variant: win32
+          source_distribution_build_variant: win32
       - func: write_preload_script
       - func: spawn_host
         vars:
@@ -560,13 +590,13 @@ tasks:
   - name: pkg_test_ssh_win32msi
     tags: ["smoke-test"]
     depends_on:
-      - name: package_and_upload_artifact_win
-        variant: win32msi
+      - name: package_and_upload_artifact_winmsi
+        variant: win32
     commands:
       - func: checkout
       - func: get_artifact_url
         vars:
-          source_build_variant: win32msi
+          source_distribution_build_variant: win32msi
       - command: shell.exec
         params:
           working_dir: src
@@ -586,13 +616,13 @@ tasks:
   - name: pkg_test_docker_ubuntu1604
     tags: ["smoke-test"]
     depends_on:
-      - name: package_and_upload_artifact_linux
-        variant: debian
+      - name: package_and_upload_artifact_debian
+        variant: linux
     commands:
       - func: checkout
       - func: get_artifact_url
         vars:
-          source_build_variant: debian
+          source_distribution_build_variant: debian
       - func: write_preload_script
       - func: test_artifact_docker
         vars:
@@ -600,13 +630,13 @@ tasks:
   - name: pkg_test_docker_ubuntu1804
     tags: ["smoke-test"]
     depends_on:
-      - name: package_and_upload_artifact_linux
-        variant: debian
+      - name: package_and_upload_artifact_debian
+        variant: linux
     commands:
       - func: checkout
       - func: get_artifact_url
         vars:
-          source_build_variant: debian
+          source_distribution_build_variant: debian
       - func: write_preload_script
       - func: test_artifact_docker
         vars:
@@ -614,13 +644,13 @@ tasks:
   - name: pkg_test_docker_ubuntu2004
     tags: ["smoke-test"]
     depends_on:
-      - name: package_and_upload_artifact_linux
-        variant: debian
+      - name: package_and_upload_artifact_debian
+        variant: linux
     commands:
       - func: checkout
       - func: get_artifact_url
         vars:
-          source_build_variant: debian
+          source_distribution_build_variant: debian
       - func: write_preload_script
       - func: test_artifact_docker
         vars:
@@ -628,13 +658,13 @@ tasks:
   - name: pkg_test_docker_centos7
     tags: [ "smoke-test" ]
     depends_on:
-      - name: package_and_upload_artifact_linux
-        variant: rhel
+      - name: package_and_upload_artifact_rhel
+        variant: linux
     commands:
       - func: checkout
       - func: get_artifact_url
         vars:
-          source_build_variant: rhel
+          source_distribution_build_variant: rhel
       - func: write_preload_script
       - func: test_artifact_docker
         vars:
@@ -642,13 +672,13 @@ tasks:
   - name: pkg_test_docker_centos8
     tags: ["smoke-test"]
     depends_on:
-      - name: package_and_upload_artifact_linux
-        variant: rhel
+      - name: package_and_upload_artifact_rhel
+        variant: linux
     commands:
       - func: checkout
       - func: get_artifact_url
         vars:
-          source_build_variant: rhel
+          source_distribution_build_variant: rhel
       - func: write_preload_script
       - func: test_artifact_docker
         vars:
@@ -662,9 +692,11 @@ tasks:
       - func: checkout
       - func: get_artifact_url
         vars:
-          source_build_variant: darwin_codesign
+          source_distribution_build_variant: darwin
       - func: write_preload_script
       - func: test_artifact_macos
+  
+  # RELEASE TASKS
   - name: release_draft
     git_tag_only: true
     depends_on:
@@ -711,12 +743,13 @@ buildvariants:
       - name: test_m40x_n12
       - name: test_m42x_n12
       - name: test_m44x_n12
-      #- name: test_mlatest_n12
+      - name: test_mlatest_n12
       - name: test_m40x_n14
       - name: test_m42x_n14
       - name: test_m44x_n14
-      #- name: test_mlatest_n14
+      - name: test_mlatest_n14
       - name: compile_artifact
+
   - name: linux
     display_name: "Ubuntu 18.04"
     run_on: ubuntu1804-small
@@ -735,6 +768,8 @@ buildvariants:
       - name: test_vscode
       - name: test_connectivity
       - name: package_and_upload_artifact_linux
+      - name: package_and_upload_artifact_debian
+      - name: package_and_upload_artifact_rhel
   - name: linux_build
     display_name: "Ubuntu 18.04 (build)"
     run_on: ubuntu1804-build
@@ -742,20 +777,7 @@ buildvariants:
       executable_os_id: linux
     tasks:
       - name: compile_artifact
-  - name: rhel
-    display_name: "Ubuntu 18.04 (rpm target)"
-    run_on: ubuntu1804-small
-    expansions:
-      executable_os_id: linux
-    tasks:
-      - name: package_and_upload_artifact_linux
-  - name: debian
-    display_name: "Ubuntu 18.04 (deb target)"
-    run_on: ubuntu1804-small
-    expansions:
-      executable_os_id: linux
-    tasks:
-      - name: package_and_upload_artifact_linux
+
   - name: rhel70
     display_name: "RHEL 7.0 (artifact test)"
     run_on: rhel70-small
@@ -786,6 +808,7 @@ buildvariants:
     run_on: debian10-small
     tasks:
       - name: test_linux_artifact
+
   - name: win32
     display_name: "Windows VS 2019"
     run_on: windows-64-vs2019-small
@@ -802,6 +825,7 @@ buildvariants:
       - name: test_m44x_n14
       - name: test_mlatest_n14
       - name: package_and_upload_artifact_win
+      - name: package_and_upload_artifact_winmsi
   - name: win32_build
     display_name: "Windows VS 2019 (build)"
     run_on: windows-64-vs2019-build
@@ -809,13 +833,7 @@ buildvariants:
       executable_os_id: win32
     tasks:
       - name: compile_artifact
-  - name: win32msi
-    display_name: "Windows VS 2019 (msi target)"
-    run_on: windows-64-vs2019-small
-    expansions:
-      executable_os_id: win32
-    tasks:
-      - name: package_and_upload_artifact_win
+
   - name: pkg_smoke_tests_docker
     display_name: "package smoke tests (Docker)"
     run_on: ubuntu1804-small
@@ -836,6 +854,7 @@ buildvariants:
     run_on: macos-1014
     tasks:
       - name: pkg_test_macos1014
+
   - name: draft_publish_release
     display_name: "Draft/Publish Release"
     run_on: ubuntu1804-small

--- a/.evergreen/compile-artifact.sh
+++ b/.evergreen/compile-artifact.sh
@@ -13,7 +13,7 @@ if [ "$(uname)" == Linux ]; then
   docker run -e PUPPETEER_SKIP_CHROMIUM_DOWNLOAD \
     -e EVERGREEN_EXPANSIONS_PATH=/tmp/build/tmp/expansions.yaml \
     -e NODE_JS_VERSION \
-    -e BUILD_VARIANT \
+    -e DISTRIBUTION_BUILD_VARIANT \
     --rm -v $PWD:/tmp/build --network host centos7-build \
     -c 'source /opt/rh/devtoolset-8/enable && cd /tmp/build && npm run evergreen-release compile && dist/mongosh --version'
 else

--- a/.evergreen/package-and-upload-artifact.sh
+++ b/.evergreen/package-and-upload-artifact.sh
@@ -15,10 +15,10 @@ dist/mongosh --version
 if [ "$(uname)" == Linux ]; then
   # For the rpm, we want to download the RHEL/CentOS 7 mongocryptd binary.
   # (We can/should probably remove this after https://jira.mongodb.org/browse/MONGOSH-541)
-  if [ "$BUILD_VARIANT" = rhel ]; then
+  if [ "$DISTRIBUTION_BUILD_VARIANT" = rhel ]; then
     export DISTRO_ID_OVERRIDE=rhel70
   fi
-  if [ "$BUILD_VARIANT" = debian ]; then
+  if [ "$DISTRIBUTION_BUILD_VARIANT" = debian ]; then
     # We need ubuntu1804 in order for mongocryptd to work on ubuntu1804 and above.
     export DISTRO_ID_OVERRIDE=ubuntu1804
   fi
@@ -29,7 +29,7 @@ if [ "$(uname)" == Linux ]; then
   docker run -e PUPPETEER_SKIP_CHROMIUM_DOWNLOAD \
     -e EVERGREEN_EXPANSIONS_PATH=/tmp/build/tmp/expansions.yaml \
     -e NODE_JS_VERSION \
-    -e BUILD_VARIANT \
+    -e DISTRIBUTION_BUILD_VARIANT \
     -e ARTIFACT_URL_FILE="/tmp/build/artifact-url.txt" \
     -e DISTRO_ID_OVERRIDE \
     --rm -v $PWD:/tmp/build --network host centos7-package \

--- a/config/build.conf.js
+++ b/config/build.conf.js
@@ -58,11 +58,10 @@ const APPLE_NOTARIZATION_BUNDLE_ID = 'com.mongodb.mongosh';
 /**
  * The SHA for the current git HEAD.
  */
+// TODO: replace with "real" SHA after EVG-13919
 const REVISION = process.env.IS_PATCH ?
   `pr-${process.env.GITHUB_PR_NUMBER}-${process.env.REVISION_ORDER_ID}` :
   process.env.REVISION;
-
-const BUILD_VARIANT = (process.env.BUILD_VARIANT || '').split('_')[0];
 
 /**
  * Export the configuration for the build.
@@ -89,7 +88,7 @@ module.exports = {
   triggeringGitTag: process.env.TRIGGERED_BY_GIT_TAG,
   platform: os.platform(),
   execNodeVersion: process.env.NODE_JS_VERSION || `^${process.version.slice(1)}`,
-  buildVariant: BUILD_VARIANT,
+  distributionBuildVariant: process.env.DISTRIBUTION_BUILD_VARIANT,
   appleCodesignIdentity: process.env.APPLE_CODESIGN_IDENTITY,
   appleCodesignEntitlementsFile: path.resolve(__dirname, 'macos-entitlements.xml'),
   appleNotarizationBundleId: APPLE_NOTARIZATION_BUNDLE_ID,

--- a/packages/build/README.md
+++ b/packages/build/README.md
@@ -66,7 +66,7 @@ const config = {
   appleCodesignIdentity: 'appleCodesignIdentity',
   isCi: true,
   platform: 'platform',
-  buildVariant: 'linux',
+  distributionBuildVariant: 'linux',
   repo: {
     owner: 'owner',
     repo: 'repo',
@@ -152,7 +152,7 @@ const tarball = require('@mongosh/build').tarball;
 const executable = 'path/to/executable'
 const config = {
   outputDir: 'path/to/output/directory',
-  buildVariant: 'windows_ps',
+  distributionBuildVariant: 'windows_ps',
   version: '0.2.0',
   rootDir: 'path/to/root/directory',
 }
@@ -160,7 +160,7 @@ const config = {
 const artifact = await createTarball(
   executable,
   config.outputDir,
-  config.buildVariant,
+  config.distributionBuildVariant,
   config.version,
   config.rootDir
 );

--- a/packages/build/src/barque.spec.ts
+++ b/packages/build/src/barque.spec.ts
@@ -37,7 +37,7 @@ describe('Barque', () => {
       appleCodesignIdentity: 'appleCodesignIdentity',
       isCi: true,
       platform: 'linux',
-      buildVariant: BuildVariant.Linux,
+      distributionBuildVariant: BuildVariant.Linux,
       repo: {
         owner: 'owner',
         repo: 'repo',
@@ -112,44 +112,44 @@ describe('Barque', () => {
 
   describe('.determineDistro', () => {
     it('determines distro for ubuntu', async() => {
-      const distro = barque.determineDistro('linux');
+      const distro = barque.determineDistro(BuildVariant.Linux);
       expect(distro).to.be.equal('ubuntu1804');
     });
 
     it('determines distro for debian', async() => {
-      const distro = barque.determineDistro('debian');
+      const distro = barque.determineDistro(BuildVariant.Debian);
       expect(distro).to.be.equal('debian10');
     });
 
     it('determines distro for redhat', async() => {
-      const distro = barque.determineDistro('rhel');
+      const distro = barque.determineDistro(BuildVariant.Redhat);
       expect(distro).to.be.equal('rhel80');
     });
 
     it('defaults to ubuntu distro', async() => {
-      const distro = barque.determineDistro('redhat');
+      const distro = barque.determineDistro('wrong' as any);
       expect(distro).to.be.equal('ubuntu1804');
     });
   });
 
   describe('.determineArch', () => {
     it('determines arch for ubuntu', async() => {
-      const distro = barque.determineArch('linux');
+      const distro = barque.determineArch(BuildVariant.Linux);
       expect(distro).to.be.equal('amd64');
     });
 
     it('determines arch for debian', async() => {
-      const distro = barque.determineArch('debian');
+      const distro = barque.determineArch(BuildVariant.Debian);
       expect(distro).to.be.equal('amd64');
     });
 
     it('determines arch for redhat', async() => {
-      const distro = barque.determineArch('rhel');
+      const distro = barque.determineArch(BuildVariant.Redhat);
       expect(distro).to.be.equal('x86_64');
     });
 
     it('defaults to ubuntu arch', async() => {
-      const distro = barque.determineArch('redhat');
+      const distro = barque.determineArch('wrong' as any);
       expect(distro).to.be.equal('amd64');
     });
   });

--- a/packages/build/src/config/build-variant.ts
+++ b/packages/build/src/config/build-variant.ts
@@ -2,7 +2,7 @@
  * Build Variant enum.
  *
  * Different from 'platform': platform is extracted from os.platform() and
- * build variant is the host evergreen is building on.
+ * build variant defines the desired distribution type to build for.
  */
 export enum BuildVariant {
   Windows = 'win32',

--- a/packages/build/src/config/config.ts
+++ b/packages/build/src/config/config.ts
@@ -29,7 +29,7 @@ export interface Config {
   isCi?: boolean;
   platform?: string;
   execNodeVersion: string;
-  buildVariant: BuildVariant;
+  distributionBuildVariant?: BuildVariant;
   repo: {
     owner: string;
     repo: string;

--- a/packages/build/src/config/redact-config.ts
+++ b/packages/build/src/config/redact-config.ts
@@ -6,7 +6,7 @@ export function redactConfig(config: Config): Partial<Config> {
     appleNotarizationBundleId: config.appleNotarizationBundleId,
     rootDir: config.rootDir,
     input: config.input,
-    buildVariant: config.buildVariant,
+    distributionBuildVariant: config.distributionBuildVariant,
     executablePath: config.executablePath,
     execInput: config.execInput,
     outputDir: config.outputDir,

--- a/packages/build/src/index.ts
+++ b/packages/build/src/index.ts
@@ -1,5 +1,5 @@
 import path from 'path';
-import { BuildVariant } from './config';
+import { ALL_BUILD_VARIANTS } from './config';
 import { downloadMongoDb } from './download-mongodb';
 import { getArtifactUrl } from './evergreen';
 import { release, ReleaseCommand } from './release';
@@ -21,11 +21,9 @@ if (require.main === module) {
       .filter(Boolean)[0];
     if (cliBuildVariant) {
       config.buildVariant = cliBuildVariant[1];
-    }
-
-    // Resolve 'Windows' to 'win32' etc.
-    if (config.buildVariant in BuildVariant) {
-      config.buildVariant = (BuildVariant as any)[config.buildVariant];
+      if (!ALL_BUILD_VARIANTS.includes(config.buildVariant)) {
+        throw new Error(`Unknown build variant: ${config.buildVariant} - must be one of: ${ALL_BUILD_VARIANTS}`);
+      }
     }
 
     await release(command as ReleaseCommand, config);

--- a/packages/build/src/package/run-package.ts
+++ b/packages/build/src/package/run-package.ts
@@ -8,12 +8,17 @@ import { createTarball, TarballFile } from '../tarball';
 export async function runPackage(
   config: Config,
 ): Promise<TarballFile> {
+  const distributionBuildVariant = config.distributionBuildVariant;
+  if (!distributionBuildVariant) {
+    throw new Error('distributionBuildVariant is missing in configuration - make sure the expansion is present');
+  }
+
   await fs.copyFile(await downloadMongocrypt(), config.mongocryptdPath, fsConstants.COPYFILE_FICLONE);
 
   const runCreateTarball = async(): Promise<TarballFile> => {
     return await createTarball(
       config.outputDir,
-      config.buildVariant,
+      distributionBuildVariant,
       config.packageInformation as (Required<Config>['packageInformation'])
     );
   };

--- a/packages/build/src/run-publish.spec.ts
+++ b/packages/build/src/run-publish.spec.ts
@@ -56,7 +56,7 @@ describe('publish', () => {
       appleCodesignIdentity: 'appleCodesignIdentity',
       isCi: true,
       platform: 'platform',
-      buildVariant: BuildVariant.Linux,
+      distributionBuildVariant: BuildVariant.Linux,
       repo: {
         owner: 'owner',
         repo: 'repo',

--- a/packages/build/src/run-upload.spec.ts
+++ b/packages/build/src/run-upload.spec.ts
@@ -37,7 +37,7 @@ describe('do-upload', () => {
       appleCodesignIdentity: 'appleCodesignIdentity',
       isCi: true,
       platform: 'platform',
-      buildVariant: BuildVariant.Linux,
+      distributionBuildVariant: BuildVariant.Linux,
       repo: {
         owner: 'owner',
         repo: 'repo',


### PR DESCRIPTION
Uses an explicit expansion to define the "variant" the distribution should be built for. Also uses task tags for easier dependency definition.