### PR TITLE
feat(autocomplete): add show/use completions MONGOSH-563

### DIFF
--- a/packages/autocomplete/index.spec.ts
+++ b/packages/autocomplete/index.spec.ts
@@ -531,7 +531,7 @@ describe('completer.completer', () => {
     it('completes commands like exit', async() => {
       const i = 'exi';
       expect(await completer(noParams, i))
-        .to.deep.equal([['exit'], i, 'exclusive']);
+        .to.deep.equal([['exit'], i]);
     });
   });
 });

--- a/packages/autocomplete/index.spec.ts
+++ b/packages/autocomplete/index.spec.ts
@@ -4,6 +4,7 @@ import { signatures as shellSignatures, Topologies } from '@mongosh/shell-api';
 import { expect } from 'chai';
 
 let collections: string[];
+let databases: string[];
 const standalone440 = {
   topology: () => Topologies.Standalone,
   connectionInfo: () => ({
@@ -11,7 +12,8 @@ const standalone440 = {
     is_data_lake: false,
     server_version: '4.4.0'
   }),
-  getCollectionCompletionsForCurrentDb: () => collections
+  getCollectionCompletionsForCurrentDb: () => collections,
+  getDatabaseCompletions: () => databases
 };
 const sharded440 = {
   topology: () => Topologies.Sharded,
@@ -20,7 +22,8 @@ const sharded440 = {
     is_data_lake: false,
     server_version: '4.4.0'
   }),
-  getCollectionCompletionsForCurrentDb: () => collections
+  getCollectionCompletionsForCurrentDb: () => collections,
+  getDatabaseCompletions: () => databases
 };
 
 const standalone300 = {
@@ -30,7 +33,8 @@ const standalone300 = {
     is_data_lake: false,
     server_version: '3.0.0'
   }),
-  getCollectionCompletionsForCurrentDb: () => collections
+  getCollectionCompletionsForCurrentDb: () => collections,
+  getDatabaseCompletions: () => databases
 };
 const datalake440 = {
   topology: () => Topologies.Sharded,
@@ -39,13 +43,15 @@ const datalake440 = {
     is_data_lake: true,
     server_version: '4.4.0'
   }),
-  getCollectionCompletionsForCurrentDb: () => collections
+  getCollectionCompletionsForCurrentDb: () => collections,
+  getDatabaseCompletions: () => databases
 };
 
 const noParams = {
   topology: () => Topologies.Standalone,
   connectionInfo: () => undefined,
-  getCollectionCompletionsForCurrentDb: () => collections
+  getCollectionCompletionsForCurrentDb: () => collections,
+  getDatabaseCompletions: () => databases
 };
 
 describe('completer.completer', () => {
@@ -66,7 +72,7 @@ describe('completer.completer', () => {
 
     it('is an exact match to one of shell completions', async() => {
       const i = 'use';
-      expect(await completer(standalone440, i)).to.deep.equal([[i], i]);
+      expect(await completer(standalone440, i)).to.deep.equal([[], i, 'exclusive']);
     });
   });
 
@@ -480,6 +486,52 @@ describe('completer.completer', () => {
     it('does not match if it is not .find or .aggregate', async() => {
       const i = 'db.shipwrecks.moo({feature_type: "Wrecks - Visible"}).';
       expect(await completer(standalone440, i)).to.deep.equal([[], i]);
+    });
+  });
+
+  context('for shell commands', () => {
+    it('completes partial commands', async() => {
+      const i = 'sho';
+      expect(await completer(noParams, i))
+        .to.deep.equal([['show'], i]);
+    });
+
+    it('completes partial commands', async() => {
+      const i = 'show';
+      const result = await completer(noParams, i);
+      expect(result[0]).to.contain('show databases');
+    });
+
+    it('completes show databases', async() => {
+      const i = 'show d';
+      expect(await completer(noParams, i))
+        .to.deep.equal([['show databases'], i, 'exclusive']);
+    });
+
+    it('completes show profile', async() => {
+      const i = 'show pr';
+      expect(await completer(noParams, i))
+        .to.deep.equal([['show profile'], i, 'exclusive']);
+    });
+
+    it('completes use db', async() => {
+      databases = ['db1', 'db2'];
+      const i = 'use';
+      expect(await completer(noParams, i))
+        .to.deep.equal([['use db1', 'use db2'], i, 'exclusive']);
+    });
+
+    it('does not try to complete over-long commands', async() => {
+      databases = ['db1', 'db2'];
+      const i = 'use db1 d';
+      expect(await completer(noParams, i))
+        .to.deep.equal([[], i, 'exclusive']);
+    });
+
+    it('completes commands like exit', async() => {
+      const i = 'exi';
+      expect(await completer(noParams, i))
+        .to.deep.equal([['exit'], i, 'exclusive']);
     });
   });
 });

--- a/packages/browser-runtime-core/src/autocompleter/shell-api-autocompleter.spec.ts
+++ b/packages/browser-runtime-core/src/autocompleter/shell-api-autocompleter.spec.ts
@@ -9,7 +9,8 @@ const standalone440 = {
     is_data_lake: false,
     server_version: '4.4.0'
   }),
-  getCollectionCompletionsForCurrentDb: () => ['bananas']
+  getCollectionCompletionsForCurrentDb: () => ['bananas'],
+  getDatabaseCompletions: () => ['databaseOne']
 };
 
 describe('Autocompleter', () => {
@@ -41,6 +42,14 @@ describe('Autocompleter', () => {
 
       expect(completions).to.deep.contain({
         completion: 'db.bananas'
+      });
+    });
+
+    it('returns database names after use', async() => {
+      const completions = await autocompleter.getCompletions('use da');
+
+      expect(completions).to.deep.contain({
+        completion: 'use databaseOne'
       });
     });
   });

--- a/packages/cli-repl/src/mongosh-repl.ts
+++ b/packages/cli-repl/src/mongosh-repl.ts
@@ -137,8 +137,7 @@ class MongoshNodeRepl implements EvaluationListener {
         this.insideAutoComplete = true;
         try {
           // Merge the results from the repl completer and the mongosh completer.
-          // eslint-disable-next-line @typescript-eslint/no-unused-vars
-          const [ [replResults], [mongoshResults, _, mongoshResultsExclusive] ] = await Promise.all([
+          const [ [replResults], [mongoshResults,, mongoshResultsExclusive] ] = await Promise.all([
             (async() => await origReplCompleter(text) || [[]])(),
             (async() => await mongoshCompleter(text))()
           ]);

--- a/packages/shell-api/src/aggregation-cursor.spec.ts
+++ b/packages/shell-api/src/aggregation-cursor.spec.ts
@@ -28,7 +28,9 @@ describe('AggregationCursor', () => {
         returnType: 'AggregationCursor',
         platforms: ALL_PLATFORMS,
         topologies: ALL_TOPOLOGIES,
-        serverVersions: ALL_SERVER_VERSIONS
+        serverVersions: ALL_SERVER_VERSIONS,
+        isDirectShellCommand: false,
+        shellCommandCompleter: undefined
       });
     });
   });

--- a/packages/shell-api/src/bulk.spec.ts
+++ b/packages/shell-api/src/bulk.spec.ts
@@ -39,7 +39,9 @@ describe('Bulk API', () => {
           returnType: 'BulkFindOp',
           platforms: ALL_PLATFORMS,
           topologies: ALL_TOPOLOGIES,
-          serverVersions: ALL_SERVER_VERSIONS
+          serverVersions: ALL_SERVER_VERSIONS,
+          isDirectShellCommand: false,
+          shellCommandCompleter: undefined
         });
       });
       it('hasAsyncChild', () => {
@@ -241,7 +243,9 @@ describe('Bulk API', () => {
           returnType: 'BulkFindOp',
           platforms: ALL_PLATFORMS,
           topologies: ALL_TOPOLOGIES,
-          serverVersions: ALL_SERVER_VERSIONS
+          serverVersions: ALL_SERVER_VERSIONS,
+          isDirectShellCommand: false,
+          shellCommandCompleter: undefined
         });
       });
       it('hasAsyncChild', () => {

--- a/packages/shell-api/src/change-stream-cursor.spec.ts
+++ b/packages/shell-api/src/change-stream-cursor.spec.ts
@@ -34,7 +34,9 @@ describe('ChangeStreamCursor', () => {
         returnType: { type: 'unknown', attributes: {} },
         platforms: ALL_PLATFORMS,
         topologies: ALL_TOPOLOGIES,
-        serverVersions: ALL_SERVER_VERSIONS
+        serverVersions: ALL_SERVER_VERSIONS,
+        isDirectShellCommand: false,
+        shellCommandCompleter: undefined
       });
     });
   });

--- a/packages/shell-api/src/collection.spec.ts
+++ b/packages/shell-api/src/collection.spec.ts
@@ -44,7 +44,9 @@ describe('Collection', () => {
         returnType: 'AggregationCursor',
         platforms: ALL_PLATFORMS,
         topologies: ALL_TOPOLOGIES,
-        serverVersions: ALL_SERVER_VERSIONS
+        serverVersions: ALL_SERVER_VERSIONS,
+        isDirectShellCommand: false,
+        shellCommandCompleter: undefined
       });
     });
     it('hasAsyncChild', () => {

--- a/packages/shell-api/src/cursor.spec.ts
+++ b/packages/shell-api/src/cursor.spec.ts
@@ -32,7 +32,9 @@ describe('Cursor', () => {
         returnType: 'Cursor',
         platforms: ALL_PLATFORMS,
         topologies: ALL_TOPOLOGIES,
-        serverVersions: ALL_SERVER_VERSIONS
+        serverVersions: ALL_SERVER_VERSIONS,
+        isDirectShellCommand: false,
+        shellCommandCompleter: undefined
       });
     });
   });

--- a/packages/shell-api/src/database.spec.ts
+++ b/packages/shell-api/src/database.spec.ts
@@ -84,7 +84,9 @@ describe('Database', () => {
         returnType: 'AggregationCursor',
         platforms: ALL_PLATFORMS,
         topologies: ALL_TOPOLOGIES,
-        serverVersions: ALL_SERVER_VERSIONS
+        serverVersions: ALL_SERVER_VERSIONS,
+        isDirectShellCommand: false,
+        shellCommandCompleter: undefined
       });
     });
     it('hasAsyncChild', () => {

--- a/packages/shell-api/src/decorators.ts
+++ b/packages/shell-api/src/decorators.ts
@@ -369,6 +369,8 @@ export function returnsPromise(_target: any, _propertyKey: string, descriptor: P
     nonAsyncFunctionsReturningPromises.push(orig.name);
   }
 }
+// This is use to mark functions that are executable in the shell in a POSIX-shell-like
+// fashion, e.g. `show foo` which is translated into a call to `show('foo')`.
 export function directShellCommand(_target: any, _propertyKey: string, descriptor: PropertyDescriptor): void {
   descriptor.value.isDirectShellCommand = true;
 }

--- a/packages/shell-api/src/explainable-cursor.spec.ts
+++ b/packages/shell-api/src/explainable-cursor.spec.ts
@@ -25,7 +25,9 @@ describe('ExplainableCursor', () => {
         returnType: 'ExplainableCursor',
         platforms: ALL_PLATFORMS,
         topologies: ALL_TOPOLOGIES,
-        serverVersions: ALL_SERVER_VERSIONS
+        serverVersions: ALL_SERVER_VERSIONS,
+        isDirectShellCommand: false,
+        shellCommandCompleter: undefined
       });
     });
   });

--- a/packages/shell-api/src/explainable.spec.ts
+++ b/packages/shell-api/src/explainable.spec.ts
@@ -32,7 +32,9 @@ describe('Explainable', () => {
         returnType: 'ExplainableCursor',
         platforms: ALL_PLATFORMS,
         topologies: ALL_TOPOLOGIES,
-        serverVersions: ALL_SERVER_VERSIONS
+        serverVersions: ALL_SERVER_VERSIONS,
+        isDirectShellCommand: false,
+        shellCommandCompleter: undefined
       });
     });
     it('hasAsyncChild', () => {

--- a/packages/shell-api/src/field-level-encryption.spec.ts
+++ b/packages/shell-api/src/field-level-encryption.spec.ts
@@ -98,7 +98,9 @@ describe('Field Level Encryption', () => {
         returnType: { attributes: {}, type: 'unknown' },
         platforms: ALL_PLATFORMS,
         topologies: ALL_TOPOLOGIES,
-        serverVersions: ALL_SERVER_VERSIONS
+        serverVersions: ALL_SERVER_VERSIONS,
+        isDirectShellCommand: false,
+        shellCommandCompleter: undefined
       });
       expect(signatures.ClientEncryption.attributes.encrypt).to.deep.equal({
         type: 'function',
@@ -107,7 +109,9 @@ describe('Field Level Encryption', () => {
         returnType: { attributes: {}, type: 'unknown' },
         platforms: ALL_PLATFORMS,
         topologies: ALL_TOPOLOGIES,
-        serverVersions: ALL_SERVER_VERSIONS
+        serverVersions: ALL_SERVER_VERSIONS,
+        isDirectShellCommand: false,
+        shellCommandCompleter: undefined
       });
     });
     it('hasAsyncChild', () => {

--- a/packages/shell-api/src/integration.spec.ts
+++ b/packages/shell-api/src/integration.spec.ts
@@ -1919,6 +1919,7 @@ describe('Shell API (integration)', function() {
         expect(await database._getCollectionNames()).to.deep.equal(['docs']);
         expect(await params.getCollectionCompletionsForCurrentDb('d')).to.deep.equal(['docs']);
         expect(await params.getCollectionCompletionsForCurrentDb('e')).to.deep.equal([]);
+        expect(await params.getDatabaseCompletions('test-')).to.deep.equal([database.getName()]);
       });
     });
   });

--- a/packages/shell-api/src/mongo.spec.ts
+++ b/packages/shell-api/src/mongo.spec.ts
@@ -48,7 +48,9 @@ describe('Mongo', () => {
         returnType: { attributes: {}, type: 'unknown' },
         platforms: ALL_PLATFORMS,
         topologies: ALL_TOPOLOGIES,
-        serverVersions: ALL_SERVER_VERSIONS
+        serverVersions: ALL_SERVER_VERSIONS,
+        isDirectShellCommand: false,
+        shellCommandCompleter: undefined
       });
     });
     it('hasAsyncChild', () => {

--- a/packages/shell-api/src/plan-cache.spec.ts
+++ b/packages/shell-api/src/plan-cache.spec.ts
@@ -26,7 +26,9 @@ describe('PlanCache', () => {
         returnType: { attributes: {}, type: 'unknown' },
         platforms: ALL_PLATFORMS,
         topologies: ALL_TOPOLOGIES,
-        serverVersions: ['4.4.0', ServerVersions.latest]
+        serverVersions: ['4.4.0', ServerVersions.latest],
+        isDirectShellCommand: false,
+        shellCommandCompleter: undefined
       });
     });
     it('hasAsyncChild', () => {

--- a/packages/shell-api/src/replica-set.spec.ts
+++ b/packages/shell-api/src/replica-set.spec.ts
@@ -48,7 +48,9 @@ describe('ReplicaSet', () => {
         returnType: { type: 'unknown', attributes: {} },
         platforms: ALL_PLATFORMS,
         topologies: ALL_TOPOLOGIES,
-        serverVersions: ALL_SERVER_VERSIONS
+        serverVersions: ALL_SERVER_VERSIONS,
+        isDirectShellCommand: false,
+        shellCommandCompleter: undefined
       });
     });
 

--- a/packages/shell-api/src/session.spec.ts
+++ b/packages/shell-api/src/session.spec.ts
@@ -39,7 +39,9 @@ describe('Session', () => {
         returnType: { type: 'unknown', attributes: {} },
         platforms: ALL_PLATFORMS,
         topologies: ALL_TOPOLOGIES,
-        serverVersions: ALL_SERVER_VERSIONS
+        serverVersions: ALL_SERVER_VERSIONS,
+        isDirectShellCommand: false,
+        shellCommandCompleter: undefined
       });
     });
   });

--- a/packages/shell-api/src/shard.spec.ts
+++ b/packages/shell-api/src/shard.spec.ts
@@ -37,7 +37,9 @@ describe('Shard', () => {
         returnType: { type: 'unknown', attributes: {} },
         platforms: ALL_PLATFORMS,
         topologies: ALL_TOPOLOGIES,
-        serverVersions: ALL_SERVER_VERSIONS
+        serverVersions: ALL_SERVER_VERSIONS,
+        isDirectShellCommand: false,
+        shellCommandCompleter: undefined
       });
     });
     it('hasAsyncChild', () => {

--- a/packages/shell-api/src/shell-api.spec.ts
+++ b/packages/shell-api/src/shell-api.spec.ts
@@ -40,7 +40,9 @@ describe('ShellApi', () => {
         returnType: { type: 'unknown', attributes: {} },
         platforms: ALL_PLATFORMS,
         topologies: ALL_TOPOLOGIES,
-        serverVersions: ALL_SERVER_VERSIONS
+        serverVersions: ALL_SERVER_VERSIONS,
+        isDirectShellCommand: true,
+        shellCommandCompleter: signatures.ShellApi.attributes.use.shellCommandCompleter
       });
       expect(signatures.ShellApi.attributes.show).to.deep.equal({
         type: 'function',
@@ -49,7 +51,9 @@ describe('ShellApi', () => {
         returnType: { type: 'unknown', attributes: {} },
         platforms: ALL_PLATFORMS,
         topologies: ALL_TOPOLOGIES,
-        serverVersions: ALL_SERVER_VERSIONS
+        serverVersions: ALL_SERVER_VERSIONS,
+        isDirectShellCommand: true,
+        shellCommandCompleter: signatures.ShellApi.attributes.show.shellCommandCompleter
       });
       expect(signatures.ShellApi.attributes.exit).to.deep.equal({
         type: 'function',
@@ -58,7 +62,9 @@ describe('ShellApi', () => {
         returnType: { type: 'unknown', attributes: {} },
         platforms: [ ReplPlatform.CLI ],
         topologies: ALL_TOPOLOGIES,
-        serverVersions: ALL_SERVER_VERSIONS
+        serverVersions: ALL_SERVER_VERSIONS,
+        isDirectShellCommand: true,
+        shellCommandCompleter: undefined
       });
       expect(signatures.ShellApi.attributes.it).to.deep.equal({
         type: 'function',
@@ -67,7 +73,9 @@ describe('ShellApi', () => {
         returnType: { type: 'unknown', attributes: {} },
         platforms: ALL_PLATFORMS,
         topologies: ALL_TOPOLOGIES,
-        serverVersions: ALL_SERVER_VERSIONS
+        serverVersions: ALL_SERVER_VERSIONS,
+        isDirectShellCommand: true,
+        shellCommandCompleter: undefined
       });
       expect(signatures.ShellApi.attributes.print).to.deep.equal({
         type: 'function',
@@ -76,7 +84,9 @@ describe('ShellApi', () => {
         returnType: { type: 'unknown', attributes: {} },
         platforms: ALL_PLATFORMS,
         topologies: ALL_TOPOLOGIES,
-        serverVersions: ALL_SERVER_VERSIONS
+        serverVersions: ALL_SERVER_VERSIONS,
+        isDirectShellCommand: false,
+        shellCommandCompleter: undefined
       });
       expect(signatures.ShellApi.attributes.printjson).to.deep.equal({
         type: 'function',
@@ -85,7 +95,9 @@ describe('ShellApi', () => {
         returnType: { type: 'unknown', attributes: {} },
         platforms: ALL_PLATFORMS,
         topologies: ALL_TOPOLOGIES,
-        serverVersions: ALL_SERVER_VERSIONS
+        serverVersions: ALL_SERVER_VERSIONS,
+        isDirectShellCommand: false,
+        shellCommandCompleter: undefined
       });
       expect(signatures.ShellApi.attributes.sleep).to.deep.equal({
         type: 'function',
@@ -94,7 +106,9 @@ describe('ShellApi', () => {
         returnType: { type: 'unknown', attributes: {} },
         platforms: ALL_PLATFORMS,
         topologies: ALL_TOPOLOGIES,
-        serverVersions: ALL_SERVER_VERSIONS
+        serverVersions: ALL_SERVER_VERSIONS,
+        isDirectShellCommand: false,
+        shellCommandCompleter: undefined
       });
       expect(signatures.ShellApi.attributes.cls).to.deep.equal({
         type: 'function',
@@ -103,7 +117,9 @@ describe('ShellApi', () => {
         returnType: { type: 'unknown', attributes: {} },
         platforms: ALL_PLATFORMS,
         topologies: ALL_TOPOLOGIES,
-        serverVersions: ALL_SERVER_VERSIONS
+        serverVersions: ALL_SERVER_VERSIONS,
+        isDirectShellCommand: true,
+        shellCommandCompleter: undefined
       });
       expect(signatures.ShellApi.attributes.Mongo).to.deep.equal({
         type: 'function',
@@ -112,7 +128,9 @@ describe('ShellApi', () => {
         returnType: 'Mongo',
         platforms: [ ReplPlatform.CLI ],
         topologies: ALL_TOPOLOGIES,
-        serverVersions: ALL_SERVER_VERSIONS
+        serverVersions: ALL_SERVER_VERSIONS,
+        isDirectShellCommand: false,
+        shellCommandCompleter: undefined
       });
       expect(signatures.ShellApi.attributes.connect).to.deep.equal({
         type: 'function',
@@ -121,7 +139,9 @@ describe('ShellApi', () => {
         returnType: 'Database',
         platforms: [ ReplPlatform.CLI ],
         topologies: ALL_TOPOLOGIES,
-        serverVersions: ALL_SERVER_VERSIONS
+        serverVersions: ALL_SERVER_VERSIONS,
+        isDirectShellCommand: false,
+        shellCommandCompleter: undefined
       });
     });
   });
@@ -670,6 +690,24 @@ describe('ShellApi', () => {
           expect(await config.set('somekey', 'value')).to.equal('Option "somekey" is not available in this environment');
         });
       });
+    });
+  });
+  describe('command completers', () => {
+    const params = {
+      getCollectionCompletionsForCurrentDb: () => [''],
+      getDatabaseCompletions: (dbName) => ['dbOne', 'dbTwo'].filter(s => s.startsWith(dbName))
+    };
+
+    it('provides completions for show', async() => {
+      const completer = signatures.ShellApi.attributes.show.shellCommandCompleter;
+      expect(await completer(params, ['show', ''])).to.contain('databases');
+      expect(await completer(params, ['show', 'pro'])).to.deep.equal(['profile']);
+    });
+
+    it('provides completions for use', async() => {
+      const completer = signatures.ShellApi.attributes.use.shellCommandCompleter;
+      expect(await completer(params, ['use', ''])).to.deep.equal(['dbOne', 'dbTwo']);
+      expect(await completer(params, ['use', 'dbO'])).to.deep.equal(['dbOne']);
     });
   });
 });


### PR DESCRIPTION
Add support for autocompletion for shell commands, in particular,
`show` and `use`. Autocompletion for `use` works similar to
autocompletion for `db.<collection>`.

The implementation details for use/show autocompletion here have
been left to the shell-api package, so that changes to them do not
require any autocompletion changes.