### PR TITLE
chore(build): fix detection of tasks for latest draft build

### DIFF
--- a/packages/build/src/evergreen/rest-api.spec.ts
+++ b/packages/build/src/evergreen/rest-api.spec.ts
@@ -64,7 +64,7 @@ describe('evergreen rest-api', () => {
       );
     });
 
-    it('executes a proper GET', async() => {
+    it('returns all tasks from the API when there is no tag filter', async() => {
       const task: EvergreenTask = {
         task_id: 'task_id',
         version_id: 'version',
@@ -80,7 +80,40 @@ describe('evergreen rest-api', () => {
       const tasks = await api.getTasks('mongosh', 'sha');
       expect(tasks).to.deep.equal([task]);
       expect(fetch).to.have.been.calledWith(
-        '//basePath/api/rest/v2/projects/mongosh/revisions/sha/tasks',
+        '//basePath/api/rest/v2/projects/mongosh/revisions/sha/tasks?limit=5000',
+        {
+          headers: {
+            'Api-User': 'user',
+            'Api-Key': 'key'
+          }
+        }
+      );
+    });
+
+    it('returns only matching tasks from the API for a tag filter', async() => {
+      const task1: EvergreenTask = {
+        task_id: 'task_id',
+        version_id: 'version',
+        status: 'success',
+        display_name: 'Task',
+        build_variant: 'variant'
+      };
+      const task2: EvergreenTask = {
+        task_id: 'task_id2',
+        version_id: 'mongosh_v0.8.2_draft.0_29jasdf',
+        status: 'success',
+        display_name: 'Task',
+        build_variant: 'variant'
+      };
+      fetch.resolves({
+        status: 200,
+        json: sinon.stub().resolves([task1, task2])
+      });
+
+      const tasks = await api.getTasks('mongosh', 'sha', 'v0.8.2-draft.0');
+      expect(tasks).to.deep.equal([task2]);
+      expect(fetch).to.have.been.calledWith(
+        '//basePath/api/rest/v2/projects/mongosh/revisions/sha/tasks?limit=5000',
         {
           headers: {
             'Api-User': 'user',

--- a/packages/build/src/evergreen/rest-api.ts
+++ b/packages/build/src/evergreen/rest-api.ts
@@ -46,13 +46,26 @@ export class EvergreenApi {
     );
   }
 
+  /**
+   * This will return the tasks that were executed for a given commit SHA.
+   * HOWEVER, Evergreen will return tasks from _all_ patch / waterfull runs based on the commit.
+   * One way to narrow the tasks down is to filter by a given tag that was used to trigger
+   * the waterfall build.
+   *
+   * @param project The Evergreen project
+   * @param commitSha The commit SHA of the desired commit to get tasks for
+   * @param tagFilter An optional filter to only look for tasks triggered by a specific tag
+   */
   public async getTasks(
     project: string,
-    commitSha: string
+    commitSha: string,
+    tagFilter?: string
   ): Promise<EvergreenTask[]> {
-    return await this.apiGET<EvergreenTask[]>(
-      `/projects/${project}/revisions/${commitSha}/tasks`
+    // we use limit=5000 to make sure we really get all of those tasks (default limit is 100)
+    const tasks = await this.apiGET<EvergreenTask[]>(
+      `/projects/${project}/revisions/${commitSha}/tasks?limit=5000`
     );
+    return !tagFilter ? tasks : tasks.filter(t => t.version_id.startsWith(`${project}_${tagFilter.replace(/-/g, '_')}`));
   }
 
   private async apiGET<T>(path: string): Promise<T> {


### PR DESCRIPTION
The Evergreen REST API returns all tasks that ever ran _based_ on the commit SHA. This includes multiple waterfall builds (e.g.  because these were triggered by tags), and also patch builds that are based on the given SHA.

We therefore have to filter based on the draft tag we are looking for.