### PR TITLE
chore(build): ensure packages are published for all distros MONGOSH-483

### DIFF
--- a/packages/build/src/barque.spec.ts
+++ b/packages/build/src/barque.spec.ts
@@ -6,7 +6,7 @@ import path from 'path';
 import sinon from 'sinon';
 import { URL } from 'url';
 import { Barque, LATEST_CURATOR } from './barque';
-import { BuildVariant, Config } from './config';
+import { ALL_BUILD_VARIANTS, BuildVariant, Config } from './config';
 
 describe('Barque', () => {
   let barque: Barque;
@@ -47,23 +47,16 @@ describe('Barque', () => {
     barque = new Barque(config);
   });
 
-  describe('.releaseToBarque', () => {
+  describe('releaseToBarque', () => {
     context('platform is linux', () => {
       it('execCurator function succeeds', async() => {
         barque.execCurator = sinon.stub().returns(Promise.resolve(true));
         barque.createCuratorDir = sinon.stub().returns(Promise.resolve('./'));
         barque.extractLatestCurator = sinon.stub().returns(Promise.resolve(true));
 
-        const tarballURL = 'https://s3.amazonaws.com/mciuploads/mongosh/5ed7ee5d8683818eb28d9d3b5c65837cde4a08f5/mongosh-0.1.0-linux.tgz';
+        const debUrl = 'https://s3.amazonaws.com/mciuploads/mongosh/5ed7ee5d8683818eb28d9d3b5c65837cde4a08f5/mongosh_0.1.0_amd64.deb';
 
-        let err;
-
-        try {
-          await barque.releaseToBarque(BuildVariant.Linux, tarballURL);
-        } catch (error) {
-          err = error;
-        }
-        expect(err).to.be.undefined;
+        await barque.releaseToBarque(BuildVariant.Debian, debUrl);
         expect(barque.createCuratorDir).to.have.been.called;
         expect(barque.extractLatestCurator).to.have.been.called;
         expect(barque.execCurator).to.have.been.called;
@@ -74,21 +67,18 @@ describe('Barque', () => {
         barque.createCuratorDir = sinon.stub().returns(Promise.resolve('./'));
         barque.extractLatestCurator = sinon.stub().returns(Promise.resolve(true));
 
-        const tarballURL = 'https://s3.amazonaws.com/mciuploads/mongosh/5ed7ee5d8683818eb28d9d3b5c65837cde4a08f5/mongosh-0.1.0-linux.tgz';
-
-        let err;
+        const debUrl = 'https://s3.amazonaws.com/mciuploads/mongosh/5ed7ee5d8683818eb28d9d3b5c65837cde4a08f5/mongosh_0.1.0_amd64.deb';
 
         try {
-          await barque.releaseToBarque(BuildVariant.Linux, tarballURL);
+          await barque.releaseToBarque(BuildVariant.Debian, debUrl);
         } catch (error) {
-          err = error;
+          expect(error.message).to.include('Curator is unable to upload to barque');
+          expect(barque.createCuratorDir).to.have.been.called;
+          expect(barque.extractLatestCurator).to.have.been.called;
+          expect(barque.execCurator).to.have.been.called;
+          return;
         }
-
-        expect(err).to.not.be.undefined;
-        expect(err.message).to.include('Curator is unable to upload to barque');
-        expect(barque.createCuratorDir).to.have.been.called;
-        expect(barque.extractLatestCurator).to.have.been.called;
-        expect(barque.execCurator).to.have.been.called;
+        expect.fail('Expected error');
       });
     });
 
@@ -100,71 +90,78 @@ describe('Barque', () => {
       barque.createCuratorDir = sinon.stub().returns(Promise.resolve('./'));
       barque.extractLatestCurator = sinon.stub().returns(Promise.resolve(true));
 
-      const tarballURL = 'https://s3.amazonaws.com/mciuploads/mongosh/5ed7ee5d8683818eb28d9d3b5c65837cde4a08f5/mongosh-0.1.0-linux.tgz';
+      const debUrl = 'https://s3.amazonaws.com/mciuploads/mongosh/5ed7ee5d8683818eb28d9d3b5c65837cde4a08f5/mongosh_0.1.0_linux.deb';
 
-      await barque.releaseToBarque(BuildVariant.Linux, tarballURL);
-      expect(barque.createCuratorDir).to.have.been.called;
-      expect(barque.extractLatestCurator).to.have.been.called;
+      await barque.releaseToBarque(BuildVariant.Debian, debUrl);
+      expect(barque.createCuratorDir).to.not.have.been.called;
+      expect(barque.extractLatestCurator).to.not.have.been.called;
       expect(barque.execCurator).to.not.have.been.called;
     });
   });
 
-  describe('.determineDistro', () => {
-    it('determines distro for ubuntu', async() => {
-      const distro = barque.determineDistro(BuildVariant.Linux);
-      expect(distro).to.be.equal('ubuntu1804');
+  describe('getTargetDistro', () => {
+    it('determines distro for debian build variant', async() => {
+      const distro = barque.getTargetDistros(BuildVariant.Debian);
+      expect(distro).to.deep.equal(['debian10', 'ubuntu1804', 'ubuntu2004']);
     });
 
-    it('determines distro for debian', async() => {
-      const distro = barque.determineDistro(BuildVariant.Debian);
-      expect(distro).to.be.equal('debian10');
+    it('determines distro for redhat build variant', async() => {
+      const distro = barque.getTargetDistros(BuildVariant.Redhat);
+      expect(distro).to.deep.equal(['rhel80']);
     });
 
-    it('determines distro for redhat', async() => {
-      const distro = barque.determineDistro(BuildVariant.Redhat);
-      expect(distro).to.be.equal('rhel80');
-    });
-
-    it('defaults to ubuntu distro', async() => {
-      const distro = barque.determineDistro('wrong' as any);
-      expect(distro).to.be.equal('ubuntu1804');
-    });
+    ALL_BUILD_VARIANTS
+      .filter(v => v !== BuildVariant.Debian && v !== BuildVariant.Redhat)
+      .forEach(variant => {
+        it(`throws an error for ${variant}`, async() => {
+          try {
+            barque.getTargetDistros(variant);
+          } catch (e) {
+            expect(e.message).to.include(variant);
+            return;
+          }
+          expect.fail('Expected error');
+        });
+      });
   });
 
-  describe('.determineArch', () => {
-    it('determines arch for ubuntu', async() => {
-      const distro = barque.determineArch(BuildVariant.Linux);
-      expect(distro).to.be.equal('amd64');
-    });
-
+  describe('getTargetArchitecture', () => {
     it('determines arch for debian', async() => {
-      const distro = barque.determineArch(BuildVariant.Debian);
+      const distro = barque.getTargetArchitecture(BuildVariant.Debian);
       expect(distro).to.be.equal('amd64');
     });
 
     it('determines arch for redhat', async() => {
-      const distro = barque.determineArch(BuildVariant.Redhat);
+      const distro = barque.getTargetArchitecture(BuildVariant.Redhat);
       expect(distro).to.be.equal('x86_64');
     });
 
-    it('defaults to ubuntu arch', async() => {
-      const distro = barque.determineArch('wrong' as any);
-      expect(distro).to.be.equal('amd64');
-    });
+    ALL_BUILD_VARIANTS
+      .filter(v => v !== BuildVariant.Debian && v !== BuildVariant.Redhat)
+      .forEach(variant => {
+        it(`throws an error for ${variant}`, async() => {
+          try {
+            barque.getTargetArchitecture(variant);
+          } catch (e) {
+            expect(e.message).to.include(variant);
+            return;
+          }
+          expect.fail('Expected error');
+        });
+      });
   });
 
-  describe('.createCuratorDir', () => {
+  describe('createCuratorDir', () => {
     it('creates tmp directory that exists', async() => {
       const curatorDirPath = await barque.createCuratorDir();
 
-      let accessErr;
+      let accessErr: Error | undefined = undefined;
       try {
         await fs.access(curatorDirPath);
       } catch (e) {
         accessErr = e;
       }
-      // eslint-disable-next-line
-      expect(accessErr).to.be.undefined
+      expect(accessErr).to.be.undefined;
     });
   });
 
@@ -178,7 +175,7 @@ describe('Barque', () => {
     });
   });
 
-  describe('.extractLatestCurator', () => {
+  describe('extractLatestCurator', () => {
     beforeEach(() => {
       nock.cleanAll();
       const latestCuratorUrl = new URL(LATEST_CURATOR);
@@ -199,14 +196,13 @@ describe('Barque', () => {
 
       await barque.extractLatestCurator(curatorDirPath);
 
-      let accessErr;
+      let accessErr: Error | undefined = undefined;
       try {
         await fs.access(curatorPath);
       } catch (e) {
         accessErr = e;
       }
-      // eslint-disable-next-line
-      expect(accessErr).to.be.undefined
+      expect(accessErr).to.be.undefined;
     });
   });
 });


### PR DESCRIPTION
The issue was caused because it tried to publish the `-linux.tgz` files to the Ubuntu PPA instead of the `.deb` packages.

It is more or less "safe" to test for a release since publishing to Barque is the first step in the publishing stage. So in the worst case we will have to re-start publishing.