### PR TITLE
chore(build): fix releasing to barque and evergreen checks

### DIFF
--- a/packages/build/src/barque.spec.ts
+++ b/packages/build/src/barque.spec.ts
@@ -37,7 +37,6 @@ describe('Barque', () => {
       appleCodesignIdentity: 'appleCodesignIdentity',
       isCi: true,
       platform: 'linux',
-      distributionBuildVariant: BuildVariant.Linux,
       repo: {
         owner: 'owner',
         repo: 'repo',
@@ -60,7 +59,7 @@ describe('Barque', () => {
         let err;
 
         try {
-          await barque.releaseToBarque(tarballURL);
+          await barque.releaseToBarque(BuildVariant.Linux, tarballURL);
         } catch (error) {
           err = error;
         }
@@ -80,7 +79,7 @@ describe('Barque', () => {
         let err;
 
         try {
-          await barque.releaseToBarque(tarballURL);
+          await barque.releaseToBarque(BuildVariant.Linux, tarballURL);
         } catch (error) {
           err = error;
         }
@@ -103,7 +102,7 @@ describe('Barque', () => {
 
       const tarballURL = 'https://s3.amazonaws.com/mciuploads/mongosh/5ed7ee5d8683818eb28d9d3b5c65837cde4a08f5/mongosh-0.1.0-linux.tgz';
 
-      await barque.releaseToBarque(tarballURL);
+      await barque.releaseToBarque(BuildVariant.Linux, tarballURL);
       expect(barque.createCuratorDir).to.have.been.called;
       expect(barque.extractLatestCurator).to.have.been.called;
       expect(barque.execCurator).to.not.have.been.called;

--- a/packages/build/src/barque.ts
+++ b/packages/build/src/barque.ts
@@ -63,12 +63,7 @@ export class Barque {
    *
    * @returns {Promise} The promise.
    */
-  async releaseToBarque(tarballURL: string): Promise<any> {
-    const buildVariant = this.config.distributionBuildVariant;
-    if (!buildVariant) {
-      throw new Error('distributionBuildVariant is not set in configuration');
-    }
-
+  async releaseToBarque(buildVariant: BuildVariant, tarballURL: string): Promise<any> {
     const repoConfig = path.join(this.config.rootDir, 'config', 'repo-config.yml');
     const curatorDirPath = await this.createCuratorDir();
     await this.extractLatestCurator(curatorDirPath);

--- a/packages/build/src/local/trigger-release-publish.spec.ts
+++ b/packages/build/src/local/trigger-release-publish.spec.ts
@@ -211,16 +211,24 @@ describe('local trigger-release-publish', () => {
       expect.fail('Expected error');
     });
 
-    it('fails if there are failed tasks', async() => {
+    it('fails if there are failed tasks and user cancels', async() => {
       getTasks.resolves([successTask, failedTask]);
+      const confirm = sinon.stub().resolves(false);
       try {
-        await verifyEvergreenStatusFn('sha', evergreenProvider);
+        await verifyEvergreenStatusFn('sha', evergreenProvider, confirm);
       } catch (e) {
         expect(e.message).to.contain('Some Evergreen tasks were not successful');
         expect(getTasks).to.have.been.calledWith('mongosh', 'sha');
         return;
       }
       expect.fail('Expected error');
+    });
+
+    it('continues if there are failed tasks but user acknowledges', async() => {
+      getTasks.resolves([successTask, failedTask]);
+      const confirm = sinon.stub().resolves(true);
+      await verifyEvergreenStatusFn('sha', evergreenProvider, confirm);
+      expect(confirm).to.have.been.called;
     });
   });
 });

--- a/packages/build/src/run-publish.spec.ts
+++ b/packages/build/src/run-publish.spec.ts
@@ -56,7 +56,6 @@ describe('publish', () => {
       appleCodesignIdentity: 'appleCodesignIdentity',
       isCi: true,
       platform: 'platform',
-      distributionBuildVariant: BuildVariant.Linux,
       repo: {
         owner: 'owner',
         repo: 'repo',
@@ -178,12 +177,15 @@ describe('publish', () => {
 
       expect(barque.releaseToBarque).to.have.been.callCount(3);
       expect(barque.releaseToBarque).to.have.been.calledWith(
+        BuildVariant.Linux,
         'https://s3.amazonaws.com/mciuploads/project/v0.7.0-draft.42/mongosh-0.7.0-linux.tgz'
       );
       expect(barque.releaseToBarque).to.have.been.calledWith(
+        BuildVariant.Redhat,
         'https://s3.amazonaws.com/mciuploads/project/v0.7.0-draft.42/mongosh-0.7.0-x86_64.rpm'
       );
       expect(barque.releaseToBarque).to.have.been.calledWith(
+        BuildVariant.Debian,
         'https://s3.amazonaws.com/mciuploads/project/v0.7.0-draft.42/mongosh_0.7.0_amd64.deb'
       );
     });

--- a/packages/build/src/run-publish.ts
+++ b/packages/build/src/run-publish.ts
@@ -96,7 +96,7 @@ async function publishArtifactsToBarque(
     const tarballName = getTarballFile(variant, releaseVersion, packageName);
     const tarballUrl = getEvergreenArtifactUrl(project, mostRecentDraftTag, tarballName.path);
     console.info(`mongosh: Publishing ${variant} artifact to barque ${tarballUrl}`);
-    await barque.releaseToBarque(tarballUrl);
+    await barque.releaseToBarque(variant, tarballUrl);
   }
   console.info('mongosh: Submitting to barque complete');
 }


### PR DESCRIPTION
Fixes an issue with releasing to Barque and asks to still publish a release if some evergreen tasks failed.