### PR TITLE
chore(cli-repl): work around Node.js REPL bug MONGOSH-589

### DIFF
--- a/packages/cli-repl/test/e2e.spec.ts
+++ b/packages/cli-repl/test/e2e.spec.ts
@@ -8,7 +8,7 @@ import { promises as fs, createReadStream } from 'fs';
 import { promisify } from 'util';
 import rimraf from 'rimraf';
 import path from 'path';
-import { readReplLogfile } from './repl-helpers';
+import { readReplLogfile, hasNodeBug38314 } from './repl-helpers';
 
 describe('e2e', function() {
   const testServer = startTestServer('shared');
@@ -517,6 +517,8 @@ describe('e2e', function() {
       let result;
       result = await shell.executeLine('require("a")');
       expect(result).to.match(/Error: Cannot find module 'a'/);
+      // Wait for double prompt because of Node.js REPL bug
+      if (hasNodeBug38314()) await eventually(() => shell.assertContainsOutput('> > '));
       result = await shell.executeLine('require("./a")');
       expect(result).to.match(/^A$/m);
       result = await shell.executeLine('require("b")');

--- a/packages/cli-repl/test/repl-helpers.ts
+++ b/packages/cli-repl/test/repl-helpers.ts
@@ -7,6 +7,8 @@ import chai, { expect } from 'chai';
 import sinon from 'ts-sinon';
 import sinonChai from 'sinon-chai';
 import chaiAsPromised from 'chai-as-promised';
+import repl from 'repl';
+import { PassThrough } from 'stream';
 import type { MongoshBus, MongoshBusEventsMap } from '@mongosh/types';
 
 chai.use(sinonChai);
@@ -76,6 +78,17 @@ async function readReplLogfile(logPath: string) {
     .map((line) => JSON.parse(line));
 }
 
+// https://github.com/nodejs/node/pull/38314
+function hasNodeBug38314() {
+  const input = new PassThrough();
+  const output = new PassThrough();
+  const evalFn = (code, ctx, filename, cb) => cb(new Error('err'));
+  const prompt = 'prompt#';
+  repl.start({ input, output, eval: evalFn, prompt });
+  input.end('s\n');
+  return String(output.read()).includes('prompt#prompt#');
+}
+
 export {
   expect,
   sinon,
@@ -85,5 +98,6 @@ export {
   waitEval,
   waitCompletion,
   fakeTTYProps,
-  readReplLogfile
+  readReplLogfile,
+  hasNodeBug38314
 };


### PR DESCRIPTION
In addition to the fix in c8cee80616162f, the test here is also flaky
because of a Node.js REPL bug where `repl.displayPrompt()` was called
twice after we reported an error, which confused the prompt detection
in the shell and made the test flaky depending on whether both prompts
where received in the same output data chunk or not.

For now, just wait until both parts of the double prompt are present
in the output before executing the next input line.