### PR TITLE
fix(async-rewriter2): fix interaction with domains MONGOSH-662

### DIFF
--- a/packages/async-rewriter2/package.json
+++ b/packages/async-rewriter2/package.json
@@ -4,6 +4,7 @@
   "description": "MongoDB Shell Async Rewriter Package",
   "main": "./lib/index.js",
   "scripts": {
+    "pretest": "npm run compile-ts",
     "test": "mocha -r \"../../scripts/import-expansions.js\" --timeout 60000 --colors -r ts-node/register \"./{src,lib}/**/*.spec.ts\"",
     "test-ci": "mocha -r \"../../scripts/import-expansions.js\" --timeout 60000 -r ts-node/register \"./{src,lib}/**/*.spec.ts\"",
     "lint": "eslint \"**/*.{js,ts,tsx}\"",

--- a/packages/async-rewriter2/test/fixtures/with-domain.js
+++ b/packages/async-rewriter2/test/fixtures/with-domain.js
@@ -1,0 +1,18 @@
+// eslint-disable-next-line strict
+'use strict';
+const { default: AsyncWriter } = require('../../');
+const domain = require('domain');
+const vm = require('vm');
+
+// This script should not enter an infinite loop. In the past, it did on
+// Node.js < 14.15.2, because domains use Array.prototype.every when being
+// entered, for which we provide a polyfill, which could lead to an async call
+// because of the async wrapping, which in turn would lead to the domain being
+// entered, and so on.
+
+const d = domain.create();
+const aw = new AsyncWriter();
+d.run(() => {
+  vm.runInThisContext(aw.runtimeSupportCode());
+  return vm.runInThisContext('(async() => 42)()');
+});


### PR DESCRIPTION
The fix I previously inserted for the “Node.js prints a warning
if we intentionally disregard a rejected Promise from the generated
inner async function” problem turned out to be problematic, because
it creates an infinite loop in the domain handler system.

This problem goes away with Node.js v14.15.2 (due to https://github.com/nodejs/node/commit/0ad4f70db596934b3ff390cde7380ab8bf5480f5),
but since we also support Node.js-v12.x environments
(and we would want to be resilient against changes to the
platform internals anyway), it makes sense to aim for a better
solution here.

This patch makes sure that the generated inner async function only
returns a meaningful value if its return value is actually used,
i.e. if we’re encountering an async-evaluation case where the
generated outer function actually just forwards the returned
Promise.