### PR TITLE
fix(java-shell): update tests for latest server alpha MONGOSH-667

### DIFF
--- a/packages/java-shell/src/test/resources/collection/createIndex.expected.txt
+++ b/packages/java-shell/src/test/resources/collection/createIndex.expected.txt
@@ -4,5 +4,5 @@ category_1
 category_1
 "de"
 { "nIndexesWas": 2, "ok": 1 }
-category_1_v_1
+category_text_v_text
 { "category": 10, "v": 5 }

--- a/packages/java-shell/src/test/resources/collection/createIndex.js
+++ b/packages/java-shell/src/test/resources/collection/createIndex.js
@@ -16,7 +16,7 @@ db.coll.getIndexes();
 // command
 db.coll.dropIndex({category: 1});
 // command
-db.coll.createIndex({category: 1, v: 1}, {weights: {category: 10, v: 5}});
+db.coll.createIndex({category: 'text', v: 'text'}, {weights: {category: 10, v: 5}});
 // command getArrayItem=1 extractProperty=weights
 db.coll.getIndexes();
 // clear


### PR DESCRIPTION
`weight` is only valid for text indices, so use a text index here.