### PR TITLE
fix(service-provider-core): connection str options casing MONGOSH-669

### DIFF
--- a/packages/service-provider-core/src/connection-string.spec.ts
+++ b/packages/service-provider-core/src/connection-string.spec.ts
@@ -126,6 +126,22 @@ describe('ConnectionString', () => {
       expect(cs.hosts).to.deep.equal(['a', 'b', 'c']);
       expect(cs.toString()).to.equal('mongodb://a,b,c/');
     });
+
+    it('performs case-insensitive matches on connection options', () => {
+      const cs = new ConnectionString('mongodb://localhost/?SERVERSELECTIONTIMEOUTMS=100');
+      cs.searchParams.set('serverSelectionTimeoutMS', '200');
+      cs.searchParams.append('serverSelectionTimeoutMS', '300');
+
+      expect(cs.toString()).to.equal('mongodb://localhost/?SERVERSELECTIONTIMEOUTMS=200&SERVERSELECTIONTIMEOUTMS=300');
+      expect(cs.searchParams.has('serverSelectionTimeoutMS')).to.equal(true);
+      expect(cs.searchParams.has('SERVERSELECTIONTIMEOUTMS')).to.equal(true);
+      expect(cs.searchParams.get('serverSelectionTimeoutMS')).to.equal('200');
+      expect(cs.searchParams.getAll('serverSelectionTimeoutMS')).to.deep.equal(['200', '300']);
+
+      cs.searchParams.delete('serverSelectionTimeoutMS');
+      expect(cs.searchParams.has('serverSelectionTimeoutMS')).to.equal(false);
+      expect(cs.searchParams.has('SERVERSELECTIONTIMEOUTMS')).to.equal(false);
+    });
   });
 
   context('cloning', () => {

--- a/packages/service-provider-core/src/connection-string.ts
+++ b/packages/service-provider-core/src/connection-string.ts
@@ -1,6 +1,6 @@
 import assert from 'assert';
 import { CommonErrors, MongoshInvalidInputError, MongoshInternalError } from '@mongosh/errors';
-import { URL } from './whatwg-url';
+import { URL, URLSearchParams } from './whatwg-url';
 
 const DUMMY_HOSTNAME = '__this_is_a_placeholder__';
 
@@ -9,6 +9,43 @@ const DUMMY_HOSTNAME = '__this_is_a_placeholder__';
 const HOSTS_REGEX = new RegExp(
   String.raw`(?<protocol>mongodb(?:\+srv|)):\/\/(?:(?<username>[^:]*)(?::(?<password>[^@]*))?@)?(?<hosts>(?!:)[^\/?@]+)(?<rest>.*)`
 );
+
+class CaseInsenstiveURLSearchParams extends URLSearchParams {
+  append(name: any, value: any): void {
+    return super.append(this._normalizeKey(name), value);
+  }
+
+  delete(name: any): void {
+    return super.delete(this._normalizeKey(name));
+  }
+
+  get(name: any): string | null {
+    return super.get(this._normalizeKey(name));
+  }
+
+  getAll(name: any): string[] {
+    return super.getAll(this._normalizeKey(name));
+  }
+
+  has(name: any): boolean {
+    return super.has(this._normalizeKey(name));
+  }
+
+  set(name: any, value: any): void {
+    return super.set(this._normalizeKey(name), value);
+  }
+
+  _normalizeKey(name: any): string {
+    name = `${name}`;
+    for (const key of this.keys()) {
+      if (key.toLowerCase() === name.toLowerCase()) {
+        name = key;
+        break;
+      }
+    }
+    return name;
+  }
+}
 
 // Abstract middle class to appease TypeScript, see https://github.com/microsoft/TypeScript/pull/37894
 abstract class URLWithoutHost extends URL {
@@ -77,6 +114,7 @@ export class ConnectionString extends URLWithoutHost {
     if (!this.pathname) {
       this.pathname = '/';
     }
+    Object.setPrototypeOf(this.searchParams, CaseInsenstiveURLSearchParams.prototype);
   }
 
   // The getters here should throw, but that would break .toString() because of

--- a/packages/service-provider-core/src/uri-generator.spec.ts
+++ b/packages/service-provider-core/src/uri-generator.spec.ts
@@ -255,6 +255,24 @@ describe('uri-generator.generate-uri', () => {
           expect(generateUri(options)).to.equal('');
         });
       });
+
+      context('when providing explicit serverSelectionTimeoutMS', () => {
+        const uri = 'mongodb://127.0.0.2/foo?serverSelectionTimeoutMS=10';
+        const options = { _: [uri] };
+
+        it('returns an empty string', () => {
+          expect(generateUri(options)).to.equal('mongodb://127.0.0.2/foo?serverSelectionTimeoutMS=10&directConnection=true');
+        });
+      });
+
+      context('when providing explicit serverSelectionTimeoutMS (different case)', () => {
+        const uri = 'mongodb://127.0.0.2/foo?SERVERSELECTIONTIMEOUTMS=10';
+        const options = { _: [uri] };
+
+        it('returns an empty string', () => {
+          expect(generateUri(options)).to.equal('mongodb://127.0.0.2/foo?SERVERSELECTIONTIMEOUTMS=10&directConnection=true');
+        });
+      });
     });
 
     context('when providing a URI with query parameters', () => {

--- a/packages/service-provider-core/src/uri-generator.spec.ts
+++ b/packages/service-provider-core/src/uri-generator.spec.ts
@@ -260,7 +260,7 @@ describe('uri-generator.generate-uri', () => {
         const uri = 'mongodb://127.0.0.2/foo?serverSelectionTimeoutMS=10';
         const options = { _: [uri] };
 
-        it('returns an empty string', () => {
+        it('does not override the existing value', () => {
           expect(generateUri(options)).to.equal('mongodb://127.0.0.2/foo?serverSelectionTimeoutMS=10&directConnection=true');
         });
       });
@@ -269,7 +269,7 @@ describe('uri-generator.generate-uri', () => {
         const uri = 'mongodb://127.0.0.2/foo?SERVERSELECTIONTIMEOUTMS=10';
         const options = { _: [uri] };
 
-        it('returns an empty string', () => {
+        it('does not override the existing value', () => {
           expect(generateUri(options)).to.equal('mongodb://127.0.0.2/foo?SERVERSELECTIONTIMEOUTMS=10&directConnection=true');
         });
       });

--- a/packages/service-provider-core/src/whatwg-url.ts
+++ b/packages/service-provider-core/src/whatwg-url.ts
@@ -18,12 +18,14 @@ const _global = new Function('return this')();
 // URL has to be defined dynamically to allow browser environments get rid of
 // the polyfill that can potentially break them, even when not used
 let URL: typeof import('url').URL;
+let URLSearchParams: typeof import('url').URLSearchParams;
 
 // URL should be available in global scope both in Node >= 10 and in browser
 // (this also means that electron renderer should have it available one way or
 // another)
 if ('URL' in _global) {
   URL = _global.URL;
+  URLSearchParams = _global.URLSearchParams;
 } else {
   // java-shell js runtime (and older Node versions, but we don't support those)
   // doesn't have URL available so we fallback to the `whatwg-url` polyfill.
@@ -33,6 +35,7 @@ if ('URL' in _global) {
   // using `service-provider-core` in browser environment, make sure that this
   // import does not actually import the library
   URL = require('whatwg-url').URL;
+  URLSearchParams = require('whatwg-url').URLSearchParams;
 }
 
 // Basic encoder/decoder polyfill for java-shell environment (see above)
@@ -51,4 +54,4 @@ function textEncodingPolyfill(): any {
   return { TextDecoder, TextEncoder };
 }
 
-export { textEncodingPolyfill, URL };
+export { textEncodingPolyfill, URL, URLSearchParams };


### PR DESCRIPTION
When adding or changing keys, make sure not to ignore already-existing
but differently-cased keys.