### PR TITLE
fix(build): run compile-cli before compile-exec

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "compile-compass": "npm run compile-browser && lerna run --stream compile --scope @mongodb-js/compass-shell",
     "start-compass": "lerna run --stream start-compass --scope @mongodb-js/compass-shell",
     "start": "npm run start-cli",
+    "precompile-exec": "npm run compile-cli",
     "compile-exec": "npm run evergreen-release compile",
     "compile-all": "npm run compile-compass && npm run compile-exec",
     "evergreen-release": "cd packages/build && npm run evergreen-release --",


### PR DESCRIPTION
Up until very recently, this was taken care of by always running
compile-ts before evergreen-release, but since that’s no longer
the case, we need to manually run compile-cli before compile-exec.