### PR TITLE
fix(async-rewriter): give each input its own line MONGOSH-644

### DIFF
--- a/packages/async-rewriter/src/async-writer-babel.spec.ts
+++ b/packages/async-rewriter/src/async-writer-babel.spec.ts
@@ -146,7 +146,7 @@ describe('async-writer-babel', () => {
     });
     it('compiles db.coll.insertOne({})', () => {
       expect(writer.process('db.coll.insertOne({})'))
-        .to.equal('(async () => { return (await db.coll.insertOne({})); })()');
+        .to.equal('(async () => {\nreturn (await db.coll.insertOne({}));\n})()');
     });
     it('compiles async function within a function', () => {
       expect(writer.process('function fn() { db.coll.insertOne({}); }'))
@@ -154,11 +154,11 @@ describe('async-writer-babel', () => {
     });
     it('compiles variable declarations', () => {
       expect(writer.process('db.coll.insertOne({}); var a = "foo";'))
-        .to.equal('(async () => { await db.coll.insertOne({});\nvoid (a = "foo"); })()');
+        .to.equal('(async () => {\nawait db.coll.insertOne({});\nvoid (a = "foo");\n})()');
       expect(writer.process('db.coll.insertOne({}); var b;'))
-        .to.equal('(async () => { await db.coll.insertOne({});\nvoid (b=undefined); })()');
+        .to.equal('(async () => {\nawait db.coll.insertOne({});\nvoid (b=undefined);\n})()');
       expect(writer.process('db.coll.insertOne({}); var q=0,p=1;'))
-        .to.equal('(async () => { await db.coll.insertOne({});\nvoid ( (q = 0),\n    (p = 1)); })()');
+        .to.equal('(async () => {\nawait db.coll.insertOne({});\nvoid ( (q = 0),\n    (p = 1));\n})()');
     });
     it('does not add TLA if there is a return statement', () => {
       expect(writer.process('(() => { db.coll.insertOne({}); return; var a = "foo"; })()'))
@@ -192,7 +192,8 @@ function insertDoc(name) {
 names.forEach(n => insertDoc(n));
 (names.length);
 `;
-      expect(writer.process(code)).to.equal(`(async () => { void (names = ['Angela', 'Barack', 'Charles']);
+      expect(writer.process(code)).to.equal(`(async () => {
+void (names = ['Angela', 'Barack', 'Charles']);
 
 insertDoc=async function insertDoc(name) {
   await db.coll.insertOne({
@@ -201,7 +202,8 @@ insertDoc=async function insertDoc(name) {
 }
 
 await toIterator(names).forEach(async n => await insertDoc(n));
-return (names.length); })()`);
+return (names.length);
+})()`);
     });
   });
   describe('MemberExpression', () => {

--- a/packages/async-rewriter/src/await.spec.ts
+++ b/packages/async-rewriter/src/await.spec.ts
@@ -29,10 +29,12 @@ return someVar;
 var someVar = "test value";
 await db.coll.insertOne({ someVar });
 `;
-      expect(processTopLevelAwait(code)).to.equal(`(async () => { 
+      expect(processTopLevelAwait(code)).to.equal(`(async () => {
+
 void (someVar = "test value");
 return (await db.coll.insertOne({ someVar }));
- })()`);
+
+})()`);
     });
 
     it('multiple', () => {
@@ -40,10 +42,12 @@ return (await db.coll.insertOne({ someVar }));
 var someVar = "test value", anotherVar;
 await db.coll.insertOne({ someVar });
 `;
-      expect(processTopLevelAwait(code)).to.equal(`(async () => { 
+      expect(processTopLevelAwait(code)).to.equal(`(async () => {
+
 void ( (someVar = "test value"), (anotherVar=undefined));
 return (await db.coll.insertOne({ someVar }));
- })()`);
+
+})()`);
     });
 
     it('lets and consts', () => {
@@ -52,11 +56,13 @@ let someVar = "test value";
 const anotherVar = "has value";
 await db.coll.insertOne({ someVar });
 `;
-      expect(processTopLevelAwait(code)).to.equal(`(async () => { 
+      expect(processTopLevelAwait(code)).to.equal(`(async () => {
+
 void (someVar = "test value");
 void (anotherVar = "has value");
 return (await db.coll.insertOne({ someVar }));
- })()`);
+
+})()`);
     });
 
     it('hoisted vars but not let', () => {
@@ -71,7 +77,8 @@ function call() {
 }
 await db.coll.insertOne({});
 `;
-      expect(processTopLevelAwait(code)).to.equal(`(async () => { 
+      expect(processTopLevelAwait(code)).to.equal(`(async () => {
+
 if (callMeMaybe) {
   void (ringRing = "hey, it's me!");
   let bingBing = "c'est moi!";
@@ -81,7 +88,8 @@ call=function call() {
   var thisIsNested;
 }
 return (await db.coll.insertOne({}));
- })()`);
+
+})()`);
     });
   });
 
@@ -92,12 +100,21 @@ async function callingTheFunc() {
   return await db.coll.insertOne({});
 }
 `;
-    expect(processTopLevelAwait(code)).to.equal(`(async () => { 
+    expect(processTopLevelAwait(code)).to.equal(`(async () => {
+
 await callingTheFunc();
 callingTheFunc=async function callingTheFunc() {
   return await db.coll.insertOne({});
 }
- })()`);
+
+})()`);
+  });
+
+  it('accepts comments at the end of the code', () => {
+    const code = 'await print() // comment';
+    expect(processTopLevelAwait(code)).to.equal(`(async () => {
+return (await print()) // comment
+})()`);
   });
 
   context('processes for-of statements', () => {
@@ -107,11 +124,13 @@ for await (const c of names) {
   const otherName = c;
 }
 `;
-      expect(processTopLevelAwait(code)).to.equal(`(async () => { 
+      expect(processTopLevelAwait(code)).to.equal(`(async () => {
+
 for await (const c of names) {
   const otherName = c;
 }
- })()`);
+
+})()`);
     });
 
     it('checks for await inside loop', () => {
@@ -120,11 +139,13 @@ for (const c of names) {
   await db.coll.insertOne({ name: c });
 }
 `;
-      expect(processTopLevelAwait(code)).to.equal(`(async () => { 
+      expect(processTopLevelAwait(code)).to.equal(`(async () => {
+
 for (const c of names) {
   await db.coll.insertOne({ name: c });
 }
- })()`);
+
+})()`);
     });
 
     it('checks for return inside loop', () => {

--- a/packages/async-rewriter/src/await.ts
+++ b/packages/async-rewriter/src/await.ts
@@ -80,7 +80,7 @@ for (const nodeType of Object.keys(walk.base)) {
 }
 
 function processTopLevelAwait(src: string): null | string {
-  const wrapped = `(async () => { ${src} })()`;
+  const wrapped = `(async () => {\n${src}\n})()`;
   const wrappedArray = wrapped.split('');
   let root;
   try {


### PR DESCRIPTION
This allows having single-line comments on the last line of input.