### PR TITLE
fix(async-rewriter2): properly stringify functions MONGOSH-664

### DIFF
--- a/packages/async-rewriter2/README.md
+++ b/packages/async-rewriter2/README.md
@@ -92,6 +92,8 @@ made for readability).
 
 ```js
 (() => {
+  // Keep a copy of the original source code for Function.prototype.toString.
+  '<async_rewriter>(() => {\n  return db.test.find().toArray();\n})</>';
   const _syntheticPromise = Symbol.for("@@mongosh.syntheticPromise");
 
   function _markSyntheticPromise(p) {

--- a/packages/async-rewriter2/src/async-writer-babel.spec.ts
+++ b/packages/async-rewriter2/src/async-writer-babel.spec.ts
@@ -551,6 +551,30 @@ describe('AsyncWriter', () => {
         expect(plainFn).to.have.been.calledWith(6, 6, set);
       });
     });
+
+    context('Function.prototype.toString', () => {
+      it('returns the original function source', () => {
+        expect(runTranspiledCode('Function.prototype.toString.call(() => {})'))
+          .to.equal('() => {}');
+        expect(runTranspiledCode('Function.prototype.toString.call(function () {})'))
+          .to.equal('function () {}');
+        expect(runTranspiledCode('Function.prototype.toString.call(async function () {})'))
+          .to.equal('async function () {}');
+        expect(runTranspiledCode('Function.prototype.toString.call(function* () {})'))
+          .to.equal('function* () {}');
+        expect(runTranspiledCode('Function.prototype.toString.call(async function* () {})'))
+          .to.equal('async function* () {}');
+        expect(runTranspiledCode('Function.prototype.toString.call((class { method() {} }).prototype.method)'))
+          .to.equal('method() {}');
+      });
+
+      it('lets us not worry about special characters', () => {
+        expect(runTranspiledCode('Function.prototype.toString.call(() => {\n  method();\n})'))
+          .to.equal('() => {\n    method();\n  }');
+        expect(runTranspiledCode('Function.prototype.toString.call(() => { const 八 = 8; })'))
+          .to.equal('() => {\n    const 八 = 8;\n  }');
+      });
+    });
   });
 
   context('error messages', () => {

--- a/packages/async-rewriter2/src/runtime-support.nocov.js
+++ b/packages/async-rewriter2/src/runtime-support.nocov.js
@@ -468,4 +468,17 @@ module.exports = '(' + function() {
     const array = Array.prototype.filter.call(this, func, thisArg);
     return new (this.constructor)(array);
   };
+
+  // Special addition: Function.prototype.toString!
+  const origFptS = Function.prototype.toString;
+  Function.prototype.toString = function() {
+    const source = origFptS.call(this, arguments);
+    const match = source.match(/^[^"]*"<async_rewriter>(?<encoded>[a-z0-9]+)<\/>";/);
+    if (match) {
+      // Decode using hex + UTF-16
+      return String.fromCharCode(
+        ...match.groups.encoded.match(/.{4}/g).map(hex => parseInt(hex, 16)));
+    }
+    return source;
+  };
 } + ')();';


### PR DESCRIPTION
Add a copy of the original source code at the beginning of transformed
functions, so that `Function.prototype.toString` works properly
for them.