### PR TITLE
feat(compass-shell): Always use new worker runtime COMPASS-4678

### DIFF
--- a/packages/compass-shell/package.json
+++ b/packages/compass-shell/package.json
@@ -57,10 +57,8 @@
     "@leafygreen-ui/icon": "^5.1.0",
     "@leafygreen-ui/icon-button": "^5.0.2",
     "@mongosh/browser-repl": "0.0.0-dev.0",
-    "@mongosh/browser-runtime-electron": "0.0.0-dev.0",
     "@mongosh/node-runtime-worker-thread": "0.0.0-dev.0",
     "@mongosh/service-provider-core": "0.0.0-dev.0",
-    "@mongosh/service-provider-server": "0.0.0-dev.0",
     "hadron-react-buttons": "^4.0.4",
     "mongodb-redux-common": "0.0.2"
   },

--- a/packages/compass-shell/src/modules/worker-runtime.js
+++ b/packages/compass-shell/src/modules/worker-runtime.js
@@ -1,5 +1,8 @@
 import { createRequire } from 'module';
 
+/**
+ * @type {{ WorkerRuntime: typeof import('@mongosh/node-runtime-worker-thread').WorkerRuntime }}
+ */
 const { WorkerRuntime } = (() => {
   // Workaround for webpack require that overrides global require
   const req = createRequire(__filename);


### PR DESCRIPTION
We decided that runtime will go into the next compass version without the flag. This PR removes the flag, removes `ElectronRuntime` and deps from `compass-shell` and updates the tests to work nicely with the new runtime