### PR TITLE
chore(async-rewriter2): add small helper cli for testing

### DIFF
--- a/packages/async-rewriter2/bin/async-rewrite.js
+++ b/packages/async-rewriter2/bin/async-rewrite.js
@@ -1,0 +1,8 @@
+#!/usr/bin/env node
+/* eslint-disable strict, no-sync */
+'use strict';
+const AsyncWriter = require('../').default;
+const fs = require('fs');
+const input = fs.readFileSync(process.argv[2]);
+const asyncWriter = new AsyncWriter();
+process.stdout.write(asyncWriter.process(input));


### PR DESCRIPTION
I’ve used this during development a few times recently,
so it might make sense to just commit it.