### PR TITLE
chore(deps): update driver to 4.0.0-beta.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14260,9 +14260,9 @@
       }
     },
     "mongodb": {
-      "version": "4.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.0.0-beta.1.tgz",
-      "integrity": "sha512-NHnek7m1qOK36yVNiETLsEtOgrWsE6STFl4BxqSHg1dO5s70dJQJK/yPA1f4NtnkgCfTHiwgTKWN8hr9toQRsw==",
+      "version": "4.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.0.0-beta.2.tgz",
+      "integrity": "sha512-V6zgRBXikCAxbm+cN5CriQB8KlvMcRYmDQyt3DSUcdVQ40iBBLPQknwG38ZsjA5N3YrP6ghYQ2ncQE6f2Jcf1w==",
       "dev": true,
       "requires": {
         "bson": "^4.2.2",

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "karma-typescript": "^4.1.1",
     "lerna": "^3.10.7",
     "mocha": "^7.1.2",
-    "mongodb": "4.0.0-beta.1",
+    "mongodb": "4.0.0-beta.2",
     "mongodb-download-url": "^0.6.3",
     "mongodb-js-precommit": "^2.0.0",
     "node-codesign": "^0.3.2",

--- a/packages/i18n/src/locales/en_US.ts
+++ b/packages/i18n/src/locales/en_US.ts
@@ -1278,6 +1278,21 @@ const translations: Catalog = {
               description: 'Returns information on the query plan for db.collection.findAndModify().',
               example: 'db.coll.explain().findAndModify({ query: { ... }, update: { ... } })'
             },
+            findOneAndDelete: {
+              link: 'https://docs.mongodb.com/manual/reference/method/db.collection.explain',
+              description: 'Returns information on the query plan for db.collection.findOneAndDelete().',
+              example: 'db.coll.explain().findOneAndDelete({ ... query ... })'
+            },
+            findOneAndReplace: {
+              link: 'https://docs.mongodb.com/manual/reference/method/db.collection.explain',
+              description: 'Returns information on the query plan for db.collection.findOneAndReplace().',
+              example: 'db.coll.explain().findOneAndReplace({ ... query ... }, { ... replacement ... })'
+            },
+            findOneAndUpdate: {
+              link: 'https://docs.mongodb.com/manual/reference/method/db.collection.explain',
+              description: 'Returns information on the query plan for db.collection.findOneAndUpdate().',
+              example: 'db.coll.explain().findOneAndUpdate({ ... query ... }, { ... update operators ... })'
+            },
             getCollection: {
               link: '',
               description: 'Returns the explainable collection.',

--- a/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/service/JavaServiceProvider.kt
+++ b/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/service/JavaServiceProvider.kt
@@ -112,11 +112,6 @@ internal class JavaServiceProvider(private val client: MongoClient,
     }
 
     @HostAccess.Export
-    override fun findAndModify(database: String, collection: String, filter: Value?, sort: Value?, update: Value?, options: Value?, dbOptions: Value?) {
-        throw NotImplementedError()
-    }
-
-    @HostAccess.Export
     override fun updateOne(database: String, collection: String, filter: Value, update: Value, options: Value?): Value = promise<Any?> {
         val filter = toDocument(filter, "filter")
         val options = toDocument(options, "options")

--- a/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/service/WritableServiceProvider.kt
+++ b/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/service/WritableServiceProvider.kt
@@ -19,7 +19,6 @@ internal interface WritableServiceProvider {
     fun insertOne(database: String, collection: String, document: Value?, options: Value?): Value
     fun replaceOne(database: String, collection: String, filter: Value, replacement: Value, options: Value?): Value
     fun updateMany(database: String, collection: String, filter: Value, update: Value, options: Value?): Value
-    fun findAndModify(database: String, collection: String, filter: Value?, sort: Value?, update: Value?, options: Value?, dbOptions: Value?)
     fun updateOne(database: String, collection: String, filter: Value, update: Value, options: Value?): Value
     fun save(database: String, collection: String, document: Value, options: Value?, dbOptions: Value?): Value
     fun remove(database: String, collection: String, query: Value, options: Value?): Value

--- a/packages/service-provider-core/package-lock.json
+++ b/packages/service-provider-core/package-lock.json
@@ -296,9 +296,9 @@
       }
     },
     "mongodb": {
-      "version": "4.0.0-beta.1",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.0.0-beta.1.tgz",
-      "integrity": "sha512-NHnek7m1qOK36yVNiETLsEtOgrWsE6STFl4BxqSHg1dO5s70dJQJK/yPA1f4NtnkgCfTHiwgTKWN8hr9toQRsw==",
+      "version": "4.0.0-beta.2",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.0.0-beta.2.tgz",
+      "integrity": "sha512-V6zgRBXikCAxbm+cN5CriQB8KlvMcRYmDQyt3DSUcdVQ40iBBLPQknwG38ZsjA5N3YrP6ghYQ2ncQE6f2Jcf1w==",
       "requires": {
         "bson": "^4.2.2",
         "denque": "^1.4.1",
@@ -311,9 +311,9 @@
       "integrity": "sha512-HC4ZG98ObbWGM3ikL3VfSvuug3iQVpA2kBob/MxK+mn2PNdVTvR5lShio+Ev1rDqODfq3ePcfO6prfi0agQp8g=="
     },
     "mongodb-client-encryption": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-1.2.1.tgz",
-      "integrity": "sha512-FdAzufBIOEJqzF7TauWsNiSPhI7Zoumzj9ccUAKviurhenLhdcc3HIXyz7LSGKPqtwl1AlYMVwBWZ0jgja4/gQ==",
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-1.2.2.tgz",
+      "integrity": "sha512-s42Oo3YhkpFwboXknDw7T9cak6UwH6K67q1nyfQ9zwyI/n4eh6FoJKSL6ZXFZ+sNlod4gYJbM0Irpkg4Eql0wQ==",
       "optional": true,
       "requires": {
         "bindings": "^1.5.0",
@@ -335,9 +335,9 @@
       "optional": true
     },
     "node-abi": {
-      "version": "2.19.3",
-      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.19.3.tgz",
-      "integrity": "sha512-9xZrlyfvKhWme2EXFKQhZRp1yNWT/uI1luYPr3sFl+H4keYY4xR+1jO7mvTTijIsHf1M+QDe9uWuKeEpLInIlg==",
+      "version": "2.21.0",
+      "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.21.0.tgz",
+      "integrity": "sha512-smhrivuPqEM3H5LmnY3KU6HfYv0u4QklgAxfFyRNujKUzbUcYZ+Jc2EhukB9SRcD2VpqhxM7n/MIcp1Ua1/JMg==",
       "optional": true,
       "requires": {
         "semver": "^5.4.1"

--- a/packages/service-provider-core/package.json
+++ b/packages/service-provider-core/package.json
@@ -30,7 +30,7 @@
     "@mongosh/errors": "0.0.0-dev.0",
     "@mongosh/i18n": "0.0.0-dev.0",
     "bson": "^4.2.3",
-    "mongodb": "4.0.0-beta.1",
+    "mongodb": "4.0.0-beta.2",
     "mongodb-build-info": "^1.1.1",
     "whatwg-url": "^8.4.0"
   },
@@ -39,7 +39,7 @@
     "@types/whatwg-url": "^8.0.0"
   },
   "optionalDependencies": {
-    "mongodb-client-encryption": "^1.2.1"
+    "mongodb-client-encryption": "^1.2.2"
   },
   "dependency-check": {
     "entries": [

--- a/packages/service-provider-core/src/all-transport-types.ts
+++ b/packages/service-provider-core/src/all-transport-types.ts
@@ -69,8 +69,8 @@ export type {
   Binary as BinaryType,
   Topology,
   TopologyDescription,
-  TopologyType,
-  ServerType,
+  TopologyTypeId,
+  ServerTypeId,
   AutoEncryptionOptions,
   MongoClient // mostly for testing
 } from 'mongodb';

--- a/packages/service-provider-core/src/writable.ts
+++ b/packages/service-provider-core/src/writable.ts
@@ -260,29 +260,6 @@ export default interface Writable {
     dbOptions?: DbOptions): Promise<UpdateResult>;
 
   /**
-   * find and update or remove a document.
-   *
-   * @param {String} database - The database name.
-   * @param {String} collection - The collection name.
-   * @param {Document} query - The filter.
-   * @param {Document} sort - The sort option.
-   * @param {Document} update - The update document.
-   * @param {Document} options - The update options.
-   * @param {DbOptions} dbOptions - The DB options
-   *
-   * @returns {Promise} The promise of the result.
-   */
-  findAndModify(
-    database: string,
-    collection: string,
-    query: Document,
-    sort: any[] | Document | undefined,
-    update: Document | undefined,
-    options?: FindAndModifyOptions,
-    dbOptions?: DbOptions
-  ): Promise<Document>;
-
-  /**
    * Update a document.
    *
    * @param {String} database - The database name.

--- a/packages/service-provider-server/package-lock.json
+++ b/packages/service-provider-server/package-lock.json
@@ -298,9 +298,9 @@
 			}
 		},
 		"mongodb": {
-			"version": "4.0.0-beta.1",
-			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.0.0-beta.1.tgz",
-			"integrity": "sha512-NHnek7m1qOK36yVNiETLsEtOgrWsE6STFl4BxqSHg1dO5s70dJQJK/yPA1f4NtnkgCfTHiwgTKWN8hr9toQRsw==",
+			"version": "4.0.0-beta.2",
+			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.0.0-beta.2.tgz",
+			"integrity": "sha512-V6zgRBXikCAxbm+cN5CriQB8KlvMcRYmDQyt3DSUcdVQ40iBBLPQknwG38ZsjA5N3YrP6ghYQ2ncQE6f2Jcf1w==",
 			"requires": {
 				"bson": "^4.2.2",
 				"denque": "^1.4.1",
@@ -308,9 +308,9 @@
 			}
 		},
 		"mongodb-client-encryption": {
-			"version": "1.2.1",
-			"resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-1.2.1.tgz",
-			"integrity": "sha512-FdAzufBIOEJqzF7TauWsNiSPhI7Zoumzj9ccUAKviurhenLhdcc3HIXyz7LSGKPqtwl1AlYMVwBWZ0jgja4/gQ==",
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-1.2.2.tgz",
+			"integrity": "sha512-s42Oo3YhkpFwboXknDw7T9cak6UwH6K67q1nyfQ9zwyI/n4eh6FoJKSL6ZXFZ+sNlod4gYJbM0Irpkg4Eql0wQ==",
 			"optional": true,
 			"requires": {
 				"bindings": "^1.5.0",
@@ -332,9 +332,9 @@
 			"optional": true
 		},
 		"node-abi": {
-			"version": "2.19.3",
-			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.19.3.tgz",
-			"integrity": "sha512-9xZrlyfvKhWme2EXFKQhZRp1yNWT/uI1luYPr3sFl+H4keYY4xR+1jO7mvTTijIsHf1M+QDe9uWuKeEpLInIlg==",
+			"version": "2.21.0",
+			"resolved": "https://registry.npmjs.org/node-abi/-/node-abi-2.21.0.tgz",
+			"integrity": "sha512-smhrivuPqEM3H5LmnY3KU6HfYv0u4QklgAxfFyRNujKUzbUcYZ+Jc2EhukB9SRcD2VpqhxM7n/MIcp1Ua1/JMg==",
 			"optional": true,
 			"requires": {
 				"semver": "^5.4.1"

--- a/packages/service-provider-server/package.json
+++ b/packages/service-provider-server/package.json
@@ -43,13 +43,13 @@
     "@types/sinon": "^7.5.1",
     "@types/sinon-chai": "^3.2.3",
     "aws4": "^1.11.0",
-    "mongodb": "4.0.0-beta.1",
+    "mongodb": "4.0.0-beta.2",
     "saslprep": "mongodb-js/saslprep#v1.0.4"
   },
   "devDependencies": {
     "@types/bl": "^2.1.0"
   },
   "optionalDependencies": {
-    "mongodb-client-encryption": "^1.2.1"
+    "mongodb-client-encryption": "^1.2.2"
   }
 }

--- a/packages/service-provider-server/src/cli-service-provider.integration.spec.ts
+++ b/packages/service-provider-server/src/cli-service-provider.integration.spec.ts
@@ -30,7 +30,7 @@ describe('CliServiceProvider [integration]', function() {
   });
 
   describe('.connect', () => {
-    let instance;
+    let instance: CliServiceProvider;
     beforeEach(async() => {
       instance = await CliServiceProvider.connect(connectionString);
     });
@@ -42,14 +42,10 @@ describe('CliServiceProvider [integration]', function() {
     it('returns a CliServiceProvider', async() => {
       expect(instance).to.be.instanceOf(CliServiceProvider);
     });
-
-    it('connects mongo client', () => {
-      expect(instance.mongoClient.isConnected()).to.equal(true);
-    });
   });
 
   describe('.getNewConnection', () => {
-    let instance;
+    let instance: CliServiceProvider;
 
     beforeEach(async() => {
       instance = await serviceProvider.getNewConnection(connectionString);
@@ -61,10 +57,6 @@ describe('CliServiceProvider [integration]', function() {
 
     it('returns a CliServiceProvider', async() => {
       expect(instance).to.be.instanceOf(CliServiceProvider);
-    });
-
-    it('connects mongo client', () => {
-      expect(instance.mongoClient.isConnected()).to.equal(true);
     });
 
     it('differs from the original CliServiceProvider', () => {

--- a/packages/service-provider-server/src/cli-service-provider.spec.ts
+++ b/packages/service-provider-server/src/cli-service-provider.spec.ts
@@ -287,31 +287,6 @@ describe('CliServiceProvider', () => {
     });
   });
 
-  describe('#findAndModify', () => {
-    const commandResult = { result: { n: 1, ok: 1 } };
-
-    beforeEach(() => {
-      collectionStub = stubInterface<Collection>();
-      collectionStub.findAndModify.resolves(commandResult);
-      serviceProvider = new CliServiceProvider(createClientStub(collectionStub));
-    });
-
-    it('executes the command against the database', async() => {
-      const result = await serviceProvider.findAndModify(
-        'music', 'bands',
-        { query: 1 },
-        { sort: 1 },
-        { update: 1 },
-        { options: 1 } as any
-      );
-      expect(result).to.deep.equal(commandResult);
-      expect(collectionStub.findAndModify).to.have.been.calledWith({ query: 1 },
-        { sort: 1 },
-        { update: 1 },
-        { ...DEFAULT_BASE_OPTS, options: 1 });
-    });
-  });
-
   describe('#findOneAndDelete', () => {
     const commandResult = { result: { n: 1, ok: 1 } };
 

--- a/packages/service-provider-server/src/cli-service-provider.ts
+++ b/packages/service-provider-server/src/cli-service-provider.ts
@@ -293,21 +293,6 @@ class CliServiceProvider extends ServiceProviderCore implements ServiceProvider 
     return await this.db(database, dbOptions).renameCollection(oldName, newName, options);
   }
 
-  async findAndModify(
-    database: string,
-    collection: string,
-    query: Document,
-    sort: any[] | Document | undefined,
-    update: Document | undefined,
-    options: FindAndModifyOptions = {},
-    dbOptions?: DbOptions
-  ): Promise<Document> {
-    options = { ...this.baseCmdOptions, ...options };
-    return await (this.db(database, dbOptions)
-      .collection(collection) as any)
-      .findAndModify(query, sort, update, options);
-  }
-
   /**
    * Get the Db object from the client.
    *

--- a/packages/shell-api/src/collection.spec.ts
+++ b/packages/shell-api/src/collection.spec.ts
@@ -1100,16 +1100,18 @@ describe('Collection', () => {
 
       beforeEach(() => {
         mockResult = { value: {} };
-        serviceProvider.findAndModify.resolves(mockResult);
+        serviceProvider.findOneAndUpdate.resolves(mockResult);
+        serviceProvider.findOneAndReplace.resolves(mockResult);
+        serviceProvider.findOneAndDelete.resolves(mockResult);
       });
 
-      it('returns result.value from serviceProvider.findAndModify', async() => {
-        expect(await collection.findAndModify({ query: {} })).to.equal(mockResult.value);
+      it('returns result.value from serviceProvider.findOneAndReplace', async() => {
+        expect(await collection.findAndModify({ query: {}, update: {} })).to.equal(mockResult.value);
       });
 
       it('throws if no query is provided', async() => {
         try {
-          await collection.findAndModify({});
+          await collection.findAndModify({} as any);
         } catch (e) {
           return expect(e.name).to.equal('MongoshInvalidInputError');
         }
@@ -1117,7 +1119,7 @@ describe('Collection', () => {
       });
       it('throws if no argument is provided', async() => {
         try {
-          await collection.findAndModify();
+          await (collection.findAndModify as any)();
         } catch (e) {
           return expect(e.name).to.equal('MongoshInvalidInputError');
         }
@@ -1132,7 +1134,7 @@ describe('Collection', () => {
           upsert: true,
           bypassDocumentValidation: true,
           writeConcern: { writeConcern: 1 },
-          collation: { collation: 1 },
+          collation: { collation: 1, locale: 'en_US' },
           arrayFilters: [ { filter: 1 } ]
         };
 
@@ -1143,13 +1145,11 @@ describe('Collection', () => {
           ...options
         });
 
-        expect(serviceProvider.findAndModify).to.have.been.calledWith(
+        expect(serviceProvider.findOneAndDelete).to.have.been.calledWith(
           collection._database._name,
           collection._name,
           { query: 1 },
-          { sort: 1 },
-          { update: 1 },
-          options
+          { ...options, sort: { sort: 1 } }
         );
       });
     });
@@ -1688,7 +1688,7 @@ describe('Collection', () => {
       initializeUnorderedBulkOp: { m: 'initializeBulkOp' },
       distinct: { i: 4 },
       estimatedDocumentCount: { i: 2 },
-      findAndModify: { i: 5 },
+      findAndModify: { a: [{ query: {}, update: {} }], m: 'findOneAndReplace', i: 4 },
       findOneAndReplace: { i: 4 },
       findOneAndUpdate: { i: 4 },
       replaceOne: { i: 4 },

--- a/packages/shell-api/src/explainable.ts
+++ b/packages/shell-api/src/explainable.ts
@@ -14,6 +14,7 @@ import {
   validateExplainableVerbosity,
   processRemoveOptions,
   RemoveShellOptions,
+  FindAndModifyShellOptions,
   FindAndModifyMethodShellOptions,
   processMapReduceOptions,
   MapReduceShellOptions
@@ -23,7 +24,8 @@ import type {
   ExplainVerbosityLike,
   CountOptions,
   DistinctOptions,
-  UpdateOptions
+  UpdateOptions,
+  FindAndModifyOptions
 } from '@mongosh/service-provider-core';
 
 @shellApiClassDefault
@@ -123,6 +125,24 @@ export default class Explainable extends ShellApiClass {
   async findAndModify(options: FindAndModifyMethodShellOptions): Promise<Document> {
     this._emitExplainableApiCall('findAndModify', { options });
     return this._collection.findAndModify({ ...options, explain: this._verbosity });
+  }
+
+  @returnsPromise
+  async findOneAndDelete(filter: Document, options: FindAndModifyOptions = {}): Promise<Document> {
+    this._emitExplainableApiCall('findOneAndDelete', { filter, options });
+    return this._collection.findOneAndDelete(filter, { ...options, explain: this._verbosity });
+  }
+
+  @returnsPromise
+  async findOneAndReplace(filter: Document, replacement: Document, options: FindAndModifyShellOptions = {}): Promise<Document> {
+    this._emitExplainableApiCall('findOneAndReplace', { filter, options });
+    return this._collection.findOneAndReplace(filter, replacement, { ...options, explain: this._verbosity });
+  }
+
+  @returnsPromise
+  async findOneAndUpdate(filter: Document, update: Document, options: FindAndModifyShellOptions = {}): Promise<Document> {
+    this._emitExplainableApiCall('findOneAndUpdate', { filter, options });
+    return this._collection.findOneAndUpdate(filter, update, { ...options, explain: this._verbosity });
   }
 
   @returnsPromise

--- a/packages/shell-api/src/field-level-encryption.spec.ts
+++ b/packages/shell-api/src/field-level-encryption.spec.ts
@@ -322,59 +322,55 @@ describe('Field Level Encryption', () => {
       });
     });
     describe('addKeyAlternateName', () => {
-      it('calls findAndModify on key coll', async() => {
+      it('calls findOneAndUpdate on key coll', async() => {
         const r = { value: { ok: 1 } } as any;
-        sp.findAndModify.resolves(r);
+        sp.findOneAndUpdate.resolves(r);
         const result = await keyVault.addKeyAlternateName(KEY_ID, 'altname');
-        expect(sp.findAndModify).to.have.been.calledOnceWithExactly(
+        expect(sp.findOneAndUpdate).to.have.been.calledOnceWithExactly(
           DB,
           COLL,
           { _id: KEY_ID },
-          undefined,
           { $push: { 'keyAltNames': 'altname' }, $currentDate: { 'updateDate': true } },
-          {}
+          { returnOriginal: true }
         );
         expect(result).to.deep.equal({ ok: 1 });
       });
     });
     describe('removeKeyAlternateName', () => {
-      it('calls findAndModify on key coll without empty result', async() => {
+      it('calls findOneAndUpdate on key coll without empty result', async() => {
         const r = { value: { ok: 1, keyAltNames: ['other'] } } as any;
-        sp.findAndModify.resolves(r);
+        sp.findOneAndUpdate.resolves(r);
         const result = await keyVault.removeKeyAlternateName(KEY_ID, 'altname');
-        expect(sp.findAndModify).to.have.been.calledOnceWithExactly(
+        expect(sp.findOneAndUpdate).to.have.been.calledOnceWithExactly(
           DB,
           COLL,
           { _id: KEY_ID },
-          undefined,
           { $pull: { 'keyAltNames': 'altname' }, $currentDate: { 'updateDate': true } },
-          {}
+          { returnOriginal: true }
         );
         expect(result).to.deep.equal({ ok: 1, keyAltNames: ['other'] });
       });
-      it('calls findAndModify on key coll with empty result', async() => {
+      it('calls findOneAndUpdate on key coll with empty result', async() => {
         const r = { value: { ok: 1, keyAltNames: ['altname'] } } as any;
         const r2 = { value: { ok: 2 } } as any;
-        sp.findAndModify.onFirstCall().resolves(r);
-        sp.findAndModify.onSecondCall().resolves(r2);
+        sp.findOneAndUpdate.onFirstCall().resolves(r);
+        sp.findOneAndUpdate.onSecondCall().resolves(r2);
         const result = await keyVault.removeKeyAlternateName(KEY_ID, 'altname');
-        const calls = sp.findAndModify.getCalls();
+        const calls = sp.findOneAndUpdate.getCalls();
         expect(calls.length).to.equal(2);
         expect(calls[0].args).to.deep.equal([
           DB,
           COLL,
           { _id: KEY_ID },
-          undefined,
           { $pull: { 'keyAltNames': 'altname' }, $currentDate: { 'updateDate': true } },
-          {}
+          { returnOriginal: true }
         ]);
         expect(calls[1].args).to.deep.equal([
           DB,
           COLL,
           { _id: KEY_ID, keyAltNames: undefined },
-          undefined,
           { $unset: { 'keyAltNames': '' }, $currentDate: { 'updateDate': true } },
-          {}
+          { returnOriginal: true }
         ]);
         expect(result).to.deep.equal(r2.value);
       });

--- a/packages/shell-api/src/helpers.ts
+++ b/packages/shell-api/src/helpers.ts
@@ -531,8 +531,8 @@ export async function iterate(
 }
 
 export type FindAndModifyMethodShellOptions = {
-  query?: Document;
-  sort?: Document | Document[];
+  query: Document;
+  sort?: FindAndModifyOptions['sort'];
   update?: Document | Document[];
   remove?: boolean;
   new?: boolean;
@@ -540,7 +540,7 @@ export type FindAndModifyMethodShellOptions = {
   upsert?: boolean;
   bypassDocumentValidation?: boolean;
   writeConcern?: Document;
-  collation?: Document;
+  collation?: FindAndModifyOptions['collation'];
   arrayFilters?: Document[];
   explain?: ExplainVerbosityLike;
 };
@@ -558,6 +558,11 @@ export function processFindAndModifyOptions(options: FindAndModifyShellOptions):
   if ('returnNewDocument' in options) {
     options.returnOriginal = !options.returnNewDocument;
     delete options.returnNewDocument;
+    return options;
+  }
+  if ('new' in options) {
+    options.returnOriginal = !options.new;
+    delete options.new;
     return options;
   }
   // No explicit option passed: We set 'returnOriginal' to true because the

--- a/packages/shell-api/src/integration.spec.ts
+++ b/packages/shell-api/src/integration.spec.ts
@@ -1152,6 +1152,57 @@ describe('Shell API (integration)', function() {
       });
     });
 
+    describe('findOneAndDelete', () => {
+      it('provides explain information', async() => {
+        await collection.insertOne({});
+        const explained = await collection.explain()
+          .findOneAndDelete({});
+        expect(explained).to.include.all.keys(['ok', 'serverInfo', 'queryPlanner']);
+        expect(explained).to.not.include.any.keys(['executionStats']);
+      });
+
+      it('includes executionStats when requested', async() => {
+        await collection.insertOne({});
+        const explained = await collection.explain('executionStats')
+          .findOneAndDelete({});
+        expect(explained).to.include.all.keys(['ok', 'serverInfo', 'queryPlanner', 'executionStats']);
+      });
+    });
+
+    describe('findOneAndReplace', () => {
+      it('provides explain information', async() => {
+        await collection.insertOne({});
+        const explained = await collection.explain()
+          .findOneAndReplace({}, {});
+        expect(explained).to.include.all.keys(['ok', 'serverInfo', 'queryPlanner']);
+        expect(explained).to.not.include.any.keys(['executionStats']);
+      });
+
+      it('includes executionStats when requested', async() => {
+        await collection.insertOne({});
+        const explained = await collection.explain('executionStats')
+          .findOneAndReplace({}, {});
+        expect(explained).to.include.all.keys(['ok', 'serverInfo', 'queryPlanner', 'executionStats']);
+      });
+    });
+
+    describe('findOneAndUpdate', () => {
+      it('provides explain information', async() => {
+        await collection.insertOne({});
+        const explained = await collection.explain()
+          .findOneAndUpdate({}, { $set: { a: 1 } });
+        expect(explained).to.include.all.keys(['ok', 'serverInfo', 'queryPlanner']);
+        expect(explained).to.not.include.any.keys(['executionStats']);
+      });
+
+      it('includes executionStats when requested', async() => {
+        await collection.insertOne({});
+        const explained = await collection.explain('executionStats')
+          .findOneAndUpdate({}, { $set: { a: 1 } });
+        expect(explained).to.include.all.keys(['ok', 'serverInfo', 'queryPlanner', 'executionStats']);
+      });
+    });
+
     describe('remove', () => {
       it('provides explain information', async() => {
         const explained = await collection.explain().remove({ notfound: 1 });
@@ -1569,23 +1620,19 @@ describe('Shell API (integration)', function() {
     describe('setReadConcern', () => {
       it('reconnects', async() => {
         const oldMC = serviceProvider.mongoClient;
-        expect(oldMC.isConnected()).to.equal(true);
         expect(mongo.getReadConcern()).to.equal(undefined);
         await mongo.setReadConcern('local');
         expect(mongo.getReadConcern()).to.equal('local');
-        expect(oldMC.isConnected()).to.equal(false);
-        expect(serviceProvider.mongoClient.isConnected()).to.equal(true);
+        expect(serviceProvider.mongoClient).to.not.equal(oldMC);
       });
     });
     describe('setReadPref', () => {
       it('reconnects', async() => {
         const oldMC = serviceProvider.mongoClient;
-        expect(oldMC.isConnected()).to.equal(true);
         expect((serviceProvider.mongoClient as any).s.options.readPreference.mode).to.deep.equal('primary');
         await mongo.setReadPref('secondaryPreferred');
-        expect(oldMC.isConnected()).to.equal(false);
-        expect(serviceProvider.mongoClient.isConnected()).to.equal(true);
         expect((serviceProvider.mongoClient as any).s.options.readPreference.mode).to.equal('secondaryPreferred');
+        expect(serviceProvider.mongoClient).to.not.equal(oldMC);
       });
     });
   });

--- a/packages/shell-api/src/shell-internal-state.ts
+++ b/packages/shell-api/src/shell-internal-state.ts
@@ -1,6 +1,6 @@
 import AsyncWriter from '@mongosh/async-rewriter';
 import { CommonErrors, MongoshInvalidInputError } from '@mongosh/errors';
-import { ConnectInfo, DEFAULT_DB, ReplPlatform, ServiceProvider, TopologyDescription, TopologyType } from '@mongosh/service-provider-core';
+import { ConnectInfo, DEFAULT_DB, ReplPlatform, ServiceProvider, TopologyDescription, TopologyTypeId } from '@mongosh/service-provider-core';
 import type { ApiEvent, MongoshBus } from '@mongosh/types';
 import { EventEmitter } from 'events';
 import redactInfo from 'mongodb-redact';
@@ -238,7 +238,7 @@ export default class ShellInternalState {
       topology: () => {
         let topology: Topologies;
         const topologyDescription = this.initialServiceProvider.getTopology()?.description as TopologyDescription;
-        const topologyType: TopologyType | undefined = topologyDescription?.type;
+        const topologyType: TopologyTypeId | undefined = topologyDescription?.type;
         switch (topologyType) {
           case 'ReplicaSetNoPrimary':
           case 'ReplicaSetWithPrimary':


### PR DESCRIPTION
Along with this:
- Update mongodb-client-encryption to 1.2.2
- ~~Revert adc916e9cca2ddeadb7a (go back to `npm@latest`)~~ (need at least also https://jira.mongodb.org/browse/NODE-3161)
- Remove `findAndModify()` from the service providers
  because it is gone in the drivers
- Make the shell `findAndModify()` API method multiplex
  over its `findOneAnd...` replacements
- Fix explain functionality for `findOneAnd...` methods
- Add `findOneAnd...` methods to the `Explainable` class
- Update driver type names where they have changed