### PR TITLE
fix: make explain output fully expanded MONGOSH-583

### DIFF
--- a/packages/cli-repl/src/format-output.spec.ts
+++ b/packages/cli-repl/src/format-output.spec.ts
@@ -288,5 +288,23 @@ for (const colors of [ false, true ]) {
         expect(output).to.contain('list available databases');
       });
     });
+
+    context('when the result is ExplainOutput or ExplainableCursor', () => {
+      for (const type of ['ExplainOutput', 'ExplainableCursor']) {
+        it(`returns output with large depth (${type})`, () => {
+          const value = {};
+          let it = value;
+          for (let i = 0; i <= 20; i++) {
+            it = it[`level${i}`] = {};
+          }
+          const output = stripAnsiColors(format({
+            value,
+            type
+          }));
+
+          expect(output).to.contain('level20');
+        });
+      }
+    });
   });
 }

--- a/packages/cli-repl/src/format-output.ts
+++ b/packages/cli-repl/src/format-output.ts
@@ -15,6 +15,7 @@ type EvaluationResult = {
 
 type FormatOptions = {
   colors: boolean;
+  depth?: number;
 };
 
 /**
@@ -94,6 +95,10 @@ Use db.getCollection('system.profile').find() to show raw profile entries.`, 'ye
     return formatError(value, options);
   }
 
+  if (type === 'ExplainOutput' || type === 'ExplainableCursor') {
+    return formatSimpleType(value, { ...options, depth: Infinity });
+  }
+
   return formatSimpleType(value, options);
 }
 
@@ -164,7 +169,7 @@ function inspect(output: any, options: FormatOptions): any {
   return util.inspect(output, {
     showProxy: false,
     colors: options.colors ?? true,
-    depth: 6
+    depth: options.depth ?? 6
   });
 }
 

--- a/packages/cli-repl/test/e2e.spec.ts
+++ b/packages/cli-repl/test/e2e.spec.ts
@@ -341,6 +341,18 @@ describe('e2e', function() {
 
       shell.assertNoErrors();
     });
+
+    it('expands explain output indefinitely', async() => {
+      await shell.executeLine('explainOutput = db.test.find().explain()');
+      await shell.executeLine('explainOutput.a = {b:{c:{d:{e:{f:{g:{h:{i:{j:{}}}}}}}}}}');
+      expect(await shell.executeLine('explainOutput')).to.match(/g:\s*\{\s*h:\s*\{\s*i:\s*\{\s*j:/);
+    });
+
+    it('expands explain output from aggregation indefinitely', async() => {
+      await shell.executeLine('explainOutput = db.test.aggregate([{ $limit: 1 }], {explain: "queryPlanner"})');
+      await shell.executeLine('explainOutput.a = {b:{c:{d:{e:{f:{g:{h:{i:{j:{}}}}}}}}}}');
+      expect(await shell.executeLine('explainOutput')).to.match(/g:\s*\{\s*h:\s*\{\s*i:\s*\{\s*j:/);
+    });
   });
 
   describe('Ctrl+C aka SIGINT', () => {

--- a/packages/service-provider-core/src/all-transport-types.ts
+++ b/packages/service-provider-core/src/all-transport-types.ts
@@ -31,6 +31,7 @@ export type {
   DropCollectionOptions,
   DropDatabaseOptions,
   EstimatedDocumentCountOptions,
+  ExplainOptions,
   ExplainVerbosityLike,
   FindAndModifyOptions,
   FindOperators,

--- a/packages/shell-api/src/aggregation-cursor.spec.ts
+++ b/packages/shell-api/src/aggregation-cursor.spec.ts
@@ -188,6 +188,24 @@ describe('AggregationCursor', () => {
       });
     });
 
+    describe('#explain', () => {
+      let spCursor: StubbedInstance<SPAggregationCursor>;
+      let shellApiCursor;
+
+      beforeEach(() => {
+        spCursor = stubInterface<SPAggregationCursor>();
+        shellApiCursor = new AggregationCursor(mongo, spCursor);
+        spCursor.explain.resolves({ ok: 1 });
+      });
+
+      it('returns an ExplainOutput object', async() => {
+        const explained = await shellApiCursor.explain();
+        expect(spCursor.explain).to.have.been.calledWith('queryPlanner');
+        expect((await toShellResult(explained)).type).to.equal('ExplainOutput');
+        expect((await toShellResult(explained)).printable).to.deep.equal({ ok: 1 });
+      });
+    });
+
     describe('toShellResult', () => {
       let shellApiCursor;
       let i;

--- a/packages/shell-api/src/aggregation-cursor.ts
+++ b/packages/shell-api/src/aggregation-cursor.ts
@@ -14,7 +14,7 @@ import type {
 } from '@mongosh/service-provider-core';
 import { CursorIterationResult } from './result';
 import { asPrintable, DEFAULT_BATCH_SIZE } from './enums';
-import { iterate, validateExplainableVerbosity } from './helpers';
+import { iterate, validateExplainableVerbosity, markAsExplainOutput } from './helpers';
 
 @shellApiClassDefault
 @hasAsyncChild
@@ -109,9 +109,9 @@ export default class AggregationCursor extends ShellApiClass {
   }
 
   @returnsPromise
-  explain(verbosity: ExplainVerbosityLike = 'queryPlanner'): Promise<any> {
+  async explain(verbosity: ExplainVerbosityLike = 'queryPlanner'): Promise<any> {
     verbosity = validateExplainableVerbosity(verbosity);
-    return this._cursor.explain(verbosity);
+    return markAsExplainOutput(await this._cursor.explain(verbosity));
   }
 
   @returnType('AggregationCursor')

--- a/packages/shell-api/src/collection.spec.ts
+++ b/packages/shell-api/src/collection.spec.ts
@@ -228,6 +228,7 @@ describe('Collection', () => {
         );
 
         expect(explainResult).to.equal(expectedExplainResult);
+        expect((await toShellResult(explainResult)).type).to.equal('ExplainOutput');
         expect(serviceProviderCursor.explain).to.have.been.calledOnce;
       });
 
@@ -363,6 +364,14 @@ describe('Collection', () => {
           { writeConcern: { w: 'majority' } }
         );
       });
+
+      it('returns an ExplainOutput object when explained', async() => {
+        serviceProvider.deleteMany.resolves({ ok: 1 } as any);
+
+        const explained = await collection.deleteMany({}, { explain: 'queryPlanner' });
+        expect((await toShellResult(explained)).type).to.equal('ExplainOutput');
+        expect((await toShellResult(explained)).printable).to.deep.equal({ ok: 1 });
+      });
     });
 
     describe('deleteOne', () => {
@@ -381,6 +390,24 @@ describe('Collection', () => {
           {},
           { writeConcern: { w: 'majority' } }
         );
+      });
+
+      it('returns an ExplainOutput object when explained', async() => {
+        serviceProvider.deleteOne.resolves({ ok: 1 } as any);
+
+        const explained = await collection.deleteOne({}, { explain: 'queryPlanner' });
+        expect((await toShellResult(explained)).type).to.equal('ExplainOutput');
+        expect((await toShellResult(explained)).printable).to.deep.equal({ ok: 1 });
+      });
+    });
+
+    describe('distinct', () => {
+      it('returns an ExplainOutput object when explained', async() => {
+        serviceProvider.distinct.resolves({ ok: 1 } as any);
+
+        const explained = await collection.distinct('_id', {}, { explain: 'queryPlanner' });
+        expect((await toShellResult(explained)).type).to.equal('ExplainOutput');
+        expect((await toShellResult(explained)).printable).to.deep.equal({ ok: 1 });
       });
     });
 
@@ -423,6 +450,14 @@ describe('Collection', () => {
         expect(serviceProvider.deleteOne).to.not.have.been.called;
         expect(serviceProvider.deleteMany).to.have.been.calledWith('db1', 'coll1', {}, {});
       });
+
+      it('returns an ExplainOutput object when explained', async() => {
+        serviceProvider.deleteMany = sinon.spy(() => Promise.resolve({ ok: 1 })) as any;
+
+        const explained = await collection.remove({}, { explain: 'queryPlanner' });
+        expect((await toShellResult(explained)).type).to.equal('ExplainOutput');
+        expect((await toShellResult(explained)).printable).to.deep.equal({ ok: 1 });
+      });
     });
 
     describe('findOneAndReplace', () => {
@@ -459,6 +494,14 @@ describe('Collection', () => {
           { returnOriginal: false }
         );
       });
+
+      it('returns an ExplainOutput object when explained', async() => {
+        serviceProvider.findOneAndReplace.resolves({ ok: 1 });
+
+        const explained = await collection.findOneAndReplace({}, {}, { explain: 'queryPlanner' });
+        expect((await toShellResult(explained)).type).to.equal('ExplainOutput');
+        expect((await toShellResult(explained)).printable).to.deep.equal({ ok: 1 });
+      });
     });
 
     describe('findOneAndUpdate', () => {
@@ -494,6 +537,14 @@ describe('Collection', () => {
           {},
           { returnOriginal: false }
         );
+      });
+
+      it('returns an ExplainOutput object when explained', async() => {
+        serviceProvider.findOneAndUpdate.resolves({ ok: 1 });
+
+        const explained = await collection.findOneAndUpdate({}, {}, { explain: 'queryPlanner' });
+        expect((await toShellResult(explained)).type).to.equal('ExplainOutput');
+        expect((await toShellResult(explained)).printable).to.deep.equal({ ok: 1 });
       });
     });
 
@@ -604,6 +655,14 @@ describe('Collection', () => {
           { writeConcern: { w: 'majority' } }
         );
       });
+
+      it('returns an ExplainOutput object when explained', async() => {
+        serviceProvider.updateOne.resolves({ ok: 1 } as any);
+
+        const explained = await collection.updateOne({}, {}, { explain: 'queryPlanner' });
+        expect((await toShellResult(explained)).type).to.equal('ExplainOutput');
+        expect((await toShellResult(explained)).printable).to.deep.equal({ ok: 1 });
+      });
     });
 
     describe('updateMany', () => {
@@ -623,6 +682,14 @@ describe('Collection', () => {
           {},
           { writeConcern: { w: 'majority' } }
         );
+      });
+
+      it('returns an ExplainOutput object when explained', async() => {
+        serviceProvider.updateMany.resolves({ ok: 1 } as any);
+
+        const explained = await collection.updateMany({}, {}, { explain: 'queryPlanner' });
+        expect((await toShellResult(explained)).type).to.equal('ExplainOutput');
+        expect((await toShellResult(explained)).printable).to.deep.equal({ ok: 1 });
       });
     });
 

--- a/packages/shell-api/src/collection.ts
+++ b/packages/shell-api/src/collection.ts
@@ -27,7 +27,9 @@ import {
   RemoveShellOptions,
   MapReduceShellOptions,
   processMapReduceOptions,
-  setHideIndex
+  setHideIndex,
+  maybeMarkAsExplainOutput,
+  markAsExplainOutput
 } from './helpers';
 import {
   AnyBulkWriteOperation,
@@ -173,7 +175,7 @@ export default class Collection extends ShellApiClass {
     const cursor = new AggregationCursor(this._mongo, providerCursor);
 
     if (explain) {
-      return await cursor.explain('queryPlanner');
+      return await cursor.explain(explain);
     }
 
     this._mongo._internalState.currentCursor = cursor;
@@ -295,7 +297,7 @@ export default class Collection extends ShellApiClass {
       { ...this._database._baseOptions, ...options }
     );
     if (options.explain) {
-      return result;
+      return markAsExplainOutput(result);
     }
 
     return new DeleteResult(
@@ -328,7 +330,7 @@ export default class Collection extends ShellApiClass {
       { ...this._database._baseOptions, ...options }
     );
     if (options.explain) {
-      return result;
+      return markAsExplainOutput(result);
     }
 
     return new DeleteResult(
@@ -352,7 +354,14 @@ export default class Collection extends ShellApiClass {
   @returnsPromise
   async distinct(field: string, query: Document, options: DistinctOptions = {}): Promise<Document> {
     this._emitCollectionApiCall('distinct', { field, query, options });
-    return this._mongo._serviceProvider.distinct(this._database._name, this._name, field, query, { ...this._database._baseOptions, ...options });
+    return maybeMarkAsExplainOutput(
+      await this._mongo._serviceProvider.distinct(
+        this._database._name,
+        this._name,
+        field,
+        query,
+        { ...this._database._baseOptions, ...options }),
+      options);
   }
 
   /**
@@ -506,7 +515,7 @@ export default class Collection extends ShellApiClass {
     );
 
     if (options.explain) {
-      return result;
+      return markAsExplainOutput(result);
     }
     return result.value;
   }
@@ -545,7 +554,7 @@ export default class Collection extends ShellApiClass {
     );
 
     if (options.explain) {
-      return result;
+      return markAsExplainOutput(result);
     }
     return result.value;
   }
@@ -583,7 +592,7 @@ export default class Collection extends ShellApiClass {
     );
 
     if (options.explain) {
-      return result;
+      return markAsExplainOutput(result);
     }
     return result.value;
   }
@@ -732,7 +741,7 @@ export default class Collection extends ShellApiClass {
       { ...this._database._baseOptions, ...removeOptions }
     );
     if (removeOptions.explain) {
-      return result;
+      return markAsExplainOutput(result);
     }
     return new DeleteResult(
       !!result.acknowledged,
@@ -815,7 +824,7 @@ export default class Collection extends ShellApiClass {
       );
     }
     if (options.explain) {
-      return result;
+      return markAsExplainOutput(result);
     }
     return new UpdateResult(
       !!result.acknowledged,
@@ -852,7 +861,7 @@ export default class Collection extends ShellApiClass {
       { ...this._database._baseOptions, ...options }
     );
     if (options.explain) {
-      return result;
+      return markAsExplainOutput(result);
     }
 
     return new UpdateResult(
@@ -894,7 +903,7 @@ export default class Collection extends ShellApiClass {
       { ...this._database._baseOptions, ...options }
     );
     if (options.explain) {
-      return result;
+      return markAsExplainOutput(result);
     }
 
     return new UpdateResult(

--- a/packages/shell-api/src/cursor.spec.ts
+++ b/packages/shell-api/src/cursor.spec.ts
@@ -625,7 +625,8 @@ describe('Cursor', () => {
           ok: 1
         });
 
-        await shellApiCursor.explain();
+        const explained = await shellApiCursor.explain();
+        expect((await toShellResult(explained)).type).to.equal('ExplainOutput');
         expect(nativeCursorStub.explain).to.have.been.calledWith();
       });
 

--- a/packages/shell-api/src/cursor.ts
+++ b/packages/shell-api/src/cursor.ts
@@ -26,7 +26,7 @@ import {
   TagSet,
   HedgeOptions
 } from '@mongosh/service-provider-core';
-import { iterate, validateExplainableVerbosity } from './helpers';
+import { iterate, validateExplainableVerbosity, markAsExplainOutput } from './helpers';
 import Mongo from './mongo';
 import { CursorIterationResult } from './result';
 import { printWarning } from './deprecation-warning';
@@ -160,7 +160,7 @@ export default class Cursor extends ShellApiClass {
       delete explain.executionStats.allPlansExecution;
     }
 
-    return explain;
+    return markAsExplainOutput(explain);
   }
 
   @returnsPromise

--- a/packages/shell-api/src/database.ts
+++ b/packages/shell-api/src/database.ts
@@ -288,7 +288,7 @@ export default class Database extends ShellApiClass {
     const cursor = new AggregationCursor(this._mongo, providerCursor);
 
     if (explain) {
-      return await cursor.explain('queryPlanner');
+      return await cursor.explain(explain);
     }
 
     this._mongo._internalState.currentCursor = cursor;

--- a/packages/shell-api/src/explainable-cursor.spec.ts
+++ b/packages/shell-api/src/explainable-cursor.spec.ts
@@ -35,7 +35,7 @@ describe('ExplainableCursor', () => {
     beforeEach(() => {
       wrappee = {
         map: sinon.spy(),
-        explain: (verbosity): any => ({ ok: verbosity })
+        explain: sinon.spy((verbosity): any => ({ ok: verbosity }))
       };
       wrappee._cursor = wrappee;
       eCursor = new ExplainableCursor({} as any, wrappee as any, 'queryPlannerExtended');
@@ -46,6 +46,7 @@ describe('ExplainableCursor', () => {
       expect((await toShellResult(eCursor.help)).type).to.equal('Help');
       expect((await toShellResult(eCursor)).printable).to.deep.equal({ ok: 'queryPlannerExtended' });
       expect(eCursor._verbosity).to.equal('queryPlannerExtended');
+      expect(wrappee.explain).to.have.callCount(1);
     });
 
     it('returns the same ExplainableCursor', () => {

--- a/packages/shell-api/src/explainable-cursor.ts
+++ b/packages/shell-api/src/explainable-cursor.ts
@@ -8,18 +8,23 @@ import type { Document, ExplainVerbosityLike } from '@mongosh/service-provider-c
 export default class ExplainableCursor extends Cursor {
   _baseCursor: Cursor;
   _verbosity: ExplainVerbosityLike;
+  _explained: any;
 
   constructor(mongo: Mongo, cursor: Cursor, verbosity: ExplainVerbosityLike) {
     super(mongo, cursor._cursor);
     this._baseCursor = cursor;
     this._verbosity = verbosity;
+    this._explained = null;
   }
 
   /**
    * Internal method to determine what is printed for this class.
    */
   async [asPrintable](): Promise<any> {
-    return await this._baseCursor.explain(this._verbosity);
+    // Cache the result so that we don't explain over and over again for the
+    // same object.
+    this._explained ??= await this._baseCursor.explain(this._verbosity);
+    return this._explained;
   }
 
   @returnType('ExplainableCursor')

--- a/packages/shell-api/src/explainable.spec.ts
+++ b/packages/shell-api/src/explainable.spec.ts
@@ -148,15 +148,9 @@ describe('Explainable', () => {
 
     describe('aggregate', () => {
       let explainResult;
-      let expectedExplainResult;
-      let cursor;
+      const expectedExplainResult = { ok: 1 };
       beforeEach(async() => {
-        explainResult = { ok: 1 };
-        cursor = {
-          explain: sinon.spy(() => Promise.resolve(expectedExplainResult))
-        };
-
-        collection.aggregate = sinon.spy(() => Promise.resolve(cursor));
+        collection.aggregate = sinon.spy(() => Promise.resolve(expectedExplainResult)) as any;
 
         explainResult = await explainable.aggregate(
           { pipeline: 1 },
@@ -167,14 +161,8 @@ describe('Explainable', () => {
       it('calls collection.aggregate with arguments', () => {
         expect(collection.aggregate).to.have.been.calledOnceWithExactly(
           { pipeline: 1 },
-          { aggregate: 1, explain: false }
+          { aggregate: 1, explain: 'queryPlanner' }
         );
-      });
-
-      it('calls explain with verbosity', async() => {
-        expect(
-          cursor.explain
-        ).to.have.been.calledOnceWithExactly('queryPlanner');
       });
 
       it('returns the explain result', () => {


### PR DESCRIPTION
Fully expand output from explain commands, by identifying them
with a specific ShellResult type tag.
This also un-breaks `db.coll.aggregate(..., { explain: ... })`.