### PR TITLE
fix(autocomplete): do not act as if input is completion MONGOSH-646

### DIFF
--- a/packages/autocomplete/index.spec.ts
+++ b/packages/autocomplete/index.spec.ts
@@ -246,7 +246,7 @@ describe('completer.completer', () => {
 
     it('does not provide anything if there is a function call instead of a collection name', async() => {
       const i = 'db.getMongo().find';
-      expect(await completer(standalone440, i)).to.deep.equal([[i], i]);
+      expect(await completer(standalone440, i)).to.deep.equal([[], i]);
     });
 
     it('provides results if the function call is getCollection', async() => {
@@ -479,7 +479,7 @@ describe('completer.completer', () => {
 
     it('does not match if it is not .find or .aggregate', async() => {
       const i = 'db.shipwrecks.moo({feature_type: "Wrecks - Visible"}).';
-      expect(await completer(standalone440, i)).to.deep.equal([[i], i]);
+      expect(await completer(standalone440, i)).to.deep.equal([[], i]);
     });
   });
 });

--- a/packages/autocomplete/index.ts
+++ b/packages/autocomplete/index.ts
@@ -82,7 +82,7 @@ async function completer(params: AutocompleteParameters, line: string): Promise<
       // alphanumeric character. This could be a function call, for example.
       // In any case, we can't currently provide reasonable autocompletion
       // suggestions for this.
-      return [[line], line];
+      return [[], line];
     }
 
     if (splitLine.length > 3) {
@@ -99,7 +99,7 @@ async function completer(params: AutocompleteParameters, line: string): Promise<
         return [hits.length ? hits : [], line];
       }
       // This is something else, and we currently don't know what this is.
-      return [[line], line];
+      return [[], line];
     }
 
     // complete aggregation and collection  queries/stages
@@ -134,7 +134,7 @@ async function completer(params: AutocompleteParameters, line: string): Promise<
     return [hits.length ? hits : [], line];
   }
 
-  return [[line], line];
+  return [[], line];
 }
 
 function isAcceptable(

--- a/packages/cli-repl/src/cli-repl.spec.ts
+++ b/packages/cli-repl/src/cli-repl.spec.ts
@@ -809,10 +809,19 @@ describe('CliRepl', () => {
         await waitEval(cliRepl.bus);
       });
 
-      it('completes JS value properties properly', async() => {
+      it('completes JS value properties properly (incomplete, double tab)', async() => {
         input.write('JSON.\u0009\u0009');
         await waitCompletion(cliRepl.bus);
         expect(output).to.include('JSON.parse');
+        expect(output).to.include('JSON.stringify');
+        expect(output).not.to.include('rawValue');
+      });
+
+      it('completes JS value properties properly (complete, single tab)', async() => {
+        input.write('JSON.pa\u0009');
+        await waitCompletion(cliRepl.bus);
+        expect(output).to.include('JSON.parse');
+        expect(output).not.to.include('JSON.stringify');
         expect(output).not.to.include('rawValue');
       });
     });


### PR DESCRIPTION
Passing back the input as a possible completion would prevent
single-tab autocompletion in the shell.