### PR TITLE
fix: change runtime importing approach MONGOSH-618

### DIFF
--- a/packages/compass-shell/config/webpack.base.config.js
+++ b/packages/compass-shell/config/webpack.base.config.js
@@ -134,5 +134,6 @@ module.exports = {
     // main import and for that reason it needs to stay external to the
     // compass-shell
     '@mongosh/node-runtime-worker-thread': 'commonjs2 @mongosh/node-runtime-worker-thread',
-  }
+  },
+  node: false
 };

--- a/packages/compass-shell/src/modules/runtime.js
+++ b/packages/compass-shell/src/modules/runtime.js
@@ -1,6 +1,6 @@
 import { ElectronRuntime } from '@mongosh/browser-runtime-electron';
 import { CompassServiceProvider } from '@mongosh/service-provider-server';
-import { WorkerRuntime } from '@mongosh/node-runtime-worker-thread';
+import { WorkerRuntime } from './worker-runtime';
 import { adaptDriverV36ConnectionParams } from './adapt-driver-v36-connection-params';
 
 /**

--- a/packages/compass-shell/src/modules/worker-runtime.js
+++ b/packages/compass-shell/src/modules/worker-runtime.js
@@ -1,0 +1,23 @@
+import path from 'path';
+import { createRequire } from 'module';
+
+const { WorkerRuntime } = (() => {
+  // Workaround for webpack require that overrides global require
+  const req = createRequire(path.resolve(__filename));
+  const realModulePath = req.resolve('@mongosh/node-runtime-worker-thread');
+  // Runtime needs to be outside the asar bundle to function properly, so if we
+  // resolved it inside of one, we will try to import it from outside (and hard
+  // fail if this didn't work)
+  if (/\.asar(?!\.unpacked)/.test(realModulePath)) {
+    try {
+      return req(realModulePath.replace('.asar', '.asar.unpacked'));
+    } catch (e) {
+      e.message += '\n\n@mongosh/node-runtime-worker-thread module and all its dependencies needs to be unpacked before it can be used';
+      throw e;
+    }
+  }
+
+  return req(realModulePath);
+})();
+
+export { WorkerRuntime };

--- a/packages/compass-shell/src/modules/worker-runtime.js
+++ b/packages/compass-shell/src/modules/worker-runtime.js
@@ -1,9 +1,8 @@
-import path from 'path';
 import { createRequire } from 'module';
 
 const { WorkerRuntime } = (() => {
   // Workaround for webpack require that overrides global require
-  const req = createRequire(path.resolve(__filename));
+  const req = createRequire(__filename);
   const realModulePath = req.resolve('@mongosh/node-runtime-worker-thread');
   // Runtime needs to be outside the asar bundle to function properly, so if we
   // resolved it inside of one, we will try to import it from outside (and hard
@@ -12,7 +11,8 @@ const { WorkerRuntime } = (() => {
     try {
       return req(realModulePath.replace('.asar', '.asar.unpacked'));
     } catch (e) {
-      e.message += '\n\n@mongosh/node-runtime-worker-thread module and all its dependencies needs to be unpacked before it can be used';
+      e.message +=
+        '\n\n@mongosh/node-runtime-worker-thread module and all its dependencies needs to be unpacked before it can be used';
       throw e;
     }
   }

--- a/packages/node-runtime-worker-thread/src/child-process-proxy.ts
+++ b/packages/node-runtime-worker-thread/src/child-process-proxy.ts
@@ -15,20 +15,13 @@
  */
 import { once } from 'events';
 import { SHARE_ENV, Worker } from 'worker_threads';
-import fs from 'fs';
 import path from 'path';
 import { exposeAll, createCaller } from './rpc';
 import { InterruptHandle, interrupt as nativeInterrupt } from 'interruptor';
 
 const workerRuntimeSrcPath = path.resolve(__dirname, 'worker-runtime.js');
 
-const workerProcess = new Worker(
-  // It's fine in this use-case: this process is spawned so we are not blocking
-  // anything in the main process
-  // eslint-disable-next-line no-sync
-  fs.readFileSync(workerRuntimeSrcPath, 'utf8'),
-  { env: SHARE_ENV, eval: true }
-);
+const workerProcess = new Worker(workerRuntimeSrcPath, { env: SHARE_ENV });
 
 // We expect the amount of listeners to be more than the default value of 10 but
 // probably not more than ~25 (all exposed methods on


### PR DESCRIPTION
This change should finally allow us to include compass-shell with new runtime in compass without any issues. Current implementation doesn't work because `worker_threads` Worker when spawned in electron environment can't resolve anything correctly inside the `.asar` bundle, so worker code just fails when trying to resolve `interruptor` (that needs to stay external because it has a native module dependency). As a workaround we will ensure that if we are trying to import `node-runtime-worker-thread` from inside the `.asar` archive we would instead look for the unpacked version and hard fail if it doesn't exist as requiring one that is not unpacked would not work correctly anyway.