### PR TITLE
chore(cli-repl): add async-rewriter library integration test

### DIFF
--- a/packages/cli-repl/package-lock.json
+++ b/packages/cli-repl/package-lock.json
@@ -404,9 +404,9 @@
 			"integrity": "sha1-uEF7dQZho5K+4sJTfGiyqdSXfNU="
 		},
 		"lodash": {
-			"version": "4.17.20",
-			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.20.tgz",
-			"integrity": "sha512-PlhdFcillOINfeV7Ni6oF1TAEayyZBoZ8bcshTHqOYJYlrqzRK5hagpagky5o4HfCzzd1TRkXPMFq6cKk9rGmA=="
+			"version": "4.17.21",
+			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
+			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
 		},
 		"lodash.isstring": {
 			"version": "4.0.1",
@@ -461,6 +461,12 @@
 					"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
 				}
 			}
+		},
+		"moment": {
+			"version": "2.29.1",
+			"resolved": "https://registry.npmjs.org/moment/-/moment-2.29.1.tgz",
+			"integrity": "sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==",
+			"dev": true
 		},
 		"mongodb-ace-autocompleter": {
 			"version": "0.4.8",

--- a/packages/cli-repl/package.json
+++ b/packages/cli-repl/package.json
@@ -75,7 +75,9 @@
     "@types/read": "^0.0.28",
     "@types/text-table": "^0.2.1",
     "@types/yargs-parser": "^15.0.0",
-    "chai-as-promised": "^7.1.1"
+    "chai-as-promised": "^7.1.1",
+    "lodash": "^4.17.21",
+    "moment": "^2.29.1"
   },
   "optionalDependencies": {
     "macos-export-certificate-and-key": "^1.0.0",

--- a/packages/cli-repl/test/e2e.spec.ts
+++ b/packages/cli-repl/test/e2e.spec.ts
@@ -365,6 +365,7 @@ describe('e2e', function() {
     });
 
     it('rewrites async properly for common libraries', async function() {
+      this.timeout(120_000);
       // This is being run under the new async rewriter because the old one
       // did not support these libraries at all (for various reasons).
       // Once the new async rewriter is the default, this block can be removed.
@@ -385,7 +386,7 @@ describe('e2e', function() {
         // Use eventually explicitly to get a bigger timeout, lodash is
         // quite “big” in terms of async rewriting
         shell.assertContainsOutput('loadedscripts');
-      }, { timeout: 40_000 });
+      }, { timeout: 60_000 });
       const result = await shell.executeLine(
         'moment(_.first(_.map(db.test.find().toArray(), "d"))).format("X")');
       expect(result).to.include('1617787494');


### PR DESCRIPTION
Load lodash (all of it) and moment.js into the shell and perform
a basic test that verifies that they can be used with the new
async rewriter.