### PR TITLE
chore(cli-repl): add compile-ts as pretest script

### DIFF
--- a/packages/cli-repl/package.json
+++ b/packages/cli-repl/package.json
@@ -21,6 +21,7 @@
     "compile-ts": "tsc -p tsconfig.json",
     "start": "node bin/mongosh.js start",
     "start-async": "node bin/mongosh.js start --async",
+    "pretest": "npm run compile-ts",
     "test": "cross-env TS_NODE_PROJECT=../../config/tsconfig.test.json mocha -r \"../../scripts/import-expansions.js\" --timeout 60000 --colors -r ts-node/register \"./{src,test}/**/*.spec.ts\"",
     "test-ci": "cross-env TS_NODE_PROJECT=../../config/tsconfig.test.json mocha -r \"../../scripts/import-expansions.js\" --timeout 60000 -r ts-node/register \"./{src,test}/**/*.spec.ts\"",
     "pretest-e2e": "npm run compile-ts",


### PR DESCRIPTION
`npm test` also runs the end-to-end tests. Because the e2e tests
are run on the already-compiled code, we have a `pretest-e2e`
script that recompiles TypeScript, but we should also run that
script before `npm test` for the same reason.