### PR TITLE
chore(github): set branch name for github action

### DIFF
--- a/.github/workflows/cron-tasks.yml
+++ b/.github/workflows/cron-tasks.yml
@@ -34,3 +34,4 @@ jobs:
         uses: ad-m/github-push-action@v0.6.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: main


### PR DESCRIPTION
Apparently, this action does not actually check the default branch
name.