### PR TITLE
fix: always autocomplete with read pref primaryPreferred MONGOSH-624

### DIFF
--- a/packages/shell-api/src/database.ts
+++ b/packages/shell-api/src/database.ts
@@ -150,7 +150,7 @@ export default class Database extends ShellApiClass {
   async _getCollectionNamesForCompletion(): Promise<string[]> {
     return await Promise.race([
       (async() => {
-        return await this._getCollectionNames();
+        return await this._getCollectionNames({ readPreference: 'primaryPreferred' });
       })(),
       (async() => {
         // 200ms should be a good compromise between giving the server a chance

--- a/packages/shell-api/src/shell-internal-state.spec.ts
+++ b/packages/shell-api/src/shell-internal-state.spec.ts
@@ -51,7 +51,10 @@ describe('ShellInternalState', () => {
       serviceProvider.listCollections
         .resolves([ { name: 'coll1' }, { name: 'coll2' } ]);
       expect(run('db = db.getSiblingDB("moo"); db.getName()')).to.equal('moo');
-      expect(serviceProvider.listCollections.calledWith('moo', {}, { nameOnly: true })).to.equal(true);
+      expect(serviceProvider.listCollections.calledWith('moo', {}, {
+        readPreference: 'primaryPreferred',
+        nameOnly: true
+      })).to.equal(true);
     });
   });
 

--- a/packages/shell-api/src/shell-internal-state.ts
+++ b/packages/shell-api/src/shell-internal-state.ts
@@ -133,7 +133,7 @@ export default class ShellInternalState {
     this.context.sh = new Shard(this.currentDb);
     this.fetchConnectionInfo().catch(err => this.messageBus.emit('mongosh:error', err));
     // Pre-fetch for autocompletion.
-    this.currentDb._getCollectionNames().catch(err => this.messageBus.emit('mongosh:error', err));
+    this.currentDb._getCollectionNamesForCompletion().catch(err => this.messageBus.emit('mongosh:error', err));
     return newDb;
   }
 


### PR DESCRIPTION
This is also what we do for `show dbs`/`show collections` in order
to ensure that they work on secondary nodes.