### PR TITLE
chore: move load() __filename and __dirname handling to shell-api

### DIFF
--- a/packages/cli-repl/src/mongosh-repl.ts
+++ b/packages/cli-repl/src/mongosh-repl.ts
@@ -3,7 +3,7 @@ import { MongoshCommandFailed, MongoshInternalError, MongoshWarning } from '@mon
 import { changeHistory } from '@mongosh/history';
 import i18n from '@mongosh/i18n';
 import type { ServiceProvider } from '@mongosh/service-provider-core';
-import { EvaluationListener, ShellCliOptions, ShellInternalState, OnLoadParameters } from '@mongosh/shell-api';
+import { EvaluationListener, ShellCliOptions, ShellInternalState, OnLoadResult } from '@mongosh/shell-api';
 import { ShellEvaluator, ShellResult } from '@mongosh/shell-evaluator';
 import type { MongoshBus, UserConfig } from '@mongosh/types';
 import askpassword from 'askpassword';
@@ -317,7 +317,7 @@ class MongoshNodeRepl implements EvaluationListener {
     }
   }
 
-  async onLoad(filename: string): Promise<OnLoadParameters> {
+  async onLoad(filename: string): Promise<OnLoadResult> {
     const repl = this.runtimeState().repl;
     const {
       contents,

--- a/packages/shell-api/src/index.ts
+++ b/packages/shell-api/src/index.ts
@@ -5,7 +5,7 @@ import Database from './database';
 import Explainable from './explainable';
 import ExplainableCursor from './explainable-cursor';
 import Help, { HelpProperties } from './help';
-import ShellInternalState, { EvaluationListener, ShellCliOptions } from './shell-internal-state';
+import ShellInternalState, { EvaluationListener, ShellCliOptions, OnLoadParameters } from './shell-internal-state';
 import toIterator from './toIterator';
 import Shard from './shard';
 import ReplicaSet from './replica-set';
@@ -62,5 +62,6 @@ export {
   getShellApiType,
   ShellResult,
   ShellCliOptions,
-  TypeSignature
+  TypeSignature,
+  OnLoadParameters
 };

--- a/packages/shell-api/src/index.ts
+++ b/packages/shell-api/src/index.ts
@@ -5,7 +5,7 @@ import Database from './database';
 import Explainable from './explainable';
 import ExplainableCursor from './explainable-cursor';
 import Help, { HelpProperties } from './help';
-import ShellInternalState, { EvaluationListener, ShellCliOptions, OnLoadParameters } from './shell-internal-state';
+import ShellInternalState, { EvaluationListener, ShellCliOptions, OnLoadResult } from './shell-internal-state';
 import toIterator from './toIterator';
 import Shard from './shard';
 import ReplicaSet from './replica-set';
@@ -63,5 +63,5 @@ export {
   ShellResult,
   ShellCliOptions,
   TypeSignature,
-  OnLoadParameters
+  OnLoadResult
 };

--- a/packages/shell-api/src/shell-api.spec.ts
+++ b/packages/shell-api/src/shell-api.spec.ts
@@ -570,9 +570,22 @@ describe('ShellApi', () => {
     });
     describe('load', () => {
       it('asks the evaluation listener to load a file', async() => {
-        evaluationListener.onLoad.resolves();
+        evaluationListener.onLoad.callsFake(async(filename: string) => {
+          expect(filename).to.equal('abc.js');
+          expect(internalState.context.__filename).to.equal(undefined);
+          expect(internalState.context.__dirname).to.equal(undefined);
+          return {
+            resolvedFilename: '/resolved/abc.js',
+            evaluate: async() => {
+              expect(internalState.context.__filename).to.equal('/resolved/abc.js');
+              expect(internalState.context.__dirname).to.equal('/resolved');
+            }
+          };
+        });
         await internalState.context.load('abc.js');
-        expect(evaluationListener.onLoad).to.have.been.calledWith('abc.js');
+        expect(evaluationListener.onLoad).to.have.callCount(1);
+        expect(internalState.context.__filename).to.equal(undefined);
+        expect(internalState.context.__dirname).to.equal(undefined);
       });
     });
     for (const cmd of ['print', 'printjson']) {

--- a/packages/shell-api/src/shell-internal-state.ts
+++ b/packages/shell-api/src/shell-internal-state.ts
@@ -35,6 +35,19 @@ export interface AutocompleteParameters {
   getCollectionCompletionsForCurrentDb: (collName: string) => Promise<string[]>;
 }
 
+export interface OnLoadParameters {
+  /**
+   * The absolute path of the file that should be load()ed.
+   */
+  resolvedFilename: string;
+
+  /**
+   * The actual steps that are needed to evaluate the load()ed file.
+   * For the duration of this call, __filename and __dirname are set as expected.
+   */
+  evaluate(): Promise<void>;
+}
+
 export interface EvaluationListener {
   /**
    * Called when print() or printjson() is run from the shell.
@@ -66,7 +79,7 @@ export interface EvaluationListener {
   /**
    * Called when load() is used in the shell.
    */
-  onLoad?: (filename: string) => Promise<void>;
+  onLoad?: (filename: string) => Promise<OnLoadParameters> | OnLoadParameters;
 }
 
 /**

--- a/packages/shell-api/src/shell-internal-state.ts
+++ b/packages/shell-api/src/shell-internal-state.ts
@@ -35,7 +35,7 @@ export interface AutocompleteParameters {
   getCollectionCompletionsForCurrentDb: (collName: string) => Promise<string[]>;
 }
 
-export interface OnLoadParameters {
+export interface OnLoadResult {
   /**
    * The absolute path of the file that should be load()ed.
    */
@@ -79,7 +79,7 @@ export interface EvaluationListener {
   /**
    * Called when load() is used in the shell.
    */
-  onLoad?: (filename: string) => Promise<OnLoadParameters> | OnLoadParameters;
+  onLoad?: (filename: string) => Promise<OnLoadResult> | OnLoadResult;
 }
 
 /**


### PR DESCRIPTION
This will make it easier to implement these features in a fully
equivalent way in Compass/VSCode, without having to duplicate this
particular bit of code (and not risk divergence, e.g. if we should
ever decide to use a separate stack for storing filename info).