### PR TITLE
chore(cli-repl): (hopefully) fix flaky mongocryptd test

### DIFF
--- a/packages/cli-repl/src/mongocryptd-manager.spec.ts
+++ b/packages/cli-repl/src/mongocryptd-manager.spec.ts
@@ -2,11 +2,11 @@
 import Nanobus from 'nanobus';
 import { promises as fs } from 'fs';
 import path from 'path';
-import { promisify } from 'util';
 import { getMongocryptdPaths, MongocryptdManager } from './mongocryptd-manager';
 import type { MongoshBus } from '@mongosh/types';
 import { ShellHomeDirectory } from './config-directory';
 import { startTestServer } from '../../../testing/integration-testing-hooks';
+import { eventually } from '../test/helpers';
 import { expect } from 'chai';
 
 describe('getMongocryptdPaths', () => {
@@ -180,8 +180,9 @@ describe('MongocryptdManager', () => {
       manager.idleShutdownTimeoutSecs = 1;
       await manager.start();
       const pidfile = path.join(manager.path, 'mongocryptd.pid');
-      await promisify(setTimeout)(2000);
-      expect(JSON.parse(await fs.readFile(pidfile, 'utf8')).connections).to.be.greaterThan(1);
+      await eventually(async() => {
+        expect(JSON.parse(await fs.readFile(pidfile, 'utf8')).connections).to.be.greaterThan(1);
+      });
     });
   });
 });


### PR DESCRIPTION
Example failure:

    [2021/04/01 09:26:24.908]   1) MongocryptdManager
    [2021/04/01 09:26:24.908]        with network testing
    [2021/04/01 09:26:24.908]          performs keepalive pings:
    [2021/04/01 09:26:24.908]      SyntaxError: Unexpected end of JSON input
    [2021/04/01 09:26:24.908]       at JSON.parse (<anonymous>)
    [2021/04/01 09:26:24.908]       at Context.<anonymous> (src/mongocryptd-manager.spec.ts:184:19)

Presumably this is happening because the connections aren’t established
fast enough when the host is under load, e.g. because multiple tests
are running at the same time. Using the `eventually` helper would be
the right thing to do here anyway, because it allows for a longer
timeout while at the same time finishing faster under normal
circumstances.