### PR TITLE
chore(build): give each bundling test its own tmpdir

### DIFF
--- a/packages/build/src/compile/generate-bundle.spec.ts
+++ b/packages/build/src/compile/generate-bundle.spec.ts
@@ -10,7 +10,7 @@ const execFile = promisify(childProcess.execFile);
 
 describe('compile generateBundle', function() {
   this.timeout(60_000);
-  let tmpdir;
+  let tmpdir: string;
 
   beforeEach(async() => {
     tmpdir = path.resolve(

--- a/packages/build/src/compile/generate-bundle.spec.ts
+++ b/packages/build/src/compile/generate-bundle.spec.ts
@@ -10,11 +10,12 @@ const execFile = promisify(childProcess.execFile);
 
 describe('compile generateBundle', function() {
   this.timeout(60_000);
-  const tmpdir = path.resolve(
-    __dirname, '..', '..', '..', 'tmp', `test-build-${Date.now()}-${Math.random()}`
-  );
+  let tmpdir;
 
   beforeEach(async() => {
+    tmpdir = path.resolve(
+      __dirname, '..', '..', '..', 'tmp', `test-build-${Date.now()}-${Math.random()}`
+    );
     await fs.mkdir(tmpdir, { recursive: true });
   });
 


### PR DESCRIPTION
This *might* fix flakiness like this:

    [2021/04/19 11:53:57.707]   1) compile generateBundle
    [2021/04/19 11:53:57.707]        does not attempt to load ES6 modules because parcel cannot handle them properly:
    [2021/04/19 11:53:57.707]      Error: ENOENT: no such file or directory, open 'Z:\data\mci\b2b62ed7d54f2bcd3c5e2ddd5846c7d9\src\packages\tmp\test-build-1618833168859-0.6650505642822344\a.js'