### PR TITLE
chore(shell-evaluator): do not log full rewritten code

### DIFF
--- a/packages/cli-repl/src/setup-logger-and-telemetry.spec.ts
+++ b/packages/cli-repl/src/setup-logger-and-telemetry.spec.ts
@@ -53,7 +53,7 @@ describe('setupLoggerAndTelemetry', () => {
     bus.emit('mongosh:setCtx', { method: 'setCtx' });
     bus.emit('mongosh:api-call', { method: 'auth', class: 'Database', db: 'test-1603986682000', arguments: { } });
     bus.emit('mongosh:api-call', { method: 'redactable', arguments: { email: 'mongosh@example.com' } });
-    bus.emit('mongosh:rewritten-async-input', { original: '1+1', rewritten: '2' });
+    bus.emit('mongosh:evaluate-input', { input: '1+1' });
     bus.emit('mongosh:driver-initialized', { driver: { name: 'nodejs', version: '3.6.1' } });
 
     bus.emit('mongosh:start-loading-cli-scripts', { usesShellOption: true });
@@ -90,9 +90,8 @@ describe('setupLoggerAndTelemetry', () => {
     expect(logOutput[13].msg).to.match(/"db":"test-1603986682000"/);
     expect(logOutput[14].msg).to.match(/^mongosh:api-call/);
     expect(logOutput[14].msg).to.match(/"email":"<email>"/);
-    expect(logOutput[15].msg).to.match(/^mongosh:rewritten-async-input/);
-    expect(logOutput[15].msg).to.match(/"original":"1\+1"/);
-    expect(logOutput[15].msg).to.match(/"rewritten":"2"/);
+    expect(logOutput[15].msg).to.match(/^mongosh:evaluate-input/);
+    expect(logOutput[15].msg).to.match(/"input":"1\+1"/);
     expect(logOutput[16].msg).to.match(/"version":"3.6.1"/);
     expect(logOutput[17].msg).to.equal('mongosh:start-loading-cli-scripts');
     expect(logOutput[18].msg).to.match(/^mongosh:api-load-file/);

--- a/packages/cli-repl/src/setup-logger-and-telemetry.ts
+++ b/packages/cli-repl/src/setup-logger-and-telemetry.ts
@@ -6,7 +6,7 @@ import type {
   MongoshBus,
   ApiEvent,
   UseEvent,
-  AsyncRewriterEvent,
+  EvaluateInputEvent,
   ShowEvent,
   ConnectEvent,
   ScriptLoadFileEvent,
@@ -139,8 +139,8 @@ export default function setupLoggerAndTelemetry(
     }
   });
 
-  bus.on('mongosh:rewritten-async-input', function(args: AsyncRewriterEvent) {
-    log.info('mongosh:rewritten-async-input', args);
+  bus.on('mongosh:evaluate-input', function(args: EvaluateInputEvent) {
+    log.info('mongosh:evaluate-input', args);
   });
 
   bus.on('mongosh:use', function(args: UseEvent) {

--- a/packages/cli-repl/test/e2e.spec.ts
+++ b/packages/cli-repl/test/e2e.spec.ts
@@ -709,7 +709,7 @@ describe('e2e', function() {
           await eventually(async() => {
             expect(shell.output).to.include('579');
             const log = await readLogfile();
-            expect(log.filter(logEntry => /rewritten-async-input/.test(logEntry.msg)))
+            expect(log.filter(logEntry => /evaluate-input/.test(logEntry.msg)))
               .to.have.lengthOf(1);
           });
         });

--- a/packages/shell-evaluator/src/shell-evaluator.ts
+++ b/packages/shell-evaluator/src/shell-evaluator.ts
@@ -58,8 +58,8 @@ class ShellEvaluator<EvaluationResultType = ShellResult> {
     const hiddenCommands = RegExp(HIDDEN_COMMANDS, 'g');
     if (!hiddenCommands.test(input) && !hiddenCommands.test(rewrittenInput)) {
       this.internalState.messageBus.emit(
-        'mongosh:rewritten-async-input',
-        { original: removeCommand(input.trim()), rewritten: removeCommand(rewrittenInput.trim()) }
+        'mongosh:evaluate-input',
+        { input: removeCommand(input.trim()) }
       );
     }
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -23,9 +23,8 @@ export interface UseEvent {
   db: string;
 }
 
-export interface AsyncRewriterEvent {
-  original: string;
-  rewritten: string;
+export interface EvaluateInputEvent {
+  input: string;
 }
 
 export interface ShowEvent {
@@ -80,7 +79,7 @@ export interface MongoshBusEventsMap {
   'mongosh:update-user': (id: string, enableTelemetry: boolean) => void;
   'mongosh:error': (error: Error) => void;
   'mongosh:help': () => void;
-  'mongosh:rewritten-async-input': (ev: AsyncRewriterEvent) => void;
+  'mongosh:evaluate-input': (ev: EvaluateInputEvent) => void;
   'mongosh:use': (ev: UseEvent) => void;
   'mongosh:getDB': (ev: UseEvent) => void;
   'mongosh:show': (ev: ShowEvent) => void;


### PR DESCRIPTION
With the new async rewriter, the rewritten code is unfortunately quite
a bit larger in size than the input, so logging both input and output
leads to large log files. However, since the new rewriter is stateless,
we also don’t need to worry about the output anymore, and can just
skip logging it.