### PR TITLE
chore: update to driver 4.0.0-beta.3 MONGOSH-673

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5563,9 +5563,9 @@
       }
     },
     "bson": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-4.2.3.tgz",
-      "integrity": "sha512-3ztgjpKp0itFxGqzrLMHWqyZH5oMOIRWsjeY61yNVzrDGB/KxtgD6djFlz9n3vx7lLr2r6bkHagBCgyk1ZjETA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.3.0.tgz",
+      "integrity": "sha512-LkKKeFJx5D6RRCRvLE+fDs40M2ZQNuk7W7tFXmKd7OOcQQ+BHdzCgRdL4XEGjc1UEGtiYuMvIVk91Bv8qsI50A==",
       "dev": true,
       "requires": {
         "buffer": "^5.6.0"
@@ -13907,9 +13907,9 @@
       }
     },
     "mongodb": {
-      "version": "4.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.0.0-beta.2.tgz",
-      "integrity": "sha512-V6zgRBXikCAxbm+cN5CriQB8KlvMcRYmDQyt3DSUcdVQ40iBBLPQknwG38ZsjA5N3YrP6ghYQ2ncQE6f2Jcf1w==",
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.0.0-beta.3.tgz",
+      "integrity": "sha512-xzb+6JZbUG1mDLBbc6avReNLAHeGHgtMeih/d052LqU3hL+syw7E3cFpeZO7ESaAbExZ4tQcLqJAsC2/RGoQlw==",
       "dev": true,
       "requires": {
         "bson": "^4.2.2",

--- a/package.json
+++ b/package.json
@@ -125,7 +125,7 @@
     "karma-typescript": "^4.1.1",
     "lerna": "^3.10.7",
     "mocha": "^7.1.2",
-    "mongodb": "4.0.0-beta.2",
+    "mongodb": "4.0.0-beta.3",
     "mongodb-download-url": "^1.0.0",
     "mongodb-js-precommit": "^2.0.0",
     "nock": "^13.0.11",

--- a/packages/node-runtime-worker-thread/package-lock.json
+++ b/packages/node-runtime-worker-thread/package-lock.json
@@ -633,9 +633,9 @@
 			}
 		},
 		"bson": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/bson/-/bson-4.2.3.tgz",
-			"integrity": "sha512-3ztgjpKp0itFxGqzrLMHWqyZH5oMOIRWsjeY61yNVzrDGB/KxtgD6djFlz9n3vx7lLr2r6bkHagBCgyk1ZjETA==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/bson/-/bson-4.3.0.tgz",
+			"integrity": "sha512-LkKKeFJx5D6RRCRvLE+fDs40M2ZQNuk7W7tFXmKd7OOcQQ+BHdzCgRdL4XEGjc1UEGtiYuMvIVk91Bv8qsI50A==",
 			"requires": {
 				"buffer": "^5.6.0"
 			},

--- a/packages/node-runtime-worker-thread/package.json
+++ b/packages/node-runtime-worker-thread/package.json
@@ -42,7 +42,7 @@
     "@mongosh/service-provider-core": "0.0.0-dev.0",
     "@mongosh/service-provider-server": "0.0.0-dev.0",
     "@mongosh/types": "0.0.0-dev.0",
-    "bson": "^4.2.3",
+    "bson": "^4.3.0",
     "interruptor": "^1.0.1",
     "postmsg-rpc": "^2.4.0"
   }

--- a/packages/service-provider-core/package-lock.json
+++ b/packages/service-provider-core/package-lock.json
@@ -82,9 +82,9 @@
       }
     },
     "bson": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-4.2.3.tgz",
-      "integrity": "sha512-3ztgjpKp0itFxGqzrLMHWqyZH5oMOIRWsjeY61yNVzrDGB/KxtgD6djFlz9n3vx7lLr2r6bkHagBCgyk1ZjETA==",
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.3.0.tgz",
+      "integrity": "sha512-LkKKeFJx5D6RRCRvLE+fDs40M2ZQNuk7W7tFXmKd7OOcQQ+BHdzCgRdL4XEGjc1UEGtiYuMvIVk91Bv8qsI50A==",
       "requires": {
         "buffer": "^5.6.0"
       }
@@ -97,28 +97,6 @@
         "base64-js": "^1.3.1",
         "ieee754": "^1.1.13"
       }
-    },
-    "buffer-alloc": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
-      "integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
-      "optional": true,
-      "requires": {
-        "buffer-alloc-unsafe": "^1.1.0",
-        "buffer-fill": "^1.0.0"
-      }
-    },
-    "buffer-alloc-unsafe": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-      "integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
-      "optional": true
-    },
-    "buffer-fill": {
-      "version": "1.0.0",
-      "resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
-      "integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
-      "optional": true
     },
     "chownr": {
       "version": "1.1.4",
@@ -145,12 +123,12 @@
       "optional": true
     },
     "decompress-response": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
-      "integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
+      "integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
       "optional": true,
       "requires": {
-        "mimic-response": "^1.0.0"
+        "mimic-response": "^2.0.0"
       }
     },
     "deep-extend": {
@@ -275,9 +253,9 @@
       "optional": true
     },
     "mimic-response": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-      "integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
+      "integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
       "optional": true
     },
     "minimist": {
@@ -286,19 +264,16 @@
       "integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
       "optional": true
     },
-    "mkdirp": {
-      "version": "0.5.5",
-      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-      "integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-      "optional": true,
-      "requires": {
-        "minimist": "^1.2.5"
-      }
+    "mkdirp-classic": {
+      "version": "0.5.3",
+      "resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+      "integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+      "optional": true
     },
     "mongodb": {
-      "version": "4.0.0-beta.2",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.0.0-beta.2.tgz",
-      "integrity": "sha512-V6zgRBXikCAxbm+cN5CriQB8KlvMcRYmDQyt3DSUcdVQ40iBBLPQknwG38ZsjA5N3YrP6ghYQ2ncQE6f2Jcf1w==",
+      "version": "4.0.0-beta.3",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.0.0-beta.3.tgz",
+      "integrity": "sha512-xzb+6JZbUG1mDLBbc6avReNLAHeGHgtMeih/d052LqU3hL+syw7E3cFpeZO7ESaAbExZ4tQcLqJAsC2/RGoQlw==",
       "requires": {
         "bson": "^4.2.2",
         "denque": "^1.4.1",
@@ -311,15 +286,15 @@
       "integrity": "sha512-HC4ZG98ObbWGM3ikL3VfSvuug3iQVpA2kBob/MxK+mn2PNdVTvR5lShio+Ev1rDqODfq3ePcfO6prfi0agQp8g=="
     },
     "mongodb-client-encryption": {
-      "version": "1.2.2",
-      "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-1.2.2.tgz",
-      "integrity": "sha512-s42Oo3YhkpFwboXknDw7T9cak6UwH6K67q1nyfQ9zwyI/n4eh6FoJKSL6ZXFZ+sNlod4gYJbM0Irpkg4Eql0wQ==",
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-1.2.3.tgz",
+      "integrity": "sha512-w+mvB2wLwWjnGvPYUmVDfec7OmkXfPTJh/BRAt23A1Q0g+duOFlZD+qRB0fQYwhGblkno5NBMR7HXSSRx5+AwQ==",
       "optional": true,
       "requires": {
         "bindings": "^1.5.0",
         "bl": "^2.2.1",
-        "nan": "^2.14.0",
-        "prebuild-install": "5.3.0"
+        "nan": "^2.14.2",
+        "prebuild-install": "6.0.1"
       }
     },
     "nan": {
@@ -382,32 +357,25 @@
         "wrappy": "1"
       }
     },
-    "os-homedir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-      "integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-      "optional": true
-    },
     "prebuild-install": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.0.tgz",
-      "integrity": "sha512-aaLVANlj4HgZweKttFNUVNRxDukytuIuxeK2boIMHjagNJCiVKWFsKF4tCE3ql3GbrD2tExPQ7/pwtEJcHNZeg==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-6.0.1.tgz",
+      "integrity": "sha512-7GOJrLuow8yeiyv75rmvZyeMGzl8mdEX5gY69d6a6bHWmiPevwqFw+tQavhK0EYMaSg3/KD24cWqeQv1EWsqDQ==",
       "optional": true,
       "requires": {
         "detect-libc": "^1.0.3",
         "expand-template": "^2.0.3",
         "github-from-package": "0.0.0",
-        "minimist": "^1.2.0",
-        "mkdirp": "^0.5.1",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
         "napi-build-utils": "^1.0.1",
         "node-abi": "^2.7.0",
         "noop-logger": "^0.1.1",
         "npmlog": "^4.0.1",
-        "os-homedir": "^1.0.1",
-        "pump": "^2.0.1",
+        "pump": "^3.0.0",
         "rc": "^1.2.7",
-        "simple-get": "^2.7.0",
-        "tar-fs": "^1.13.0",
+        "simple-get": "^3.0.3",
+        "tar-fs": "^2.0.0",
         "tunnel-agent": "^0.6.0",
         "which-pm-runs": "^1.0.0"
       }
@@ -419,9 +387,9 @@
       "optional": true
     },
     "pump": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-      "integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+      "integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
       "optional": true,
       "requires": {
         "end-of-stream": "^1.1.0",
@@ -508,12 +476,12 @@
       "optional": true
     },
     "simple-get": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
-      "integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.0.tgz",
+      "integrity": "sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==",
       "optional": true,
       "requires": {
-        "decompress-response": "^3.3.0",
+        "decompress-response": "^4.2.0",
         "once": "^1.3.1",
         "simple-concat": "^1.0.0"
       }
@@ -571,61 +539,53 @@
       "optional": true
     },
     "tar-fs": {
-      "version": "1.16.3",
-      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.3.tgz",
-      "integrity": "sha512-NvCeXpYx7OsmOh8zIOP/ebG55zZmxLE0etfWRbWok+q2Qo8x/vOR/IJT1taADXPe+jsiu9axDb3X4B+iIgNlKw==",
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+      "integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
       "optional": true,
       "requires": {
-        "chownr": "^1.0.1",
-        "mkdirp": "^0.5.1",
-        "pump": "^1.0.0",
-        "tar-stream": "^1.1.2"
-      },
-      "dependencies": {
-        "pump": {
-          "version": "1.0.3",
-          "resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
-          "integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
-          "optional": true,
-          "requires": {
-            "end-of-stream": "^1.1.0",
-            "once": "^1.3.1"
-          }
-        }
+        "chownr": "^1.1.1",
+        "mkdirp-classic": "^0.5.2",
+        "pump": "^3.0.0",
+        "tar-stream": "^2.1.4"
       }
     },
     "tar-stream": {
-      "version": "1.6.2",
-      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
-      "integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+      "integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
       "optional": true,
       "requires": {
-        "bl": "^1.0.0",
-        "buffer-alloc": "^1.2.0",
-        "end-of-stream": "^1.0.0",
+        "bl": "^4.0.3",
+        "end-of-stream": "^1.4.1",
         "fs-constants": "^1.0.0",
-        "readable-stream": "^2.3.0",
-        "to-buffer": "^1.1.1",
-        "xtend": "^4.0.0"
+        "inherits": "^2.0.3",
+        "readable-stream": "^3.1.1"
       },
       "dependencies": {
         "bl": {
-          "version": "1.2.3",
-          "resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
-          "integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
+          "version": "4.1.0",
+          "resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+          "integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
           "optional": true,
           "requires": {
-            "readable-stream": "^2.3.5",
-            "safe-buffer": "^5.1.1"
+            "buffer": "^5.5.0",
+            "inherits": "^2.0.4",
+            "readable-stream": "^3.4.0"
+          }
+        },
+        "readable-stream": {
+          "version": "3.6.0",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+          "integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+          "optional": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
           }
         }
       }
-    },
-    "to-buffer": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
-      "integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
-      "optional": true
     },
     "tr46": {
       "version": "2.0.2",
@@ -684,12 +644,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-      "optional": true
-    },
-    "xtend": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-      "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
       "optional": true
     }
   }

--- a/packages/service-provider-core/package.json
+++ b/packages/service-provider-core/package.json
@@ -29,8 +29,8 @@
   "dependencies": {
     "@mongosh/errors": "0.0.0-dev.0",
     "@mongosh/i18n": "0.0.0-dev.0",
-    "bson": "^4.2.3",
-    "mongodb": "4.0.0-beta.2",
+    "bson": "^4.3.0",
+    "mongodb": "4.0.0-beta.3",
     "mongodb-build-info": "^1.1.1",
     "whatwg-url": "^8.4.0"
   },
@@ -39,7 +39,7 @@
     "@types/whatwg-url": "^8.0.0"
   },
   "optionalDependencies": {
-    "mongodb-client-encryption": "^1.2.2"
+    "mongodb-client-encryption": "^1.2.3"
   },
   "dependency-check": {
     "entries": [

--- a/packages/service-provider-server/package-lock.json
+++ b/packages/service-provider-server/package-lock.json
@@ -90,9 +90,9 @@
 			}
 		},
 		"bson": {
-			"version": "4.2.3",
-			"resolved": "https://registry.npmjs.org/bson/-/bson-4.2.3.tgz",
-			"integrity": "sha512-3ztgjpKp0itFxGqzrLMHWqyZH5oMOIRWsjeY61yNVzrDGB/KxtgD6djFlz9n3vx7lLr2r6bkHagBCgyk1ZjETA==",
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/bson/-/bson-4.3.0.tgz",
+			"integrity": "sha512-LkKKeFJx5D6RRCRvLE+fDs40M2ZQNuk7W7tFXmKd7OOcQQ+BHdzCgRdL4XEGjc1UEGtiYuMvIVk91Bv8qsI50A==",
 			"requires": {
 				"buffer": "^5.6.0"
 			}
@@ -105,28 +105,6 @@
 				"base64-js": "^1.3.1",
 				"ieee754": "^1.1.13"
 			}
-		},
-		"buffer-alloc": {
-			"version": "1.2.0",
-			"resolved": "https://registry.npmjs.org/buffer-alloc/-/buffer-alloc-1.2.0.tgz",
-			"integrity": "sha512-CFsHQgjtW1UChdXgbyJGtnm+O/uLQeZdtbDo8mfUgYXCHSM1wgrVxXm6bSyrUuErEb+4sYVGCzASBRot7zyrow==",
-			"optional": true,
-			"requires": {
-				"buffer-alloc-unsafe": "^1.1.0",
-				"buffer-fill": "^1.0.0"
-			}
-		},
-		"buffer-alloc-unsafe": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/buffer-alloc-unsafe/-/buffer-alloc-unsafe-1.1.0.tgz",
-			"integrity": "sha512-TEM2iMIEQdJ2yjPJoSIsldnleVaAk1oW3DBVUykyOLsEsFmEc9kn+SFFPz+gl54KQNxlDnAwCXosOS9Okx2xAg==",
-			"optional": true
-		},
-		"buffer-fill": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/buffer-fill/-/buffer-fill-1.0.0.tgz",
-			"integrity": "sha1-+PeLdniYiO858gXNY39o5wISKyw=",
-			"optional": true
 		},
 		"chownr": {
 			"version": "1.1.4",
@@ -153,12 +131,12 @@
 			"optional": true
 		},
 		"decompress-response": {
-			"version": "3.3.0",
-			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-3.3.0.tgz",
-			"integrity": "sha1-gKTdMjdIOEv6JICDYirt7Jgq3/M=",
+			"version": "4.2.1",
+			"resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-4.2.1.tgz",
+			"integrity": "sha512-jOSne2qbyE+/r8G1VU+G/82LBs2Fs4LAsTiLSHOCOMZQl2OKZ6i8i4IyHemTe+/yIXOtTcRQMzPcgyhoFlqPkw==",
 			"optional": true,
 			"requires": {
-				"mimic-response": "^1.0.0"
+				"mimic-response": "^2.0.0"
 			}
 		},
 		"deep-extend": {
@@ -277,9 +255,9 @@
 			"integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg=="
 		},
 		"mimic-response": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-1.0.1.tgz",
-			"integrity": "sha512-j5EctnkH7amfV/q5Hgmoal1g2QHFJRraOtmx0JpIqkxhBhI/lJSl1nMpQ45hVarwNETOoWEimndZ4QK0RHxuxQ==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-2.1.0.tgz",
+			"integrity": "sha512-wXqjST+SLt7R009ySCglWBCFpjUygmCIfD790/kVbiGmUgfYGuB14PiTd5DwVxSV4NcYHjzMkoj5LjQZwTQLEA==",
 			"optional": true
 		},
 		"minimist": {
@@ -288,46 +266,32 @@
 			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw==",
 			"optional": true
 		},
-		"mkdirp": {
-			"version": "0.5.5",
-			"resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.5.tgz",
-			"integrity": "sha512-NKmAlESf6jMGym1++R0Ra7wvhV+wFW63FaSOFPwRahvea0gMUcGUhVeAg/0BC0wiv9ih5NYPB1Wn1UEI1/L+xQ==",
-			"optional": true,
-			"requires": {
-				"minimist": "^1.2.5"
-			}
+		"mkdirp-classic": {
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/mkdirp-classic/-/mkdirp-classic-0.5.3.tgz",
+			"integrity": "sha512-gKLcREMhtuZRwRAfqP3RFW+TK4JqApVBtOIftVgjuABpAtpxhPGaDcfvbhNvD0B8iD1oUr/txX35NjcaY6Ns/A==",
+			"optional": true
 		},
 		"mongodb": {
-			"version": "4.0.0-beta.2",
-			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.0.0-beta.2.tgz",
-			"integrity": "sha512-V6zgRBXikCAxbm+cN5CriQB8KlvMcRYmDQyt3DSUcdVQ40iBBLPQknwG38ZsjA5N3YrP6ghYQ2ncQE6f2Jcf1w==",
+			"version": "4.0.0-beta.3",
+			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.0.0-beta.3.tgz",
+			"integrity": "sha512-xzb+6JZbUG1mDLBbc6avReNLAHeGHgtMeih/d052LqU3hL+syw7E3cFpeZO7ESaAbExZ4tQcLqJAsC2/RGoQlw==",
 			"requires": {
 				"bson": "^4.2.2",
 				"denque": "^1.4.1",
 				"saslprep": "^1.0.0"
-			},
-			"dependencies": {
-				"saslprep": {
-					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
-					"integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
-					"optional": true,
-					"requires": {
-						"sparse-bitfield": "^3.0.3"
-					}
-				}
 			}
 		},
 		"mongodb-client-encryption": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-1.2.2.tgz",
-			"integrity": "sha512-s42Oo3YhkpFwboXknDw7T9cak6UwH6K67q1nyfQ9zwyI/n4eh6FoJKSL6ZXFZ+sNlod4gYJbM0Irpkg4Eql0wQ==",
+			"version": "1.2.3",
+			"resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-1.2.3.tgz",
+			"integrity": "sha512-w+mvB2wLwWjnGvPYUmVDfec7OmkXfPTJh/BRAt23A1Q0g+duOFlZD+qRB0fQYwhGblkno5NBMR7HXSSRx5+AwQ==",
 			"optional": true,
 			"requires": {
 				"bindings": "^1.5.0",
 				"bl": "^2.2.1",
-				"nan": "^2.14.0",
-				"prebuild-install": "5.3.0"
+				"nan": "^2.14.2",
+				"prebuild-install": "6.0.1"
 			}
 		},
 		"nan": {
@@ -390,32 +354,25 @@
 				"wrappy": "1"
 			}
 		},
-		"os-homedir": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/os-homedir/-/os-homedir-1.0.2.tgz",
-			"integrity": "sha1-/7xJiDNuDoM94MFox+8VISGqf7M=",
-			"optional": true
-		},
 		"prebuild-install": {
-			"version": "5.3.0",
-			"resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-5.3.0.tgz",
-			"integrity": "sha512-aaLVANlj4HgZweKttFNUVNRxDukytuIuxeK2boIMHjagNJCiVKWFsKF4tCE3ql3GbrD2tExPQ7/pwtEJcHNZeg==",
+			"version": "6.0.1",
+			"resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-6.0.1.tgz",
+			"integrity": "sha512-7GOJrLuow8yeiyv75rmvZyeMGzl8mdEX5gY69d6a6bHWmiPevwqFw+tQavhK0EYMaSg3/KD24cWqeQv1EWsqDQ==",
 			"optional": true,
 			"requires": {
 				"detect-libc": "^1.0.3",
 				"expand-template": "^2.0.3",
 				"github-from-package": "0.0.0",
-				"minimist": "^1.2.0",
-				"mkdirp": "^0.5.1",
+				"minimist": "^1.2.3",
+				"mkdirp-classic": "^0.5.3",
 				"napi-build-utils": "^1.0.1",
 				"node-abi": "^2.7.0",
 				"noop-logger": "^0.1.1",
 				"npmlog": "^4.0.1",
-				"os-homedir": "^1.0.1",
-				"pump": "^2.0.1",
+				"pump": "^3.0.0",
 				"rc": "^1.2.7",
-				"simple-get": "^2.7.0",
-				"tar-fs": "^1.13.0",
+				"simple-get": "^3.0.3",
+				"tar-fs": "^2.0.0",
 				"tunnel-agent": "^0.6.0",
 				"which-pm-runs": "^1.0.0"
 			}
@@ -427,9 +384,9 @@
 			"optional": true
 		},
 		"pump": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/pump/-/pump-2.0.1.tgz",
-			"integrity": "sha512-ruPMNRkN3MHP1cWJc9OWr+T/xDP0jhXYCLfJcBuX54hhfIBnaQmAUMfDcG4DM5UMWByBbJY69QSphm3jtDKIkA==",
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
+			"integrity": "sha512-LwZy+p3SFs1Pytd/jYct4wpv49HiYCqd9Rlc5ZVdk0V+8Yzv6jR5Blk3TRmPL1ft69TxP0IMZGJ+WPFU2BFhww==",
 			"optional": true,
 			"requires": {
 				"end-of-stream": "^1.1.0",
@@ -509,12 +466,12 @@
 			"optional": true
 		},
 		"simple-get": {
-			"version": "2.8.1",
-			"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-2.8.1.tgz",
-			"integrity": "sha512-lSSHRSw3mQNUGPAYRqo7xy9dhKmxFXIjLjp4KHpf99GEH2VH7C3AM+Qfx6du6jhfUi6Vm7XnbEVEf7Wb6N8jRw==",
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/simple-get/-/simple-get-3.1.0.tgz",
+			"integrity": "sha512-bCR6cP+aTdScaQCnQKbPKtJOKDp/hj9EDLJo3Nw4y1QksqaovlW/bnptB6/c1e+qmNIDHRK+oXFDdEqBT8WzUA==",
 			"optional": true,
 			"requires": {
-				"decompress-response": "^3.3.0",
+				"decompress-response": "^4.2.0",
 				"once": "^1.3.1",
 				"simple-concat": "^1.0.0"
 			}
@@ -571,61 +528,53 @@
 			"optional": true
 		},
 		"tar-fs": {
-			"version": "1.16.3",
-			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-1.16.3.tgz",
-			"integrity": "sha512-NvCeXpYx7OsmOh8zIOP/ebG55zZmxLE0etfWRbWok+q2Qo8x/vOR/IJT1taADXPe+jsiu9axDb3X4B+iIgNlKw==",
+			"version": "2.1.1",
+			"resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.1.tgz",
+			"integrity": "sha512-V0r2Y9scmbDRLCNex/+hYzvp/zyYjvFbHPNgVTKfQvVrb6guiE/fxP+XblDNR011utopbkex2nM4dHNV6GDsng==",
 			"optional": true,
 			"requires": {
-				"chownr": "^1.0.1",
-				"mkdirp": "^0.5.1",
-				"pump": "^1.0.0",
-				"tar-stream": "^1.1.2"
-			},
-			"dependencies": {
-				"pump": {
-					"version": "1.0.3",
-					"resolved": "https://registry.npmjs.org/pump/-/pump-1.0.3.tgz",
-					"integrity": "sha512-8k0JupWme55+9tCVE+FS5ULT3K6AbgqrGa58lTT49RpyfwwcGedHqaC5LlQNdEAumn/wFsu6aPwkuPMioy8kqw==",
-					"optional": true,
-					"requires": {
-						"end-of-stream": "^1.1.0",
-						"once": "^1.3.1"
-					}
-				}
+				"chownr": "^1.1.1",
+				"mkdirp-classic": "^0.5.2",
+				"pump": "^3.0.0",
+				"tar-stream": "^2.1.4"
 			}
 		},
 		"tar-stream": {
-			"version": "1.6.2",
-			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-1.6.2.tgz",
-			"integrity": "sha512-rzS0heiNf8Xn7/mpdSVVSMAWAoy9bfb1WOTYC78Z0UQKeKa/CWS8FOq0lKGNa8DWKAn9gxjCvMLYc5PGXYlK2A==",
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-2.2.0.tgz",
+			"integrity": "sha512-ujeqbceABgwMZxEJnk2HDY2DlnUZ+9oEcb1KzTVfYHio0UE6dG71n60d8D2I4qNvleWrrXpmjpt7vZeF1LnMZQ==",
 			"optional": true,
 			"requires": {
-				"bl": "^1.0.0",
-				"buffer-alloc": "^1.2.0",
-				"end-of-stream": "^1.0.0",
+				"bl": "^4.0.3",
+				"end-of-stream": "^1.4.1",
 				"fs-constants": "^1.0.0",
-				"readable-stream": "^2.3.0",
-				"to-buffer": "^1.1.1",
-				"xtend": "^4.0.0"
+				"inherits": "^2.0.3",
+				"readable-stream": "^3.1.1"
 			},
 			"dependencies": {
 				"bl": {
-					"version": "1.2.3",
-					"resolved": "https://registry.npmjs.org/bl/-/bl-1.2.3.tgz",
-					"integrity": "sha512-pvcNpa0UU69UT341rO6AYy4FVAIkUHuZXRIWbq+zHnsVcRzDDjIAhGuuYoi0d//cwIwtt4pkpKycWEfjdV+vww==",
+					"version": "4.1.0",
+					"resolved": "https://registry.npmjs.org/bl/-/bl-4.1.0.tgz",
+					"integrity": "sha512-1W07cM9gS6DcLperZfFSj+bWLtaPGSOHWhPiGzXmvVJbRLdG82sH/Kn8EtW1VqWVA54AKf2h5k5BbnIbwF3h6w==",
 					"optional": true,
 					"requires": {
-						"readable-stream": "^2.3.5",
-						"safe-buffer": "^5.1.1"
+						"buffer": "^5.5.0",
+						"inherits": "^2.0.4",
+						"readable-stream": "^3.4.0"
+					}
+				},
+				"readable-stream": {
+					"version": "3.6.0",
+					"resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.0.tgz",
+					"integrity": "sha512-BViHy7LKeTz4oNnkcLJ+lVSL6vpiFeX6/d3oSH8zCW7UxP2onchk+vTGB143xuFjHS3deTgkKoXXymXqymiIdA==",
+					"optional": true,
+					"requires": {
+						"inherits": "^2.0.3",
+						"string_decoder": "^1.1.1",
+						"util-deprecate": "^1.0.1"
 					}
 				}
 			}
-		},
-		"to-buffer": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/to-buffer/-/to-buffer-1.1.1.tgz",
-			"integrity": "sha512-lx9B5iv7msuFYE3dytT+KE5tap+rNYw+K4jVkb9R/asAb+pbBSM17jtunHplhBe6RRJdZx3Pn2Jph24O32mOVg==",
-			"optional": true
 		},
 		"tunnel-agent": {
 			"version": "0.6.0",
@@ -661,12 +610,6 @@
 			"version": "1.0.2",
 			"resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
 			"integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
-			"optional": true
-		},
-		"xtend": {
-			"version": "4.0.2",
-			"resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
-			"integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
 			"optional": true
 		}
 	}

--- a/packages/service-provider-server/package.json
+++ b/packages/service-provider-server/package.json
@@ -43,13 +43,13 @@
     "@types/sinon": "^7.5.1",
     "@types/sinon-chai": "^3.2.3",
     "aws4": "^1.11.0",
-    "mongodb": "4.0.0-beta.2",
+    "mongodb": "4.0.0-beta.3",
     "saslprep": "mongodb-js/saslprep#v1.0.4"
   },
   "devDependencies": {
     "@types/bl": "^2.1.0"
   },
   "optionalDependencies": {
-    "mongodb-client-encryption": "^1.2.2"
+    "mongodb-client-encryption": "^1.2.3"
   }
 }


### PR DESCRIPTION
Also updates `mongodb-client-encryption` to `1.2.3`.