### PR TITLE
chore(cli-repl): add Segment API integration test MONGOSH-363

### DIFF
--- a/packages/cli-repl/src/arg-parser.ts
+++ b/packages/cli-repl/src/arg-parser.ts
@@ -45,6 +45,7 @@ const OPTIONS = {
   boolean: [
     'async',
     'help',
+    'internalTestCommands',
     'ipv6',
     'nodb',
     'norc',
@@ -87,6 +88,7 @@ function getLocale(args: string[], env: any): string {
   return lang ? lang.split('.')[0] : lang;
 }
 
+type AllCliOptions = CliOptions & { smokeTests: boolean, internalTestCommands: boolean };
 /**
  * Parses arguments into a JS object.
  *
@@ -94,7 +96,7 @@ function getLocale(args: string[], env: any): string {
  *
  * @returns {CliOptions} The arguments as cli options.
  */
-function parse(args: string[]): (CliOptions & { smokeTests: boolean }) {
+function parse(args: string[]): AllCliOptions {
   const programArgs = args.slice(2);
   i18n.setLocale(getLocale(programArgs, process.env));
 
@@ -111,7 +113,7 @@ function parse(args: string[]): (CliOptions & { smokeTests: boolean }) {
       ${USAGE}`
     );
   });
-  return parsed as unknown as (CliOptions & { smokeTests: boolean });
+  return parsed as unknown as AllCliOptions;
 }
 
 export default parse;

--- a/packages/cli-repl/src/cli-repl.spec.ts
+++ b/packages/cli-repl/src/cli-repl.spec.ts
@@ -379,6 +379,7 @@ describe('CliRepl', () => {
           await once(srv, 'listening');
           host = `http://localhost:${(srv.address() as any).port}`;
           cliReplOptions.analyticsOptions = { host, apiKey: '🔑' };
+          cliReplOptions.shellCliOptions.internalTestCommands = true;
           cliRepl = new CliRepl(cliReplOptions);
           await cliRepl.start(await testServer.connectionString(), {});
         });
@@ -416,6 +417,14 @@ describe('CliRepl', () => {
           const useEvents = requests.map(
             req => JSON.parse(req.body).batch.filter(entry => entry.event === 'Use')).flat();
           expect(useEvents).to.have.lengthOf(2);
+        });
+
+        it('can self-test the analytics implementation', async() => {
+          input.write('__verifyAnalytics();\n');
+          await waitEval(cliRepl.bus);
+          const selfTestEvents = requests.map(
+            req => JSON.parse(req.body).batch.filter(entry => entry.event === '__verifyAnalytics')).flat();
+          expect(selfTestEvents).to.have.lengthOf(1);
         });
       });
 

--- a/packages/cli-repl/src/mongosh-repl.ts
+++ b/packages/cli-repl/src/mongosh-repl.ts
@@ -230,7 +230,7 @@ class MongoshNodeRepl implements EvaluationListener {
       } catch { /* ... */ }
     });
 
-    internalState.setCtx(repl.context);
+    internalState.setCtx(this.context);
     // Only start reading from the input *after* we set up everything, including
     // internalState.setCtx().
     this.lineByLineInput.start();
@@ -385,6 +385,10 @@ class MongoshNodeRepl implements EvaluationListener {
       throw new MongoshInternalError('Mongosh not started yet');
     }
     return this._runtimeState;
+  }
+
+  get context(): any {
+    return this.runtimeState().repl.context;
   }
 
   async close(): Promise<void> {

--- a/packages/cli-repl/src/smoke-tests.ts
+++ b/packages/cli-repl/src/smoke-tests.ts
@@ -14,6 +14,7 @@ export async function runSmokeTests(smokeTestServer: string | undefined, executa
     assert(!!smokeTestServer, 'Make sure MONGOSH_SMOKE_TEST_SERVER is set in CI');
   }
 
+  let n = 0;
   for (const { input, output, testArgs } of [{
     input: 'print("He" + "llo" + " Wor" + "ld!")',
     output: /Hello World!/,
@@ -22,10 +23,15 @@ export async function runSmokeTests(smokeTestServer: string | undefined, executa
     input: fleSmokeTestScript,
     output: /Test succeeded|Test skipped/,
     testArgs: [smokeTestServer as string]
+  }] : []).concat(process.execPath === process.argv[1] ? [{
+    input: '__verifyAnalytics()',
+    output: /API call succeeded/,
+    testArgs: ['--internalTestCommands', '--nodb']
   }] : [])) {
+    n++;
     await runSmokeTest(executable, [...args, ...testArgs], input, output);
   }
-  console.log('all tests passed');
+  console.log(`${n} tests passed!`);
 }
 
 async function runSmokeTest(executable: string, args: string[], input: string, output: RegExp): Promise<void> {


### PR DESCRIPTION
Includes #669 because it’s needed here.

Add a test that verifies the actual API key bundled into the actual
release binary. In order to achieve this, add an internal test command
that performs a Segment API request and verifies that its callback
does not return an error.

Note that this is, currently, a test that with somewhat limited
meaningfullness, because the Segment API currently always gives
successful HTTP responses, regardless of the validitity of the API key.

(As such, I would also consider it okay to not merge this. It still tests
that we can reach the Segment API endpoint, though, i.e. the 
`analytics-node` package is properly configured.)