### PR TITLE
MONGOSH-596: sh status should include not sharder dbs

### DIFF
--- a/packages/shell-api/src/helpers.ts
+++ b/packages/shell-api/src/helpers.ts
@@ -402,7 +402,7 @@ export async function getPrintableShardStatus(db: Database, verbose: boolean): P
     return a._id > b._id;
   });
 
-  result.databases = await Promise.all(databases.filter(db => db.partitioned).map(async(db) => {
+  result.databases = await Promise.all(databases.map(async(db) => {
     const escapeRegex = (string: string): string => {
       return string.replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
     };

--- a/packages/shell-api/src/shard.spec.ts
+++ b/packages/shell-api/src/shard.spec.ts
@@ -1319,5 +1319,40 @@ describe('Shard', () => {
         expect(ret).to.equal(true);
       });
     });
+    describe('databases', () => {
+      let dbRegular: Database;
+      let dbSh: Database;
+      const dbRegularName = 'db';
+      const dbShName = 'dbSh';
+      const collRegularName = 'testRegular';
+      const collShName = 'testSh';
+
+      before(() => {
+        dbRegular = sh._database.getSiblingDB(dbRegularName);
+        dbSh = sh._database.getSiblingDB(dbShName);
+      });
+
+      afterEach(async() => {
+        await dbRegular.dropDatabase();
+        await dbSh.dropDatabase();
+      });
+
+      it('the list includes not partitioned databses', async() => {
+        await dbRegular.getCollection(collRegularName).insertOne({ foo: 'bar', key: 99 });
+
+        const collSh = dbSh.getCollection(collShName);
+        await collSh.insertOne({ name: 'some', zipcode: '11111' });
+        await collSh.createIndex({ zipcode: 1 });
+        await sh.enableSharding(dbShName);
+        await sh.shardCollection(`${dbShName}.${collShName}`, { zipcode: 1 });
+
+        const result = await sh.status();
+
+        const databasesDbItem = result.value.databases.find((item) => (item.database._id === 'db'));
+        expect(databasesDbItem.database.partitioned).to.equal(false);
+        const databasesDbShItem = result.value.databases.find((item) => (item.database._id === 'dbSh'));
+        expect(databasesDbShItem.database.partitioned).to.equal(true);
+      });
+    });
   });
 });

--- a/packages/shell-api/src/shard.spec.ts
+++ b/packages/shell-api/src/shard.spec.ts
@@ -1337,7 +1337,7 @@ describe('Shard', () => {
         await dbSh.dropDatabase();
       });
 
-      it('the list includes not partitioned databses', async() => {
+      it('the list includes not partitioned databases', async() => {
         await dbRegular.getCollection(collRegularName).insertOne({ foo: 'bar', key: 99 });
 
         const collSh = dbSh.getCollection(collShName);


### PR DESCRIPTION
The old `mongodb shell` returns sharded and not shared databases as a result of `sh.status()` command. Remove the filtering by `partitioned` value in order to ensure `mongosh` behavior compatible with the old shell.