### PR TITLE
feat: add compass shell progress indicator COMPASS-4515

### DIFF
--- a/packages/browser-repl/src/components/shell-input.spec.tsx
+++ b/packages/browser-repl/src/components/shell-input.spec.tsx
@@ -5,7 +5,7 @@ import { shallow, mount } from '../../testing/enzyme';
 
 import { ShellInput } from './shell-input';
 import { Editor } from './editor';
-import Loader from './shell-loader';
+import ShellLoader from './shell-loader';
 
 function changeValue(wrapper, value): void {
   wrapper.find(Editor).prop('onChange')(value);
@@ -117,7 +117,7 @@ describe('<ShellInput />', () => {
         operationInProgress
       />);
 
-      expect(wrapper.find(Loader).exists()).to.equal(true);
+      expect(wrapper.find(ShellLoader).exists()).to.equal(true);
     });
 
     it('does not show a loader when operationInProgress is false', () => {
@@ -126,7 +126,7 @@ describe('<ShellInput />', () => {
         operationInProgress={false}
       />);
 
-      expect(wrapper.find(Loader).exists()).to.equal(false);
+      expect(wrapper.find(ShellLoader).exists()).to.equal(false);
     });
   });
 

--- a/packages/browser-repl/src/components/shell-input.tsx
+++ b/packages/browser-repl/src/components/shell-input.tsx
@@ -3,7 +3,7 @@ import { Autocompleter } from '@mongosh/browser-runtime-core';
 import classnames from 'classnames';
 import React, { Component } from 'react';
 import { Editor } from './editor';
-import Loader from './shell-loader';
+import ShellLoader from './shell-loader';
 import { LineWithIcon } from './utils/line-with-icon';
 
 const styles = require('./shell-input.less');
@@ -109,9 +109,7 @@ export class ShellInput extends Component<ShellInputProps, ShellInputState> {
   render(): JSX.Element {
     let prompt: JSX.Element;
     if (this.props.operationInProgress) {
-      prompt = (<Loader
-        size={12}
-      />);
+      prompt = (<ShellLoader />);
     } else if (this.props.prompt) {
       const trimmed = this.props.prompt.trim();
       if (trimmed.endsWith('>')) {

--- a/packages/browser-repl/src/components/shell-loader.less
+++ b/packages/browser-repl/src/components/shell-loader.less
@@ -1,15 +1,15 @@
 @import '~@leafygreen-ui/palette/dist/ui-colors.less';
 
 .shell-loader {
-  border: 2px solid @leafygreen__gray--light-3;
-  border-top: 2px solid @leafygreen__green--base;
+  border: 2px solid transparent;// @leafygreen__gray--light-3;
+  border-top: 2px solid @leafygreen__green--light-2;
   border-radius: 50%;
   padding: 0;
   margin: 0;
   box-sizing: border-box;
   display: inline-block;
 
-  animation: shell-loader-spin 500ms linear infinite;
+  animation: shell-loader-spin 700ms ease infinite;
 }
 
 @keyframes shell-loader-spin {

--- a/packages/browser-repl/src/components/shell-loader.less
+++ b/packages/browser-repl/src/components/shell-loader.less
@@ -1,7 +1,7 @@
 @import '~@leafygreen-ui/palette/dist/ui-colors.less';
 
 .shell-loader {
-  border: 2px solid transparent;// @leafygreen__gray--light-3;
+  border: 2px solid transparent;
   border-top: 2px solid @leafygreen__green--light-2;
   border-radius: 50%;
   padding: 0;

--- a/packages/browser-repl/src/components/shell-loader.less
+++ b/packages/browser-repl/src/components/shell-loader.less
@@ -7,6 +7,7 @@
   padding: 0;
   margin: 0;
   box-sizing: border-box;
+  display: inline-block;
 
   animation: shell-loader-spin 500ms linear infinite;
 }

--- a/packages/browser-repl/src/components/shell-loader.tsx
+++ b/packages/browser-repl/src/components/shell-loader.tsx
@@ -4,19 +4,31 @@ import classnames from 'classnames';
 const styles = require('./shell-loader.less');
 
 interface ShellLoaderProps {
-  size: number;
+  className: string;
+  size?: string;
 }
 
 export default class ShellLoader extends Component<ShellLoaderProps> {
+  static defaultProps = {
+    className: '',
+    size: '12px'
+  };
+
   render(): JSX.Element {
-    const { size } = this.props;
+    const {
+      className,
+      size
+    } = this.props;
 
     return (
       <div
-        className={classnames(styles['shell-loader'])}
+        className={classnames(
+          className,
+          styles['shell-loader']
+        )}
         style={{
-          height: `${size}px`,
-          width: `${size}px`
+          width: size,
+          height: size
         }}
       />
     );

--- a/packages/browser-repl/src/components/shell.spec.tsx
+++ b/packages/browser-repl/src/components/shell.spec.tsx
@@ -17,6 +17,8 @@ const wait: (ms?: number) => Promise<void> = (ms = 10) => {
 describe('<Shell />', () => {
   let onOutputChangedSpy;
   let onHistoryChangedSpy;
+  let onOperationStartedSpy;
+  let onOperationEndSpy;
   let fakeRuntime;
   let wrapper: ShallowWrapper | ReactWrapper;
   let scrollIntoView;
@@ -40,11 +42,16 @@ describe('<Shell />', () => {
 
     onOutputChangedSpy = sinon.spy();
     onHistoryChangedSpy = sinon.spy();
+    onOperationStartedSpy = sinon.spy();
+    onOperationEndSpy = sinon.spy();
 
     wrapper = shallow(<Shell
       runtime={fakeRuntime}
       onOutputChanged={onOutputChangedSpy}
-      onHistoryChanged={onHistoryChangedSpy} />);
+      onHistoryChanged={onHistoryChangedSpy}
+      onOperationStarted={onOperationStartedSpy}
+      onOperationEnd={onOperationEndSpy}
+    />);
   });
 
   afterEach(() => {
@@ -215,6 +222,14 @@ describe('<Shell />', () => {
       await onInput('db.createUser()');
       expect(wrapper.state('history')).to.deep.equal([]);
     });
+
+    it('calls onOperationStarted', async() => {
+      expect(onOperationStartedSpy).to.have.been.calledOnce;
+    });
+
+    it('calls onOperationEnd', async() => {
+      expect(onOperationEndSpy).to.have.been.calledOnce;
+    });
   });
 
   context('when empty input is entered', () => {
@@ -315,6 +330,10 @@ describe('<Shell />', () => {
 
     it('calls onHistoryChanged', () => {
       expect(onHistoryChangedSpy).to.have.been.calledOnceWith(['some code']);
+    });
+
+    it('calls onOperationEnd', async() => {
+      expect(onOperationEndSpy).to.have.been.calledOnce;
     });
   });
 

--- a/packages/browser-repl/src/components/shell.tsx
+++ b/packages/browser-repl/src/components/shell.tsx
@@ -126,7 +126,6 @@ export class Shell extends Component<ShellProps, ShellState> {
 
       this.props.runtime.setEvaluationListener(this);
       const result = await this.props.runtime.evaluate(code);
-
       outputLine = {
         format: 'output',
         type: result.type,
@@ -152,7 +151,6 @@ export class Shell extends Component<ShellProps, ShellState> {
     } catch (e) {
       // Just ignore errors when getting the prompt...
     }
-
     this.setState({ shellPrompt });
   }
 

--- a/packages/browser-repl/src/components/shell.tsx
+++ b/packages/browser-repl/src/components/shell.tsx
@@ -94,7 +94,6 @@ export class Shell extends Component<ShellProps, ShellState> {
     passwordPrompt: ''
   };
 
-  private isMounted = false;
   private shellInputElement: HTMLElement | null = null;
   private shellInputRef?: {
     editor?: HTMLElement;
@@ -113,16 +112,10 @@ export class Shell extends Component<ShellProps, ShellState> {
   componentDidMount(): void {
     this.scrollToBottom();
     this.updateShellPrompt();
-
-    this.isMounted = true;
   }
 
   componentDidUpdate(): void {
     this.scrollToBottom();
-  }
-
-  componentWillUnmount(): void {
-    this.isMounted = false;
   }
 
   private evaluate = async(code: string): Promise<ShellOutputEntry> => {
@@ -145,9 +138,7 @@ export class Shell extends Component<ShellProps, ShellState> {
         value: error
       };
     } finally {
-      if (this.isMounted) {
-        await this.updateShellPrompt();
-      }
+      await this.updateShellPrompt();
       this.props.onOperationEnd();
     }
 

--- a/packages/browser-repl/src/index.tsx
+++ b/packages/browser-repl/src/index.tsx
@@ -1,2 +1,5 @@
+import ShellLoader from './components/shell-loader';
+
 export { Shell } from './components/shell';
 export { IframeRuntime } from './iframe-runtime';
+export { ShellLoader };

--- a/packages/compass-shell/src/components/compass-shell/compass-shell.jsx
+++ b/packages/compass-shell/src/components/compass-shell/compass-shell.jsx
@@ -45,7 +45,8 @@ export class CompassShell extends Component {
 
     this.state = {
       initialHistory: this.props.historyStorage ? null : [],
-      isExpanded: !!this.props.isExpanded
+      isExpanded: !!this.props.isExpanded,
+      isOperationInProgress: false
     };
   }
 
@@ -55,6 +56,18 @@ export class CompassShell extends Component {
 
   onShellOutputChanged = (output) => {
     this.shellOutput = output;
+  }
+
+  onOperationStarted = () => {
+    this.setState({
+      isOperationInProgress: true
+    });
+  }
+
+  onOperationEnd = () => {
+    this.setState({
+      isOperationInProgress: false
+    });
   }
 
   lastOpenHeight = defaultShellHeightOpened;
@@ -123,7 +136,8 @@ export class CompassShell extends Component {
    */
   render() {
     const {
-      isExpanded
+      isExpanded,
+      isOperationInProgress
     } = this.state;
 
     if (!this.props.runtime || !this.state.initialHistory) {
@@ -154,6 +168,7 @@ export class CompassShell extends Component {
           <ShellHeader
             isExpanded={isExpanded}
             onShellToggleClicked={this.shellToggleClicked}
+            isOperationInProgress={isOperationInProgress}
           />
           {isExpanded && (
             <div
@@ -165,6 +180,8 @@ export class CompassShell extends Component {
                 initialOutput={this.shellOutput}
                 onHistoryChanged={this.saveHistory}
                 onOutputChanged={this.onShellOutputChanged}
+                onOperationStarted={this.onOperationStarted}
+                onOperationEnd={this.onOperationEnd}
               />
             </div>
           )}

--- a/packages/compass-shell/src/components/compass-shell/compass-shell.jsx
+++ b/packages/compass-shell/src/components/compass-shell/compass-shell.jsx
@@ -170,21 +170,23 @@ export class CompassShell extends Component {
             onShellToggleClicked={this.shellToggleClicked}
             isOperationInProgress={isOperationInProgress}
           />
-          {isExpanded && (
-            <div
-              className={classnames(styles['compass-shell-shell-container'])}
-            >
-              <Shell
-                runtime={this.props.runtime}
-                initialHistory={this.state.initialHistory}
-                initialOutput={this.shellOutput}
-                onHistoryChanged={this.saveHistory}
-                onOutputChanged={this.onShellOutputChanged}
-                onOperationStarted={this.onOperationStarted}
-                onOperationEnd={this.onOperationEnd}
-              />
-            </div>
-          )}
+          <div
+            className={classnames(
+              styles['compass-shell-shell-container'], {
+                [styles['compass-shell-shell-container-visible']]: isExpanded
+              }
+            )}
+          >
+            <Shell
+              runtime={this.props.runtime}
+              initialHistory={this.state.initialHistory}
+              initialOutput={this.shellOutput}
+              onHistoryChanged={this.saveHistory}
+              onOutputChanged={this.onShellOutputChanged}
+              onOperationStarted={this.onOperationStarted}
+              onOperationEnd={this.onOperationEnd}
+            />
+          </div>
         </Resizable>
       </Fragment>
     );

--- a/packages/compass-shell/src/components/compass-shell/compass-shell.less
+++ b/packages/compass-shell/src/components/compass-shell/compass-shell.less
@@ -12,8 +12,12 @@
 
   &-shell-container {
     flex-grow: 1;
-    display: flex;
+    display: none;
     overflow: auto;
     border-top: 1px solid @leafygreen__gray--dark-2;
+
+    &-visible {
+      display: flex;
+    }
   }
 }

--- a/packages/compass-shell/src/components/compass-shell/compass-shell.spec.js
+++ b/packages/compass-shell/src/components/compass-shell/compass-shell.spec.js
@@ -23,8 +23,6 @@ describe('CompassShell', () => {
         runtime={fakeRuntime}
         isExpanded={false}
       />);
-      // const containerStyle = wrapper.find('#item-id').style;
-      // expect(containerStyle).to.have.property('display', 'none');
       expect(wrapper.find(`.${styles['compass-shell-shell-container-visible']}`).exists()).to.equal(false);
     });
 

--- a/packages/compass-shell/src/components/compass-shell/compass-shell.spec.js
+++ b/packages/compass-shell/src/components/compass-shell/compass-shell.spec.js
@@ -8,6 +8,7 @@ import { CompassShell } from './compass-shell';
 import ResizeHandle from '../resize-handle';
 import ShellHeader from '../shell-header';
 import InfoModal from '../info-modal';
+import styles from './compass-shell.less';
 
 function updateAndWaitAsync(wrapper) {
   wrapper.update();
@@ -16,10 +17,15 @@ function updateAndWaitAsync(wrapper) {
 
 describe('CompassShell', () => {
   context('when the prop isExpanded is false', () => {
-    it('does not render a shell', () => {
+    it('has the shell display none', () => {
       const fakeRuntime = {};
-      const wrapper = shallow(<CompassShell runtime={fakeRuntime} isExpanded={false} />);
-      expect(wrapper.find(Shell).exists()).to.equal(false);
+      const wrapper = shallow(<CompassShell
+        runtime={fakeRuntime}
+        isExpanded={false}
+      />);
+      // const containerStyle = wrapper.find('#item-id').style;
+      // expect(containerStyle).to.have.property('display', 'none');
+      expect(wrapper.find(`.${styles['compass-shell-shell-container-visible']}`).exists()).to.equal(false);
     });
 
     context('when is it expanded', () => {
@@ -59,6 +65,7 @@ describe('CompassShell', () => {
         const fakeRuntime = {};
         const wrapper = shallow(<CompassShell runtime={fakeRuntime} isExpanded />);
         expect(wrapper.find(Shell).prop('runtime')).to.equal(fakeRuntime);
+        expect(wrapper.find(`.${styles['compass-shell-shell-container-visible']}`).exists()).to.equal(true);
       });
 
       it('renders the ShellHeader component', () => {

--- a/packages/compass-shell/src/components/shell-header/shell-header.jsx
+++ b/packages/compass-shell/src/components/shell-header/shell-header.jsx
@@ -1,8 +1,10 @@
 import IconButton from '@leafygreen-ui/icon-button';
 import Icon from '@leafygreen-ui/icon';
 import PropTypes from 'prop-types';
-import React, { Component, Fragment } from 'react';
+import React, { Component } from 'react';
 import { connect } from 'react-redux';
+
+import { ShellLoader } from '@mongosh/browser-repl';
 
 import { SET_SHOW_INFO_MODAL } from '../../modules/info-modal';
 
@@ -11,6 +13,7 @@ import styles from './shell-header.less';
 export class ShellHeader extends Component {
   static propTypes = {
     isExpanded: PropTypes.bool.isRequired,
+    isOperationInProgress: PropTypes.bool.isRequired,
     onShellToggleClicked: PropTypes.func.isRequired,
     showInfoModal: PropTypes.func.isRequired
   };
@@ -23,38 +26,58 @@ export class ShellHeader extends Component {
   render() {
     const {
       isExpanded,
+      isOperationInProgress,
       onShellToggleClicked,
       showInfoModal
     } = this.props;
 
     return (
       <div className={styles['compass-shell-header']}>
-        <button
-          className={styles['compass-shell-header-toggle']}
-          onClick={onShellToggleClicked}
-        >
-          &gt;_MongoSH Beta
-        </button>
+        <div className={styles['compass-shell-header-left']}>
+          <button
+            className={styles['compass-shell-header-toggle']}
+            onClick={onShellToggleClicked}
+          >
+            &gt;_MongoSH Beta
+            {!isExpanded && isOperationInProgress && (
+              <>
+                <ShellLoader
+                  className={styles['compass-shell-header-loader-icon']}
+                  size="10px"
+                />
+                <span
+                  className={styles['compass-shell-header-operation-in-progress']}
+                >Command in progress...</span>
+              </>
+            )}
+          </button>
+        </div>
         <div className={styles['compass-shell-header-right-actions']}>
           {isExpanded && (
-            <Fragment>
+            <>
               <IconButton
-                className={styles['compass-shell-header-info-btn']}
+                className={styles['compass-shell-header-btn']}
                 variant="dark"
                 aria-label="Shell Info"
                 onClick={showInfoModal}
               >
-                <Icon glyph="InfoWithCircle" />
+                <Icon
+                  glyph="InfoWithCircle"
+                  size="small"
+                />
               </IconButton>
               <IconButton
-                className={styles['compass-shell-header-close-btn']}
+                className={styles['compass-shell-header-btn']}
                 variant="dark"
                 aria-label="Close Shell"
                 onClick={onShellToggleClicked}
               >
-                <Icon glyph="ChevronDown" />
+                <Icon
+                  glyph="ChevronDown"
+                  size="small"
+                />
               </IconButton>
-            </Fragment>
+            </>
           )}
           {!isExpanded && (
             <IconButton
@@ -63,7 +86,9 @@ export class ShellHeader extends Component {
               aria-label="Open Shell"
               onClick={onShellToggleClicked}
             >
-              <Icon glyph="ChevronUp" />
+              <Icon
+                glyph="ChevronUp"
+              />
             </IconButton>
           )}
         </div>

--- a/packages/compass-shell/src/components/shell-header/shell-header.less
+++ b/packages/compass-shell/src/components/shell-header/shell-header.less
@@ -40,14 +40,13 @@
   }
 
   &-operation-in-progress {
-    color: @leafygreen__green--base;
+    color: @leafygreen__green--light-2;
   }
 
   &-loader-icon {
     margin: auto;
     margin-left: 16px;
     margin-right: 6px;
-    color: @leafygreen__green--base;
   }
 
   &-btn {

--- a/packages/compass-shell/src/components/shell-header/shell-header.less
+++ b/packages/compass-shell/src/components/shell-header/shell-header.less
@@ -6,28 +6,53 @@
   display: flex;
   color: @leafygreen__gray--light-1;
 
+  &-left {
+    flex-grow: 1;
+  }
+
   &-right-actions {
-    position: absolute;
-    right: 4px;
-    top: -2px;
-    text-align: right;
+    display: flex;
   }
 
   &-toggle {
     background: none;
     border: none;
     cursor: pointer;
-    padding: 1px 8px;
+    padding: 0px 8px;
+    height: 100%;
+    display: flex;
+    vertical-align: middle;
+    flex-direction: row;
+    align-items: center;
+    margin: auto 0;
+    font-weight: bold;
+    font-size: 12px;
+    line-height: 24px;
 
     transition: all 200ms;
     user-select: none;
+
+    text-transform: uppercase;
 
     &:hover {
       color: @leafygreen__gray--light-3;
     }  
   }
 
-  &-info-btn {
-    margin-right: 8px;
+  &-operation-in-progress {
+    color: @leafygreen__green--base;
+  }
+
+  &-loader-icon {
+    margin: auto;
+    margin-left: 16px;
+    margin-right: 6px;
+    color: @leafygreen__green--base;
+  }
+
+  &-btn {
+    margin-right: 4px;
+    width: 24px;
+    height: 24px;
   }
 }

--- a/packages/compass-shell/src/components/shell-header/shell-header.spec.js
+++ b/packages/compass-shell/src/components/shell-header/shell-header.spec.js
@@ -15,6 +15,7 @@ describe('ShellHeader', () => {
     beforeEach(() => {
       wrapper = mount(<ShellHeader
         isExpanded
+        isOperationInProgress={false}
         onShellToggleClicked={() => {}}
         showInfoModal={() => {}}
       />);
@@ -44,6 +45,7 @@ describe('ShellHeader', () => {
     beforeEach(() => {
       wrapper = mount(<ShellHeader
         isExpanded={false}
+        isOperationInProgress={false}
         onShellToggleClicked={() => {}}
         showInfoModal={() => {}}
       />);
@@ -68,7 +70,7 @@ describe('ShellHeader', () => {
         showInfoModal={() => {}}
       />);
 
-      expect(wrapper.find(ShellLoader).exists()).to.equal(false);
+      expect(wrapper.find(ShellLoader).exists()).to.equal(true);
     });
   });
 
@@ -76,6 +78,7 @@ describe('ShellHeader', () => {
     it('has a button to toggle the container', async() => {
       const wrapper = shallow(<ShellHeader
         isExpanded={false}
+        isOperationInProgress={false}
         onShellToggleClicked={() => {}}
         showInfoModal={() => {}}
       />);

--- a/packages/compass-shell/src/components/shell-header/shell-header.spec.js
+++ b/packages/compass-shell/src/components/shell-header/shell-header.spec.js
@@ -3,54 +3,72 @@ import { mount, shallow } from 'enzyme';
 import Icon from '@leafygreen-ui/icon';
 import IconButton from '@leafygreen-ui/icon-button';
 
+import { ShellLoader } from '@mongosh/browser-repl';
+
 import { ShellHeader } from './shell-header';
 import styles from './shell-header.less';
 
 describe('ShellHeader', () => {
   context('when isExpanded prop is true', () => {
-    it('renders a close chevron button', () => {
-      const wrapper = mount(<ShellHeader
+    let wrapper;
+
+    beforeEach(() => {
+      wrapper = mount(<ShellHeader
         isExpanded
         onShellToggleClicked={() => {}}
         showInfoModal={() => {}}
       />);
+    });
 
+    it('renders a close chevron button', () => {
       expect(wrapper.find(IconButton).exists()).to.equal(true);
       expect(wrapper.find(Icon).at(1).prop('glyph')).to.equal('ChevronDown');
     });
 
     it('renders an info button', () => {
-      const wrapper = mount(<ShellHeader
-        isExpanded
-        onShellToggleClicked={() => {}}
-        showInfoModal={() => {}}
-      />);
-
       expect(wrapper.find(IconButton).exists()).to.equal(true);
       expect(wrapper.find(Icon).at(0).prop('glyph')).to.equal('InfoWithCircle');
     });
 
     it('renders an actions area', () => {
-      const wrapper = mount(<ShellHeader
-        isExpanded
-        onShellToggleClicked={() => {}}
-        showInfoModal={() => {}}
-      />);
-
       expect(wrapper.find(`.${styles['compass-shell-header-right-actions']}`).exists()).to.equal(true);
+    });
+
+    it('does not render the loader', () => {
+      expect(wrapper.find(ShellLoader).exists()).to.equal(false);
     });
   });
 
   context('when isExpanded prop is false', () => {
-    it('renders an open chevron button', () => {
-      const wrapper = mount(<ShellHeader
+    let wrapper;
+    beforeEach(() => {
+      wrapper = mount(<ShellHeader
         isExpanded={false}
         onShellToggleClicked={() => {}}
         showInfoModal={() => {}}
       />);
+    });
 
+    it('renders an open chevron button', () => {
       expect(wrapper.find(IconButton).exists()).to.equal(true);
       expect(wrapper.find(Icon).prop('glyph')).to.equal('ChevronUp');
+    });
+
+    it('does not render the loader', () => {
+      expect(wrapper.find(ShellLoader).exists()).to.equal(false);
+    });
+  });
+
+  context('when isExpanded is false and isOperationInProgress is true', () => {
+    it('renders the loader', () => {
+      const wrapper = mount(<ShellHeader
+        isExpanded={false}
+        isOperationInProgress
+        onShellToggleClicked={() => {}}
+        showInfoModal={() => {}}
+      />);
+
+      expect(wrapper.find(ShellLoader).exists()).to.equal(false);
     });
   });
 


### PR DESCRIPTION
Adds a `Command in Progress...` indicator while a command is in progress and the shell is collapsed. 
Couple other changes:
- Tweaks to the styles of the header text.
- Updated the loader indicator - different color and animation.
- Keep the shell mounted when collapsed so we avoid reloading react-ace and also can keep using the component coupled with the runtime (set state doesn't blow up when collapsed).


https://user-images.githubusercontent.com/1791149/108212349-0c13f180-712e-11eb-929e-d78d54d32497.mp4

