### PR TITLE
fix(shell-api): handle coll.stats() in sharded clusters MONGOSH-731

### DIFF
--- a/packages/shell-api/src/collection.ts
+++ b/packages/shell-api/src/collection.ts
@@ -1418,10 +1418,8 @@ export default class Collection extends ShellApiClass {
     };
     updateStats(result);
 
-    if (result.sharded) {
-      for (const shardName of result.shards) {
-        updateStats(result.shards[shardName]);
-      }
+    for (const shardName of Object.keys(result.shards ?? {})) {
+      updateStats(result.shards[shardName]);
     }
     return result;
   }

--- a/packages/shell-api/src/shard.spec.ts
+++ b/packages/shell-api/src/shard.spec.ts
@@ -1313,6 +1313,56 @@ describe('Shard', () => {
         }
       });
     });
+    describe('collection.stats()', () => {
+      let db: Database;
+      const dbName = 'shard-stats-test';
+      const ns = `${dbName}.test`;
+
+      beforeEach(async() => {
+        db = sh._database.getSiblingDB(dbName);
+        await db.getCollection('test').insertOne({ key: 1 });
+        await db.getCollection('test').createIndex({ key: 1 });
+      });
+      afterEach(async() => {
+        await db.dropDatabase();
+      });
+      context('unsharded collections', () => {
+        it('works without indexDetails', async() => {
+          const result = await db.getCollection('test').stats();
+          expect(result.sharded).to.equal(false);
+          expect(result.count).to.equal(1);
+          expect(result.shards[result.primary].totalSize).to.be.a('number');
+          expect(result.shards[result.primary].indexDetails).to.equal(undefined);
+        });
+        it('works with indexDetails', async() => {
+          const result = await db.getCollection('test').stats({ indexDetails: true });
+          expect(result.shards[result.primary].indexDetails._id_.metadata.formatVersion).to.be.a('number');
+        });
+      });
+      context('sharded collections', () => {
+        beforeEach(async() => {
+          expect((await sh.enableSharding(dbName)).ok).to.equal(1);
+          expect((await sh.shardCollection(ns, { key: 1 })).collectionsharded).to.equal(ns);
+        });
+        it('works without indexDetails', async() => {
+          const result = await db.getCollection('test').stats();
+          expect(result.sharded).to.equal(true);
+          expect(result.count).to.equal(1);
+          expect(result.primary).to.equal(undefined);
+          for (const shard of Object.values(result.shards) as any[]) {
+            expect(shard.totalSize).to.be.a('number');
+            expect(shard.indexDetails).to.equal(undefined);
+          }
+        });
+        it('works with indexDetails', async() => {
+          const result = await db.getCollection('test').stats({ indexDetails: true });
+          for (const shard of Object.values(result.shards) as any[]) {
+            expect(shard.totalSize).to.be.a('number');
+            expect(shard.indexDetails._id_.metadata.formatVersion).to.be.a('number');
+          }
+        });
+      });
+    });
     describe('collection.isCapped', () => {
       it('returns true for config.changelog', async() => {
         const ret = await sh._database.getSiblingDB('config').getCollection('changelog').isCapped();


### PR DESCRIPTION
`result.shards` is an object in sharded clusters, so it is never
an iterable.

`result.shards` is also a (non-empty object) in sharded clusters
for unsharded collections.

Therefore, just always iterate over all entries in the object here.