### PR TITLE
fix(shell-api): handle errors in cursor.map/.forEach MONGOSH-703

### DIFF
--- a/packages/java-shell/src/test/resources/cursor/forEach.expected.txt
+++ b/packages/java-shell/src/test/resources/cursor/forEach.expected.txt
@@ -1,2 +1,1 @@
-null
 [ { "_id": 1, "name": "Vasya" }, { "_id": 2, "name": "Petya" }, { "_id": 3, "name": "Lyusya" } ]

--- a/packages/shell-api/src/aggregation-cursor.spec.ts
+++ b/packages/shell-api/src/aggregation-cursor.spec.ts
@@ -67,7 +67,7 @@ describe('AggregationCursor', () => {
     it('calls wrappee.map with arguments', () => {
       const arg = {};
       cursor.map(arg);
-      expect(wrappee.map.calledWith(arg)).to.equal(true);
+      expect(wrappee.map).to.have.callCount(1);
     });
   });
 

--- a/packages/shell-api/src/change-stream-cursor.ts
+++ b/packages/shell-api/src/change-stream-cursor.ts
@@ -43,7 +43,7 @@ export default class ChangeStreamCursor extends ShellApiClass {
       throw new MongoshRuntimeError('ChangeStreamCursor is closed');
     }
     const result = this._currentIterationResult = new CursorIterationResult();
-    return iterate(result, this._cursor, this._batchSize ?? await this._mongo._batchSize());
+    return iterate(result, this, this._batchSize ?? await this._mongo._batchSize());
   }
 
   /**

--- a/packages/shell-api/src/cursor.spec.ts
+++ b/packages/shell-api/src/cursor.spec.ts
@@ -71,7 +71,7 @@ describe('Cursor', () => {
     it('calls wrappee.map with arguments', () => {
       const arg = {};
       cursor.map(arg);
-      expect(wrappee.map.calledWith(arg)).to.equal(true);
+      expect(wrappee.map).to.have.callCount(1);
     });
 
     it('has the correct metadata', () => {

--- a/packages/shell-api/src/explainable-cursor.spec.ts
+++ b/packages/shell-api/src/explainable-cursor.spec.ts
@@ -56,7 +56,7 @@ describe('ExplainableCursor', () => {
     it('calls wrappee.map with arguments', () => {
       const arg = () => {};
       eCursor.map(arg);
-      expect(wrappee.map.calledWith(arg)).to.equal(true);
+      expect(wrappee.map).to.have.callCount(1);
     });
 
     it('has the correct metadata', () => {

--- a/packages/shell-api/src/helpers.ts
+++ b/packages/shell-api/src/helpers.ts
@@ -3,12 +3,9 @@ import type {
   DbOptions,
   Document,
   ExplainVerbosityLike,
-  FindCursor,
-  AggregationCursor as SPAggregationCursor,
   FindAndModifyOptions,
   DeleteOptions,
   MapReduceOptions,
-  ChangeStream,
   KMSProviders,
   ExplainOptions
 } from '@mongosh/service-provider-core';
@@ -22,6 +19,8 @@ import { BinaryType, ReplPlatform } from '@mongosh/service-provider-core';
 import { ClientSideFieldLevelEncryptionOptions } from './field-level-encryption';
 import { AutoEncryptionOptions } from 'mongodb';
 import { shellApiType } from './enums';
+import type { AbstractCursor } from './abstract-cursor';
+import type ChangeStreamCursor from './change-stream-cursor';
 
 /**
  * Helper method to adapt aggregation pipeline options.
@@ -525,9 +524,9 @@ export function addHiddenDataProperty<T = any>(target: T, key: string|symbol, va
 
 export async function iterate(
   results: CursorIterationResult,
-  cursor: FindCursor | SPAggregationCursor | ChangeStream,
+  cursor: AbstractCursor | ChangeStreamCursor,
   batchSize: number): Promise<CursorIterationResult> {
-  if (cursor.closed) {
+  if (cursor.isClosed()) {
     return results;
   }
 


### PR DESCRIPTION
(Includes #809 for now, until that is merged.)

Handle exceptions from callbacks passed to `cursor.map()` and
`cursor.forEach()`.

Since `cursor.forEach()` returns a Promise, use that to propagate
the error to the user.

For `cursor.map()`, this is a bit trickier, since the method itself
does not return any results to the user. Therefore, we add checks
before and after accessing cursor methods that read data which forward
the exception if one has occurred.

Both of these feel like situations that the driver should take care of
explicitly, so NODE tickets have been opened for both cases.

(One alternative would have been to add async context/Node.js domain
propagation to these methods. However, I decided against that, because
that solution would be a) Node.js-specific, and b) because it would
still lead to undesirable results, like the Promise returned by
`.forEach()` never resolving.)
