### PR TITLE
chore(ci): expand LDAP integration tests MONGOSH-577

### DIFF
--- a/packages/connectivity-tests/test/all.sh
+++ b/packages/connectivity-tests/test/all.sh
@@ -13,7 +13,8 @@ TEST_TMPDIR="$PWD"
 
 git clone git@github.com:mongodb-js/devtools-docker-test-envs.git test-envs
 cd test-envs
-git checkout de257688e6b7ce265a70bf75c7127c6da0bf2cf0
+# TODO: update hash after merge!
+git checkout 3ffa562f98616cbdd9250586388b26ce4e1ac839
 
 source "$CONNECTIVITY_TEST_SOURCE_DIR/ldap.sh"
 source "$CONNECTIVITY_TEST_SOURCE_DIR/localhost.sh"

--- a/packages/connectivity-tests/test/ldap.sh
+++ b/packages/connectivity-tests/test/ldap.sh
@@ -2,22 +2,47 @@
 set -e
 set -x
 
-docker-compose -f ldap/docker-compose.yaml up -d
-FAILED=no
+function try_connect_explicit() {
+  echo 'db.runCommand({ connectionStatus: 1 }).authInfo.authenticatedUsers' |
+    (mongosh \
+      --host localhost \
+      --port 30017 \
+      --username "$1" \
+      --password "$2" \
+      --authenticationMechanism PLAIN \
+      --authenticationDatabase '$external' |
+    grep -Fq "$1" && echo 'no') || echo 'yes'
+}
 
-sleep 10 # let mongod start up
-echo 'db.runCommand({ connectionStatus: 1 }).authInfo.authenticatedUsers' | \
-mongosh \
-  --host localhost \
-  --port 30017 \
-  --username 'writer@EXAMPLE.COM' \
-  --password 'Password1!' \
-  --authenticationMechanism PLAIN \
-  --authenticationDatabase '$external' | \
-grep -Fq writer@EXAMPLE.COM || FAILED=yes
+function try_connect_connection_string() {
+  echo 'db.runCommand({ connectionStatus: 1 }).authInfo.authenticatedUsers' |
+    (mongosh "$1" | grep -Fq "$2" && echo 'no') || echo 'yes'
+}
 
-docker-compose -f ldap/docker-compose.yaml down
+function test_for_version() {
+  MONGODB_VERSION="$1" docker-compose -f ldap/docker-compose.yaml up -d
 
-if [ $FAILED = yes ]; then
+  sleep 10 # let mongod start up
+  FAILED_EXPLICIT=$(try_connect_explicit 'writer@EXAMPLE.COM' 'Password1!')
+  FAILED_CONNECTION_STRING=$(try_connect_connection_string 'mongodb://writer%40EXAMPLE.COM:Password1!@localhost:30017/$external?authMechanism=PLAIN' 'writer@EXAMPLE.COM')
+
+  MONGODB_VERSION="$1" docker-compose -f ldap/docker-compose.yaml down
+
+  if [ $FAILED_EXPLICIT = yes ]; then
+    ANY_FAILED=yes
+    echo "LDAP test with explicit username/password failed for $1"
+  fi
+
+  if [ $FAILED_CONNECTION_STRING = yes ]; then
+    ANY_FAILED=yes
+    echo "LDAP test with connection string failed for $1"
+  fi
+}
+
+ANY_FAILED=no
+test_for_version '4.2'
+test_for_version '4.4'
+
+if [ $ANY_FAILED = yes ]; then
   exit 1
 fi


### PR DESCRIPTION
Depends on https://github.com/mongodb-js/devtools-docker-test-envs/pull/3 to run the LDAP tests also against MongoDB Enterprise v4.2.