### PR TITLE
feat(async-rewriter2): introduce new async-rewriter alternative ✨

### DIFF
--- a/.nycrc
+++ b/.nycrc
@@ -9,6 +9,7 @@
     "**/tmp/**/*.{ts,js,tsx,jsx,cjs,mjs}",
     "**/*.config.{ts,js,tsx,jsx,cjs,mjs}",
     "**/lib/*.js",
-    "**/dist/**/*.js"
+    "**/dist/**/*.js",
+    "**/src/*.nocov.{ts,js}"
   ]
 }

--- a/packages/async-rewriter2/.eslintignore
+++ b/packages/async-rewriter2/.eslintignore
@@ -1,0 +1,3 @@
+node_modules
+lib
+local-test.js

--- a/packages/async-rewriter2/.eslintrc.js
+++ b/packages/async-rewriter2/.eslintrc.js
@@ -1,0 +1,1 @@
+module.exports = require('../../config/eslintrc.base');

--- a/packages/async-rewriter2/.gitignore
+++ b/packages/async-rewriter2/.gitignore
@@ -1,0 +1,2 @@
+lib/
+local-test.js

--- a/packages/async-rewriter2/.npmignore
+++ b/packages/async-rewriter2/.npmignore
@@ -1,0 +1,15 @@
+.DS_Store
+.evergreen/
+.evergreen.yml
+.gitignore
+.jshintrc
+.jsfmtrc
+.travis.yml
+.zuul.yml
+azure-pipelines.yml
+karma.conf.js
+lerna.json
+tsconfig.json
+notices/
+src/
+test/

--- a/packages/async-rewriter2/AUTHORS
+++ b/packages/async-rewriter2/AUTHORS
@@ -1,0 +1,8 @@
+Anna Herlihy <herlihyap@gmail.com>
+Durran Jordan <durran@gmail.com>
+Maurizio Casimirri <maurizio.cas@gmail.com>
+Massimiliano Marcon <me@marcon.me>
+Rhys Howell <rhys@rhysh@live.com>
+Irina Shestak <shestak.irina@gmail.com>
+Liudmila Kornilova <kornilova203@gmail.com>
+Anna Henningsen <anna@addaleax.net>

--- a/packages/async-rewriter2/LICENSE
+++ b/packages/async-rewriter2/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/packages/async-rewriter2/README.md
+++ b/packages/async-rewriter2/README.md
@@ -1,0 +1,160 @@
+# next-gen async-rewriter
+
+This package contains babel plugins that transpile code in a way that allows
+implicitly `await`ing selecting Promises.
+
+## Motivation
+
+The predecessor of this package uses a symbol-table-based approach, in which it
+uses static analysis to keep track of which function calls would end up needing
+an implicit `await` in front of it. This is brittle and strongly limits the
+set of JS features that could be used in the shell, as well as the ways in which
+one could interact with API object programmatically.
+
+Therefore, this package drops the static analysis part and focuses entirely on
+transforming the code in a way that allows all 'interesting' work to happen at
+runtime. It is fully stateless and enables removing any symbol table tracking.
+It’s also easier to introduce support for more built-in JS functions that take
+callbacks this way, as replacing them with a polyfill (that is also transformed)
+does the trick here. As such, special-casing calls to e.g. `.forEach()` is no
+longer necessary either.
+
+Downsides to this approach are that it’s not currently taking into account
+situations in which implicitly async functions cannot be used (e.g. class
+constructors or synchronous generator functions), that we don’t error for
+conflicting API usage (e.g. top-level variables with names like `db`) and
+that error messages may end up referring to odd locations in the code (at least
+without support for source maps).
+
+## Idea
+
+We (ab-)use the fact that `async function`s execute fully synchronously until
+they reach their first `await` expression, and the fact that we can determine
+which `Promise`s need `await`ing by marking them as such using decorators
+on the API surface.
+
+The transformation takes place in two main steps.
+
+### Step one: IIFE wrapping
+
+The input code is wrapped in an IIFE. For example:
+
+```js
+function foo() { return db.test.find(); }
+class A {}
+foo()
+```
+
+is converted into roughly:
+
+```js
+var A;
+
+function foo() {
+  return db.test.find();
+}
+
+(() => {
+  A = class A {};
+  return foo();
+})();
+```
+
+Note how identifiers remain accessible in the outside environment, including
+top-level functions being hoisted to the outside.
+
+### Step two: Async function wrapping
+
+We perform three operations:
+
+1. We give all shorthand arrow functions statement bodies. This is necessary
+   for the other steps to work.
+2. We turn all input functions into async functions and generate non-async
+   wrappers for them. We keep track of the execution state of the ’inner’
+   async function when it is called, and forward synchronous results
+   synchronously.
+3. We add checks for most expressions inside the ‘inner’ function, which
+   conditionally uses `await` based on whether the result of the expression
+   has a specific `Symbol` property. This `Symbol` property is set by functions
+   in the API whose results should be implicitly awaited.
+
+This does result in a significant increase in code size. For example,
+
+```js
+(() => {
+  return db.test.find().toArray();
+})();
+```
+
+(which is the result of `db.test.find().toArray()` after Step 1) would be
+turned into code looking like the following (some adjustments have been
+made for readability).
+
+```js
+(() => {
+  const _syntheticPromise = Symbol.for("@@mongosh.syntheticPromise");
+
+  function _markSyntheticPromise(p) {
+    return Object.defineProperty(p, _syntheticPromise, {
+      value: true
+    });
+  }
+
+  function _isp(p) { // '_isSyntheticPromise' would be way too long here
+    return p && p[_syntheticPromise];
+  }
+
+  let _functionState = "sync",
+      _synchronousReturnValue,
+      _ex;
+
+  const _asynchronousReturnValue = (async () => {
+    try {
+      // All return statements are decorated with `return _synchronousReturnValue = ...`
+      return _synchronousReturnValue = (
+        // Most expressions are wrapped in (_ex = ..., _isp(_ex) ? await _ex : _ex)
+        _ex = (
+          _ex = (
+            _ex = (
+              _ex = db, _isp(_ex) ? await _ex : _ex
+            ).test, _isp(_ex) ? await _ex : _ex
+          ).find(), _isp(_ex) ? await _ex : _ex
+        ).toArray()
+        , _isp(_ex) ? await _ex : _ex
+      );
+    } catch (err) {
+      if (_functionState === "sync") {
+        // Forward synchronous exceptions.
+        _synchronousReturnValue = err;
+        _functionState = "threw";
+      } else {
+        // If we are already asynchronous, just return a rejected Promise as usual.
+        throw err;
+      }
+    } finally {
+      // If we did not throw here, we returned. Tell the caller that.
+      if (_functionState !== "threw") {
+        _functionState = "returned";
+      }
+    }
+  })();
+
+  if (_functionState === "returned") {
+    return _synchronousReturnValue;
+  } else if (_functionState === "threw") {
+    throw _synchronousReturnValue;
+  }
+
+  _functionState = "async";
+  // Since this was originally a non-async function, mark this as something
+  // that should implicitly be awaited.
+  return _markSyntheticPromise(_asynchronousReturnValue);
+})();
+```
+
+## API
+
+```js
+import AsyncWriter from '@mongosh/async-rewriter2';
+const transpiledCodeString = new AsyncWriter().process(inputCodeString);
+```

--- a/packages/async-rewriter2/package-lock.json
+++ b/packages/async-rewriter2/package-lock.json
@@ -1,0 +1,423 @@
+{
+	"name": "@mongosh/async-rewriter2",
+	"version": "0.0.0-dev.0",
+	"lockfileVersion": 1,
+	"requires": true,
+	"dependencies": {
+		"@babel/code-frame": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
+			"integrity": "sha512-a9gxpmdXtZEInkCSHUJDLHZVBgb1QS0jhss4cPP93EW7s+uC5bikET2twEF3KV+7rDblJcmNvTR7VJejqd2C2g==",
+			"requires": {
+				"@babel/highlight": "^7.8.3"
+			}
+		},
+		"@babel/core": {
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.9.0.tgz",
+			"integrity": "sha512-kWc7L0fw1xwvI0zi8OKVBuxRVefwGOrKSQMvrQ3dW+bIIavBY3/NpXmpjMy7bQnLgwgzWQZ8TlM57YHpHNHz4w==",
+			"requires": {
+				"@babel/code-frame": "^7.8.3",
+				"@babel/generator": "^7.9.0",
+				"@babel/helper-module-transforms": "^7.9.0",
+				"@babel/helpers": "^7.9.0",
+				"@babel/parser": "^7.9.0",
+				"@babel/template": "^7.8.6",
+				"@babel/traverse": "^7.9.0",
+				"@babel/types": "^7.9.0",
+				"convert-source-map": "^1.7.0",
+				"debug": "^4.1.0",
+				"gensync": "^1.0.0-beta.1",
+				"json5": "^2.1.2",
+				"lodash": "^4.17.13",
+				"resolve": "^1.3.2",
+				"semver": "^5.4.1",
+				"source-map": "^0.5.0"
+			}
+		},
+		"@babel/generator": {
+			"version": "7.9.5",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.9.5.tgz",
+			"integrity": "sha512-GbNIxVB3ZJe3tLeDm1HSn2AhuD/mVcyLDpgtLXa5tplmWrJdF/elxB56XNqCuD6szyNkDi6wuoKXln3QeBmCHQ==",
+			"requires": {
+				"@babel/types": "^7.9.5",
+				"jsesc": "^2.5.1",
+				"lodash": "^4.17.13",
+				"source-map": "^0.5.0"
+			}
+		},
+		"@babel/helper-function-name": {
+			"version": "7.9.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.9.5.tgz",
+			"integrity": "sha512-JVcQZeXM59Cd1qanDUxv9fgJpt3NeKUaqBqUEvfmQ+BCOKq2xUgaWZW2hr0dkbyJgezYuplEoh5knmrnS68efw==",
+			"requires": {
+				"@babel/helper-get-function-arity": "^7.8.3",
+				"@babel/template": "^7.8.3",
+				"@babel/types": "^7.9.5"
+			}
+		},
+		"@babel/helper-get-function-arity": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.8.3.tgz",
+			"integrity": "sha512-FVDR+Gd9iLjUMY1fzE2SR0IuaJToR4RkCDARVfsBBPSP53GEqSFjD8gNyxg246VUyc/ALRxFaAK8rVG7UT7xRA==",
+			"requires": {
+				"@babel/types": "^7.8.3"
+			}
+		},
+		"@babel/helper-member-expression-to-functions": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.8.3.tgz",
+			"integrity": "sha512-fO4Egq88utkQFjbPrSHGmGLFqmrshs11d46WI+WZDESt7Wu7wN2G2Iu+NMMZJFDOVRHAMIkB5SNh30NtwCA7RA==",
+			"requires": {
+				"@babel/types": "^7.8.3"
+			}
+		},
+		"@babel/helper-module-imports": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.8.3.tgz",
+			"integrity": "sha512-R0Bx3jippsbAEtzkpZ/6FIiuzOURPcMjHp+Z6xPe6DtApDJx+w7UYyOLanZqO8+wKR9G10s/FmHXvxaMd9s6Kg==",
+			"requires": {
+				"@babel/types": "^7.8.3"
+			}
+		},
+		"@babel/helper-module-transforms": {
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.9.0.tgz",
+			"integrity": "sha512-0FvKyu0gpPfIQ8EkxlrAydOWROdHpBmiCiRwLkUiBGhCUPRRbVD2/tm3sFr/c/GWFrQ/ffutGUAnx7V0FzT2wA==",
+			"requires": {
+				"@babel/helper-module-imports": "^7.8.3",
+				"@babel/helper-replace-supers": "^7.8.6",
+				"@babel/helper-simple-access": "^7.8.3",
+				"@babel/helper-split-export-declaration": "^7.8.3",
+				"@babel/template": "^7.8.6",
+				"@babel/types": "^7.9.0",
+				"lodash": "^4.17.13"
+			}
+		},
+		"@babel/helper-optimise-call-expression": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.8.3.tgz",
+			"integrity": "sha512-Kag20n86cbO2AvHca6EJsvqAd82gc6VMGule4HwebwMlwkpXuVqrNRj6CkCV2sKxgi9MyAUnZVnZ6lJ1/vKhHQ==",
+			"requires": {
+				"@babel/types": "^7.8.3"
+			}
+		},
+		"@babel/helper-replace-supers": {
+			"version": "7.8.6",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.8.6.tgz",
+			"integrity": "sha512-PeMArdA4Sv/Wf4zXwBKPqVj7n9UF/xg6slNRtZW84FM7JpE1CbG8B612FyM4cxrf4fMAMGO0kR7voy1ForHHFA==",
+			"requires": {
+				"@babel/helper-member-expression-to-functions": "^7.8.3",
+				"@babel/helper-optimise-call-expression": "^7.8.3",
+				"@babel/traverse": "^7.8.6",
+				"@babel/types": "^7.8.6"
+			}
+		},
+		"@babel/helper-simple-access": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.8.3.tgz",
+			"integrity": "sha512-VNGUDjx5cCWg4vvCTR8qQ7YJYZ+HBjxOgXEl7ounz+4Sn7+LMD3CFrCTEU6/qXKbA2nKg21CwhhBzO0RpRbdCw==",
+			"requires": {
+				"@babel/template": "^7.8.3",
+				"@babel/types": "^7.8.3"
+			}
+		},
+		"@babel/helper-split-export-declaration": {
+			"version": "7.8.3",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.8.3.tgz",
+			"integrity": "sha512-3x3yOeyBhW851hroze7ElzdkeRXQYQbFIb7gLK1WQYsw2GWDay5gAJNw1sWJ0VFP6z5J1whqeXH/WCdCjZv6dA==",
+			"requires": {
+				"@babel/types": "^7.8.3"
+			}
+		},
+		"@babel/helper-validator-identifier": {
+			"version": "7.9.5",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.9.5.tgz",
+			"integrity": "sha512-/8arLKUFq882w4tWGj9JYzRpAlZgiWUJ+dtteNTDqrRBz9Iguck9Rn3ykuBDoUwh2TO4tSAJlrxDUOXWklJe4g=="
+		},
+		"@babel/helpers": {
+			"version": "7.9.2",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.9.2.tgz",
+			"integrity": "sha512-JwLvzlXVPjO8eU9c/wF9/zOIN7X6h8DYf7mG4CiFRZRvZNKEF5dQ3H3V+ASkHoIB3mWhatgl5ONhyqHRI6MppA==",
+			"requires": {
+				"@babel/template": "^7.8.3",
+				"@babel/traverse": "^7.9.0",
+				"@babel/types": "^7.9.0"
+			}
+		},
+		"@babel/highlight": {
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.9.0.tgz",
+			"integrity": "sha512-lJZPilxX7Op3Nv/2cvFdnlepPXDxi29wxteT57Q965oc5R9v86ztx0jfxVrTcBk8C2kcPkkDa2Z4T3ZsPPVWsQ==",
+			"requires": {
+				"@babel/helper-validator-identifier": "^7.9.0",
+				"chalk": "^2.0.0",
+				"js-tokens": "^4.0.0"
+			}
+		},
+		"@babel/parser": {
+			"version": "7.9.4",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.9.4.tgz",
+			"integrity": "sha512-bC49otXX6N0/VYhgOMh4gnP26E9xnDZK3TmbNpxYzzz9BQLBosQwfyOe9/cXUU3txYhTzLCbcqd5c8y/OmCjHA=="
+		},
+		"@babel/plugin-transform-destructuring": {
+			"version": "7.13.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.13.0.tgz",
+			"integrity": "sha512-zym5em7tePoNT9s964c0/KU3JPPnuq7VhIxPRefJ4/s82cD+q1mgKfuGRDMCPL0HTyKz4dISuQlCusfgCJ86HA==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.13.0"
+			},
+			"dependencies": {
+				"@babel/helper-plugin-utils": {
+					"version": "7.13.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.13.0.tgz",
+					"integrity": "sha512-ZPafIPSwzUlAoWT8DKs1W2VyF2gOWthGd5NGFMsBcMMol+ZhK+EQY/e6V96poa6PA/Bh+C9plWN0hXO1uB8AfQ=="
+				}
+			}
+		},
+		"@babel/plugin-transform-parameters": {
+			"version": "7.13.0",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.13.0.tgz",
+			"integrity": "sha512-Jt8k/h/mIwE2JFEOb3lURoY5C85ETcYPnbuAJ96zRBzh1XHtQZfs62ChZ6EP22QlC8c7Xqr9q+e1SU5qttwwjw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.13.0"
+			},
+			"dependencies": {
+				"@babel/helper-plugin-utils": {
+					"version": "7.13.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.13.0.tgz",
+					"integrity": "sha512-ZPafIPSwzUlAoWT8DKs1W2VyF2gOWthGd5NGFMsBcMMol+ZhK+EQY/e6V96poa6PA/Bh+C9plWN0hXO1uB8AfQ=="
+				}
+			}
+		},
+		"@babel/plugin-transform-shorthand-properties": {
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.12.13.tgz",
+			"integrity": "sha512-xpL49pqPnLtf0tVluuqvzWIgLEhuPpZzvs2yabUHSKRNlN7ScYU7aMlmavOeyXJZKgZKQRBlh8rHbKiJDraTSw==",
+			"requires": {
+				"@babel/helper-plugin-utils": "^7.12.13"
+			},
+			"dependencies": {
+				"@babel/helper-plugin-utils": {
+					"version": "7.13.0",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.13.0.tgz",
+					"integrity": "sha512-ZPafIPSwzUlAoWT8DKs1W2VyF2gOWthGd5NGFMsBcMMol+ZhK+EQY/e6V96poa6PA/Bh+C9plWN0hXO1uB8AfQ=="
+				}
+			}
+		},
+		"@babel/template": {
+			"version": "7.8.6",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.8.6.tgz",
+			"integrity": "sha512-zbMsPMy/v0PWFZEhQJ66bqjhH+z0JgMoBWuikXybgG3Gkd/3t5oQ1Rw2WQhnSrsOmsKXnZOx15tkC4qON/+JPg==",
+			"requires": {
+				"@babel/code-frame": "^7.8.3",
+				"@babel/parser": "^7.8.6",
+				"@babel/types": "^7.8.6"
+			}
+		},
+		"@babel/traverse": {
+			"version": "7.9.5",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.9.5.tgz",
+			"integrity": "sha512-c4gH3jsvSuGUezlP6rzSJ6jf8fYjLj3hsMZRx/nX0h+fmHN0w+ekubRrHPqnMec0meycA2nwCsJ7dC8IPem2FQ==",
+			"requires": {
+				"@babel/code-frame": "^7.8.3",
+				"@babel/generator": "^7.9.5",
+				"@babel/helper-function-name": "^7.9.5",
+				"@babel/helper-split-export-declaration": "^7.8.3",
+				"@babel/parser": "^7.9.0",
+				"@babel/types": "^7.9.5",
+				"debug": "^4.1.0",
+				"globals": "^11.1.0",
+				"lodash": "^4.17.13"
+			}
+		},
+		"@babel/types": {
+			"version": "7.9.5",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.5.tgz",
+			"integrity": "sha512-XjnvNqenk818r5zMaba+sLQjnbda31UfUURv3ei0qPQw4u+j2jMyJ5b11y8ZHYTRSI3NnInQkkkRT4fLqqPdHg==",
+			"requires": {
+				"@babel/helper-validator-identifier": "^7.9.5",
+				"lodash": "^4.17.13",
+				"to-fast-properties": "^2.0.0"
+			}
+		},
+		"@types/babel__core": {
+			"version": "7.1.7",
+			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.7.tgz",
+			"integrity": "sha512-RL62NqSFPCDK2FM1pSDH0scHpJvsXtZNiYlMB73DgPBaG1E38ZYVL+ei5EkWRbr+KC4YNiAUNBnRj+bgwpgjMw==",
+			"requires": {
+				"@babel/parser": "^7.1.0",
+				"@babel/types": "^7.0.0",
+				"@types/babel__generator": "*",
+				"@types/babel__template": "*",
+				"@types/babel__traverse": "*"
+			}
+		},
+		"@types/babel__generator": {
+			"version": "7.6.1",
+			"resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.1.tgz",
+			"integrity": "sha512-bBKm+2VPJcMRVwNhxKu8W+5/zT7pwNEqeokFOmbvVSqGzFneNxYcEBro9Ac7/N9tlsaPYnZLK8J1LWKkMsLAew==",
+			"requires": {
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@types/babel__template": {
+			"version": "7.0.2",
+			"resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.0.2.tgz",
+			"integrity": "sha512-/K6zCpeW7Imzgab2bLkLEbz0+1JlFSrUMdw7KoIIu+IUdu51GWaBZpd3y1VXGVXzynvGa4DaIaxNZHiON3GXUg==",
+			"requires": {
+				"@babel/parser": "^7.1.0",
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@types/babel__traverse": {
+			"version": "7.0.10",
+			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.0.10.tgz",
+			"integrity": "sha512-74fNdUGrWsgIB/V9kTO5FGHPWYY6Eqn+3Z7L6Hc4e/BxjYV7puvBqp5HwsVYYfLm6iURYBNCx4Ut37OF9yitCw==",
+			"requires": {
+				"@babel/types": "^7.3.0"
+			}
+		},
+		"ansi-styles": {
+			"version": "3.2.1",
+			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+			"requires": {
+				"color-convert": "^1.9.0"
+			}
+		},
+		"chalk": {
+			"version": "2.4.2",
+			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+			"requires": {
+				"ansi-styles": "^3.2.1",
+				"escape-string-regexp": "^1.0.5",
+				"supports-color": "^5.3.0"
+			}
+		},
+		"color-convert": {
+			"version": "1.9.3",
+			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+			"requires": {
+				"color-name": "1.1.3"
+			}
+		},
+		"color-name": {
+			"version": "1.1.3",
+			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+		},
+		"convert-source-map": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+			"integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+			"requires": {
+				"safe-buffer": "~5.1.1"
+			}
+		},
+		"debug": {
+			"version": "4.1.1",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.1.1.tgz",
+			"integrity": "sha512-pYAIzeRo8J6KPEaJ0VWOh5Pzkbw/RetuzehGM7QRRX5he4fPHx2rdKMB256ehJCkX+XRQm16eZLqLNS8RSZXZw==",
+			"requires": {
+				"ms": "^2.1.1"
+			}
+		},
+		"escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+		},
+		"gensync": {
+			"version": "1.0.0-beta.1",
+			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.1.tgz",
+			"integrity": "sha512-r8EC6NO1sngH/zdD9fiRDLdcgnbayXah+mLgManTaIZJqEC1MZstmnox8KpnI2/fxQwrp5OpCOYWLp4rBl4Jcg=="
+		},
+		"globals": {
+			"version": "11.12.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
+		},
+		"has-flag": {
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+			"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+		},
+		"js-tokens": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+		},
+		"jsesc": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
+		},
+		"json5": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.1.3.tgz",
+			"integrity": "sha512-KXPvOm8K9IJKFM0bmdn8QXh7udDh1g/giieX0NLCaMnb4hEiVFqnop2ImTXCc5e0/oHz3LTqmHGtExn5hfMkOA==",
+			"requires": {
+				"minimist": "^1.2.5"
+			}
+		},
+		"lodash": {
+			"version": "4.17.15",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.15.tgz",
+			"integrity": "sha512-8xOcRHvCjnocdS5cpwXQXVzmmh5e5+saE2QGoeQmbKmRS6J3VQppPOIt0MnmE+4xlZoumy0GPG0D0MVIQbNA1A=="
+		},
+		"minimist": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
+		},
+		"ms": {
+			"version": "2.1.2",
+			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+		},
+		"path-parse": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
+		},
+		"resolve": {
+			"version": "1.17.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.17.0.tgz",
+			"integrity": "sha512-ic+7JYiV8Vi2yzQGFWOkiZD5Z9z7O2Zhm9XMaTxdJExKasieFCr+yXZ/WmXsckHiKl12ar0y6XiXDx3m4RHn1w==",
+			"requires": {
+				"path-parse": "^1.0.6"
+			}
+		},
+		"safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+		},
+		"semver": {
+			"version": "5.7.1",
+			"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+			"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
+		},
+		"source-map": {
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
+		},
+		"supports-color": {
+			"version": "5.5.0",
+			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+			"requires": {
+				"has-flag": "^3.0.0"
+			}
+		},
+		"to-fast-properties": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
+		}
+	}
+}

--- a/packages/async-rewriter2/package.json
+++ b/packages/async-rewriter2/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "@mongosh/shell-evaluator",
+  "name": "@mongosh/async-rewriter2",
   "version": "0.0.0-dev.0",
-  "description": "MongoDB Top Level API Package",
+  "description": "MongoDB Shell Async Rewriter Package",
   "main": "./lib/index.js",
   "scripts": {
     "test": "mocha -r \"../../scripts/import-expansions.js\" --timeout 60000 --colors -r ts-node/register \"./{src,lib}/**/*.spec.ts\"",
@@ -26,13 +26,14 @@
     "node": ">=12.4.0"
   },
   "dependencies": {
-    "@mongosh/async-rewriter2": "0.0.0-dev.0",
-    "@mongosh/history": "0.0.0-dev.0",
-    "@mongosh/service-provider-core": "0.0.0-dev.0",
-    "@mongosh/shell-api": "0.0.0-dev.0"
-  },
-  "devDependencies": {
-    "@types/sinon": "^7.5.1",
-    "@types/sinon-chai": "^3.2.3"
+    "@babel/core": "^7.9.0",
+    "@babel/parser": "^7.9.4",
+    "@babel/plugin-transform-shorthand-properties": "^7.12.13",
+    "@babel/plugin-transform-parameters": "^7.13.0",
+    "@babel/plugin-transform-destructuring": "^7.13.0",
+    "@babel/traverse": "^7.9.0",
+    "@babel/types": "^7.9.0",
+    "@types/babel__core": "^7.1.6",
+    "@types/babel__traverse": "^7.0.9"
   }
 }

--- a/packages/async-rewriter2/src/async-writer-babel.spec.ts
+++ b/packages/async-rewriter2/src/async-writer-babel.spec.ts
@@ -320,6 +320,19 @@ describe('AsyncWriter', () => {
     });
   });
 
+  context('recursion', () => {
+    it('can deal with calling a recursive function', async() => {
+      const result = runTranspiledCode(`
+        function sumToN(n) {
+          if (n <= 1) return 1;
+          return n + sumToN(n - 1);
+        }
+        sumToN(2);
+      `);
+      expect(result).to.equal(3);
+    });
+  });
+
   context('runtime support', () => {
     beforeEach(() => {
       runUntranspiledCode(asyncWriter.runtimeSupportCode());

--- a/packages/async-rewriter2/src/async-writer-babel.spec.ts
+++ b/packages/async-rewriter2/src/async-writer-babel.spec.ts
@@ -1,0 +1,542 @@
+import AsyncWriter from './';
+import vm from 'vm';
+import sinon from 'ts-sinon';
+import chai, { expect } from 'chai';
+import sinonChai from 'sinon-chai';
+chai.use(sinonChai);
+
+describe('AsyncWriter', () => {
+  let implicitlyAsyncFn: sinon.SinonStub;
+  let plainFn: sinon.SinonStub;
+  let implicitlyAsyncMethod: sinon.SinonStub;
+  let plainMethod: sinon.SinonStub;
+  let ctx: any;
+  let runTranspiledCode: (code: string, context?: any) => any;
+  let runUntranspiledCode: (code: string, context?: any) => any;
+  let asyncWriter: AsyncWriter;
+
+  beforeEach(function() {
+    implicitlyAsyncFn = sinon.stub();
+    plainFn = sinon.stub();
+    implicitlyAsyncMethod = sinon.stub();
+    plainMethod = sinon.stub();
+
+    asyncWriter = new AsyncWriter();
+    ctx = vm.createContext({
+      expect,
+      console,
+      implicitlyAsyncFn: function(...args: any[]) {
+        return Object.assign(
+          Promise.resolve(implicitlyAsyncFn.call(this, ...args)),
+          { [Symbol.for('@@mongosh.syntheticPromise')]: true });
+      },
+      plainFn,
+      obj: {
+        implicitlyAsyncMethod: function(...args: any[]) {
+          return Object.assign(
+            Promise.resolve(implicitlyAsyncMethod.call(this, ...args)),
+            { [Symbol.for('@@mongosh.syntheticPromise')]: true });
+        },
+        plainMethod
+      }
+    });
+    runTranspiledCode = (code: string, context?: any) => {
+      const transpiled = asyncWriter.process(code);
+      return runUntranspiledCode(transpiled, context);
+    };
+    runUntranspiledCode = (code: string, context?: any) => {
+      return vm.runInContext(code, context ?? ctx);
+    };
+  });
+
+  context('basic testing', () => {
+    it('evaluates plain literal expressions', () => {
+      expect(runTranspiledCode('42')).to.equal(42);
+      expect(runTranspiledCode('"42"')).to.equal('42');
+      expect(runTranspiledCode('false')).to.equal(false);
+      expect(runTranspiledCode('null')).to.equal(null);
+      expect(runTranspiledCode('undefined')).to.equal(undefined);
+      expect(runTranspiledCode('[1,2,3]')).to.deep.equal([1, 2, 3]);
+      expect(runTranspiledCode('({ a: 10 })')).to.deep.equal({ a: 10 });
+    });
+
+    it('does not auto-resolve Promises automatically', () => {
+      expect(runTranspiledCode('Promise.resolve([])').constructor.name).to.equal('Promise');
+      expect(runTranspiledCode('Promise.resolve([]).constructor').name).to.equal('Promise');
+      expect(runTranspiledCode('Promise.resolve([]).constructor.name')).to.equal('Promise');
+    });
+  });
+
+  context('scoping', () => {
+    it('adds functions to the global scope as expected', () => {
+      const f = runTranspiledCode('function f() {}');
+      expect(f.constructor.name).to.equal('Function');
+      expect(ctx.f).to.equal(f);
+    });
+
+    it('adds var declarations to the global scope as expected', () => {
+      const a = runTranspiledCode('var a = 10;');
+      expect(a).to.equal(10);
+      expect(ctx.a).to.equal(a);
+    });
+
+    it('adds let declarations to the global scope as expected (unlike regular JS)', () => {
+      const a = runTranspiledCode('let a = 10;');
+      expect(a).to.equal(undefined);
+      expect(ctx.a).to.equal(10);
+    });
+
+    it('adds const declarations to the global scope as expected (unlike regular JS)', () => {
+      const a = runTranspiledCode('const a = 11;');
+      expect(a).to.equal(undefined);
+      expect(ctx.a).to.equal(11);
+    });
+
+    it('adds block-scoped functions to the global scope as expected', () => {
+      const f = runTranspiledCode('f(); { function f() {} }');
+      expect(f.constructor.name).to.equal('Function');
+      expect(ctx.f).to.equal(f);
+    });
+
+    it('adds block-scoped var declarations to the global scope as expected', () => {
+      const a = runTranspiledCode('{ var a = 10; }');
+      expect(a).to.equal(10);
+      expect(ctx.a).to.equal(a);
+    });
+
+    it('does not add block-scoped let declarations to the global scope', () => {
+      const a = runTranspiledCode('{ let a = 10; a }');
+      expect(a).to.equal(10);
+      expect(ctx.a).to.equal(undefined);
+    });
+
+    it('does not make let declarations implicit completion records', () => {
+      const a = runTranspiledCode('{ let a = 10; }');
+      expect(a).to.equal(undefined);
+      expect(ctx.a).to.equal(undefined);
+    });
+
+    it('does not make const declarations implicit completion records', () => {
+      const a = runTranspiledCode('{ const a = 10; }');
+      expect(a).to.equal(undefined);
+      expect(ctx.a).to.equal(undefined);
+    });
+
+    it('moves top-level classes into the top-level scope', () => {
+      const A = runTranspiledCode('class A {}');
+      expect(A.constructor.name).to.equal('Function');
+      expect(A.name).to.equal('A');
+      expect(ctx.A).to.equal(A);
+    });
+
+    it('does not move classes from block scopes to the top-level scope', () => {
+      const A = runTranspiledCode('{ class A {} }');
+      expect(A).to.equal(undefined);
+      expect(ctx.A).to.equal(undefined);
+    });
+
+    it('does not make top-level classes accessible before their definition', () => {
+      expect(() => runTranspiledCode('var a = new A(); class A {}')).to.throw();
+    });
+
+    it('does not make block-scoped classes accessible before their definition', () => {
+      expect(() => runTranspiledCode('{ var a = new A(); class A {} }')).to.throw();
+    });
+  });
+
+  context('implicit awaiting', () => {
+    it('does not implicitly await plain function calls', async() => {
+      plainFn.resolves({ foo: 'bar' });
+      const ret = runTranspiledCode('plainFn()');
+      expect(ret.constructor.name).to.equal('Promise');
+      expect(ret[Symbol.for('@@mongosh.syntheticPromise')]).to.equal(undefined);
+      expect((await ret).foo).to.equal('bar');
+
+      expect(await runTranspiledCode('plainFn().foo')).to.equal(undefined);
+    });
+
+    it('marks function calls as implicitly awaited when requested', async() => {
+      implicitlyAsyncFn.resolves({ foo: 'bar' });
+      const ret = runTranspiledCode('implicitlyAsyncFn()');
+      expect(ret.constructor.name).to.equal('Promise');
+      expect(ret[Symbol.for('@@mongosh.syntheticPromise')]).to.equal(true);
+      expect((await ret).foo).to.equal('bar');
+
+      expect(await runTranspiledCode('implicitlyAsyncFn().foo')).to.equal('bar');
+    });
+
+    it('does not implicitly await plain method calls', async() => {
+      plainMethod.resolves({ foo: 'bar' });
+      const ret = runTranspiledCode('obj.plainMethod()');
+      expect(ret.constructor.name).to.equal('Promise');
+      expect(ret[Symbol.for('@@mongosh.syntheticPromise')]).to.equal(undefined);
+      expect((await ret).foo).to.equal('bar');
+
+      expect(await runTranspiledCode('obj.plainMethod().foo')).to.equal(undefined);
+    });
+
+    it('marks method calls as implicitly awaited when requested', async() => {
+      implicitlyAsyncMethod.resolves({ foo: 'bar' });
+      const ret = runTranspiledCode('obj.implicitlyAsyncMethod()');
+      expect(ret.constructor.name).to.equal('Promise');
+      expect(ret[Symbol.for('@@mongosh.syntheticPromise')]).to.equal(true);
+      expect((await ret).foo).to.equal('bar');
+
+      expect(await runTranspiledCode('obj.implicitlyAsyncMethod().foo')).to.equal('bar');
+    });
+
+    it('can implicitly await inside of class methods', async() => {
+      implicitlyAsyncFn.resolves({ foo: 'bar' });
+      const ret = runTranspiledCode(`class A {
+        method() { return implicitlyAsyncFn().foo; }
+      }; new A().method()`);
+      expect(ret.constructor.name).to.equal('Promise');
+      expect(ret[Symbol.for('@@mongosh.syntheticPromise')]).to.equal(true);
+      expect(await ret).to.equal('bar');
+    });
+
+    it('cannot implicitly await inside of class constructors', async() => {
+      implicitlyAsyncFn.resolves({ foo: 'bar' });
+      expect(runTranspiledCode(`class A {
+        constructor() { this.value = implicitlyAsyncFn().foo; }
+      }; new A()`).value).to.equal(undefined);
+    });
+
+    it('can implicitly await inside of functions', async() => {
+      implicitlyAsyncFn.resolves({ foo: 'bar' });
+      const ret = runTranspiledCode(`(function() {
+        return implicitlyAsyncFn().foo;
+      })()`);
+      expect(ret.constructor.name).to.equal('Promise');
+      expect(ret[Symbol.for('@@mongosh.syntheticPromise')]).to.equal(true);
+      expect(await ret).to.equal('bar');
+    });
+
+    it('can implicitly await inside of async functions', async() => {
+      implicitlyAsyncFn.resolves({ foo: 'bar' });
+      const ret = runTranspiledCode(`(async function() {
+        return implicitlyAsyncFn().foo;
+      })()`);
+      expect(ret.constructor.name).to.equal('Promise');
+      expect(await ret).to.equal('bar');
+    });
+
+    it('can implicitly await inside of async generator functions', async() => {
+      implicitlyAsyncFn.resolves({ foo: 'bar' });
+      const ret = runTranspiledCode(`(async function() {
+        const gen = (async function*() {
+          yield implicitlyAsyncFn().foo;
+        })();
+        for await (const value of gen) return value;
+      })()`);
+      expect(ret.constructor.name).to.equal('Promise');
+      expect(await ret).to.equal('bar');
+    });
+
+    it('cannot implicitly await inside of plain generator functions', async() => {
+      implicitlyAsyncFn.resolves({ foo: 'bar' });
+      expect(runTranspiledCode(`(function() {
+        const gen = (function*() {
+          yield implicitlyAsyncFn().foo;
+        })();
+        for (const value of gen) return value;
+      })()`)).to.equal(undefined);
+    });
+
+    it('can implicitly await inside of shorthand arrow functions', async() => {
+      implicitlyAsyncFn.resolves({ foo: 'bar' });
+      const ret = runTranspiledCode('(() => implicitlyAsyncFn().foo)()');
+      expect(ret.constructor.name).to.equal('Promise');
+      expect(ret[Symbol.for('@@mongosh.syntheticPromise')]).to.equal(true);
+      expect(await ret).to.equal('bar');
+    });
+
+    it('can implicitly await inside of block-statement arrow functions', async() => {
+      implicitlyAsyncFn.resolves({ foo: 'bar' });
+      const ret = runTranspiledCode('(() => { return implicitlyAsyncFn().foo; })()');
+      expect(ret.constructor.name).to.equal('Promise');
+      expect(ret[Symbol.for('@@mongosh.syntheticPromise')]).to.equal(true);
+      expect(await ret).to.equal('bar');
+    });
+
+    it('can implicitly await inside of branches', async() => {
+      implicitlyAsyncFn.resolves({ foo: 'bar' });
+      const ret = runTranspiledCode(`
+      if (true) {
+        implicitlyAsyncFn().foo;
+      } else {
+        null;
+      }`);
+      expect(ret.constructor.name).to.equal('Promise');
+      expect(ret[Symbol.for('@@mongosh.syntheticPromise')]).to.equal(true);
+      expect(await ret).to.equal('bar');
+    });
+
+    it('can implicitly await inside of loops', async() => {
+      implicitlyAsyncFn.resolves({ foo: 'bar' });
+      const ret = runTranspiledCode(`
+      do {
+        implicitlyAsyncFn().foo;
+      } while(false)`);
+      expect(ret.constructor.name).to.equal('Promise');
+      expect(ret[Symbol.for('@@mongosh.syntheticPromise')]).to.equal(true);
+      expect(await ret).to.equal('bar');
+    });
+
+    it('can implicitly await inside of for loops', async() => {
+      implicitlyAsyncFn.resolves({ foo: 'bar' });
+      const ret = runTranspiledCode(`
+      let value;
+      for (let i = 0; i < 10; i++) {
+        value = implicitlyAsyncFn().foo;
+      }
+      value`);
+      expect(ret.constructor.name).to.equal('Promise');
+      expect(ret[Symbol.for('@@mongosh.syntheticPromise')]).to.equal(true);
+      expect(await ret).to.equal('bar');
+      expect(implicitlyAsyncFn).to.have.callCount(10);
+    });
+
+    it('works with assignments to objects', async() => {
+      implicitlyAsyncFn.resolves({ foo: 'bar' });
+      const ret = runTranspiledCode(`
+      const x = {};
+      x.key = implicitlyAsyncFn().foo;
+      x.key;`);
+      expect(ret.constructor.name).to.equal('Promise');
+      expect(ret[Symbol.for('@@mongosh.syntheticPromise')]).to.equal(true);
+      expect(await ret).to.equal('bar');
+    });
+  });
+
+  context('error handling', () => {
+    it('handles syntax errors properly', () => {
+      expect(() => runTranspiledCode('foo(')).to.throw(/Unexpected token/);
+    });
+
+    it('accepts comments at the end of code', async() => {
+      implicitlyAsyncFn.resolves({ foo: 'bar' });
+      expect(await runTranspiledCode('implicitlyAsyncFn().foo // comment')).to.equal('bar');
+    });
+  });
+
+  context('runtime support', () => {
+    beforeEach(() => {
+      runUntranspiledCode(asyncWriter.runtimeSupportCode());
+    });
+
+    context('async', () => {
+      it('supports Array.prototype.forEach', async() => {
+        implicitlyAsyncFn.resolves({ foo: 'bar' });
+        expect(await runTranspiledCode(`
+          const a = [implicitlyAsyncFn];
+          let value;
+          a.forEach((fn) => { value = fn().foo; });
+          value;
+        `)).to.equal('bar');
+      });
+
+      it('supports Array.prototype.map', async() => {
+        implicitlyAsyncFn.resolves({ foo: 'bar' });
+        expect((await runTranspiledCode(`
+          [implicitlyAsyncFn].map((fn) => fn());
+        `))[0].foo).to.equal('bar');
+      });
+
+      it('supports Array.prototype.find', async() => {
+        implicitlyAsyncFn.resolves({ foo: 'bar' });
+        expect((await runTranspiledCode(`
+          [() => 0, implicitlyAsyncFn].find((fn) => fn())();
+        `)).foo).to.equal('bar');
+      });
+
+      it('supports Array.prototype.some', async() => {
+        implicitlyAsyncFn.callsFake(value => value);
+        expect(await runTranspiledCode(`
+          [{ prop: 'prop' }].some((value) => implicitlyAsyncFn(value).prop === 'prop');
+        `)).to.equal(true);
+      });
+
+      it('supports Array.prototype.every', async() => {
+        implicitlyAsyncFn.callsFake(value => value);
+        expect(await runTranspiledCode(`
+          [{ prop: 'prop' }].every((value) => implicitlyAsyncFn(value).prop === 'prop');
+        `)).to.equal(true);
+      });
+
+      it('supports Array.prototype.filter', async() => {
+        implicitlyAsyncFn.callsFake(value => value);
+        expect(await runTranspiledCode(`
+          [
+            { prop: 'prop' },
+            { prop: 'other' }
+          ].filter((value) => implicitlyAsyncFn(value).prop === 'prop');
+        `)).to.deep.equal([{ prop: 'prop' }]);
+      });
+
+      it('supports Array.prototype.findIndex', async() => {
+        implicitlyAsyncFn.resolves({ foo: 'bar' });
+        expect(await runTranspiledCode(`
+          const arr = [() => 0, implicitlyAsyncFn];
+          arr.findIndex((fn) => fn());
+        `)).to.equal(1);
+      });
+
+      it('supports Array.prototype.reduce', async() => {
+        implicitlyAsyncFn.callsFake((left, right) => left + right);
+        expect(await runTranspiledCode(`
+          [1,2,3].reduce(implicitlyAsyncFn, 0)
+        `)).to.equal(6);
+      });
+
+      it('supports Array.prototype.reduceRight', async() => {
+        implicitlyAsyncFn.callsFake((left, right) => left + right);
+        expect(await runTranspiledCode(`
+          [1,2,3].reduceRight(implicitlyAsyncFn, 0)
+        `)).to.equal(6);
+      });
+
+      it('supports TypedArray.prototype.map', async() => {
+        implicitlyAsyncFn.callsFake(v => v + 1);
+        expect(await runTranspiledCode(`
+          new Uint8Array([ 1, 2, 3 ]).map(implicitlyAsyncFn).reduce((a, b) => a + b)
+        `)).to.equal(9);
+      });
+
+      it('supports TypedArray.prototype.filter', async() => {
+        implicitlyAsyncFn.callsFake(v => v < 3);
+        expect(await runTranspiledCode(`
+          new Uint8Array([ 1, 2, 3 ]).filter(implicitlyAsyncFn).reduce((a, b) => a + b)
+        `)).to.equal(3);
+      });
+
+      it('supports Map.prototype.forEach', async() => {
+        const map = await runTranspiledCode(`
+          const map = new Map([[1,2], [3,4]]);
+          map.forEach(implicitlyAsyncFn);
+          map
+        `);
+        expect(implicitlyAsyncFn).to.have.been.calledWith(2, 1, map);
+        expect(implicitlyAsyncFn).to.have.been.calledWith(4, 3, map);
+      });
+
+      it('supports Set.prototype.forEach', async() => {
+        const set = await runTranspiledCode(`
+          const set = new Set([ 2, 4, 6 ]);
+          set.forEach(implicitlyAsyncFn);
+          set
+        `);
+        expect(implicitlyAsyncFn).to.have.been.calledWith(2, 2, set);
+        expect(implicitlyAsyncFn).to.have.been.calledWith(4, 4, set);
+        expect(implicitlyAsyncFn).to.have.been.calledWith(6, 6, set);
+      });
+    });
+
+    context('synchronous', () => {
+      it('supports Array.prototype.forEach', () => {
+        plainFn.returns({ foo: 'bar' });
+        expect(runTranspiledCode(`
+          const a = [plainFn];
+          let value;
+          a.forEach((fn) => { value = fn().foo; });
+          value;
+        `)).to.equal('bar');
+      });
+
+      it('supports Array.prototype.map', () => {
+        plainFn.returns({ foo: 'bar' });
+        expect(( runTranspiledCode(`
+          [plainFn].map((fn) => fn());
+        `))[0].foo).to.equal('bar');
+      });
+
+      it('supports Array.prototype.find', () => {
+        plainFn.returns({ foo: 'bar' });
+        expect(( runTranspiledCode(`
+          [() => 0, plainFn].find((fn) => fn())();
+        `)).foo).to.equal('bar');
+      });
+
+      it('supports Array.prototype.some', () => {
+        plainFn.callsFake(value => value);
+        expect(runTranspiledCode(`
+          [{ prop: 'prop' }].some((value) => plainFn(value).prop === 'prop');
+        `)).to.equal(true);
+      });
+
+      it('supports Array.prototype.every', () => {
+        plainFn.callsFake(value => value);
+        expect(runTranspiledCode(`
+          [{ prop: 'prop' }].every((value) => plainFn(value).prop === 'prop');
+        `)).to.equal(true);
+      });
+
+      it('supports Array.prototype.filter', () => {
+        plainFn.callsFake(value => value);
+        expect(runTranspiledCode(`
+          [
+            { prop: 'prop' },
+            { prop: 'other' }
+          ].filter((value) => plainFn(value).prop === 'prop');
+        `)).to.deep.equal([{ prop: 'prop' }]);
+      });
+
+      it('supports Array.prototype.findIndex', () => {
+        plainFn.returns({ foo: 'bar' });
+        expect(runTranspiledCode(`
+          const arr = [() => 0, plainFn];
+          arr.findIndex((fn) => fn());
+        `)).to.equal(1);
+      });
+
+      it('supports Array.prototype.reduce', () => {
+        plainFn.callsFake((left, right) => left + right);
+        expect(runTranspiledCode(`
+          [1,2,3].reduce(plainFn, 0)
+        `)).to.equal(6);
+      });
+
+      it('supports Array.prototype.reduceRight', () => {
+        plainFn.callsFake((left, right) => left + right);
+        expect(runTranspiledCode(`
+          [1,2,3].reduceRight(plainFn, 0)
+        `)).to.equal(6);
+      });
+
+      it('supports TypedArray.prototype.map', () => {
+        plainFn.callsFake(v => v + 1);
+        expect(runTranspiledCode(`
+          new Uint8Array([ 1, 2, 3 ]).map(plainFn).reduce((a, b) => a + b)
+        `)).to.equal(9);
+      });
+
+      it('supports TypedArray.prototype.filter', () => {
+        plainFn.callsFake(v => v < 3);
+        expect(runTranspiledCode(`
+          new Uint8Array([ 1, 2, 3 ]).filter(plainFn).reduce((a, b) => a + b)
+        `)).to.equal(3);
+      });
+
+      it('supports Map.prototype.forEach', () => {
+        const map = runTranspiledCode(`
+          const map = new Map([[1,2], [3,4]]);
+          map.forEach(plainFn);
+          map
+        `);
+        expect(plainFn).to.have.been.calledWith(2, 1, map);
+        expect(plainFn).to.have.been.calledWith(4, 3, map);
+      });
+
+      it('supports Set.prototype.forEach', () => {
+        const set = runTranspiledCode(`
+          const set = new Set([ 2, 4, 6 ]);
+          set.forEach(plainFn);
+          set
+        `);
+        expect(plainFn).to.have.been.calledWith(2, 2, set);
+        expect(plainFn).to.have.been.calledWith(4, 4, set);
+        expect(plainFn).to.have.been.calledWith(6, 6, set);
+      });
+    });
+  });
+});

--- a/packages/async-rewriter2/src/async-writer-babel.ts
+++ b/packages/async-rewriter2/src/async-writer-babel.ts
@@ -422,7 +422,7 @@ export const makeMaybeAsyncFunctionPlugin = ({ types: t }: { types: typeof Babel
           // Minor adjustment: When we encounter a 'shorthand' arrow function,
           // i.e. `(...args) => returnValueExpression`, we transform it into
           // one with a block body containing a single return statement.
-          if (path.parentPath.isArrowFunctionExpression && path.key === 'body') {
+          if (path.parentPath.isArrowFunctionExpression() && path.key === 'body') {
             path.replaceWith(t.blockStatement([
               t.returnStatement(path.node)
             ]));

--- a/packages/async-rewriter2/src/async-writer-babel.ts
+++ b/packages/async-rewriter2/src/async-writer-babel.ts
@@ -1,0 +1,575 @@
+/* eslint no-sync: 0, no-console:0, complexity:0, dot-notation: 0 */
+import * as babel from '@babel/core';
+import * as BabelTypes from '@babel/types';
+import runtimeSupport from './runtime-support.nocov';
+
+/**
+ * General notes for this file:
+ *
+ * This file contains two babel plugins used in async rewriting, plus a helper
+ * to apply these plugins to plain code.
+ *
+ * If you have not worked with babel plugins,
+ * https://github.com/jamiebuilds/babel-handbook/blob/master/translations/en/plugin-handbook.md
+ * may be a good resource for starting with this.
+ *
+ * https://astexplorer.net/ is also massively helpful, and enables working
+ * with babel plugins as live transformers. It doesn't understand all TS syntax,
+ * but pasting the compiled output from lib/async-writer-babel.js is already
+ * a very good start.
+ *
+ * The README file for this repository contains a more high-level technical
+ * overview.
+ */
+
+/**
+ * First-step transform plugin: Wrap the entire program inside a function,
+ * and re-export variables.
+ *
+ * ```js
+ * function foo() { return db.test.find(); }
+ * class A {}
+* foo()```
+ *
+ * is converted into roughly:
+ * ```js
+ * var A;
+ *
+ * function foo() {
+ *   return db.test.find();
+ * }
+ *
+ * (() => {
+ *   A = class A {};
+ *   return foo();
+ * })();
+ * ```
+ *
+ * This is necessary because the second transformation step only works with
+ * functions, not top-level program code.
+ *
+ * It is also 'nice' in the sense that it converts 'let' and 'const' variable
+ * declarations into 'var' declarations, which is usually not something one
+ * wants to do in JS, but for REPLs it actually increases usability a lot.
+ */
+type WrapState = {
+  // All statements moved from the Program-level scope into the new function.
+  movedStatements: babel.types.Statement[];
+  // All function declarations. These have to be moved to the outermost scope
+  // in order to allow for proper hoisting semantics.
+  functionDeclarations: babel.types.FunctionDeclaration[];
+  // Whether the function-creating part has completed.
+  hasFinishedMoving: boolean;
+  // A list of all variables names that have been moved to outside of the function.
+  variables: string[];
+  // Whether the conversion of completion records into return statements already took place.
+  addedCompletionRecords: boolean;
+  // The identifier used for returning the completion record
+  completionRecordId: babel.types.Identifier;
+};
+export const wrapAsFunctionPlugin = ({ types: t }: { types: typeof BabelTypes }): babel.PluginObj<WrapState> => {
+  function asNodeKey(v: any): keyof babel.types.Node { return v; }
+  const excludeFromCompletion = asNodeKey(Symbol('excludedFromCompletion'));
+  return {
+    pre() {
+      this.movedStatements = [];
+      this.functionDeclarations = [];
+      this.hasFinishedMoving = false;
+      this.addedCompletionRecords = false;
+      this.variables = [];
+    },
+    visitor: {
+      Statement(path): void {
+        if (this.hasFinishedMoving) return;
+        if (path.isDeclaration() && !path.getFunctionParent()) {
+          // The complicated case: We've encountered a variable/function/class
+          // declaration.
+          if (path.isVariableDeclaration()) {
+            if (path.parentPath.isProgram() || path.node.kind === 'var') {
+              // We turn variables into outermost-scope variables if they are
+              // a) hoisted 'var's with no function parent or b) let/const
+              // at the top-level (i.e. no block scoping).
+              const asAssignments = [];
+              for (const decl of path.node.declarations) {
+                // Copy variable names.
+                this.variables.push((decl.id as babel.types.Identifier).name);
+                if (decl.init !== null) {
+                  // If there is an initializer for this variable, turn it into
+                  // an assignment expression.
+                  const expr = t.assignmentExpression('=', decl.id, decl.init);
+                  if (path.node.kind !== 'var') {
+                    Object.assign(expr, { [excludeFromCompletion]: true });
+                  }
+                  asAssignments.push(t.expressionStatement(expr));
+                }
+              }
+              if (path.parentPath.isProgram()) {
+                this.movedStatements.push(...asAssignments);
+                path.remove();
+              } else {
+                path.replaceWithMultiple(asAssignments);
+              }
+              return;
+            }
+          } else if (path.isFunctionDeclaration()) {
+            // Move top-level functions separately for hoisting.
+            this.functionDeclarations.push(path.node);
+            if (path.node.id) {
+              path.replaceWith(t.expressionStatement(path.node.id));
+            } else {
+              // Unsure how to reach this, but babel says the type of
+              // FunctionDeclaration['id'] is 'Identifier | null'.
+              path.remove();
+            }
+            return;
+          } else if (path.isClassDeclaration() && path.parentPath.isProgram()) {
+            // Convert this declaration into an assignment expression, i.e.
+            // `class A {}` becomes `A = class A {}`.
+            // Unlike `var`
+            this.variables.push(path.node.id.name);
+            this.movedStatements.push(
+              t.expressionStatement(
+                t.assignmentExpression('=', path.node.id,
+                  t.classExpression(
+                    path.node.id, path.node.superClass, path.node.body))));
+            path.replaceWith(t.expressionStatement(path.node.id));
+            return;
+          }
+        }
+        // All other declarations are currently either about TypeScript
+        // or ES modules. We treat them like non-declaration statements here
+        // and move them into the generated IIFE.
+        if (path.parentPath.isProgram()) {
+          this.movedStatements.push(path.node);
+        }
+      },
+      Program: {
+        enter(path) {
+          // If the body of the program consists of a single string literal,
+          // we want to intepret it as such and not as a a directive (that is,
+          // a "use strict"-like thing).
+          if (path.node.directives.length === 1 &&
+              path.node.directives[0].value.type === 'DirectiveLiteral') {
+            path.replaceWith(t.program([
+              t.expressionStatement(
+                t.stringLiteral(path.node.directives[0].value.value))
+            ]));
+          }
+        },
+        exit(path): void {
+          // Once we are done gathering all statements and variables,
+          // create a program that has a list of variables and the rest of the
+          // code inside an IIFE.
+          if (this.hasFinishedMoving) return;
+          this.hasFinishedMoving = true;
+          this.completionRecordId = path.scope.generateUidIdentifier('cr');
+          this.movedStatements.unshift(
+            t.variableDeclaration('var', [t.variableDeclarator(this.completionRecordId)]));
+          path.replaceWith(t.program([
+            ...this.variables.map(
+              v => t.variableDeclaration('var', [t.variableDeclarator(t.identifier(v))])),
+            ...this.functionDeclarations,
+            t.expressionStatement(t.callExpression(
+              t.arrowFunctionExpression(
+                [],
+                t.blockStatement(this.movedStatements)
+              ), []))]));
+        }
+      },
+      BlockStatement: {
+        exit(path): void {
+          if (!this.hasFinishedMoving) return;
+          // After creating the function, we look for completion records and
+          // turn them into return statements. This applies only to body of
+          // the single top-level function that we just created.
+          if (!path.parentPath.isArrowFunctionExpression()) return;
+          if (path.parentPath.getFunctionParent()) return;
+          if (this.addedCompletionRecords) return;
+          this.addedCompletionRecords = true;
+          const records = path.getCompletionRecords();
+          for (const record of records) {
+            // ExpressionWrapper = ExpressionStatement | ParenthesizedExpression
+            if (record.isExpressionWrapper() && !record.node.expression[excludeFromCompletion]) {
+              record.replaceWith(t.expressionStatement(
+                t.assignmentExpression('=', this.completionRecordId, record.node.expression)));
+            }
+          }
+          path.replaceWith(t.blockStatement([
+            ...path.node.body,
+            t.returnStatement(this.completionRecordId)
+          ]));
+        }
+      }
+    }
+  };
+};
+
+/**
+ * The second step that performs the heavy lifting of turning regular functions
+ * into maybe-async-maybe-not functions.
+ *
+ * This consists of two main components:
+ *
+ * 1. A function meta-wrapper, where an original (non-async) function is
+ *    converted into an async function and is placed (as an "inner" function)
+ *    into the body of another function and is wrapper. If the inner function
+ *    returns (or throws) synchronously, the outer function also return
+ *    synchronously. If not, the return value is marked as a Promise that should
+ *    implicitly be awaited in other rewritten code.
+ *
+ * 2. An expression wrapper, which looks at expressions inside the original
+ *    function body, and inserts code that dynamically decides whether to await
+ *    the expressions it encounters or not at runtime.
+ *
+ * The README file has more complete code snippets.
+ */
+export const makeMaybeAsyncFunctionPlugin = ({ types: t }: { types: typeof BabelTypes }): babel.PluginObj<{}> => {
+  // We mark certain AST nodes as 'already visited' using these symbols.
+  function asNodeKey(v: any): keyof babel.types.Node { return v; }
+  const isGeneratedInnerFunction = asNodeKey(Symbol('isGeneratedInnerFunction'));
+  const isGeneratedHelper = asNodeKey(Symbol('isGeneratedHelper'));
+  const isOriginalBody = asNodeKey(Symbol('isOriginalBody'));
+  // Using this key, we store data on Function nodes that contains the identifiers
+  // of helpers which are available inside the function.
+  const identifierGroupKey = '@@mongosh.identifierGroup';
+
+  // We fetch the symbol constructor as
+  //   Object.getOwnPropertySymbols(Array.prototype)[0].constructor
+  // because Symbol refers to BSONSymbol inside the target mongosh context.
+  // (This is the only mongosh-specific hack in here.)
+  const symbolConstructor = t.memberExpression(t.memberExpression(
+    t.callExpression(
+      t.memberExpression(t.identifier('Object'), t.identifier('getOwnPropertySymbols')),
+      [t.memberExpression(t.identifier('Array'), t.identifier('prototype'))]
+    ),
+    t.identifier('0'),
+    true),
+  t.identifier('constructor'));
+
+  return {
+    visitor: {
+      BlockStatement(path) {
+        // This might be a function body. If it's what we're looking for, wrap it.
+        if (!path.parentPath.isFunction()) return;
+        // Don't wrap things we've already wrapped.
+        if (path.parentPath.getData(identifierGroupKey)) return;
+        // Don't wrap the inner function we've created while wrapping another function.
+        if (path.parentPath.node[isGeneratedInnerFunction]) return;
+        // Don't wrap helper functions with async-rewriter-generated code.
+        if (path.parentPath.node[isGeneratedHelper]) return;
+        // Don't wrap generator functions. There is no good way to handle them.
+        if (path.parentPath.node.generator && !path.parentPath.node.async) return;
+        // Finally, do not wrap constructor functions. This is not a technical
+        // necessity, but rather a result of the fact that we can't handle
+        // asynchronicity in constructors well (e.g.: What happens when you
+        // subclass a class with a constructor that returns asynchronously?).
+        if (path.parentPath.isClassMethod() &&
+            path.parentPath.node.key.type === 'Identifier' &&
+            path.parentPath.node.key.name === 'constructor') {
+          return;
+        }
+
+        // A parent function might have a set of existing helper methods.
+        // If it does, we re-use the functionally equivalent ones.
+        const existingIdentifiers =
+          path.findParent(path => !!path.getData(identifierGroupKey))?.getData(identifierGroupKey);
+
+        // Generate and store a set of identifiers for helpers.
+        const functionState = path.scope.generateUidIdentifier('fs');
+        const synchronousReturnValue = path.scope.generateUidIdentifier('srv');
+        const asynchronousReturnValue = path.scope.generateUidIdentifier('arv');
+        const expressionHolder = path.scope.generateUidIdentifier('ex');
+        const markSyntheticPromise = existingIdentifiers?.markSyntheticPromise ?? path.scope.generateUidIdentifier('msp');
+        const isSyntheticPromise = existingIdentifiers?.isSyntheticPromise ?? path.scope.generateUidIdentifier('isp');
+        const syntheticPromiseSymbol = existingIdentifiers?.syntheticPromiseSymbol ?? path.scope.generateUidIdentifier('sp');
+        path.parentPath.setData(identifierGroupKey, {
+          functionState,
+          synchronousReturnValue,
+          asynchronousReturnValue,
+          expressionHolder,
+          markSyntheticPromise,
+          isSyntheticPromise,
+          syntheticPromiseSymbol
+        });
+
+        // We generate code that vaguely looks like and insert it at the top
+        // of the wrapper function:
+        // const syntheticPromise = Symbol.for('@mongosh.syntheticPromise');
+        // function markSyntheticPromise(promise) {
+        //   return Object.defineProperty(promise, syntheticPromise, { value: true });
+        // }
+        // function isSyntheticPromise(value) {
+        //   return value && value[syntheticPromise];
+        // }
+        // Note that the last check potentially triggers getters and Proxy methods
+        // and we may want to replace it by something a bit more sophisticated.
+        // All of the top-level AST nodes here are marked as generated helpers.
+        const runtimeSupport = existingIdentifiers ? [] : [
+          Object.assign(t.variableDeclaration('const', [
+            t.variableDeclarator(
+              syntheticPromiseSymbol,
+              t.callExpression(
+                t.memberExpression(symbolConstructor, t.identifier('for')),
+                [t.stringLiteral('@@mongosh.syntheticPromise')]
+              )
+            )
+          ]), { [isGeneratedHelper]: true }),
+          Object.assign(t.functionDeclaration(
+            markSyntheticPromise,
+            [t.identifier('p')],
+            t.blockStatement([t.returnStatement(
+              t.callExpression(
+                t.memberExpression(t.identifier('Object'), t.identifier('defineProperty')),
+                [
+                  t.identifier('p'),
+                  syntheticPromiseSymbol,
+                  t.objectExpression([
+                    t.objectProperty(t.identifier('value'), t.booleanLiteral(true))
+                  ])
+                ]
+              )
+            )])
+          ), { [isGeneratedHelper]: true }),
+          Object.assign(t.functionDeclaration(
+            isSyntheticPromise,
+            [t.identifier('p')],
+            t.blockStatement([t.returnStatement(
+              t.logicalExpression(
+                '&&',
+                t.identifier('p'),
+                t.memberExpression(t.identifier('p'), syntheticPromiseSymbol, true),
+              )
+            )])
+          ), { [isGeneratedHelper]: true })
+        ];
+
+        if (path.parentPath.node.async) {
+          // If we are in an async function, no async wrapping is necessary.
+          // We still want to have the runtime helpers available.
+          path.replaceWith(t.blockStatement([
+            ...runtimeSupport,
+            ...path.node.body
+          ]));
+          return;
+        }
+
+        // Generate the wrapper function. See the README for a full code snippet.
+        path.replaceWith(t.blockStatement([
+          ...runtimeSupport,
+          // Add a variable to keep track of what state the inner function is in.
+          // It will either be 'sync', 'async', 'returned' or 'threw'.
+          t.variableDeclaration('let', [
+            t.variableDeclarator(functionState, t.stringLiteral('sync')),
+            t.variableDeclarator(synchronousReturnValue),
+            t.variableDeclarator(expressionHolder),
+          ]),
+          // Since the inner function is an async function, we store its return
+          // value and will use that if no synchronous return takes place.
+          t.variableDeclaration('const', [
+            t.variableDeclarator(
+              asynchronousReturnValue,
+              t.callExpression(
+                Object.assign(t.arrowFunctionExpression([], t.blockStatement([
+                  // Add try/catch/finally to observe returns and throws.
+                  t.tryStatement(
+                    // This is where the original function body ends up.
+                    Object.assign(path.node, { [isOriginalBody]: true }),
+                    // catch(err) { ... }
+                    t.catchClause(
+                      t.identifier('err'),
+                      t.blockStatement([t.ifStatement(
+                        t.binaryExpression('===', functionState, t.stringLiteral('sync')),
+                        t.blockStatement([
+                          t.expressionStatement(
+                            t.assignmentExpression('=', synchronousReturnValue, t.identifier('err'))
+                          ),
+                          t.expressionStatement(
+                            t.assignmentExpression('=', functionState, t.stringLiteral('threw'))
+                          )
+                        ]),
+                        t.throwStatement(t.identifier('err'))
+                      )])
+                    ),
+                    // finally { ... }
+                    t.blockStatement([t.ifStatement(
+                      t.binaryExpression('!==', functionState, t.stringLiteral('threw')),
+                      t.expressionStatement(
+                        t.assignmentExpression('=', functionState, t.stringLiteral('returned'))
+                      ),
+                    )])
+                  )
+                ]), true), { [isGeneratedInnerFunction]: true }),
+                []
+              )
+            )
+          ]),
+          // If we observe a synchronous return or throw, forward it immediately
+          // after calling the inner function.
+          t.ifStatement(
+            t.binaryExpression('===', functionState, t.stringLiteral('returned')),
+            t.returnStatement(synchronousReturnValue),
+            t.ifStatement(
+              t.binaryExpression('===', functionState, t.stringLiteral('threw')),
+              t.throwStatement(synchronousReturnValue),
+            )
+          ),
+          // Indicate that we no longer care about synchronous results.
+          t.expressionStatement(
+            t.assignmentExpression('=', functionState, t.stringLiteral('async'))
+          ),
+          t.returnStatement(
+            t.callExpression(markSyntheticPromise, [asynchronousReturnValue])
+          )
+        ]));
+      },
+      Expression: {
+        enter(path) {
+          // Minor adjustment: When we encounter a 'shorthand' arrow function,
+          // i.e. `(...args) => returnValueExpression`, we transform it into
+          // one with a block body containing a single return statement.
+          if (path.parentPath.isArrowFunctionExpression && path.key === 'body') {
+            path.replaceWith(t.blockStatement([
+              t.returnStatement(path.node)
+            ]));
+          }
+        },
+        exit(path) {
+          // We have seen an expression. If we're not inside an async function,
+          // we don't care.
+          if (!path.getFunctionParent()) return;
+          if (!path.getFunctionParent().node.async) return;
+          // identifierGroup holds the list of helper identifiers available
+          // inside thie function.
+          let identifierGroup;
+          if (path.getFunctionParent().node[isGeneratedInnerFunction]) {
+            // We are inside a generated inner function. If there is no node
+            // marked as [isOriginalBody] between it and the current node,
+            // we skip this (for example, this applies to the catch and finally
+            // blocks generated above).
+            if (!path.findParent(
+              path => path.isFunction() || !!path.node[isOriginalBody]
+            ).node[isOriginalBody]) {
+              return;
+            }
+            // We know that the outer function of the inner function has
+            // helpers available.
+            identifierGroup = path.getFunctionParent().getFunctionParent().getData(identifierGroupKey);
+            if (path.parentPath.isReturnStatement() && !path.node[isGeneratedHelper]) {
+              // If this is inside a return statement that we have not already handled,
+              // we replace the `return ...` with `return synchronousReturnValue = ...`.
+              path.replaceWith(Object.assign(
+                t.assignmentExpression('=', identifierGroup.synchronousReturnValue, path.node),
+                { [isGeneratedHelper]: true }));
+              return;
+            }
+          } else {
+            // This is a regular async function. We also transformed these above.
+            identifierGroup = path.getFunctionParent().getData(identifierGroupKey);
+          }
+
+          // If there is a [isGeneratedHelper] between the function we're in
+          // and this node, that means we've already handled this node.
+          if (path.findParent(
+            path => path.isFunction() || (path.isSequenceExpression() && !!path.node[isGeneratedHelper])
+          ).node[isGeneratedHelper]) {
+            return;
+          }
+
+          // Do not transform foo.bar() into (expr = foo.bar, ... ? await expr : expr)(),
+          // because that would mean that the `this` value inside the function is
+          // incorrect. This would be hard to get right, but it should be okay for now
+          // as we don't currently have to deal with situations in which functions
+          // themselves are something that we need to `await`.
+          // If we ever do, replacing all function calls with
+          // Function.prototype.call.call(fn, target, ...originalArgs) might be
+          // a feasible solution.
+          if (path.parentPath.isCallExpression() &&
+              path.key === 'callee' &&
+              path.isMemberExpression()) {
+            return;
+          }
+
+          // This, on the other hand, (e.g. the `foo.bar` in `foo.bar = 1`) is
+          // something that we wouldn't want to modify anyway, because it would
+          // break the assignment altogether.
+          if (path.parentPath.isAssignmentExpression() && path.key === 'left') return;
+          // ++ and -- count as assignments for our purposes.
+          if (path.parentPath.isUpdateExpression()) return;
+
+          // There are a few types of expressions that we can skip.
+          // We use this opt-out-list approach so that we don't miss any important
+          // expressions.
+          if (path.isLiteral() || // type is known to be non-Promise (here and below)
+              path.isArrayExpression() ||
+              path.isObjectExpression() ||
+              path.isFunctionExpression() ||
+              path.isArrowFunctionExpression() ||
+              path.isClassExpression() ||
+              path.isAssignmentExpression() || // sub-nodes are already awaited (ditto)
+              path.isBinaryExpression() ||
+              path.isConditionalExpression() ||
+              path.isLogicalExpression() ||
+              path.isSequenceExpression() ||
+              path.isParenthesizedExpression() ||
+              path.isUnaryExpression() ||
+              path.isSuper() || // Would probably break stuff
+              path.isAwaitExpression() || // No point in awaiting twice
+              path.parentPath.isAwaitExpression()) {
+            return;
+          }
+
+          // Transform expression `foo` into
+          // `(ex = foo, isSyntheticPromise(ex) ? await ex : ex)`
+          const { expressionHolder, isSyntheticPromise } = identifierGroup;
+          path.replaceWith(Object.assign(t.sequenceExpression([
+            t.assignmentExpression('=', expressionHolder, path.node),
+            t.conditionalExpression(
+              t.callExpression(isSyntheticPromise, [expressionHolder]),
+              t.awaitExpression(expressionHolder),
+              expressionHolder
+            )
+          ]), { [isGeneratedHelper]: true }));
+        }
+      }
+    }
+  };
+};
+
+export default class AsyncWriter {
+  step(code: string, plugins: babel.PluginItem[]): string {
+    return babel.transformSync(code, {
+      plugins,
+      code: true,
+      configFile: false,
+      babelrc: false
+    })?.code as string;
+  }
+
+  /**
+   * Returns translated code.
+   * @param code - string to compile.
+   */
+  process(code: string): string {
+    try {
+      // In the first step, we apply a number of common babel transformations
+      // that are necessary in order for subsequent steps to succeed
+      // (in particular, shorthand properties and parameters would otherwise
+      // mess with detecting expressions in their proper locations).
+      code = this.step(code, [
+        require('@babel/plugin-transform-shorthand-properties').default,
+        require('@babel/plugin-transform-parameters').default,
+        require('@babel/plugin-transform-destructuring').default
+      ]);
+      code = this.step(code, [wrapAsFunctionPlugin]);
+      code = this.step(code, [makeMaybeAsyncFunctionPlugin]);
+      return code;
+    } catch (e) {
+      e.message = e.message.replace('unknown: ', '');
+      throw e;
+    }
+  }
+
+  runtimeSupportCode(): string {
+    return this.process(runtimeSupport);
+  }
+}

--- a/packages/async-rewriter2/src/index.ts
+++ b/packages/async-rewriter2/src/index.ts
@@ -1,0 +1,2 @@
+import AsyncWriter from './async-writer-babel';
+export default AsyncWriter;

--- a/packages/async-rewriter2/src/runtime-support.nocov.js
+++ b/packages/async-rewriter2/src/runtime-support.nocov.js
@@ -1,0 +1,471 @@
+/* eslint-disable no-extend-native, eqeqeq, strict, new-cap, callback-return */
+'use strict';
+module.exports = '(' + function() {
+  // Polyfills for various callback-taking JS builtins.
+  // A lot of these are from their respective MDN pages.
+  // Modifications that are not purely linter-based are
+  // marked with XXX in that case.
+  const TypedArray = Object.getPrototypeOf(Uint8Array);
+
+  // From https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/forEach
+  Array.prototype.forEach = function(callback, thisArg) {
+    if (this == null) { throw new TypeError('Array.prototype.forEach called on null or undefined'); }
+
+    let T; let k;
+    // 1. Let O be the result of calling toObject() passing the
+    // |this| value as the argument.
+    const O = Object(this);
+
+    // 2. Let lenValue be the result of calling the Get() internal
+    // method of O with the argument "length".
+    // 3. Let len be toUint32(lenValue).
+    const len = O.length >>> 0;
+
+    // 4. If isCallable(callback) is false, throw a TypeError exception.
+    // See: https://es5.github.com/#x9.11
+    if (typeof callback !== 'function') { throw new TypeError(callback + ' is not a function'); }
+
+    // 5. If thisArg was supplied, let T be thisArg; else let
+    // T be undefined.
+    if (arguments.length > 1) { T = thisArg; }
+
+    // 6. Let k be 0
+    k = 0;
+
+    // 7. Repeat, while k < len
+    while (k < len) {
+      let kValue;
+
+      // a. Let Pk be ToString(k).
+      //    This is implicit for LHS operands of the in operator
+      // b. Let kPresent be the result of calling the HasProperty
+      //    internal method of O with argument Pk.
+      //    This step can be combined with c
+      // c. If kPresent is true, then
+      if (k in O) {
+        // i. Let kValue be the result of calling the Get internal
+        // method of O with argument Pk.
+        kValue = O[k];
+
+        // ii. Call the Call internal method of callback with T as
+        // the this value and argument list containing kValue, k, and O.
+        callback.call(T, kValue, k, O);
+      }
+      // d. Increase k by 1.
+      k++;
+    }
+    // 8. return undefined
+  };
+
+  // From https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/map
+  Array.prototype.map = function(callback/* , thisArg*/) {
+    let T; let k;
+
+    if (this == null) {
+      throw new TypeError('this is null or not defined');
+    }
+
+    // 1. Let O be the result of calling ToObject passing the |this|
+    //    value as the argument.
+    const O = Object(this);
+
+    // 2. Let lenValue be the result of calling the Get internal
+    //    method of O with the argument "length".
+    // 3. Let len be ToUint32(lenValue).
+    const len = O.length >>> 0;
+
+    // 4. If IsCallable(callback) is false, throw a TypeError exception.
+    // See: https://es5.github.com/#x9.11
+    if (typeof callback !== 'function') {
+      throw new TypeError(callback + ' is not a function');
+    }
+
+    // 5. If thisArg was supplied, let T be thisArg; else let T be undefined.
+    if (arguments.length > 1) {
+      T = arguments[1];
+    }
+
+    // 6. Let A be a new array created as if by the expression new Array(len)
+    //    where Array is the standard built-in constructor with that name and
+    //    len is the value of len.
+    const A = new O.constructor(len); // XXX Was Array(len), modified for TypedArray compat
+
+    // 7. Let k be 0
+    k = 0;
+
+    // 8. Repeat, while k < len
+    while (k < len) {
+      let kValue;
+      let mappedValue;
+
+      // a. Let Pk be ToString(k).
+      //   This is implicit for LHS operands of the in operator
+      // b. Let kPresent be the result of calling the HasProperty internal
+      //    method of O with argument Pk.
+      //   This step can be combined with c
+      // c. If kPresent is true, then
+      if (k in O) {
+        // i. Let kValue be the result of calling the Get internal
+        //    method of O with argument Pk.
+        kValue = O[k];
+
+        // ii. Let mappedValue be the result of calling the Call internal
+        //     method of callback with T as the this value and argument
+        //     list containing kValue, k, and O.
+        mappedValue = callback.call(T, kValue, k, O);
+
+        // iii. Call the DefineOwnProperty internal method of A with arguments
+        // Pk, Property Descriptor
+        // { Value: mappedValue,
+        //   Writable: true,
+        //   Enumerable: true,
+        //   Configurable: true },
+        // and false.
+
+        // In browsers that support Object.defineProperty, use the following:
+        // Object.defineProperty(A, k, {
+        //   value: mappedValue,
+        //   writable: true,
+        //   enumerable: true,
+        //   configurable: true
+        // });
+
+        // For best browser support, use the following:
+        A[k] = mappedValue;
+      }
+      // d. Increase k by 1.
+      k++;
+    }
+
+    // 9. return A
+    return A;
+  };
+
+  // From https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/some
+  Array.prototype.some = function(fun, thisArg) {
+    if (this == null) {
+      throw new TypeError('Array.prototype.some called on null or undefined');
+    }
+
+    if (typeof fun !== 'function') {
+      throw new TypeError();
+    }
+
+    const t = Object(this);
+    const len = t.length >>> 0;
+
+    for (let i = 0; i < len; i++) {
+      if (i in t && fun.call(thisArg, t[i], i, t)) {
+        return true;
+      }
+    }
+
+    return false;
+  };
+
+  // From https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/every
+  Array.prototype.every = function(callbackfn, thisArg) {
+    let T; let k;
+
+    if (this == null) {
+      throw new TypeError('this is null or not defined');
+    }
+
+    // 1. Let O be the result of calling ToObject passing the this
+    //    value as the argument.
+    const O = Object(this);
+
+    // 2. Let lenValue be the result of calling the Get internal method
+    //    of O with the argument "length".
+    // 3. Let len be ToUint32(lenValue).
+    const len = O.length >>> 0;
+
+    // 4. If IsCallable(callbackfn) is false, throw a TypeError exception.
+    if (typeof callbackfn !== 'function' && Object.prototype.toString.call(callbackfn) !== '[object Function]') {
+      throw new TypeError();
+    }
+
+    // 5. If thisArg was supplied, let T be thisArg; else let T be undefined.
+    if (arguments.length > 1) {
+      T = thisArg;
+    }
+
+    // 6. Let k be 0.
+    k = 0;
+
+    // 7. Repeat, while k < len
+    while (k < len) {
+      let kValue;
+
+      // a. Let Pk be ToString(k).
+      //   This is implicit for LHS operands of the in operator
+      // b. Let kPresent be the result of calling the HasProperty internal
+      //    method of O with argument Pk.
+      //   This step can be combined with c
+      // c. If kPresent is true, then
+      if (k in O) {
+        let testResult;
+        // i. Let kValue be the result of calling the Get internal method
+        //    of O with argument Pk.
+        kValue = O[k];
+
+        // ii. Let testResult be the result of calling the Call internal method
+        // of callbackfn with T as the this value if T is not undefined
+        // else is the result of calling callbackfn
+        // and argument list containing kValue, k, and O.
+        if (T) testResult = callbackfn.call(T, kValue, k, O);
+        else testResult = callbackfn(kValue, k, O);
+
+        // iii. If ToBoolean(testResult) is false, return false.
+        if (!testResult) {
+          return false;
+        }
+      }
+      k++;
+    }
+    return true;
+  };
+
+  // From https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/filter
+  Array.prototype.filter = function(func, thisArg) {
+    if ( ! (typeof func === 'function' && this) ) {
+      throw new TypeError();
+    }
+
+    const len = this.length >>> 0;
+    const res = new Array(len); // preallocate array
+    const t = this; let c = 0; let i = -1;
+
+    let kValue;
+    if (thisArg === undefined) {
+      while (++i !== len) {
+        // checks to see if the key was set
+        if (i in this) {
+          kValue = t[i]; // in case t is changed in callback
+          if (func(t[i], i, t)) {
+            res[c++] = kValue;
+          }
+        }
+      }
+    } else {
+      while (++i !== len) {
+        // checks to see if the key was set
+        if (i in this) {
+          kValue = t[i];
+          if (func.call(thisArg, t[i], i, t)) {
+            res[c++] = kValue;
+          }
+        }
+      }
+    }
+
+    res.length = c; // shrink down array to proper size
+    return res;
+  };
+
+  // From https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/find
+  Object.defineProperty(Array.prototype, 'find', {
+    value: function(predicate) {
+      // 1. Let O be ? ToObject(this value).
+      if (this == null) {
+        throw TypeError('"this" is null or not defined');
+      }
+
+      const o = Object(this);
+
+      // 2. Let len be ? ToLength(? Get(O, "length")).
+      const len = o.length >>> 0;
+
+      // 3. If IsCallable(predicate) is false, throw a TypeError exception.
+      if (typeof predicate !== 'function') {
+        throw TypeError('predicate must be a function');
+      }
+
+      // 4. If thisArg was supplied, let T be thisArg; else let T be undefined.
+      const thisArg = arguments[1];
+
+      // 5. Let k be 0.
+      let k = 0;
+
+      // 6. Repeat, while k < len
+      while (k < len) {
+        // a. Let Pk be ! ToString(k).
+        // b. Let kValue be ? Get(O, Pk).
+        // c. Let testResult be ToBoolean(? Call(predicate, T, « kValue, k, O »)).
+        // d. If testResult is true, return kValue.
+        const kValue = o[k];
+        if (predicate.call(thisArg, kValue, k, o)) {
+          return kValue;
+        }
+        // e. Increase k by 1.
+        k++;
+      }
+
+      // 7. Return undefined.
+      return undefined;
+    },
+    configurable: true,
+    writable: true
+  });
+
+  // From https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/findIndex
+  Object.defineProperty(Array.prototype, 'findIndex', {
+    value: function(predicate) {
+      // 1. Let O be ? ToObject(this value).
+      if (this == null) {
+        throw new TypeError('"this" is null or not defined');
+      }
+
+      const o = Object(this);
+
+      // 2. Let len be ? ToLength(? Get(O, "length")).
+      const len = o.length >>> 0;
+
+      // 3. If IsCallable(predicate) is false, throw a TypeError exception.
+      if (typeof predicate !== 'function') {
+        throw new TypeError('predicate must be a function');
+      }
+
+      // 4. If thisArg was supplied, let T be thisArg; else let T be undefined.
+      const thisArg = arguments[1];
+
+      // 5. Let k be 0.
+      let k = 0;
+
+      // 6. Repeat, while k < len
+      while (k < len) {
+        // a. Let Pk be ! ToString(k).
+        // b. Let kValue be ? Get(O, Pk).
+        // c. Let testResult be ToBoolean(? Call(predicate, T, « kValue, k, O »)).
+        // d. If testResult is true, return k.
+        const kValue = o[k];
+        if (predicate.call(thisArg, kValue, k, o)) {
+          return k;
+        }
+        // e. Increase k by 1.
+        k++;
+      }
+
+      // 7. Return -1.
+      return -1;
+    },
+    configurable: true,
+    writable: true
+  });
+
+  // From https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduce
+  Array.prototype.reduce = function(callback /* , initialValue*/) {
+    if (this === null) {
+      throw new TypeError( 'Array.prototype.reduce ' +
+        'called on null or undefined' );
+    }
+    if (typeof callback !== 'function') {
+      throw new TypeError( callback +
+        ' is not a function');
+    }
+
+    // 1. Let O be ? ToObject(this value).
+    const o = Object(this);
+
+    // 2. Let len be ? ToLength(? Get(O, "length")).
+    const len = o.length >>> 0;
+
+    // Steps 3, 4, 5, 6, 7
+    let k = 0;
+    let value;
+
+    if (arguments.length >= 2) {
+      value = arguments[1];
+    } else {
+      while (k < len && !(k in o)) {
+        k++;
+      }
+
+      // 3. If len is 0 and initialValue is not present,
+      //    throw a TypeError exception.
+      if (k >= len) {
+        throw new TypeError( 'Reduce of empty array ' +
+          'with no initial value' );
+      }
+      value = o[k++];
+    }
+
+    // 8. Repeat, while k < len
+    while (k < len) {
+      // a. Let Pk be ! ToString(k).
+      // b. Let kPresent be ? HasProperty(O, Pk).
+      // c. If kPresent is true, then
+      //    i.  Let kValue be ? Get(O, Pk).
+      //    ii. Let accumulator be ? Call(
+      //          callbackfn, undefined,
+      //          « accumulator, kValue, k, O »).
+      if (k in o) {
+        value = callback(value, o[k], k, o);
+      }
+
+      // d. Increase k by 1.
+      k++;
+    }
+
+    // 9. Return accumulator.
+    return value;
+  };
+
+  // From https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Array/reduceRight
+  Array.prototype.reduceRight = function(callback /* , initialValue*/) {
+    if (this === null || typeof this === 'undefined') {
+      throw new TypeError('Array.prototype.reduce called on null or undefined');
+    }
+    if (typeof callback !== 'function') {
+      throw new TypeError(callback + ' is not a function');
+    }
+    const t = Object(this); const len = t.length >>> 0; let k = len - 1; let value;
+    if (arguments.length >= 2) {
+      value = arguments[1];
+    } else {
+      while (k >= 0 && !(k in t)) {
+        k--;
+      }
+      if (k < 0) {
+        throw new TypeError('Reduce of empty array with no initial value');
+      }
+      value = t[k--];
+    }
+    for (; k >= 0; k--) {
+      if (k in t) {
+        value = callback(value, t[k], k, t);
+      }
+    }
+    return value;
+  };
+
+  // Custom: Map.prototype.forEach and Set.prototype.forEach
+  Map.prototype.forEach = function(callback, thisArg) {
+    [...this].forEach(([key, value]) => {
+      callback.call(thisArg, value, key, this);
+    });
+  };
+  Set.prototype.forEach = function(callback, thisArg) {
+    [...this].forEach(value => {
+      callback.call(thisArg, value, value, this);
+    });
+  };
+
+  // Currently Missing: (Typed)Array.prototype.sort
+  // Currently Missing: Array.prototype.flatMap
+
+  TypedArray.prototype.reduce = Array.prototype.reduce;
+  TypedArray.prototype.reduceRight = Array.prototype.reduceRight;
+  TypedArray.prototype.findIndex = Array.prototype.findIndex;
+  TypedArray.prototype.find = Array.prototype.find;
+  TypedArray.prototype.forEach = Array.prototype.forEach;
+  TypedArray.prototype.map = Array.prototype.map;
+  TypedArray.prototype.some = Array.prototype.some;
+  TypedArray.prototype.every = Array.prototype.every;
+  // Also custom. Can't use Array.prototype.filter here because that defines
+  // the length ahead of the filtering.
+  TypedArray.prototype.filter = function(func, thisArg) {
+    const array = Array.prototype.filter.call(this, func, thisArg);
+    return new (this.constructor)(array);
+  };
+} + ')();';

--- a/packages/async-rewriter2/tsconfig.json
+++ b/packages/async-rewriter2/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "extends": "../../config/tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "./lib",
+    "allowJs": true
+  },
+  "include": [
+    "./src/**/*"
+  ],
+  "exclude": [
+    "./src/**/*.spec.*"
+  ]
+}

--- a/packages/cli-repl/test/e2e-fle.spec.ts
+++ b/packages/cli-repl/test/e2e-fle.spec.ts
@@ -111,6 +111,7 @@ describe('FLE tests', () => {
     const shell = TestShell.start({
       args: ['--nodb']
     });
+    await shell.waitForPrompt();
     await shell.executeLine('local = { key: BinData(0, "kh4Gv2N8qopZQMQYMEtww/AkPsIrXNmEMxTrs3tUoTQZbZu4msdRUaR8U5fXD7A7QXYHcEvuu4WctJLoT+NvvV3eeIg3MD+K8H9SR794m/safgRHdIfy6PD+rFpvmFbY") }');
     await shell.executeLine(`keyMongo = Mongo(${JSON.stringify(await testServer.connectionString())}, { \
       keyVaultNamespace: '${dbname}.keyVault', \

--- a/packages/shell-api/src/decorators.ts
+++ b/packages/shell-api/src/decorators.ts
@@ -123,9 +123,9 @@ function wrapWithAddSourceToResult(fn: Function): Function {
     return result;
   }
   const wrapper = (fn as any).returnsPromise ?
-    async function(this: any, ...args: any[]): Promise<any> {
+    markImplicitlyAwaited(async function(this: any, ...args: any[]): Promise<any> {
       return addSource(await fn.call(this, ...args), this);
-    } : function(this: any, ...args: any[]): any {
+    }) : function(this: any, ...args: any[]): any {
       return addSource(fn.call(this, ...args), this);
     };
   Object.setPrototypeOf(wrapper, Object.getPrototypeOf(fn));
@@ -292,6 +292,18 @@ export function shellApiClassDefault(constructor: Function): void {
   signatures[className] = classSignature;
 }
 
+function markImplicitlyAwaited<T extends(...args: any) => Promise<any>>(orig: T): ((...args: Parameters<T>) => Promise<any>) {
+  function wrapper(this: any, ...args: any[]) {
+    return addHiddenDataProperty(
+      Promise.resolve(orig.call(this, ...args)),
+      Symbol.for('@@mongosh.syntheticPromise'),
+      true);
+  }
+  Object.setPrototypeOf(wrapper, Object.getPrototypeOf(orig));
+  Object.defineProperties(wrapper, Object.getOwnPropertyDescriptors(orig));
+  return wrapper;
+}
+
 export { signatures };
 export function serverVersions(versionArray: [ string, string ]): Function {
   return function(
@@ -315,7 +327,9 @@ export function topologies(topologiesArray: Topologies[]): Function {
   };
 }
 export function returnsPromise(_target: any, _propertyKey: string, descriptor: PropertyDescriptor): void {
-  descriptor.value.returnsPromise = true;
+  const orig = descriptor.value;
+  orig.returnsPromise = true;
+  descriptor.value = markImplicitlyAwaited(descriptor.value);
 }
 export function directShellCommand(_target: any, _propertyKey: string, descriptor: PropertyDescriptor): void {
   descriptor.value.isDirectShellCommand = true;

--- a/packages/shell-api/src/decorators.ts
+++ b/packages/shell-api/src/decorators.ts
@@ -294,10 +294,12 @@ export function shellApiClassDefault(constructor: Function): void {
 
 function markImplicitlyAwaited<T extends(...args: any) => Promise<any>>(orig: T): ((...args: Parameters<T>) => Promise<any>) {
   function wrapper(this: any, ...args: any[]) {
-    return addHiddenDataProperty(
-      Promise.resolve(orig.call(this, ...args)),
+    const origResult = orig.call(this, ...args);
+    return Object.prototype.toString.call(origResult) === '[object Promise]' ? addHiddenDataProperty(
+      origResult,
       Symbol.for('@@mongosh.syntheticPromise'),
-      true);
+      true
+    ) : origResult;
   }
   Object.setPrototypeOf(wrapper, Object.getPrototypeOf(orig));
   Object.defineProperties(wrapper, Object.getOwnPropertyDescriptors(orig));

--- a/packages/shell-api/src/helpers.ts
+++ b/packages/shell-api/src/helpers.ts
@@ -507,13 +507,14 @@ export function tsToSeconds(x: any): number {
   return x / 4294967296; // low 32 bits are ordinal #s within a second
 }
 
-export function addHiddenDataProperty(target: object, key: string|symbol, value: any): void {
+export function addHiddenDataProperty<T = any>(target: T, key: string|symbol, value: any): T {
   Object.defineProperty(target, key, {
     value,
     enumerable: false,
     writable: true,
     configurable: true
   });
+  return target;
 }
 
 export async function iterate(

--- a/packages/shell-api/src/shell-internal-state.ts
+++ b/packages/shell-api/src/shell-internal-state.ts
@@ -89,7 +89,7 @@ export default class ShellInternalState {
   public currentCursor: Cursor | AggregationCursor | ChangeStreamCursor | null;
   public currentDb: Database;
   public messageBus: MongoshBus;
-  public asyncWriter: AsyncWriter;
+  public asyncWriter: { process(code: string): string };
   public initialServiceProvider: ServiceProvider; // the initial service provider
   public uri: string | null;
   public connectionInfo: any;
@@ -203,7 +203,8 @@ export default class ShellInternalState {
     } as any;
     Object.assign(apiObjects, signatures.ShellApi.attributes);
     delete apiObjects.Mongo;
-    this.asyncWriter.symbols.initializeApiObjects(apiObjects);
+    // eslint-disable-next-line chai-friendly/no-unused-expressions
+    (this.asyncWriter as any)?.symbols?.initializeApiObjects(apiObjects);
 
     const setFunc = (newDb: any): Database => {
       if (getShellApiType(newDb) !== 'Database') {

--- a/packages/shell-evaluator/src/shell-evaluator.spec.ts
+++ b/packages/shell-evaluator/src/shell-evaluator.spec.ts
@@ -79,11 +79,9 @@ describe('ShellEvaluator', () => {
     it('calls original eval for plain javascript', async() => {
       const originalEval = sinon.spy();
       await shellEvaluator.customEval(originalEval, 'doSomething();', {}, '');
-      expect(originalEval).to.have.been.calledWith(
-        'doSomething();',
-        {},
-        ''
-      );
+      expect(originalEval.firstCall.args[0]).to.include('doSomething');
+      expect(originalEval.firstCall.args[1]).to.deep.equal({});
+      expect(originalEval.firstCall.args[2]).to.equal('');
     });
     it('reverts state if error thrown', async() => {
       const originalEval = (): any => { throw new Error(); };


### PR DESCRIPTION
This is about as far as I’d want to go without some kind of confirmation that we want to explore this further, but I am quite happy with it so far, and it already passes the test suite (almost – except for the parts that specifically test the “old” async-rewriter integration) locally.

---

See the [package’s README.md](https://github.com/mongodb-js/mongosh/blob/async-rewriter2/packages/async-rewriter2/README.md) for details on the why and how.
This is feature-flagged behind the `MONGOSH_ASYNC_REWRITER2`
env var and introduced as a separate package in this commit,
but if we do adopt this it’s going to enable us to remove
a lot of code *and* have a more flexible async-rewriting system.