### PR TITLE
chore(cli-repl): print test shell output for failing e2e tests

### DIFF
--- a/packages/cli-repl/test/e2e-analytics.spec.ts
+++ b/packages/cli-repl/test/e2e-analytics.spec.ts
@@ -12,9 +12,7 @@ describe('e2e Analytics', () => {
     [ '--single', '--replSet', replSetName ]
   );
 
-  after(async() => {
-    await TestShell.killall();
-  });
+  after(TestShell.cleanup);
 
   before(async() => {
     const rsConfig = {

--- a/packages/cli-repl/test/e2e-auth.spec.ts
+++ b/packages/cli-repl/test/e2e-auth.spec.ts
@@ -103,8 +103,8 @@ describe('Auth e2e', function() {
       await db.command({ dropAllUsersFromDatabase: 1 });
 
       client.close();
-      await TestShell.killall();
     });
+    afterEach(TestShell.cleanup);
 
     describe('user management', () => {
       describe('createUser', async() => {
@@ -991,7 +991,7 @@ describe('Auth e2e', function() {
       await db.command({ dropAllUsersFromDatabase: 1 });
 
       client.close();
-      await TestShell.killall();
     });
+    afterEach(TestShell.cleanup);
   });
 });

--- a/packages/cli-repl/test/e2e-aws.spec.ts
+++ b/packages/cli-repl/test/e2e-aws.spec.ts
@@ -89,9 +89,7 @@ describe('e2e AWS AUTH', () => {
       .replace('arn:aws:iam::', 'arn:aws:sts::')}/*`;
   });
 
-  afterEach(async() => {
-    await TestShell.killall();
-  });
+  afterEach(TestShell.cleanup);
 
   context('without environment variables being present', () => {
     context('specifying explicit parameters', () => {

--- a/packages/cli-repl/test/e2e-bson.spec.ts
+++ b/packages/cli-repl/test/e2e-bson.spec.ts
@@ -33,8 +33,8 @@ describe('BSON e2e', function() {
     await db.dropDatabase();
 
     await client.close();
-    await TestShell.killall();
   });
+  afterEach(TestShell.cleanup);
   describe('printed BSON', () => {
     const outputDoc = {
       ObjectId: 'ObjectId("5f16b8bebe434dc98cdfc9ca")',

--- a/packages/cli-repl/test/e2e-direct.spec.ts
+++ b/packages/cli-repl/test/e2e-direct.spec.ts
@@ -4,7 +4,7 @@ import { expect } from 'chai';
 import { TestShell } from './test-shell';
 
 describe('e2e direct connection', () => {
-  afterEach(async() => await TestShell.killall());
+  afterEach(TestShell.cleanup);
 
   context('to a replica set', async() => {
     const replSetId = 'replset';

--- a/packages/cli-repl/test/e2e-fle.spec.ts
+++ b/packages/cli-repl/test/e2e-fle.spec.ts
@@ -32,8 +32,8 @@ describe('FLE tests', () => {
     const client = await MongoClient.connect(await testServer.connectionString(), {});
     await client.db(dbname).dropDatabase();
     await client.close();
-    await TestShell.killall();
   });
+  afterEach(TestShell.cleanup);
 
   context('with AWS KMS', () => {
     const accessKeyId = 'SxHpYMUtB1CEVg9tX0N1';

--- a/packages/cli-repl/test/e2e-tls.spec.ts
+++ b/packages/cli-repl/test/e2e-tls.spec.ts
@@ -27,9 +27,7 @@ describe('e2e TLS', () => {
     assert((await fs.stat(CRL_INCLUDING_SERVER)).isFile());
   });
 
-  afterEach(async() => {
-    await TestShell.killall();
-  });
+  afterEach(TestShell.cleanup);
 
   context('for server < 4.2', () => {
     skipIfEnvServerVersion('>= 4.2');
@@ -65,8 +63,10 @@ describe('e2e TLS', () => {
         });
         await shell.waitForPrompt();
         await shell.executeLine('db.shutdownServer({ force: true })');
-        await TestShell.killall();
+        shell.kill();
+        await shell.waitForExit();
       });
+      afterEach(TestShell.cleanup);
 
       const server = startTestServer(
         'not-shared', '--hostname', 'localhost',
@@ -166,8 +166,10 @@ describe('e2e TLS', () => {
         });
         await shell.waitForPrompt();
         await shell.executeLine('db.shutdownServer({ force: true })');
-        await TestShell.killall();
+        shell.kill();
+        await shell.waitForExit();
       });
+      afterEach(TestShell.cleanup);
 
       const server = startTestServer(
         'not-shared', '--hostname', 'localhost',

--- a/packages/cli-repl/test/e2e.spec.ts
+++ b/packages/cli-repl/test/e2e.spec.ts
@@ -13,7 +13,7 @@ import { readReplLogfile } from './repl-helpers';
 describe('e2e', function() {
   const testServer = startTestServer('shared');
 
-  afterEach(async() => await TestShell.killall());
+  afterEach(TestShell.cleanup);
 
   describe('--version', () => {
     it('shows version', async() => {
@@ -652,8 +652,8 @@ describe('e2e', function() {
       };
     });
 
-    afterEach(async() => {
-      await TestShell.killall();
+    afterEach(async function() {
+      await TestShell.killall.call(this);
       try {
         await promisify(rimraf)(homedir);
       } catch (err) {

--- a/packages/cli-repl/test/test-shell.ts
+++ b/packages/cli-repl/test/test-shell.ts
@@ -1,3 +1,4 @@
+import type Mocha from 'mocha';
 import assert from 'assert';
 import { ChildProcess, spawn } from 'child_process';
 import { once } from 'events';
@@ -72,6 +73,15 @@ export class TestShell {
       exitPromises.push(shell.waitForExit());
     }
     await Promise.all(exitPromises);
+  }
+
+  static async cleanup(this: Mocha.Context): Promise<void> {
+    if (this.currentTest?.state === 'failed') {
+      for (const shell of TestShell._openShells) {
+        console.error({ pid: shell.process.pid, output: shell.output, rawOutput: shell.rawOutput });
+      }
+    }
+    await TestShell.killall();
   }
 
   private _process: ChildProcess;


### PR DESCRIPTION
This is just to get better debugging in the future for flaky tests
in general.