### PR TITLE
chore(service-provider-server): use atlasVersion to identify Atlas

### DIFF
--- a/packages/service-provider-core/src/connect-info.spec.ts
+++ b/packages/service-provider-core/src/connect-info.spec.ts
@@ -59,6 +59,11 @@ describe('getConnectInfo', function() {
     'ok': 1
   };
 
+  const ATLAS_VERSION = {
+    'atlasVersion': '20210330.0.0.1617063608',
+    'gitVersion': '8f7e5bdde713391e8123a463895bb7fb660a5ffd'
+  };
+
   const TOPOLOGY_WITH_CREDENTIALS = {
     's': {
       'credentials': {
@@ -71,7 +76,7 @@ describe('getConnectInfo', function() {
     's': {}
   };
 
-  const ATLAS_URI = 'mongodb+srv://admin:catscatscats@cat-data-sets.cats.mongodb.net/admin';
+  const ATLAS_URI = 'mongodb+srv://admin:catscatscats@cat-data-sets.cats.example.net/admin';
 
   it('reports on an enterprise version >=3.2 of mongodb with credentials', function() {
     const output = {
@@ -83,6 +88,7 @@ describe('getConnectInfo', function() {
       auth_type: 'LDAP',
       is_data_lake: false,
       dl_version: null,
+      atlas_version: '20210330.0.0.1617063608',
       is_genuine: true,
       non_genuine_server_name: 'mongodb',
       server_arch: 'x86_64',
@@ -95,6 +101,7 @@ describe('getConnectInfo', function() {
       '0.0.6',
       BUILD_INFO,
       CMD_LINE_OPTS,
+      ATLAS_VERSION,
       TOPOLOGY_WITH_CREDENTIALS)).to.deep.equal(output);
   });
 
@@ -108,6 +115,7 @@ describe('getConnectInfo', function() {
       auth_type: null,
       is_data_lake: false,
       dl_version: null,
+      atlas_version: '20210330.0.0.1617063608',
       is_genuine: true,
       non_genuine_server_name: 'mongodb',
       server_arch: 'x86_64',
@@ -120,6 +128,7 @@ describe('getConnectInfo', function() {
       '0.0.6',
       BUILD_INFO,
       CMD_LINE_OPTS,
+      ATLAS_VERSION,
       TOPOLOGY_NO_CREDENTIALS)).to.deep.equal(output);
   });
 
@@ -133,6 +142,7 @@ describe('getConnectInfo', function() {
       auth_type: 'LDAP',
       is_data_lake: false,
       dl_version: null,
+      atlas_version: null,
       is_genuine: true,
       non_genuine_server_name: 'mongodb',
       server_arch: 'x86_64',
@@ -145,6 +155,7 @@ describe('getConnectInfo', function() {
       '0.0.6',
       BUILD_INFO,
       CMD_LINE_OPTS,
+      null,
       TOPOLOGY_WITH_CREDENTIALS)).to.deep.equal(output);
   });
 });

--- a/packages/service-provider-core/src/connect-info.ts
+++ b/packages/service-provider-core/src/connect-info.ts
@@ -14,13 +14,14 @@ export interface ConnectInfo {
   auth_type?: string;
   is_data_lake: boolean;
   dl_version?: string;
+  atlas_version?: string;
   is_genuine: boolean;
   non_genuine_server_name: string;
   node_version: string;
   uri: string;
 }
 
-export default function getConnectInfo(uri: string, mongoshVersion: string, buildInfo: any, cmdLineOpts: any, topology: any): ConnectInfo {
+export default function getConnectInfo(uri: string, mongoshVersion: string, buildInfo: any, cmdLineOpts: any, atlasVersion: any, topology: any): ConnectInfo {
   const { isGenuine: is_genuine, serverName: non_genuine_server_name } =
     getBuildInfo.getGenuineMongoDB(buildInfo, cmdLineOpts);
   const { isDataLake: is_data_lake, dlVersion: dl_version }
@@ -34,7 +35,7 @@ export default function getConnectInfo(uri: string, mongoshVersion: string, buil
     = getBuildInfo.getBuildEnv(buildInfo);
 
   return {
-    is_atlas: getBuildInfo.isAtlas(uri),
+    is_atlas: !!atlasVersion?.atlasVersion,
     is_localhost: getBuildInfo.isLocalhost(uri),
     server_version: buildInfo.version,
     node_version: process.version,
@@ -46,6 +47,7 @@ export default function getConnectInfo(uri: string, mongoshVersion: string, buil
     auth_type,
     is_data_lake,
     dl_version,
+    atlas_version: atlasVersion?.atlasVersion ?? null,
     is_genuine,
     non_genuine_server_name
   };

--- a/packages/service-provider-core/src/connect-info.ts
+++ b/packages/service-provider-core/src/connect-info.ts
@@ -35,7 +35,7 @@ export default function getConnectInfo(uri: string, mongoshVersion: string, buil
     = getBuildInfo.getBuildEnv(buildInfo);
 
   return {
-    is_atlas: !!atlasVersion?.atlasVersion,
+    is_atlas: !!atlasVersion?.atlasVersion || getBuildInfo.isAtlas(uri),
     is_localhost: getBuildInfo.isLocalhost(uri),
     server_version: buildInfo.version,
     node_version: process.version,

--- a/packages/service-provider-server/src/cli-service-provider.spec.ts
+++ b/packages/service-provider-server/src/cli-service-provider.spec.ts
@@ -781,11 +781,12 @@ describe('CliServiceProvider', () => {
   describe('#getConnectionInfo', () => {
     let clientStub: any;
     let dbStub: any;
-    let firstCall = true;
+    let firstCall;
 
     beforeEach(() => {
       dbStub = stubInterface<Db>();
       clientStub = stubInterface<MongoClient>();
+      firstCall = true;
       dbStub.command.callsFake(() => {
         if (firstCall) {
           firstCall = false;
@@ -809,7 +810,7 @@ describe('CliServiceProvider', () => {
       const info = await serviceProvider.getConnectionInfo();
       expect(info.extraInfo.is_atlas).to.equal(false);
       expect(info.extraInfo.is_localhost).to.equal(true);
-      expect(dbStub.command).to.have.callCount(3);
+      expect(dbStub.command).to.have.callCount(4);
     });
   });
 });

--- a/packages/service-provider-server/src/cli-service-provider.ts
+++ b/packages/service-provider-server/src/cli-service-provider.ts
@@ -260,8 +260,7 @@ class CliServiceProvider extends ServiceProviderCore implements ServiceProvider 
     }
     const topology = this.getTopology() as Topology;
     const { version } = require('../package.json');
-    let cmdLineOpts = null;
-    const [cmdOptions = null, atlasVersion = null] = await Promise.all([
+    const [cmdLineOpts = null, atlasVersion = null] = await Promise.all([
       this.runCommandWithCheck('admin', { getCmdLineOpts: 1 }, this.baseCmdOptions).catch(() => {}),
       this.runCommandWithCheck('admin', { atlasVersion: 1 }, this.baseCmdOptions).catch(() => {})
     ])

--- a/packages/service-provider-server/src/cli-service-provider.ts
+++ b/packages/service-provider-server/src/cli-service-provider.ts
@@ -263,7 +263,7 @@ class CliServiceProvider extends ServiceProviderCore implements ServiceProvider 
     const [cmdLineOpts = null, atlasVersion = null] = await Promise.all([
       this.runCommandWithCheck('admin', { getCmdLineOpts: 1 }, this.baseCmdOptions).catch(() => {}),
       this.runCommandWithCheck('admin', { atlasVersion: 1 }, this.baseCmdOptions).catch(() => {})
-    ])
+    ]);
 
     const extraConnectionInfo = getConnectInfo(
       this.uri?.toString() ?? '',

--- a/packages/service-provider-server/src/cli-service-provider.ts
+++ b/packages/service-provider-server/src/cli-service-provider.ts
@@ -261,19 +261,26 @@ class CliServiceProvider extends ServiceProviderCore implements ServiceProvider 
     const topology = this.getTopology() as Topology;
     const { version } = require('../package.json');
     let cmdLineOpts = null;
-    try {
-      cmdLineOpts = await this.runCommandWithCheck('admin', {
-        getCmdLineOpts: 1
-      }, this.baseCmdOptions);
-      // eslint-disable-next-line no-empty
-    } catch (e) {
-    }
+    let atlasVersion = null;
+    await Promise.all([
+      (async() => {
+        cmdLineOpts = await this.runCommandWithCheck('admin', {
+          getCmdLineOpts: 1
+        }, this.baseCmdOptions).catch(e => e);
+      })(),
+      (async() => {
+        atlasVersion = await this.runCommandWithCheck('admin', {
+          atlasVersion: 1
+        }, this.baseCmdOptions).catch(e => e);
+      })()
+    ]);
 
     const extraConnectionInfo = getConnectInfo(
       this.uri?.toString() ?? '',
       version,
       buildInfo,
       cmdLineOpts,
+      atlasVersion,
       topology
     );
 

--- a/packages/service-provider-server/src/cli-service-provider.ts
+++ b/packages/service-provider-server/src/cli-service-provider.ts
@@ -261,19 +261,10 @@ class CliServiceProvider extends ServiceProviderCore implements ServiceProvider 
     const topology = this.getTopology() as Topology;
     const { version } = require('../package.json');
     let cmdLineOpts = null;
-    let atlasVersion = null;
-    await Promise.all([
-      (async() => {
-        cmdLineOpts = await this.runCommandWithCheck('admin', {
-          getCmdLineOpts: 1
-        }, this.baseCmdOptions).catch(e => e);
-      })(),
-      (async() => {
-        atlasVersion = await this.runCommandWithCheck('admin', {
-          atlasVersion: 1
-        }, this.baseCmdOptions).catch(e => e);
-      })()
-    ]);
+    const [cmdOptions = null, atlasVersion = null] = await Promise.all([
+      this.runCommandWithCheck('admin', { getCmdLineOpts: 1 }, this.baseCmdOptions).catch(() => {}),
+      this.runCommandWithCheck('admin', { atlasVersion: 1 }, this.baseCmdOptions).catch(() => {})
+    ])
 
     const extraConnectionInfo = getConnectInfo(
       this.uri?.toString() ?? '',

--- a/packages/shell-api/src/shell-internal-state.spec.ts
+++ b/packages/shell-api/src/shell-internal-state.spec.ts
@@ -259,13 +259,14 @@ describe('ShellInternalState', () => {
         serviceProvider.getConnectionInfo.resolves({
           extraInfo: {
             uri: 'mongodb://localhost/',
-            is_atlas: true
+            is_atlas: true,
+            atlas_version: '20210330.0.0.1617063608'
           }
         });
 
         await internalState.fetchConnectionInfo();
         const prompt = await internalState.getDefaultPrompt();
-        expect(prompt).to.equal('[atlas proxy]> ');
+        expect(prompt).to.equal('[atlas]> ');
       });
     });
 

--- a/packages/shell-api/src/shell-internal-state.spec.ts
+++ b/packages/shell-api/src/shell-internal-state.spec.ts
@@ -266,7 +266,7 @@ describe('ShellInternalState', () => {
 
         await internalState.fetchConnectionInfo();
         const prompt = await internalState.getDefaultPrompt();
-        expect(prompt).to.equal('[atlas]> ');
+        expect(prompt).to.equal('> ');
       });
     });
 

--- a/packages/shell-api/src/shell-internal-state.ts
+++ b/packages/shell-api/src/shell-internal-state.ts
@@ -352,7 +352,7 @@ export default class ShellInternalState {
         serverTypePrompt = '[primary]';
         break;
       case 'Sharded':
-        serverTypePrompt = this.connectionInfo?.extraInfo?.is_atlas ? '[atlas proxy]' : '[mongos]';
+        serverTypePrompt = this.connectionInfo?.extraInfo?.atlas_version ? '[atlas]' : '[mongos]';
         break;
       default:
         return '';

--- a/packages/shell-api/src/shell-internal-state.ts
+++ b/packages/shell-api/src/shell-internal-state.ts
@@ -352,7 +352,7 @@ export default class ShellInternalState {
         serverTypePrompt = '[primary]';
         break;
       case 'Sharded':
-        serverTypePrompt = this.connectionInfo?.extraInfo?.atlas_version ? '[atlas]' : '[mongos]';
+        serverTypePrompt = this.connectionInfo?.extraInfo?.atlas_version ? '' : '[mongos]';
         break;
       default:
         return '';


### PR DESCRIPTION
This seems a bit more reliable than hostname parsing.