### PR TITLE
chore(build): ensure remote information is up-to-date MONGOSH-610

### DIFF
--- a/packages/build/src/git/repository-status.spec.ts
+++ b/packages/build/src/git/repository-status.spec.ts
@@ -11,9 +11,11 @@ describe('git repository-status', () => {
 
   describe('verifyGitStatus', () => {
     let getRepositoryStatus: sinon.SinonStub;
+    let spawnSync: sinon.SinonStub;
 
     beforeEach(()=> {
       getRepositoryStatus = sinon.stub();
+      spawnSync = sinon.stub();
     });
 
     [ 'master', 'main', 'release/v0.8.0', 'release/v0.8.x' ].forEach(branchName => {
@@ -28,8 +30,9 @@ describe('git repository-status', () => {
           hasUnpushedTags: false
         };
         getRepositoryStatus.returns(status);
-        const returnedStatus = verifyGitStatus('root', getRepositoryStatus);
+        const returnedStatus = verifyGitStatus('root', getRepositoryStatus, spawnSync);
         expect(returnedStatus).to.equal(status);
+        expect(spawnSync).to.have.been.calledWith('git', ['fetch', '--tags'], sinon.match.object);
       });
     });
 
@@ -40,7 +43,7 @@ describe('git repository-status', () => {
       };
       getRepositoryStatus.returns(status);
       try {
-        verifyGitStatus('root', getRepositoryStatus);
+        verifyGitStatus('root', getRepositoryStatus, spawnSync);
       } catch (e) {
         expect(e.message).to.contain('Could not determine local repository information');
         return;
@@ -60,7 +63,7 @@ describe('git repository-status', () => {
       };
       getRepositoryStatus.returns(status);
       try {
-        verifyGitStatus('root', getRepositoryStatus);
+        verifyGitStatus('root', getRepositoryStatus, spawnSync);
       } catch (e) {
         expect(e.message).to.contain('The current branch does not match');
         return;
@@ -80,7 +83,7 @@ describe('git repository-status', () => {
       };
       getRepositoryStatus.returns(status);
       try {
-        verifyGitStatus('root', getRepositoryStatus);
+        verifyGitStatus('root', getRepositoryStatus, spawnSync);
       } catch (e) {
         expect(e.message).to.contain('The branch you are on is not tracking any remote branch.');
         return;
@@ -100,7 +103,7 @@ describe('git repository-status', () => {
       };
       getRepositoryStatus.returns(status);
       try {
-        verifyGitStatus('root', getRepositoryStatus);
+        verifyGitStatus('root', getRepositoryStatus, spawnSync);
       } catch (e) {
         expect(e.message).to.contain('Your local repository is not clean or diverged from the remote branch');
         return;
@@ -120,7 +123,7 @@ describe('git repository-status', () => {
       };
       getRepositoryStatus.returns(status);
       try {
-        verifyGitStatus('root', getRepositoryStatus);
+        verifyGitStatus('root', getRepositoryStatus, spawnSync);
       } catch (e) {
         expect(e.message).to.contain('Your local repository is not clean or diverged from the remote branch');
         return;
@@ -140,7 +143,7 @@ describe('git repository-status', () => {
       };
       getRepositoryStatus.returns(status);
       try {
-        verifyGitStatus('root', getRepositoryStatus);
+        verifyGitStatus('root', getRepositoryStatus, spawnSync);
       } catch (e) {
         expect(e.message).to.contain('You have local tags that are not pushed to the remote');
         return;

--- a/packages/build/src/git/repository-status.ts
+++ b/packages/build/src/git/repository-status.ts
@@ -16,8 +16,14 @@ const RELEASE_BRANCH = /^release\/v([a-z0-9]+\.[a-z0-9]+\.[a-z0-9]+)$/;
 
 export function verifyGitStatus(
   repositoryRoot: string,
-  getRepositoryStatusFn: typeof getRepositoryStatus = getRepositoryStatus
+  getRepositoryStatusFn: typeof getRepositoryStatus = getRepositoryStatus,
+  spawnSync: typeof spawnSyncFn = spawnSyncFn
 ): RepositoryStatus {
+  spawnSync('git', ['fetch', '--tags'], {
+    cwd: repositoryRoot,
+    encoding: 'utf-8'
+  });
+
   const repositoryStatus = getRepositoryStatusFn(repositoryRoot);
   if (!repositoryStatus.branch?.local) {
     throw new Error('Could not determine local repository information - please verify your repository is intact.');


### PR DESCRIPTION
Runs a `git fetch --tags` before verifying local repository status on `npm run release <draft|publish>`.