### PR TITLE
chore(cli-repl): fix flaky test and improve errors

### DIFF
--- a/packages/cli-repl/test/helpers.ts
+++ b/packages/cli-repl/test/helpers.ts
@@ -21,5 +21,10 @@ export async function eventually(fn: Function, options: { frequency?: number; ti
     await new Promise(resolve => setTimeout(resolve, options.frequency));
   }
 
+  Object.assign(err, {
+    timedOut: true,
+    timeout: options.timeout,
+    message: `[Timed out ${options.timeout}ms] ${err.message}`
+  });
   throw err;
 }

--- a/packages/cli-repl/test/test-shell.ts
+++ b/packages/cli-repl/test/test-shell.ts
@@ -8,7 +8,9 @@ import { eventually } from './helpers';
 export type TestShellStartupResult = { state: 'prompt' | 'exit'; exitCode?: number | undefined };
 type SignalType = ChildProcess extends { kill: (signal: infer T) => any } ? T : never;
 
-const PROMPT_PATTERN = /^([^>]*> ?)+$/m;
+// Assume that prompt strings are those that end in '> ' but do not contain
+// < or > (so that e.g. '- <repl>' in a stack trace is not considered a prompt).
+const PROMPT_PATTERN = /^([^<>]*> ?)+$/m;
 const ERROR_PATTERN_1 = /Thrown:\n([^>]*)/mg; // node <= 12.14
 const ERROR_PATTERN_2 = /Uncaught[:\n ]+([^>]*)/mg;
 
@@ -133,7 +135,7 @@ export class TestShell {
         throw new assert.AssertionError({
           message: 'expected prompt',
           expected: PROMPT_PATTERN.toString(),
-          actual: this._output
+          actual: this._output.slice(0, start) + '[prompt search starts here]' + output
         });
       }
     });


### PR DESCRIPTION
The Node.js REPL produces errors like this when a module is not found:

```js
Uncaught Error: Cannot find module 'a'
Require stack:
- <repl>
[ ... ]
```

Our test helpers interpreted the `- <repl>` string as a prompt, which
it is not.

Fix that by requiring the prompt not to contain a matching
angle bracket, and provide more precise error messages from our
test helpers in general to help debug future problems.