### PR TITLE
chore(cli-repl): track arch in telemetry

### DIFF
--- a/packages/cli-repl/src/setup-logger-and-telemetry.spec.ts
+++ b/packages/cli-repl/src/setup-logger-and-telemetry.spec.ts
@@ -107,8 +107,26 @@ describe('setupLoggerAndTelemetry', () => {
 
     const mongosh_version = require('../package.json').version;
     expect(analyticsOutput).to.deep.equal([
-      [ 'identify', { userId: '53defe995fa47e6c13102d9d', traits: { platform: process.platform } } ],
-      [ 'identify', { userId: '53defe995fa47e6c13102d9d', traits: { platform: process.platform } } ],
+      [
+        'identify',
+        {
+          userId: '53defe995fa47e6c13102d9d',
+          traits: {
+            platform: process.platform,
+            arch: process.arch
+          }
+        }
+      ],
+      [
+        'identify',
+        {
+          userId: '53defe995fa47e6c13102d9d',
+          traits: {
+            platform: process.platform,
+            arch: process.arch
+          }
+        }
+      ],
       [
         'track',
         {

--- a/packages/cli-repl/src/setup-logger-and-telemetry.ts
+++ b/packages/cli-repl/src/setup-logger-and-telemetry.ts
@@ -47,6 +47,10 @@ export default function setupLoggerAndTelemetry(
   const mongosh_version = require('../package.json').version;
   let userId: string;
   let telemetry: boolean;
+  const userTraits = {
+    platform: process.platform,
+    arch: process.arch
+  };
 
   let analytics: MongoshAnalytics = new NoopAnalytics();
   try {
@@ -97,13 +101,13 @@ export default function setupLoggerAndTelemetry(
   bus.on('mongosh:new-user', function(id: string, enableTelemetry: boolean) {
     userId = id;
     telemetry = enableTelemetry;
-    if (telemetry) analytics.identify({ userId, traits: { platform: process.platform } });
+    if (telemetry) analytics.identify({ userId, traits: userTraits });
   });
 
   bus.on('mongosh:update-user', function(id: string, enableTelemetry: boolean) {
     userId = id;
     telemetry = enableTelemetry;
-    if (telemetry) analytics.identify({ userId, traits: { platform: process.platform } });
+    if (telemetry) analytics.identify({ userId, traits: userTraits });
     log.info('mongosh:update-user', { enableTelemetry });
   });
 


### PR DESCRIPTION
With support for multiple architectures expanding, it seems to make
sense to track the system architecture along with the OS.