### PR TITLE
fix(node-runtime-worker-thread): Propagate child process startup errors for thread runtime

### DIFF
--- a/packages/compass-shell/src/modules/worker-runtime.js
+++ b/packages/compass-shell/src/modules/worker-runtime.js
@@ -1,11 +1,14 @@
-import { createRequire } from 'module';
-
 /**
  * @type {{ WorkerRuntime: typeof import('@mongosh/node-runtime-worker-thread').WorkerRuntime }}
  */
 const { WorkerRuntime } = (() => {
   // Workaround for webpack require that overrides global require
-  const req = createRequire(__filename);
+  const req =
+    // eslint-disable-next-line camelcase
+    typeof __webpack_require__ === 'function'
+      ? // eslint-disable-next-line camelcase, no-undef
+      __non_webpack_require__
+      : require;
   const realModulePath = req.resolve('@mongosh/node-runtime-worker-thread');
   // Runtime needs to be outside the asar bundle to function properly, so if we
   // resolved it inside of one, we will try to import it from outside (and hard

--- a/packages/node-runtime-worker-thread/__fixtures__/script-that-throws.js
+++ b/packages/node-runtime-worker-thread/__fixtures__/script-that-throws.js
@@ -1,0 +1,1 @@
+throw new Error("Nope, I'm not starting");

--- a/packages/node-runtime-worker-thread/src/index.ts
+++ b/packages/node-runtime-worker-thread/src/index.ts
@@ -106,7 +106,7 @@ class WorkerRuntime implements Runtime {
     let spawnError = '';
 
     // eslint-disable-next-line chai-friendly/no-unused-expressions
-    this.childProcess?.stderr?.on('data', (chunk) => {
+    this.childProcess?.stderr?.setEncoding('utf8')?.on('data', (chunk) => {
       spawnError += chunk;
     });
 

--- a/packages/node-runtime-worker-thread/src/index.ts
+++ b/packages/node-runtime-worker-thread/src/index.ts
@@ -10,7 +10,7 @@ import {
 } from '@mongosh/browser-runtime-core';
 import { MongoshBus } from '@mongosh/types';
 import path from 'path';
-import { EventEmitter } from 'events';
+import { EventEmitter, once } from 'events';
 import { kill } from './spawn-child-from-source';
 import { Caller, createCaller, cancel } from './rpc';
 import { ChildProcessEvaluationListener } from './child-process-evaluation-listener';
@@ -19,6 +19,31 @@ import { deserializeEvaluationResult } from './serializer';
 import { ChildProcessMongoshBus } from './child-process-mongosh-bus';
 
 type ChildProcessRuntime = Caller<WorkerThreadWorkerRuntime>;
+
+function parseStderrToError(str: string): Error | null {
+  const [, errorMessageWithStack] = str
+    .split(/^\s*\^\s*$/m)
+    .map((part) => part.trim());
+
+  if (errorMessageWithStack) {
+    const e = new Error();
+    const errorHeader =
+      errorMessageWithStack.substring(
+        0,
+        errorMessageWithStack.search(/^\s*at/m)
+      ) || errorMessageWithStack;
+
+    const [name, ...message] = errorHeader.split(': ');
+
+    e.name = name;
+    e.message = message.join(': ').trim();
+    e.stack = errorMessageWithStack;
+
+    return e;
+  }
+
+  return null;
+}
 
 class WorkerRuntime implements Runtime {
   private initOptions: {
@@ -42,6 +67,11 @@ class WorkerRuntime implements Runtime {
 
   private initWorkerPromise: Promise<void>;
 
+  private childProcessProxySrcPath: string =
+    process.env
+      .CHILD_PROCESS_PROXY_SRC_PATH_DO_NOT_USE_THIS_EXCEPT_FOR_TESTING ||
+    path.resolve(__dirname, 'child-process-proxy.js');
+
   constructor(
     uri: string,
     driverOptions: MongoClientOptions = {},
@@ -57,15 +87,48 @@ class WorkerRuntime implements Runtime {
   private async initWorker() {
     const { uri, driverOptions, cliOptions, spawnOptions } = this.initOptions;
 
-    const childProcessProxySrcPath = path.resolve(
-      __dirname,
-      'child-process-proxy.js'
+    this.childProcess = spawn(
+      process.execPath,
+      [this.childProcessProxySrcPath],
+      {
+        stdio: ['inherit', 'inherit', 'pipe', 'ipc'],
+        ...spawnOptions
+      }
     );
 
-    this.childProcess = spawn(process.execPath, [childProcessProxySrcPath], {
-      stdio: ['inherit', 'inherit', 'inherit', 'ipc'],
-      ...spawnOptions
+    const waitForReadyMessage = async() => {
+      let msg: string;
+      while (([msg] = await once(this.childProcess, 'message'))) {
+        if (msg === 'ready') return;
+      }
+    };
+
+    let spawnError = '';
+
+    // eslint-disable-next-line chai-friendly/no-unused-expressions
+    this.childProcess?.stderr?.on('data', (chunk) => {
+      spawnError += chunk;
     });
+
+    const waitForError = async() => {
+      const [exitCode] = await once(this.childProcess, 'exit');
+
+      if (exitCode) {
+        let error = parseStderrToError(spawnError);
+
+        if (error) {
+          error.message = `Child process failed to start with the following error: ${error.message}`;
+        } else {
+          error = new Error(
+            `Worker runtime failed to start: child process exited with code ${exitCode}`
+          );
+        }
+
+        throw error;
+      }
+    };
+
+    await Promise.race([waitForReadyMessage(), waitForError()]);
 
     // We expect the amount of listeners to be more than the default value of 10
     // but probably not more than ~25 (all exposed methods on
@@ -122,11 +185,26 @@ class WorkerRuntime implements Runtime {
   }
 
   async terminate() {
-    await this.initWorkerPromise;
+    try {
+      await this.initWorkerPromise;
+    } catch {
+      // In case child process encountered an error during init we still want
+      // to clean up whatever possible
+    }
+
     await kill(this.childProcess);
-    this.childProcessRuntime[cancel]();
-    this.childProcessEvaluationListener.terminate();
-    this.childProcessMongoshBus.terminate();
+
+    if (this.childProcessRuntime) {
+      this.childProcessRuntime[cancel]();
+    }
+
+    if (this.childProcessEvaluationListener) {
+      this.childProcessEvaluationListener.terminate();
+    }
+
+    if (this.childProcessMongoshBus) {
+      this.childProcessMongoshBus.terminate();
+    }
   }
 
   async interrupt() {


### PR DESCRIPTION
As spotted by @addaleax if child process or worker thread fails to start (e.g., when you are developing a new feature), worker runtime just never resolves any requests to `evaluate`. This PR fixes the issue by handling possible errors during the init state of the worker runtime and re-throwing them in the main thread so users can see them in the shell:

<img width="600" alt="image" src="https://user-images.githubusercontent.com/5036933/111439445-aa7f7c80-8705-11eb-994e-8854e2534758.png">

Also spotted and fixed a tiny issue when running compass-shell in isolation locally (shakes fist at webpack)
