### PR TITLE
chore(cli-repl): use tab constant instead of using U+0009 explicitly

### DIFF
--- a/packages/cli-repl/src/cli-repl.spec.ts
+++ b/packages/cli-repl/src/cli-repl.spec.ts
@@ -795,6 +795,7 @@ describe('CliRepl', () => {
   }): void {
     describe('autocompletion', () => {
       let cliRepl: CliRepl;
+      const tab = '\u0009';
 
       beforeEach(async() => {
         if (testServer === null) {
@@ -813,7 +814,7 @@ describe('CliRepl', () => {
 
       it(`${wantWatch ? 'completes' : 'does not complete'} the watch method`, async() => {
         output = '';
-        input.write('db.wat\u0009\u0009');
+        input.write(`db.wat${tab}${tab}`);
         await waitCompletion(cliRepl.bus);
         if (wantWatch) {
           expect(output).to.include('db.watch');
@@ -824,14 +825,14 @@ describe('CliRepl', () => {
 
       it('completes the db.version method', async() => {
         output = '';
-        input.write('db.vers\u0009\u0009');
+        input.write(`db.vers\${tab}${tab}`);
         await waitCompletion(cliRepl.bus);
         expect(output).to.include('db.version');
       });
 
       it(`${wantShardDistribution ? 'completes' : 'does not complete'} the getShardDistribution method`, async() => {
         output = '';
-        input.write('db.coll.getShardDis\u0009\u0009');
+        input.write(`db.coll.getShardDis${tab}${tab}`);
         await waitCompletion(cliRepl.bus);
         if (wantShardDistribution) {
           expect(output).to.include('db.coll.getShardDistribution');
@@ -847,7 +848,7 @@ describe('CliRepl', () => {
         await waitEval(cliRepl.bus);
 
         output = '';
-        input.write('db.testcoll\u0009\u0009');
+        input.write(`db.testcoll${tab}${tab}`);
         await waitCompletion(cliRepl.bus);
         expect(output).to.include(collname);
 
@@ -856,7 +857,7 @@ describe('CliRepl', () => {
       });
 
       it('completes JS value properties properly (incomplete, double tab)', async() => {
-        input.write('JSON.\u0009\u0009');
+        input.write(`JSON.${tab}${tab}`);
         await waitCompletion(cliRepl.bus);
         expect(output).to.include('JSON.parse');
         expect(output).to.include('JSON.stringify');
@@ -864,7 +865,7 @@ describe('CliRepl', () => {
       });
 
       it('completes JS value properties properly (complete, single tab)', async() => {
-        input.write('JSON.pa\u0009');
+        input.write(`JSON.pa${tab}`);
         await waitCompletion(cliRepl.bus);
         expect(output).to.include('JSON.parse');
         expect(output).not.to.include('JSON.stringify');

--- a/packages/cli-repl/src/cli-repl.spec.ts
+++ b/packages/cli-repl/src/cli-repl.spec.ts
@@ -823,9 +823,10 @@ describe('CliRepl', () => {
         }
       });
 
-      it('completes the db.version method', async() => {
+      it('completes the 
+         ion method', async() => {
         output = '';
-        input.write(`db.vers\${tab}${tab}`);
+        input.write(`db.vers${tab}${tab}`);
         await waitCompletion(cliRepl.bus);
         expect(output).to.include('db.version');
       });

--- a/packages/cli-repl/src/cli-repl.spec.ts
+++ b/packages/cli-repl/src/cli-repl.spec.ts
@@ -823,8 +823,7 @@ describe('CliRepl', () => {
         }
       });
 
-      it('completes the 
-         ion method', async() => {
+      it('completes the version method', async() => {
         output = '';
         input.write(`db.vers${tab}${tab}`);
         await waitCompletion(cliRepl.bus);

--- a/packages/cli-repl/src/mongosh-repl.spec.ts
+++ b/packages/cli-repl/src/mongosh-repl.spec.ts
@@ -216,6 +216,8 @@ describe('MongoshNodeRepl', () => {
   });
 
   context('with terminal: true', () => {
+    const tab = '\u0009';
+
     beforeEach(async() => {
       // Node.js uses $TERM to determine what level of functionality to provide
       // in a way that goes beyond color support, in particular TERM=dumb
@@ -245,7 +247,7 @@ describe('MongoshNodeRepl', () => {
       await tick();
       expect(output).to.include('Entering editor mode');
       output = '';
-      input.write('db.\u0009\u0009');
+      input.write(`db.${tab}${tab}`);
       await tick();
       input.write('version()\n');
       input.write('\u0004'); // Ctrl+D
@@ -290,7 +292,7 @@ describe('MongoshNodeRepl', () => {
     context('autocompletion', () => {
       it('autocompletes collection methods', async() => {
         // this triggers an eval
-        input.write('db.coll.\u0009\u0009');
+        input.write(`db.coll.${tab}${tab}`);
         // first tab
         await waitEval(bus);
         // second tab
@@ -298,13 +300,13 @@ describe('MongoshNodeRepl', () => {
         expect(output).to.include('db.coll.updateOne');
       });
       it('autocompletes shell-api methods (once)', async() => {
-        input.write('vers\u0009\u0009'); // U+0009 is TAB
+        input.write(`vers${tab}${tab}`);
         await tick();
         expect(output).to.include('version');
         expect(output).to.not.match(/version\s+version/);
       });
       it('autocompletes async shell api methods', async() => {
-        input.write('db.coll.find().\u0009\u0009'); // U+0009 is TAB
+        input.write(`db.coll.find().${tab}${tab}`);
         await tick();
         expect(output).to.include('db.coll.find().close');
       });
@@ -312,7 +314,7 @@ describe('MongoshNodeRepl', () => {
         input.write('let somelongvariable = 0\n');
         await waitEval(bus);
         output = '';
-        input.write('somelong\u0009\u0009'); // U+0009 is TAB
+        input.write(`somelong${tab}${tab}`);
         await tick();
         expect(output).to.include('somelongvariable');
       });
@@ -321,7 +323,7 @@ describe('MongoshNodeRepl', () => {
         await tick();
         output = '';
         expect((mongoshRepl.runtimeState().repl as any)._prompt).to.equal('');
-        input.write('db.\u0009\u0009');
+        input.write(`db.${tab}${tab}`);
         await tick();
         input.write('foo\nbar\n');
         expect((mongoshRepl.runtimeState().repl as any)._prompt).to.equal('');


### PR DESCRIPTION
As suggested in https://github.com/mongodb-js/mongosh/pull/811#discussion_r621150695