### PR TITLE
fix(shell-api): rename kmsProvider to kmsProviders MONGOSH-604

### DIFF
--- a/packages/cli-repl/src/smoke-tests-fle.ts
+++ b/packages/cli-repl/src/smoke-tests-fle.ts
@@ -35,7 +35,7 @@ const local = { key: Buffer.from('kh4Gv2N8qopZQMQYMEtww/AkPsIrXNmEMxTrs3tUoTQZbZ
 
 const keyMongo = Mongo(db.getMongo()._uri, {
   keyVaultNamespace: 'encryption.__keyVault',
-  kmsProvider: { local }
+  kmsProviders: { local }
 });
 
 const keyVault = keyMongo.getKeyVault();
@@ -60,7 +60,7 @@ console.log('Using schema map', schemaMap);
 
 const autoMongo = Mongo(db.getMongo()._uri, {
   keyVaultNamespace: 'encryption.__keyVault',
-  kmsProvider: { local },
+  kmsProviders: { local },
   schemaMap
 });
 

--- a/packages/cli-repl/test/e2e-fle.spec.ts
+++ b/packages/cli-repl/test/e2e-fle.spec.ts
@@ -113,7 +113,7 @@ describe('FLE tests', () => {
     await shell.executeLine('local = { key: BinData(0, "kh4Gv2N8qopZQMQYMEtww/AkPsIrXNmEMxTrs3tUoTQZbZu4msdRUaR8U5fXD7A7QXYHcEvuu4WctJLoT+NvvV3eeIg3MD+K8H9SR794m/safgRHdIfy6PD+rFpvmFbY") }');
     await shell.executeLine(`keyMongo = Mongo(${JSON.stringify(await testServer.connectionString())}, { \
       keyVaultNamespace: '${dbname}.keyVault', \
-      kmsProvider: { local }, \
+      kmsProviders: { local }, \
       explicitEncryptionOnly: true \
     });`);
     await shell.executeLine('keyVault = keyMongo.getKeyVault();');

--- a/packages/shell-api/src/field-level-encryption.spec.ts
+++ b/packages/shell-api/src/field-level-encryption.spec.ts
@@ -33,7 +33,7 @@ const SCHEMA_MAP = {
 };
 const AWS_KMS = {
   keyVaultNamespace: `${DB}.${COLL}`,
-  kmsProvider: {
+  kmsProviders: {
     aws: {
       accessKeyId: 'abc',
       secretAccessKey: '123'
@@ -143,7 +143,7 @@ describe('Field Level Encryption', () => {
           {
             keyVaultClient: undefined,
             keyVaultNamespace: AWS_KMS.keyVaultNamespace,
-            kmsProviders: AWS_KMS.kmsProvider,
+            kmsProviders: AWS_KMS.kmsProviders,
             bypassAutoEncryption: AWS_KMS.bypassAutoEncryption,
             schemaMap: AWS_KMS.schemaMap
           }
@@ -393,7 +393,7 @@ describe('Field Level Encryption', () => {
     it('accepts the same local key twice', () => {
       const localKmsOptions: ClientSideFieldLevelEncryptionOptions = {
         keyVaultNamespace: `${DB}.${COLL}`,
-        kmsProvider: {
+        kmsProviders: {
           local: {
             key: new bson.Binary(Buffer.alloc(96).toString('base64'))
           }
@@ -409,7 +409,7 @@ describe('Field Level Encryption', () => {
     it('fails if both explicitEncryptionOnly and schemaMap are passed', () => {
       const localKmsOptions: ClientSideFieldLevelEncryptionOptions = {
         keyVaultNamespace: `${DB}.${COLL}`,
-        kmsProvider: {
+        kmsProviders: {
           local: {
             key: new bson.Binary(Buffer.alloc(96).toString('base64'))
           }
@@ -521,7 +521,7 @@ srDVjIT3LsvTqw==`
       it(`provides ClientEncryption for kms=${kmsName}`, async() => {
         const mongo = new Mongo(internalState, uri, {
           keyVaultNamespace: `${dbname}.__keyVault`,
-          kmsProvider: { [kmsName]: kmsOptions } as any,
+          kmsProviders: { [kmsName]: kmsOptions } as any,
           explicitEncryptionOnly: true
         }, serviceProvider);
         await mongo.connect();

--- a/packages/shell-api/src/field-level-encryption.ts
+++ b/packages/shell-api/src/field-level-encryption.ts
@@ -36,7 +36,7 @@ export type ClientSideFieldLevelEncryptionKmsProvider = Omit<KMSProviders, 'loca
 export interface ClientSideFieldLevelEncryptionOptions {
   keyVaultClient?: Mongo,
   keyVaultNamespace: string,
-  kmsProvider: ClientSideFieldLevelEncryptionKmsProvider,
+  kmsProviders: ClientSideFieldLevelEncryptionKmsProvider,
   schemaMap?: Document,
   bypassAutoEncryption?: boolean;
   explicitEncryptionOnly?: boolean;

--- a/packages/shell-api/src/helpers.ts
+++ b/packages/shell-api/src/helpers.ts
@@ -614,9 +614,9 @@ export function assertCLI(platform: ReplPlatform): void {
 }
 
 export function processFLEOptions(fleOptions: ClientSideFieldLevelEncryptionOptions): AutoEncryptionOptions {
-  assertArgsDefined(fleOptions.keyVaultNamespace, fleOptions.kmsProvider);
+  assertArgsDefined(fleOptions.keyVaultNamespace, fleOptions.kmsProviders);
   Object.keys(fleOptions).forEach(k => {
-    if (['keyVaultClient', 'keyVaultNamespace', 'kmsProvider', 'schemaMap', 'bypassAutoEncryption'].indexOf(k) === -1) {
+    if (['keyVaultClient', 'keyVaultNamespace', 'kmsProviders', 'schemaMap', 'bypassAutoEncryption'].indexOf(k) === -1) {
       throw new MongoshInvalidInputError(`Unrecognized FLE Client Option ${k}`);
     }
   });
@@ -625,12 +625,12 @@ export function processFLEOptions(fleOptions: ClientSideFieldLevelEncryptionOpti
     keyVaultNamespace: fleOptions.keyVaultNamespace
   };
 
-  const localKey = fleOptions.kmsProvider.local?.key;
+  const localKey = fleOptions.kmsProviders.local?.key;
   if (localKey && (localKey as BinaryType)._bsontype === 'Binary') {
     const rawBuff = (localKey as BinaryType).value(true);
     if (Buffer.isBuffer(rawBuff)) {
       autoEncryption.kmsProviders = {
-        ...fleOptions.kmsProvider,
+        ...fleOptions.kmsProviders,
         local: {
           key: rawBuff
         }
@@ -639,7 +639,7 @@ export function processFLEOptions(fleOptions: ClientSideFieldLevelEncryptionOpti
       throw new MongoshInvalidInputError('When specifying the key of a local KMS as BSON binary it must be constructed from a base64 encoded string');
     }
   } else {
-    autoEncryption.kmsProviders = { ...fleOptions.kmsProvider } as KMSProviders;
+    autoEncryption.kmsProviders = { ...fleOptions.kmsProviders } as KMSProviders;
   }
 
   if (fleOptions.schemaMap) {

--- a/packages/shell-api/src/shell-api.spec.ts
+++ b/packages/shell-api/src/shell-api.spec.ts
@@ -219,7 +219,7 @@ describe('ShellApi', () => {
           it(`local kms provider - key is ${type}`, async() => {
             await internalState.shellApi.Mongo('dbname', {
               keyVaultNamespace: 'encryption.dataKeys',
-              kmsProvider: {
+              kmsProviders: {
                 local: {
                   key: key
                 }
@@ -239,7 +239,7 @@ describe('ShellApi', () => {
         it('aws kms provider', async() => {
           await internalState.shellApi.Mongo('dbname', {
             keyVaultNamespace: 'encryption.dataKeys',
-            kmsProvider: {
+            kmsProviders: {
               aws: {
                 accessKeyId: 'abc',
                 secretAccessKey: '123'
@@ -259,7 +259,7 @@ describe('ShellApi', () => {
         it('local kms provider with current as Mongo', async() => {
           await internalState.shellApi.Mongo('dbname', {
             keyVaultNamespace: 'encryption.dataKeys',
-            kmsProvider: {
+            kmsProviders: {
               local: {
                 key: Buffer.from(b641234, 'base64')
               }
@@ -283,7 +283,7 @@ describe('ShellApi', () => {
           const m = new Mongo({ initialServiceProvider: sp } as any, 'dbName', undefined, sp);
           await internalState.shellApi.Mongo('dbname', {
             keyVaultNamespace: 'encryption.dataKeys',
-            kmsProvider: {
+            kmsProviders: {
               local: {
                 key: Buffer.from(b641234, 'base64')
               }
@@ -303,7 +303,7 @@ describe('ShellApi', () => {
         it('throws if missing namespace', async() => {
           try {
             await internalState.shellApi.Mongo('dbname', {
-              kmsProvider: {
+              kmsProviders: {
                 aws: {
                   accessKeyId: 'abc',
                   secretAccessKey: '123'
@@ -315,7 +315,7 @@ describe('ShellApi', () => {
           }
           expect.fail('failed to throw expected error');
         });
-        it('throws if missing kmsProvider', async() => {
+        it('throws if missing kmsProviders', async() => {
           try {
             await internalState.shellApi.Mongo('dbname', {
               keyVaultNamespace: 'encryption.dataKeys'
@@ -329,7 +329,7 @@ describe('ShellApi', () => {
           try {
             await internalState.shellApi.Mongo('dbname', {
               keyVaultNamespace: 'encryption.dataKeys',
-              kmsProvider: {
+              kmsProviders: {
                 aws: {
                   accessKeyId: 'abc',
                   secretAccessKey: '123'
@@ -345,7 +345,7 @@ describe('ShellApi', () => {
         it('passes along optional arguments', async() => {
           await internalState.shellApi.Mongo('dbname', {
             keyVaultNamespace: 'encryption.dataKeys',
-            kmsProvider: {
+            kmsProviders: {
               local: {
                 key: Buffer.from(b641234, 'base64')
               }


### PR DESCRIPTION
As noted in the issue, this was a typo in the documentation.
The old shell expects `kmsProviders` (like the drivers), and we should
not deviate here and instead update the documentation.