### PR TITLE
fix(cli-repl): allow interrupting load()ed code MONGOSH-641

### DIFF
--- a/packages/cli-repl/test/e2e.spec.ts
+++ b/packages/cli-repl/test/e2e.spec.ts
@@ -369,6 +369,13 @@ describe('e2e', function() {
       await result;
       shell.assertContainsError('interrupted');
     });
+    it('interrupts load()', async() => {
+      const filename = path.resolve(__dirname, 'fixtures', 'load', 'infinite-loop.js');
+      const result = shell.executeLine(`load(${JSON.stringify(filename)})`);
+      setTimeout(() => shell.kill('SIGINT'), 1000);
+      await result;
+      shell.assertContainsError('interrupted');
+    });
     it('behaves normally after an exception', async() => {
       await shell.executeLine('throw new Error()');
       await new Promise((resolve) => setTimeout(resolve, 100));

--- a/packages/cli-repl/test/fixtures/load/infinite-loop.js
+++ b/packages/cli-repl/test/fixtures/load/infinite-loop.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line no-constant-condition
+while (true);


### PR DESCRIPTION
This was previously broken because the async repl implementation
adds an `process.on('SIGINT')` listener for the duration of the
*async* part of the evaluation. That listener would interfere with
breaking on sigint if another *synchronous* evaluation would be
started while it is present.

Fix this by not being lazy anymore and temporarily disabling
existing `SIGINT` event listeners on both `process` and `repl`
(and not just `repl`). In this case, the “inner” evaluation
also temporarily removes the “outer” `SIGINT` listener and
can go about as usual.