### PR TITLE
fix(cli-repl): print newline after password prompt

### DIFF
--- a/packages/cli-repl/src/cli-repl.spec.ts
+++ b/packages/cli-repl/src/cli-repl.spec.ts
@@ -484,6 +484,7 @@ describe('CliRepl', () => {
       }
       expect(threw).to.be.true;
       expect(auth.password).to.equal('i want food');
+      expect(output).to.match(/^Enter password: \**$/m);
       input.write('.exit\n');
     });
 

--- a/packages/cli-repl/src/cli-repl.ts
+++ b/packages/cli-repl/src/cli-repl.ts
@@ -367,7 +367,11 @@ class CliRepl {
     });
     this.output.write('Enter password: ');
     try {
-      (driverOptions.auth as any).password = (await passwordPromise).toString();
+      try {
+        (driverOptions.auth as any).password = (await passwordPromise).toString();
+      } finally {
+        this.output.write('\n');
+      }
     } catch (error) {
       await this._fatalError(error);
     }


### PR DESCRIPTION
Otherwise, you end up with
`Enter password: ****************Current Mongosh Log ID: [...]`.