### PR TITLE
fix(service-provider-core): re-fix connection string casing

### DIFF
--- a/packages/service-provider-core/src/connection-string.ts
+++ b/packages/service-provider-core/src/connection-string.ts
@@ -10,42 +10,43 @@ const HOSTS_REGEX = new RegExp(
   String.raw`(?<protocol>mongodb(?:\+srv|)):\/\/(?:(?<username>[^:]*)(?::(?<password>[^@]*))?@)?(?<hosts>(?!:)[^\/?@]+)(?<rest>.*)`
 );
 
-class CaseInsenstiveURLSearchParams extends URLSearchParams {
-  append(name: any, value: any): void {
-    return super.append(this._normalizeKey(name), value);
-  }
-
-  delete(name: any): void {
-    return super.delete(this._normalizeKey(name));
-  }
-
-  get(name: any): string | null {
-    return super.get(this._normalizeKey(name));
-  }
-
-  getAll(name: any): string[] {
-    return super.getAll(this._normalizeKey(name));
-  }
-
-  has(name: any): boolean {
-    return super.has(this._normalizeKey(name));
-  }
-
-  set(name: any, value: any): void {
-    return super.set(this._normalizeKey(name), value);
-  }
-
-  _normalizeKey(name: any): string {
-    name = `${name}`;
-    for (const key of this.keys()) {
-      if (key.toLowerCase() === name.toLowerCase()) {
-        name = key;
-        break;
-      }
+const caseInsenstiveURLSearchParams = (Ctor: typeof URLSearchParams) =>
+  class CaseInsenstiveURLSearchParams extends Ctor {
+    append(name: any, value: any): void {
+      return super.append(this._normalizeKey(name), value);
     }
-    return name;
-  }
-}
+
+    delete(name: any): void {
+      return super.delete(this._normalizeKey(name));
+    }
+
+    get(name: any): string | null {
+      return super.get(this._normalizeKey(name));
+    }
+
+    getAll(name: any): string[] {
+      return super.getAll(this._normalizeKey(name));
+    }
+
+    has(name: any): boolean {
+      return super.has(this._normalizeKey(name));
+    }
+
+    set(name: any, value: any): void {
+      return super.set(this._normalizeKey(name), value);
+    }
+
+    _normalizeKey(name: any): string {
+      name = `${name}`;
+      for (const key of this.keys()) {
+        if (key.toLowerCase() === name.toLowerCase()) {
+          name = key;
+          break;
+        }
+      }
+      return name;
+    }
+  };
 
 // Abstract middle class to appease TypeScript, see https://github.com/microsoft/TypeScript/pull/37894
 abstract class URLWithoutHost extends URL {
@@ -114,7 +115,7 @@ export class ConnectionString extends URLWithoutHost {
     if (!this.pathname) {
       this.pathname = '/';
     }
-    Object.setPrototypeOf(this.searchParams, CaseInsenstiveURLSearchParams.prototype);
+    Object.setPrototypeOf(this.searchParams, caseInsenstiveURLSearchParams(this.searchParams.constructor as any).prototype);
   }
 
   // The getters here should throw, but that would break .toString() because of


### PR DESCRIPTION
https://github.com/mongodb-js/mongosh/pull/760 broke the compass-shell
tests, likely because there are multiple conflicting implementations of
`URLSearchParams` that come into play. We didn't notice because the
compass-shell tests don't run in CI (-> https://jira.mongodb.org/browse/MONGOSH-689).

Instead of using a fixed prototype, make the case-insensitive
URLSearchParams implementation a mixin.