### PR TITLE
chore(async-rewriter): pass along filename to babel

### DIFF
--- a/packages/async-rewriter/src/async-writer-babel.ts
+++ b/packages/async-rewriter/src/async-writer-babel.ts
@@ -742,9 +742,10 @@ export default class AsyncWriter {
    * @param {string} code - string to compile.
    * @returns {Object} - { ast, code }
    */
-  getTransform(code): any {
+  getTransform(code, filename: string): any {
     try {
       return babel.transformSync(code, {
+        filename,
         plugins: [this.plugin],
         code: true,
         ast: true,
@@ -761,16 +762,16 @@ export default class AsyncWriter {
    * Returns translated code.
    * @param {string} code - string to compile.
    */
-  compile(code: string): string {
-    return this.getTransform(code).code;
+  compile(code: string, filename: string): string {
+    return this.getTransform(code, filename).code;
   }
 
   /**
    * Returns translated code.
    * @param code - string to compile.
    */
-  process(code: string): string {
-    const input = this.compile(code);
+  process(code: string, filename: string): string {
+    const input = this.compile(code, filename);
     return processTopLevelAwait(input) || input;
   }
 }

--- a/packages/async-rewriter2/src/async-writer-babel.spec.ts
+++ b/packages/async-rewriter2/src/async-writer-babel.spec.ts
@@ -45,7 +45,7 @@ describe('AsyncWriter', () => {
       }
     });
     runTranspiledCode = (code: string, context?: any) => {
-      const transpiled = asyncWriter.process(code);
+      const transpiled = asyncWriter.process(code, '<unknown>');
       return runUntranspiledCode(transpiled, context);
     };
     runUntranspiledCode = (code: string, context?: any) => {

--- a/packages/async-rewriter2/src/async-writer-babel.ts
+++ b/packages/async-rewriter2/src/async-writer-babel.ts
@@ -24,9 +24,10 @@ import makeMaybeAsyncFunctionPlugin from './stages/transform-maybe-await';
  */
 
 export default class AsyncWriter {
-  step(code: string, plugins: babel.PluginItem[]): string {
+  step(code: string, filename: string, plugins: babel.PluginItem[]): string {
     return babel.transformSync(code, {
       plugins,
+      filename,
       code: true,
       configFile: false,
       babelrc: false
@@ -37,19 +38,19 @@ export default class AsyncWriter {
    * Returns translated code.
    * @param code - string to compile.
    */
-  process(code: string): string {
+  process(code: string, filename: string): string {
     try {
       // In the first step, we apply a number of common babel transformations
       // that are necessary in order for subsequent steps to succeed
       // (in particular, shorthand properties and parameters would otherwise
       // mess with detecting expressions in their proper locations).
-      code = this.step(code, [
+      code = this.step(code, filename, [
         require('@babel/plugin-transform-shorthand-properties').default,
         require('@babel/plugin-transform-parameters').default,
         require('@babel/plugin-transform-destructuring').default
       ]);
-      code = this.step(code, [wrapAsFunctionPlugin]);
-      code = this.step(code, [makeMaybeAsyncFunctionPlugin]);
+      code = this.step(code, filename, [wrapAsFunctionPlugin]);
+      code = this.step(code, filename, [makeMaybeAsyncFunctionPlugin]);
       return code;
     } catch (e) {
       e.message = e.message.replace('unknown: ', '');
@@ -58,6 +59,6 @@ export default class AsyncWriter {
   }
 
   runtimeSupportCode(): string {
-    return this.process(runtimeSupport);
+    return this.process(runtimeSupport, '<mongosh runtime support>');
   }
 }

--- a/packages/shell-api/src/shell-internal-state.ts
+++ b/packages/shell-api/src/shell-internal-state.ts
@@ -104,7 +104,7 @@ export default class ShellInternalState {
   public currentCursor: Cursor | AggregationCursor | ChangeStreamCursor | null;
   public currentDb: Database;
   public messageBus: MongoshBus;
-  public asyncWriter: { process(code: string): string };
+  public asyncWriter: { process(code: string, filename: string): string };
   public initialServiceProvider: ServiceProvider; // the initial service provider
   public uri: string | null;
   public connectionInfo: any;

--- a/packages/shell-evaluator/src/shell-evaluator.ts
+++ b/packages/shell-evaluator/src/shell-evaluator.ts
@@ -54,7 +54,7 @@ class ShellEvaluator<EvaluationResultType = ShellResult> {
     }
 
     this.saveState();
-    let rewrittenInput = this.internalState.asyncWriter.process(input);
+    let rewrittenInput = this.internalState.asyncWriter.process(input, filename);
 
     const hiddenCommands = RegExp(HIDDEN_COMMANDS, 'g');
     if (!hiddenCommands.test(input) && !hiddenCommands.test(rewrittenInput)) {


### PR DESCRIPTION
So that we get

    > load('/tmp/lodash.js')
    [BABEL] Note: The code generator has deoptimised the styling of /tmp/lodash.js as it exceeds the max of 500KB.

Instead of the message missing a filename (for those who do encounter
this message, which should be rare enough?).