### PR TITLE
chore(build): allow support releases MONGOSH-535

### DIFF
--- a/packages/build/src/local/get-latest-tag.spec.ts
+++ b/packages/build/src/local/get-latest-tag.spec.ts
@@ -10,61 +10,57 @@ describe('local get-latest-tag', () => {
   });
 
   describe('getLatestDraftOrReleaseTagFromLog', () => {
-    it('extracts the latest draft tag', () => {
-      spawnSync.onFirstCall().returns({
-        stdout: [
-          'v0.7.9',
-          'v0.8.0-draft.0',
-          'v0.8.0-draft.1',
-          'v0.8.0-draft.10',
-          'v0.8.0-draft.2'
-        ].join('\n')
-      });
-      spawnSync.onSecondCall().returns({
-        stdout: 'tagHash'
-      });
-
-      const result = getLatestDraftOrReleaseTagFromLog(
-        'somePath',
-        spawnSync
-      );
-      expect(result).to.deep.equal({
-        commit: 'tagHash',
-        tag: {
-          semverName: '0.8.0-draft.10',
-          releaseVersion: '0.8.0',
-          draftVersion: 10
-        }
-      });
-    });
-
-    it('extracts the latest release tag', () => {
-      spawnSync.onFirstCall().returns({
-        stdout: [
-          'v0.8.0',
-          'v0.8.0-draft.0',
-          'v0.8.0-draft.1',
-          'v0.8.0-draft.10',
-          'v0.8.1',
-          'v0.8.0-draft.2',
-          'v0.8.1-draft.0',
-        ].join('\n')
-      });
-      spawnSync.onSecondCall().returns({
-        stdout: 'tagHash'
-      });
-
-      const result = getLatestDraftOrReleaseTagFromLog(
-        'somePath',
-        spawnSync
-      );
-      expect(result).to.deep.equal({
-        commit: 'tagHash',
-        tag: {
+    [
+      {
+        restriction: undefined,
+        expected: {
           semverName: '0.8.1',
           releaseVersion: '0.8.1',
           draftVersion: undefined
         }
+      },
+      {
+        restriction: { major: 0, minor: 8, patch: 0 },
+        expected: {
+          semverName: '0.8.0',
+          releaseVersion: '0.8.0',
+          draftVersion: undefined
+        }
+      },
+      {
+        restriction: { major: 0, minor: 8, patch: undefined },
+        expected: {
+          semverName: '0.8.1',
+          releaseVersion: '0.8.1',
+          draftVersion: undefined
+        }
+      }
+    ].forEach(({ restriction, expected }) => {
+      it(`extracts the latest tag when restricted to ${JSON.stringify(restriction)}`, () => {
+        spawnSync.onFirstCall().returns({
+          stdout: [
+            'v0.8.0',
+            'v0.8.0-draft.0',
+            'v0.8.0-draft.1',
+            'v0.8.0-draft.10',
+            'v0.8.1',
+            'v0.8.0-draft.2',
+            'v0.8.1-draft.0',
+          ].join('\n')
+        });
+        spawnSync.onSecondCall().returns({
+          stdout: 'tagHash'
+        });
+
+        const result = getLatestDraftOrReleaseTagFromLog(
+          'somePath',
+          restriction,
+          spawnSync
+        );
+        expect(result).to.deep.equal({
+          commit: 'tagHash',
+          tag: expected
+        });
       });
     });
   });

--- a/packages/build/src/local/get-latest-tag.ts
+++ b/packages/build/src/local/get-latest-tag.ts
@@ -12,8 +12,15 @@ export interface TagDetails {
     draftVersion: number | undefined;
 }
 
+export interface ReleaseVersion {
+  major: number | undefined;
+  minor: number | undefined;
+  patch: number | undefined;
+}
+
 export function getLatestDraftOrReleaseTagFromLog(
   repositoryRoot: string,
+  versionRestriction: ReleaseVersion | undefined,
   spawnSync: typeof spawnSyncFn = spawnSyncFn
 ): TaggedCommit | undefined {
   const gitTags = spawnSync('git', ['tag'], {
@@ -21,7 +28,7 @@ export function getLatestDraftOrReleaseTagFromLog(
     encoding: 'utf-8'
   });
 
-  const tagDetails = extractTags(gitTags.stdout.split('\n'));
+  const tagDetails = extractTags(gitTags.stdout.split('\n'), versionRestriction);
   const sortedTagsWithCommit = tagDetails.sort((t1, t2) => {
     return -1 * semver.compare(t1.semverName, t2.semverName);
   });
@@ -42,7 +49,7 @@ export function getLatestDraftOrReleaseTagFromLog(
   };
 }
 
-function extractTags(gitTags: string[]): TagDetails[] {
+function extractTags(gitTags: string[], versionRestriction: ReleaseVersion | undefined): TagDetails[] {
   const validTags = gitTags
     .map(tag => semver.valid(tag))
     .filter(v => !!v) as string[];
@@ -53,9 +60,27 @@ function extractTags(gitTags: string[]): TagDetails[] {
       return undefined;
     }
 
+    const major = semver.major(semverTag);
+    const minor = semver.minor(semverTag);
+    const patch = semver.patch(semverTag);
+
+    if (versionRestriction?.major !== undefined) {
+      if (major !== versionRestriction.major) {
+        return undefined;
+      }
+      if (versionRestriction.minor !== undefined) {
+        if (minor !== versionRestriction.minor) {
+          return undefined;
+        }
+        if (versionRestriction.patch !== undefined && versionRestriction.patch !== patch) {
+          return undefined;
+        }
+      }
+    }
+
     return {
       semverName: semverTag,
-      releaseVersion: `${semver.major(semverTag)}.${semver.minor(semverTag)}.${semver.patch(semverTag)}`,
+      releaseVersion: `${major}.${minor}.${patch}`,
       draftVersion: prerelease ? parseInt(prerelease[1], 10) : undefined
     };
   }).filter(t => !!t) as TagDetails[];

--- a/packages/build/src/local/repository-status.ts
+++ b/packages/build/src/local/repository-status.ts
@@ -52,7 +52,7 @@ export function getRepositoryStatus(
 
   const result: RepositoryStatus = {
     clean: true,
-    hasUnpushedTags: (tagStatus.stdout.trim() + tagStatus.stderr.trim()) !== 'Everything up-to-date'
+    hasUnpushedTags: (tagStatus.stdout?.trim() ?? '' + tagStatus.stderr?.trim() ?? '') !== 'Everything up-to-date'
   };
 
   const output = gitStatus.stdout

--- a/packages/build/src/local/repository-status.ts
+++ b/packages/build/src/local/repository-status.ts
@@ -11,16 +11,19 @@ export interface RepositoryStatus {
     hasUnpushedTags: boolean
 }
 
+const MAIN_OR_MASTER_BRANCH = /^(main|master)$/;
+const RELEASE_BRANCH = /^release\/v([a-z0-9]+\.[a-z0-9]+\.[a-z0-9]+)$/;
+
 export function verifyGitStatus(
   repositoryRoot: string,
   getRepositoryStatusFn: typeof getRepositoryStatus = getRepositoryStatus
-): void {
+): RepositoryStatus {
   const repositoryStatus = getRepositoryStatusFn(repositoryRoot);
   if (!repositoryStatus.branch?.local) {
     throw new Error('Could not determine local repository information - please verify your repository is intact.');
   }
-  if (!/^(master|main|v[a-z0-9]+\.[a-z0-9]+\.[a-z0-9]+)$/.test(repositoryStatus.branch.local)) {
-    throw new Error('The current branch does not match: master|main|vX.X.X');
+  if (!MAIN_OR_MASTER_BRANCH.test(repositoryStatus.branch.local) && !RELEASE_BRANCH.test(repositoryStatus.branch.local)) {
+    throw new Error('The current branch does not match: master|main|release/vX.X.X');
   }
   if (!repositoryStatus.branch.tracking) {
     throw new Error('The branch you are on is not tracking any remote branch.');
@@ -31,6 +34,7 @@ export function verifyGitStatus(
   if (repositoryStatus.hasUnpushedTags) {
     throw new Error('You have local tags that are not pushed to the remote. Remove or push those tags to continue.');
   }
+  return repositoryStatus;
 }
 
 export function getRepositoryStatus(
@@ -48,7 +52,7 @@ export function getRepositoryStatus(
 
   const result: RepositoryStatus = {
     clean: true,
-    hasUnpushedTags: tagStatus.stdout.trim() !== 'Everything up-to-date'
+    hasUnpushedTags: (tagStatus.stdout.trim() + tagStatus.stderr.trim()) !== 'Everything up-to-date'
   };
 
   const output = gitStatus.stdout
@@ -57,13 +61,13 @@ export function getRepositoryStatus(
     .filter(l => !!l);
 
   const branchOutput = output.find(l => l.match(/^## /));
-  const branchInfo = branchOutput?.match(/^## ([^\s.]+)(\.\.\.([^\s]+)( \[[^\]]+])?)?/);
+  const branchInfo = branchOutput?.match(/^## ([^\s]+?((?=\.\.\.)|$))(\.\.\.([^\s]+)( \[[^\]]+])?)?/);
 
   if (branchInfo) {
     result.branch = {
       local: branchInfo[1],
-      tracking: branchInfo[3],
-      diverged: !!branchInfo[4]
+      tracking: branchInfo[4],
+      diverged: !!branchInfo[5]
     };
   }
 
@@ -71,5 +75,24 @@ export function getRepositoryStatus(
   result.clean = fileInfo.length === 0;
 
   return result;
+}
+
+export function getReleaseVersionFromBranch(branchName: string | undefined): { major: number | undefined, minor: number | undefined, patch: number | undefined} | undefined {
+  const match = branchName?.match(RELEASE_BRANCH);
+  if (!match) {
+    return undefined;
+  }
+
+  const versionParts = match[1].split('.');
+  const numOrUndefiend = (num: string): number | undefined => {
+    const value = parseInt(num, 10);
+    return isNaN(value) ? undefined : value;
+  };
+
+  return {
+    major: numOrUndefiend(versionParts[0]),
+    minor: numOrUndefiend(versionParts[1]),
+    patch: numOrUndefiend(versionParts[2]),
+  };
 }
 

--- a/packages/build/src/local/trigger-release-publish.ts
+++ b/packages/build/src/local/trigger-release-publish.ts
@@ -15,7 +15,7 @@ export async function triggerReleasePublish(
 
   verifyGitStatus(repositoryRoot);
 
-  const latestDraftTag = getLatestDraftOrReleaseTagFromLog(repositoryRoot);
+  const latestDraftTag = getLatestDraftOrReleaseTagFromLog(repositoryRoot, undefined);
   if (!latestDraftTag) {
     throw new Error('Failed to find a prior tag to release from.');
   }


### PR DESCRIPTION
This also allows running the local release task from a branch of the form `release/v0.0.0` or `release/v0.x.x`. In these cases `draft` will auto-bump the patch if the latest tag matching the branch version is a release. Otherwise it will create a new draft as usual.