### PR TITLE
chore(async-rewriter): use babel compact option MONGOSH-678

### DIFF
--- a/packages/async-rewriter/src/async-writer-babel.ts
+++ b/packages/async-rewriter/src/async-writer-babel.ts
@@ -749,7 +749,8 @@ export default class AsyncWriter {
         code: true,
         ast: true,
         configFile: false,
-        babelrc: false
+        babelrc: false,
+        compact: code.length > 10_000
       });
     } catch (e) {
       e.message = e.message.replace('unknown: ', '');

--- a/packages/async-rewriter2/src/async-writer-babel.ts
+++ b/packages/async-rewriter2/src/async-writer-babel.ts
@@ -30,7 +30,8 @@ export default class AsyncWriter {
       plugins,
       code: true,
       configFile: false,
-      babelrc: false
+      babelrc: false,
+      compact: code.length > 10_000
     })?.code as string;
   }
 

--- a/packages/cli-repl/test/e2e.spec.ts
+++ b/packages/cli-repl/test/e2e.spec.ts
@@ -390,6 +390,7 @@ describe('e2e', function() {
       const result = await shell.executeLine(
         'moment(_.first(_.map(db.test.find().toArray(), "d"))).format("X")');
       expect(result).to.include('1617787494');
+      shell.assertNotContainsOutput('[BABEL]');
     });
 
     it('expands explain output indefinitely', async() => {


### PR DESCRIPTION
This turns off warnings when processing large scripts.
This change uses a lower ‘compact’ code size limit than the
babel default, because we don’t really need the code to
be auto-styled except when we’re developing.