### PR TITLE
chore(build): wait until packages are really available in PPAs MONGOSH-619

### DIFF
--- a/packages/build/src/run-publish.spec.ts
+++ b/packages/build/src/run-publish.spec.ts
@@ -81,7 +81,8 @@ describe('publish', () => {
     githubRepo = createStubRepo();
     mongoHomebrewRepo = createStubRepo();
     barque = createStubBarque({
-      releaseToBarque: sinon.stub().resolves(true)
+      releaseToBarque: sinon.stub().resolves(['package-url']),
+      waitUntilPackagesAreAvailable: sinon.stub().resolves()
     });
   });
 
@@ -188,6 +189,7 @@ describe('publish', () => {
         BuildVariant.Debian,
         'https://s3.amazonaws.com/mciuploads/project/v0.7.0-draft.42/mongosh_0.7.0_amd64.deb'
       );
+      expect(barque.waitUntilPackagesAreAvailable).to.have.been.called;
     });
 
     it('updates the download center config', async() => {

--- a/packages/build/src/run-publish.ts
+++ b/packages/build/src/run-publish.ts
@@ -92,11 +92,17 @@ async function publishArtifactsToBarque(
     BuildVariant.Debian,
     BuildVariant.Redhat
   ];
+
+  const publishedPackages: string[] = [];
   for await (const variant of variantsForBarque) {
     const tarballName = getTarballFile(variant, releaseVersion, packageName);
     const tarballUrl = getEvergreenArtifactUrl(project, mostRecentDraftTag, tarballName.path);
     console.info(`mongosh: Publishing ${variant} artifact to barque ${tarballUrl}`);
-    await barque.releaseToBarque(variant, tarballUrl);
+    const packageUrls = await barque.releaseToBarque(variant, tarballUrl);
+    publishedPackages.push(...packageUrls);
   }
+
+  await barque.waitUntilPackagesAreAvailable(publishedPackages, 300);
+
   console.info('mongosh: Submitting to barque complete');
 }


### PR DESCRIPTION
This PR adds the following behavior:
* Publishing a distributable using Barque returns the URLs we expect the packages to be available at
* After all distributables are published we wait at most 5 minutes for them to become available checking every 10 seconds

Note: We are only doing a `HEAD` request instead of downloading the full package. Example to see with an existing package locally:
```
$ curl --head https://repo.mongodb.org/yum/redhat/8/mongodb-org/4.4/x86_64/RPMS/mongosh-0.8.2-x86_64.rpm
HTTP/2 200
...
```

**Open Question:** Should I calibrate timeout and interval to different values?