### PR TITLE
fix(async-rewriter2): treat for-in/of as assignments

### DIFF
--- a/packages/async-rewriter2/src/async-writer-babel.spec.ts
+++ b/packages/async-rewriter2/src/async-writer-babel.spec.ts
@@ -314,6 +314,14 @@ describe('AsyncWriter', () => {
       expect(implicitlyAsyncFn).to.have.callCount(10);
     });
 
+    it('can use for loops as weird assignments', async() => {
+      const obj = { foo: null };
+      implicitlyAsyncFn.resolves(obj);
+      await runTranspiledCode('for (implicitlyAsyncFn().foo of ["foo", "bar"]);');
+      expect(implicitlyAsyncFn).to.have.callCount(2);
+      expect(obj.foo).to.equal('bar');
+    });
+
     it('works with assignments to objects', async() => {
       implicitlyAsyncFn.resolves({ foo: 'bar' });
       const ret = runTranspiledCode(`

--- a/packages/async-rewriter2/src/stages/transform-maybe-await.ts
+++ b/packages/async-rewriter2/src/stages/transform-maybe-await.ts
@@ -401,6 +401,9 @@ export default ({ types: t }: { types: typeof BabelTypes }): babel.PluginObj<{ f
           // something that we wouldn't want to modify anyway, because it would
           // break the assignment altogether.
           if (path.parentPath.isAssignmentExpression() && path.key === 'left') return;
+          // Assignments can happen in weird places, including in situations like
+          // `for (obj.prop of [1,2,3]);`.
+          if (path.parentPath.isForXStatement() && path.key === 'left') return;
           // ++ and -- count as assignments for our purposes.
           if (path.parentPath.isUpdateExpression()) return;
 


### PR DESCRIPTION
Treat for-in/for-of with a non-variable-declarator left-hand side
like assignment expressions (which they effectively are).