### PR TITLE
chore(shell-api): be more accurate in message from 'use'

### DIFF
--- a/packages/shell-api/src/mongo.spec.ts
+++ b/packages/shell-api/src/mongo.spec.ts
@@ -16,6 +16,7 @@ import ShellInternalState from './shell-internal-state';
 import Collection from './collection';
 import Cursor from './cursor';
 import ChangeStreamCursor from './change-stream-cursor';
+import NoDatabase from './no-db';
 import { MongoshDeprecatedError, MongoshInternalError, MongoshUnimplementedError } from '@mongosh/errors';
 
 const sampleOpts = {
@@ -526,6 +527,25 @@ describe('Mongo', () => {
         const msg = mongo.use('moo');
         expect(msg).to.equal('switched to db moo');
         expect(internalState.context.db.getName()).to.equal('moo');
+      });
+      it('reports if no db switch has taken place', () => {
+        mongo.use('moo1');
+        const msg = mongo.use('moo1');
+        expect(msg).to.equal('already on db moo1');
+        expect(internalState.context.db.getName()).to.equal('moo1');
+      });
+      it('reports if db has the same name but different Mongo objects', () => {
+        internalState.context.db = new Mongo(internalState, undefined, undefined, serviceProvider).getDB('moo1');
+        expect(internalState.context.db.getName()).to.equal('moo1');
+        const msg = mongo.use('moo1');
+        expect(msg).to.equal('switched to db moo1');
+        expect(internalState.context.db.getName()).to.equal('moo1');
+      });
+      it('works if previously there was no db', () => {
+        internalState.context.db = new NoDatabase();
+        const msg = mongo.use('moo1');
+        expect(msg).to.equal('switched to db moo1');
+        expect(internalState.context.db.getName()).to.equal('moo1');
       });
     });
     describe('deprecated mongo methods', () => {

--- a/packages/shell-api/src/mongo.ts
+++ b/packages/shell-api/src/mongo.ts
@@ -169,13 +169,29 @@ export default class Mongo extends ShellApiClass {
 
   @returnType('Database')
   getDB(db: string): Database {
-    this._internalState.messageBus.emit( 'mongosh:getDB', { db });
+    this._internalState.messageBus.emit('mongosh:getDB', { db });
     return this._getDb(db);
   }
 
   use(db: string): string {
-    this._internalState.messageBus.emit( 'mongosh:use', { db });
+    this._internalState.messageBus.emit('mongosh:use', { db });
+
+    let previousDbName;
+    let previousDbMongo;
+    try {
+      const previousDb = this._internalState.context.db;
+      previousDbName = previousDb?.getName?.();
+      previousDbMongo = previousDb?._mongo;
+    } catch (e) {
+      if (e.code !== ShellApiErrors.NotConnected) {
+        throw e;
+      }
+    }
+
     this._internalState.context.db = this._getDb(db);
+    if (db === previousDbName && previousDbMongo === this) {
+      return `already on db ${db}`;
+    }
     return `switched to db ${db}`;
   }
 


### PR DESCRIPTION
Only tell users that the db has been changed if it actually
has been changed, so that they are not confused about whether
the previous state of the shell has been different from the
current one.