### PR TITLE
chore(build): fix updating draft releases to contain tag

### DIFF
--- a/packages/build/src/github-repo.spec.ts
+++ b/packages/build/src/github-repo.spec.ts
@@ -227,6 +227,7 @@ describe('GithubRepo', () => {
       await githubRepo.updateDraftRelease(params);
       expect(updateRelease).to.have.been.calledWith({
         release_id: 'existing_id',
+        tag_name: params.tag,
         owner: 'mongodb-js',
         repo: 'mongosh',
         name: params.name,

--- a/packages/build/src/github-repo.ts
+++ b/packages/build/src/github-repo.ts
@@ -122,6 +122,7 @@ export class GithubRepo {
       await this.octokit.repos.updateRelease({
         ...this.repo,
         release_id: existingRelease.id,
+        tag_name: release.tag,
         name: release.name,
         body: release.notes,
         draft: true


### PR DESCRIPTION
The GitHub API for updating a release requires the `tag_name` to be present or otherwise it will remove the associated tag (at least for draft releases where the tag does not yet exist).