### PR TITLE
fix(cli-repl): add aws4 as dependency to cli-repl to enable AWS auth

### DIFF
--- a/packages/service-provider-server/package-lock.json
+++ b/packages/service-provider-server/package-lock.json
@@ -60,6 +60,11 @@
 				"readable-stream": "^2.0.6"
 			}
 		},
+		"aws4": {
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
+			"integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
+		},
 		"base64-js": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",

--- a/packages/service-provider-server/package.json
+++ b/packages/service-provider-server/package.json
@@ -42,6 +42,7 @@
     "@mongosh/service-provider-core": "0.0.0-dev.0",
     "@types/sinon": "^7.5.1",
     "@types/sinon-chai": "^3.2.3",
+    "aws4": "^1.11.0",
     "mongodb": "4.0.0-beta.1",
     "saslprep": "mongodb-js/saslprep#v1.0.4"
   },


### PR DESCRIPTION
Since the Homebrew formula uses the cli-repl package, the aws4
dependency has to be added to it in order for it to be available after
brewing it.