### PR TITLE
fix(shell-evaluator): only apply async-rewriter2 runtime support once

### DIFF
--- a/packages/shell-evaluator/src/shell-evaluator.ts
+++ b/packages/shell-evaluator/src/shell-evaluator.ts
@@ -65,6 +65,7 @@ class ShellEvaluator<EvaluationResultType = ShellResult> {
     }
 
     if (!this.hasAppliedAsyncWriterRuntimeSupport) {
+      this.hasAppliedAsyncWriterRuntimeSupport = true;
       const supportCode = (this.internalState.asyncWriter as any).runtimeSupportCode();
       // Eval twice: We need the modified prototypes to be present in both
       // the evaluation context and the current one, because e.g. the value of


### PR DESCRIPTION
`hasAppliedAsyncWriterRuntimeSupport` was supposed to be a run-only
guard, it was just the actual setting of the variable that was missing
so far.

This fix makes the shell respond a lot faster when using the new async
rewriter. :)