### PR TITLE
chore(i18n): Update load description

### DIFF
--- a/packages/i18n/src/locales/en_US.ts
+++ b/packages/i18n/src/locales/en_US.ts
@@ -119,7 +119,8 @@ const translations: Catalog = {
               link: 'https://docs.mongodb.com/manual/reference/method/version/'
             },
             load: {
-              description: 'Load a file into the shell context. Not currently implemented, if running mongosh from the CLI you can use .load <filename> as an alternative'
+              description: 'Loads and runs a JavaScript file into the current shell environment',
+              example: 'load("path/to/file.js")'
             },
             enableTelemetry: {
               description: 'Enables collection of anonymous usage data to improve the mongosh CLI'


### PR DESCRIPTION
Copied description from [mongo docs](https://docs.mongodb.com/manual/reference/method/load/). No link yet as `mongosh` version of the docs is WIP, but a quick fix that removes the "not implemented" part seems warranted before we do 0.9.0 release