### PR TITLE
feat(shell-api): make db.hello() fall back to legacy variant MONGOSH-558

### DIFF
--- a/packages/shell-api/src/integration.spec.ts
+++ b/packages/shell-api/src/integration.spec.ts
@@ -1926,14 +1926,17 @@ describe('Shell API (integration)', function() {
   describe('database commands', () => {
     it('db.isMaster() works', async() => {
       expect((await database.isMaster()).ismaster).to.equal(true);
+      expect((await database.isMaster()).isWritablePrimary).to.equal(true);
+    });
+
+    it('db.hello() works', async() => {
+      const result = await database.hello();
+      expect(result.ismaster).to.equal(undefined);
+      expect(result.isWritablePrimary).to.equal(true);
     });
 
     context('with 5.0+ server', () => {
       skipIfServerVersion(testServer, '<= 4.4');
-
-      it('db.hello() works', async() => {
-        expect((await database.hello()).isWritablePrimary).to.equal(true);
-      });
 
       it('db.rotateCertificates() works', async() => {
         expect((await database.rotateCertificates()).ok).to.equal(1);


### PR DESCRIPTION
If `db.hello()` is not available, fall back to the legacy variant, and
always make `isWritablePrimary` available in the return value for both
variants.