### PR TITLE
fix(shell-api): do not expose internalState as global

### DIFF
--- a/packages/shell-api/src/shell-api.ts
+++ b/packages/shell-api/src/shell-api.ts
@@ -22,18 +22,26 @@ import { promisify } from 'util';
 import { ClientSideFieldLevelEncryptionOptions } from './field-level-encryption';
 import { dirname } from 'path';
 
+const internalStateSymbol = Symbol.for('@@mongosh.internalState');
+
 @shellApiClassDefault
 @hasAsyncChild
 export default class ShellApi extends ShellApiClass {
-  readonly internalState: ShellInternalState;
+  // Use a symbol to make sure this is *not* one of the things copied over into
+  // the global scope.
+  [internalStateSymbol]: ShellInternalState;
   public DBQuery: DBQuery;
   loadCallNestingLevel: number;
 
   constructor(internalState: ShellInternalState) {
     super();
-    this.internalState = internalState;
+    this[internalStateSymbol] = internalState;
     this.DBQuery = new DBQuery();
     this.loadCallNestingLevel = 0;
+  }
+
+  get internalState(): ShellInternalState {
+    return this[internalStateSymbol];
   }
 
   @directShellCommand


### PR DESCRIPTION
I don’t think this was intentionally exposed as a global
(it was because all own properties of the `ShellApi` instance
are copied onto the global object). Hide it by making it a non-own
property.