### PR TITLE
chore(shell-api): ensure backwards compatibility of old number classes

### DIFF
--- a/packages/shell-api/src/helpers.spec.ts
+++ b/packages/shell-api/src/helpers.spec.ts
@@ -10,7 +10,7 @@ import chai, { expect } from 'chai';
 import sinonChai from 'sinon-chai';
 chai.use(sinonChai);
 
-const fakeConfigDb = makeFakeConfigDatabase(constructShellBson(bson));
+const fakeConfigDb = makeFakeConfigDatabase(constructShellBson(bson, sinon.stub()));
 
 describe('dataFormat', () => {
   it('formats byte amounts', () => {

--- a/packages/shell-api/src/helpers.ts
+++ b/packages/shell-api/src/helpers.ts
@@ -81,17 +81,23 @@ export function validateExplainableVerbosity(verbosity: ExplainVerbosityLike): E
   return verbosity;
 }
 
+function getAssertCaller(caller?: string): string {
+  return caller ? ` (${caller})` : '';
+}
+
 export function assertArgsDefined(...args: any[]): void {
   if (args.some(a => a === undefined)) {
     throw new MongoshInvalidInputError('Missing required argument', CommonErrors.InvalidArgument);
   }
 }
 
-export function assertArgsType(args: any[], expectedTypes: string[]): void {
+export function assertArgsType(args: any[], expectedTypes: Array<string|string[]>, func?: string): void {
   args.forEach((arg, i) => {
-    if (arg !== undefined && typeof arg !== expectedTypes[i]) {
+    const expected = expectedTypes[i];
+    if (arg !== undefined && ((typeof expected === 'string' && typeof arg !== expected) || !expected.includes(typeof arg))) {
+      const expectedMsg = typeof expected === 'string' ? expected : expected.join(' or ');
       throw new MongoshInvalidInputError(
-        `Argument at position ${i} must be of type ${expectedTypes[i]}, got ${typeof arg} instead`,
+        `Argument at position ${i} must be of type ${expectedMsg}, got ${typeof arg} instead${getAssertCaller(func)}`,
         CommonErrors.InvalidArgument
       );
     }

--- a/packages/shell-api/src/shell-internal-state.ts
+++ b/packages/shell-api/src/shell-internal-state.ts
@@ -106,7 +106,11 @@ export default class ShellInternalState {
     this.messageBus = messageBus;
     this.asyncWriter = new AsyncWriter(signatures);
     this.shellApi = new ShellApi(this);
-    this.shellBson = constructShellBson(initialServiceProvider.bsonLibrary);
+    this.shellBson = constructShellBson(initialServiceProvider.bsonLibrary, (msg: string) => {
+      if (this.context.print) {
+        this.context.print(`Warning: ${msg}`);
+      }
+    });
     this.mongos = [];
     this.connectionInfo = { buildInfo: {} };
     if (!cliOptions.nodb) {


### PR DESCRIPTION
Ensures that the following classes accept both number and string arguments:
* `NumberDecimal`
* `NumberLong`
* `NumberInt`

Also shows a deprecation / precision warning:
```
> NumberDecimal(128)
Warning: NumberDecimal: specifying a number as argument is deprecated and may lead to loss of precision
```