### PR TITLE
fix(shell-api): never check $clusterTime in rs integration tests

### DIFF
--- a/packages/shell-api/src/replica-set.spec.ts
+++ b/packages/shell-api/src/replica-set.spec.ts
@@ -3,7 +3,6 @@ import { bson, FindCursor as ServiceProviderCursor, ServiceProvider } from '@mon
 import chai, { expect } from 'chai';
 import { EventEmitter } from 'events';
 import sinonChai from 'sinon-chai';
-import semver from 'semver';
 import { StubbedInstance, stubInterface } from 'ts-sinon';
 import { ensureMaster } from '../../../testing/helpers';
 import { MongodSetup, skipIfServerVersion, startTestCluster } from '../../../testing/integration-testing-hooks';
@@ -653,9 +652,7 @@ describe('ReplicaSet', () => {
       const result = await rs.initiate(cfg);
       expect(result.ok).to.equal(1);
       // https://jira.mongodb.org/browse/SERVER-55371
-      if (!semver.satisfies(await srv0.serverVersion(), '>= 4.2.13 < 4.4.x')) {
-        expect(result.$clusterTime).to.not.be.undefined;
-      }
+      // expect(result.$clusterTime).to.not.be.undefined;
     });
 
     beforeEach(async() => {


### PR DESCRIPTION
See the referenced server issue, the problematic change has been
applied not only to 4.2.x but also to 4.0.x and 4.4.x, so let’s
skip this entirely for now.