### PR TITLE
fix(ci): work around CI Windows git failure MONGOSH-660

### DIFF
--- a/.evergreen/.setup_env
+++ b/.evergreen/.setup_env
@@ -1,7 +1,7 @@
 set -e
 set -x
 export BASEDIR="$PWD/.evergreen"
-export PATH="$BASEDIR/node-v$NODE_JS_VERSION-win-x64:/opt/python/3.6/bin:/opt/chefdk/gitbin:/cygdrive/c/Python39/Scripts:/cygdrive/c/Python39:/cygdrive/c/cmake/bin:$PATH"
+export PATH="$BASEDIR/node-v$NODE_JS_VERSION-win-x64:/opt/python/3.6/bin:/opt/chefdk/gitbin:/cygdrive/c/Program Files/Git/bin:/cygdrive/c/Program Files/Git/mingw32/libexec/git-core:/cygdrive/c/Python39/Scripts:/cygdrive/c/Python39:/cygdrive/c/cmake/bin:$PATH"
 export IS_MONGOSH_EVERGREEN_CI=1
 
 if [ "$OS" != "Windows_NT" ]; then


### PR DESCRIPTION
For some reason, Windows builds started failing recently.
The windows-64-vs2019-small image, the Node.js version,
the npm version, the git version, and the package-lock.json
all remained the same in that period, so it is unclear
what exactly caused this.

While a full investigation would likely be interesting,
that’s not easy with Evergreen’s current capabilities.

However, fixing this seems possible by explicitly adding
the git binaries (including libexec ones) to the PATH,
so let’s do that for now.