### PR TITLE
chore(cli-repl): add awsIamSessionToken support MONGOSH-572

### DIFF
--- a/packages/cli-repl/src/arg-mapper.spec.ts
+++ b/packages/cli-repl/src/arg-mapper.spec.ts
@@ -192,6 +192,18 @@ describe('arg-mapper.mapCliToDriver', () => {
     });
   });
 
+  context('when the cli args have awsIamSessionToken', () => {
+    const cliOptions: CliOptions = { awsIamSessionToken: 'token' };
+
+    it('maps to authMechanismProperties.AWS_SESSION_TOKEN', async() => {
+      expect(await mapCliToDriver(cliOptions)).to.deep.equal({
+        authMechanismProperties: {
+          AWS_SESSION_TOKEN: 'token'
+        }
+      });
+    });
+  });
+
   context('when the cli args have keyVaultNamespace', () => {
     const cliOptions: CliOptions = { keyVaultNamespace: 'db.datakeys' };
 

--- a/packages/cli-repl/src/arg-mapper.ts
+++ b/packages/cli-repl/src/arg-mapper.ts
@@ -8,6 +8,7 @@ const MAPPINGS = {
   awsAccessKeyId: 'autoEncryption.kmsProviders.aws.accessKeyId',
   awsSecretAccessKey: 'autoEncryption.kmsProviders.aws.secretAccessKey',
   awsSessionToken: 'autoEncryption.kmsProviders.aws.sessionToken',
+  awsIamSessionToken: 'authMechanismProperties.AWS_SESSION_TOKEN',
   authenticationDatabase: 'authSource',
   authenticationMechanism: 'authMechanism',
   keyVaultNamespace: 'autoEncryption.keyVaultNamespace',

--- a/packages/cli-repl/src/arg-parser.spec.ts
+++ b/packages/cli-repl/src/arg-parser.spec.ts
@@ -348,6 +348,18 @@ describe('arg-parser', () => {
                 expect(parseCliArgs(argv).gssapiHostName).to.equal('example.com');
               });
             });
+
+            context('when providing --awsIamSessionToken', () => {
+              const argv = [ ...baseArgv, uri, '--awsIamSessionToken', 'tok' ];
+
+              it('returns the URI in the object', () => {
+                expect(parseCliArgs(argv)._[0]).to.equal(uri);
+              });
+
+              it('sets the awsIamSessionToken in the object', () => {
+                expect(parseCliArgs(argv).awsIamSessionToken).to.equal('tok');
+              });
+            });
           });
 
           context('when providing TLS options', () => {

--- a/packages/cli-repl/src/arg-parser.ts
+++ b/packages/cli-repl/src/arg-parser.ts
@@ -26,6 +26,7 @@ const OPTIONS = {
     'awsIamSessionToken',
     'awsSecretAccessKey',
     'awsSessionToken',
+    'awsIamSessionToken',
     'db',
     'eval',
     'gssapiHostName',


### PR DESCRIPTION
##### ~~chore(cli-repl): deduplicate arg-parser tests~~

~~The arg-parser tests contained hundreds of duplicated lines.
This was confusing for when it comes to adding new tests, and in fact,
the two duplicated sections were already slightly out of sync.
Improve this by only having one copy of each of those tests.~~

##### chore(cli-repl): add awsIamSessionToken support MONGOSH-572

Since testing this is a separate issue, I’ve only confirmed that it
“works” insofar as that I’ve verified that AWS authentication breaks
when I specify an invalid token (but works without any token at all).
