### PR TITLE
chore(async-rewriter2): further limit number of wrapped expressions

### DIFF
--- a/packages/async-rewriter2/src/async-writer-babel.spec.ts
+++ b/packages/async-rewriter2/src/async-writer-babel.spec.ts
@@ -694,7 +694,7 @@ describe('AsyncWriter', () => {
     });
 
     it('throws sensible error messages for long expressions', () => {
-      expect(() => runTranspiledCode('var abcdefghijklmnopqrstuvwxyz; abcdefghijklmnopqrstuvwxyz()'))
+      expect(() => runTranspiledCode('globalThis.abcdefghijklmnopqrstuvwxyz = {}; abcdefghijklmnopqrstuvwxyz()'))
         .to.throw('abcdefghijklm ... uvwxyz is not a function');
     });
   });

--- a/packages/async-rewriter2/src/stages/transform-maybe-await.ts
+++ b/packages/async-rewriter2/src/stages/transform-maybe-await.ts
@@ -456,10 +456,16 @@ export default ({ types: t }: { types: typeof BabelTypes }): babel.PluginObj<{ f
               path.isParenthesizedExpression() ||
               path.isUnaryExpression() ||
               path.isSuper() || // Would probably break stuff
+              path.isThisExpression() ||
               path.isAwaitExpression() || // No point in awaiting twice
               path.parentPath.isAwaitExpression()) {
             return;
           }
+
+          // If it's an identifier and we know where it has been declared, it's fine as well
+          // because having seen a declaration means either being undefined or having seen
+          // an assignment as well.
+          if (path.isIdentifier() && path.scope.hasBinding(path.node.name)) return;
 
           const { expressionHolder, isSyntheticPromise, assertNotSyntheticPromise } = identifierGroup;
           const prettyOriginalString = limitStringLength(


### PR DESCRIPTION
This might help with performance a bit.