### PR TITLE
fix(cli-repl): print result of --eval MONGOSH-683

### DIFF
--- a/packages/cli-repl/src/cli-repl.spec.ts
+++ b/packages/cli-repl/src/cli-repl.spec.ts
@@ -361,7 +361,7 @@ describe('CliRepl', () => {
         });
 
         it('evaluates code passed through --eval', async() => {
-          cliReplOptions.shellCliOptions.eval = 'print("i am being evaluated")';
+          cliReplOptions.shellCliOptions.eval = '"i am" + " being evaluated"';
           cliRepl = new CliRepl(cliReplOptions);
           await startWithExpectedImmediateExit(cliRepl, '');
           expect(output).to.include('i am being evaluated');

--- a/packages/cli-repl/src/cli-repl.ts
+++ b/packages/cli-repl/src/cli-repl.ts
@@ -190,7 +190,8 @@ class CliRepl {
   async loadCommandLineFilesAndEval(files: string[]) {
     if (this.cliOptions.eval) {
       this.bus.emit('mongosh:eval-cli-script');
-      await this.mongoshRepl.loadExternalCode(this.cliOptions.eval, '@(shell eval)');
+      const evalResult = await this.mongoshRepl.loadExternalCode(this.cliOptions.eval, '@(shell eval)');
+      this.output.write(this.mongoshRepl.writer(evalResult) + '\n');
     } else if (this.cliOptions.eval === '') {
       // This happens e.g. when --eval is followed by another option, for example
       // when running `mongosh --eval --shell "eval script"`, which can happen

--- a/packages/cli-repl/test/e2e.spec.ts
+++ b/packages/cli-repl/test/e2e.spec.ts
@@ -595,9 +595,10 @@ describe('e2e', function() {
     });
 
     context('--eval', () => {
+      const script = 'const a = "hello", b = " one"; a + b';
       it('loads a script from the command line as requested', async() => {
         const shell = TestShell.start({
-          args: [ '--nodb', '--eval', 'print("hello one")' ]
+          args: [ '--nodb', '--eval', script ]
         });
         await eventually(() => {
           shell.assertContainsOutput('hello one');
@@ -608,7 +609,7 @@ describe('e2e', function() {
 
       it('drops into shell if --shell is used', async() => {
         const shell = TestShell.start({
-          args: [ '--nodb', '--eval', 'print("hello one")', '--shell' ]
+          args: [ '--nodb', '--eval', script, '--shell' ]
         });
         await shell.waitForPrompt();
         shell.assertContainsOutput('hello one');


### PR DESCRIPTION
`--eval` always prints its result in the old shell (with or
without `--shell`). Do the same thing in mongosh.