### PR TITLE
feat: flip async-rewriter switch MONGOSH-651

### DIFF
--- a/packages/cli-repl/src/cli-repl.spec.ts
+++ b/packages/cli-repl/src/cli-repl.spec.ts
@@ -515,10 +515,7 @@ describe('CliRepl', () => {
       input.write('let cursor = db.test.find();\n');
       await waitEval(cliRepl.bus);
 
-      const rewrittenPromise = waitBus(cliRepl.bus, 'mongosh:rewritten-async-input');
       input.write('cursor.forEach(doc => db.test.insertOne({ a: doc.a + 1 }))\n');
-      const [{ rewritten }] = await rewrittenPromise;
-      expect(rewritten).to.include('toIterator'); // Make sure we're testing the right thing
       await waitEval(cliRepl.bus);
 
       output = '';

--- a/packages/cli-repl/test/e2e.spec.ts
+++ b/packages/cli-repl/test/e2e.spec.ts
@@ -343,16 +343,6 @@ describe('e2e', function() {
     });
 
     it('rewrites async properly for mapReduce', async() => {
-      // This is being run under the new async rewriter because the old one
-      // did not support mapReduce at all (because of needing 'this').
-      // Once the new async rewriter is the default, this block can be removed.
-      shell = TestShell.start({
-        args: [ await testServer.connectionString() ],
-        env: { ...process.env, MONGOSH_ASYNC_REWRITER2: '1' }
-      });
-      await shell.waitForPrompt();
-      shell.assertNoErrors();
-
       await shell.executeLine(`use ${dbName}`);
       await shell.executeLine('db.test.insertMany([{i:1},{i:2},{i:3},{i:4}]);');
       const result = await shell.executeLine(`db.test.mapReduce(function() {
@@ -366,16 +356,6 @@ describe('e2e', function() {
 
     it('rewrites async properly for common libraries', async function() {
       this.timeout(120_000);
-      // This is being run under the new async rewriter because the old one
-      // did not support these libraries at all (for various reasons).
-      // Once the new async rewriter is the default, this block can be removed.
-      shell = TestShell.start({
-        args: [ await testServer.connectionString() ],
-        env: { ...process.env, MONGOSH_ASYNC_REWRITER2: '1' }
-      });
-      await shell.waitForPrompt();
-      shell.assertNoErrors();
-
       await shell.executeLine(`use ${dbName}`);
       await shell.executeLine('db.test.insertOne({ d: new Date("2021-04-07T11:24:54+02:00") })');
       shell.writeInputLine(`load(${JSON.stringify(require.resolve('lodash'))})`);

--- a/packages/cli-repl/test/e2e.spec.ts
+++ b/packages/cli-repl/test/e2e.spec.ts
@@ -407,14 +407,14 @@ describe('e2e', function() {
     });
     it('interrupts async awaiting', async() => {
       const result = shell.executeLine('new Promise(() => {});');
-      setTimeout(() => shell.kill('SIGINT'), 1000);
+      setTimeout(() => shell.kill('SIGINT'), 3000);
       await result;
       shell.assertContainsError('interrupted');
     });
     it('interrupts load()', async() => {
       const filename = path.resolve(__dirname, 'fixtures', 'load', 'infinite-loop.js');
       const result = shell.executeLine(`load(${JSON.stringify(filename)})`);
-      setTimeout(() => shell.kill('SIGINT'), 1000);
+      setTimeout(() => shell.kill('SIGINT'), 3000);
       await result;
       shell.assertContainsError('interrupted');
     });

--- a/packages/node-runtime-worker-thread/src/index.spec.ts
+++ b/packages/node-runtime-worker-thread/src/index.spec.ts
@@ -246,7 +246,7 @@ describe('WorkerRuntime', () => {
             // This is flaky when not enought time given to the worker to
             // finish the sync part of the work. If it causes too much issues
             // it would be okay to disable this test completely
-            await sleep(1500);
+            await sleep(5000);
             await runtime.interrupt();
           })()
         ]);

--- a/packages/node-runtime-worker-thread/src/worker-runtime.spec.ts
+++ b/packages/node-runtime-worker-thread/src/worker-runtime.spec.ts
@@ -109,7 +109,7 @@ describe('worker', () => {
           'function def() {}; def.def = 1; def',
           '[Function: def] { def: 1 }'
         ],
-        ['anonymous function', '(() => {})', /\[Function( \(anonymous\))?\]/],
+        ['anonymous function', '(() => {})', /\[Function.+\]/],
         ['class constructor', 'class BCD {}; BCD', '[class BCD]'],
         [
           'class instalce',

--- a/packages/shell-api/src/collection.ts
+++ b/packages/shell-api/src/collection.ts
@@ -1114,7 +1114,8 @@ export default class Collection extends ShellApiClass {
           Array.isArray(indexes) &&
           indexes.length > 0 &&
           (await this._database.version()).match(/^4\.0\./)) {
-        const all = await Promise.all((indexes as string[]).map(index => this.dropIndexes(index)));
+        const all = await Promise.all((indexes as string[]).map(
+          async index => await this.dropIndexes(index)));
         const errored = all.find(result => !result.ok);
         if (errored) return errored;
         // Return the entry with the highest nIndexesWas value.

--- a/packages/shell-evaluator/src/shell-evaluator.ts
+++ b/packages/shell-evaluator/src/shell-evaluator.ts
@@ -20,8 +20,7 @@ class ShellEvaluator<EvaluationResultType = ShellResult> {
   constructor(internalState: ShellInternalState, resultHandler: ResultHandler<EvaluationResultType> = toShellResult as any) {
     this.internalState = internalState;
     this.resultHandler = resultHandler;
-    if (process.env.MONGOSH_ASYNC_REWRITER2) {
-      process.emitWarning(new Error('Using @mongosh/async-rewriter2'));
+    if (process.env.MONGOSH_ASYNC_REWRITER2 !== '0') {
       this.internalState.asyncWriter = new AsyncWriter();
       this.hasAppliedAsyncWriterRuntimeSupport = false;
     }


### PR DESCRIPTION
After further manual testing, it seems to be a good idea to
flip the switch to enable the new async rewriter by default,
as doing so does improve the user experience significantly
and we do likely want to have some time between enabling it and
the shell 1.0 release.

(e.g.: Without this, running scripts like https://github.com/addaleax/mongosh-snippets/blob/main/snippets/analyze-schema/index.js would be virtually impossible)