### PR TITLE
fix(cli-repl): print Date objects as ISODate MONGOSH-723

### DIFF
--- a/packages/cli-repl/src/format-output.ts
+++ b/packages/cli-repl/src/format-output.ts
@@ -187,14 +187,25 @@ function removeUndefinedValues<T>(obj: T) {
   return Object.fromEntries(Object.entries(obj).filter(keyValue => keyValue[1] !== undefined));
 }
 
+function dateInspect(this: Date): string {
+  return `ISODate("${this.toISOString()}")`;
+}
+
 function inspect(output: any, options: FormatOptions): any {
-  return util.inspect(output, removeUndefinedValues({
-    showProxy: false,
-    colors: options.colors ?? true,
-    depth: options.depth ?? 6,
-    maxArrayLength: options.maxArrayLength,
-    maxStringLength: options.maxStringLength
-  }));
+  // Set a custom inspection function for 'Date' objects. Since we only want this
+  // to affect mongosh scripts, we unset it later.
+  (Date.prototype as any)[util.inspect.custom] = dateInspect;
+  try {
+    return util.inspect(output, removeUndefinedValues({
+      showProxy: false,
+      colors: options.colors ?? true,
+      depth: options.depth ?? 6,
+      maxArrayLength: options.maxArrayLength,
+      maxStringLength: options.maxStringLength
+    }));
+  } finally {
+    delete (Date.prototype as any)[util.inspect.custom];
+  }
 }
 
 function formatCursor(value: any, options: FormatOptions): any {

--- a/packages/cli-repl/src/mongosh-repl.spec.ts
+++ b/packages/cli-repl/src/mongosh-repl.spec.ts
@@ -588,9 +588,9 @@ describe('MongoshNodeRepl', () => {
     });
 
     it('colorizes output', async() => {
-      input.write('ISODate()\n');
+      input.write('55 + 89\n');
       await waitEval(bus);
-      expect(output).to.match(/\x1b\[.*mISODate\(.+\)\x1b\[.*m/);
+      expect(output).to.match(/\x1b\[.*m144\x1b\[.*m/);
     });
 
     it('can ask for passwords', async() => {

--- a/packages/cli-repl/src/mongosh-repl.spec.ts
+++ b/packages/cli-repl/src/mongosh-repl.spec.ts
@@ -590,7 +590,7 @@ describe('MongoshNodeRepl', () => {
     it('colorizes output', async() => {
       input.write('ISODate()\n');
       await waitEval(bus);
-      expect(output).to.match(/\x1b\[.*m\d+-\d+-\d+T\d+:\d+:\d+.\d+Z\x1b\[.*m/);
+      expect(output).to.match(/\x1b\[.*mISODate\(.+\)\x1b\[.*m/);
     });
 
     it('can ask for passwords', async() => {

--- a/packages/cli-repl/src/mongosh-repl.spec.ts
+++ b/packages/cli-repl/src/mongosh-repl.spec.ts
@@ -214,6 +214,12 @@ describe('MongoshNodeRepl', () => {
       await waitEval(bus);
       expect(output).to.include('returns true if the cursor returned by the');
     });
+
+    it('prints Date objects using the ISODate constructor variant', async() => {
+      input.write('new Date(1620143373000)\n');
+      await waitEval(bus);
+      expect(output).to.include('ISODate("2021-05-04T15:49:33.000Z")');
+    });
   });
 
   context('with terminal: true', () => {

--- a/packages/cli-repl/src/mongosh-repl.ts
+++ b/packages/cli-repl/src/mongosh-repl.ts
@@ -122,6 +122,10 @@ class MongoshNodeRepl implements EvaluationListener {
     this.onClearCommand = console.clear.bind(console);
     repl.context.console = console;
 
+    // Copy our context's Date object into the inner one because we have a custom
+    // util.inspect override for Date objects.
+    repl.context.Date = Date;
+
     this._runtimeState = {
       shellEvaluator,
       internalState,

--- a/packages/cli-repl/test/e2e-bson.spec.ts
+++ b/packages/cli-repl/test/e2e-bson.spec.ts
@@ -47,7 +47,9 @@ describe('BSON e2e', function() {
       Symbol: 'abc',
       Code: 'Code("abc")',
       NumberDecimal: 'Decimal128.fromString("1")',
-      BinData: 'Binary(Buffer.from("31323334", "hex"), 128)'
+      BinData: 'Binary(Buffer.from("31323334", "hex"), 128)',
+      ISODate: 'ISODate("2021-05-04T15:49:33.000Z")',
+      RegExp: '/match/'
     };
     it('Entire doc prints when returned from the server', async() => {
       const buffer = Buffer.from('MTIzNA==', 'base64');
@@ -60,7 +62,9 @@ describe('BSON e2e', function() {
         Symbol: new bson.BSONSymbol('abc'),
         Code: new bson.Code('abc'),
         NumberDecimal: bson.Decimal128.fromString('1'),
-        BinData: new bson.Binary(buffer, 128)
+        BinData: new bson.Binary(buffer, 128),
+        ISODate: new Date('2021-05-04T15:49:33.000Z'),
+        RegExp: /match/
       };
       await shell.writeInputLine(`use ${dbName}`);
       await db.collection('test').insertOne(inputDoc);
@@ -75,6 +79,8 @@ describe('BSON e2e', function() {
         shell.assertContainsOutput(outputDoc.Code);
         shell.assertContainsOutput(outputDoc.NumberDecimal);
         shell.assertContainsOutput(outputDoc.BinData);
+        shell.assertContainsOutput(outputDoc.ISODate);
+        shell.assertContainsOutput(outputDoc.RegExp);
       });
       shell.assertNoErrors();
     });
@@ -90,7 +96,9 @@ describe('BSON e2e', function() {
         Symbol: new Symbol('abc'),
         Code: new Code('abc'),
         NumberDecimal: NumberDecimal('1'),
-        BinData: BinData(128, 'MTIzNA==')
+        BinData: BinData(128, 'MTIzNA=='),
+        ISODate: ISODate("2021-05-04T15:49:33.000Z"),
+        RegExp: /match/
       }\n`;
       await shell.writeInputLine(value);
       await eventually(() => {
@@ -103,6 +111,8 @@ describe('BSON e2e', function() {
         shell.assertContainsOutput(outputDoc.Code);
         shell.assertContainsOutput(outputDoc.NumberDecimal);
         shell.assertContainsOutput(outputDoc.BinData);
+        shell.assertContainsOutput(outputDoc.ISODate);
+        shell.assertContainsOutput(outputDoc.RegExp);
       });
       shell.assertNoErrors();
     });
@@ -184,6 +194,26 @@ describe('BSON e2e', function() {
       await shell.writeInputLine('db.test.findOne().value');
       await eventually(() => {
         shell.assertContainsOutput('Binary(Buffer.from("31323334", "hex"), 128)');
+      });
+      shell.assertNoErrors();
+    });
+    it('ISODate prints when returned from the server', async() => {
+      const value = new Date('2021-05-04T15:49:33.000Z');
+      await shell.writeInputLine(`use ${dbName}`);
+      await db.collection('test').insertOne({ value: value });
+      await shell.writeInputLine('db.test.findOne().value');
+      await eventually(() => {
+        shell.assertContainsOutput('ISODate("2021-05-04T15:49:33.000Z")');
+      });
+      shell.assertNoErrors();
+    });
+    it('RegExp prints when returned from the server', async() => {
+      const value = /match/;
+      await shell.writeInputLine(`use ${dbName}`);
+      await db.collection('test').insertOne({ value: value });
+      await shell.writeInputLine('db.test.findOne().value');
+      await eventually(() => {
+        shell.assertContainsOutput('/match/');
       });
       shell.assertNoErrors();
     });
@@ -314,6 +344,22 @@ describe('BSON e2e', function() {
       await shell.writeInputLine(value);
       await eventually(() => {
         shell.assertContainsOutput('Binary(Buffer.from("abcdef", "hex"), 4)');
+      });
+      shell.assertNoErrors();
+    });
+    it('ISODate prints when created by user', async() => {
+      const value = 'ISODate("2021-05-04T15:49:33.000Z")';
+      await shell.writeInputLine(value);
+      await eventually(() => {
+        shell.assertContainsOutput('ISODate("2021-05-04T15:49:33.000Z")');
+      });
+      shell.assertNoErrors();
+    });
+    it('RegExp prints when created by user', async() => {
+      const value = '/match/';
+      await shell.writeInputLine(value);
+      await eventually(() => {
+        shell.assertContainsOutput('/match/');
       });
       shell.assertNoErrors();
     });


### PR DESCRIPTION
This is done a bit differently from the other BSON types because
it is a JS builtin type.