### PR TITLE
fix(ci): do not try to install npm globally

### DIFF
--- a/.evergreen/.install_node
+++ b/.evergreen/.install_node
@@ -18,7 +18,6 @@ else
 
   nvm install --no-progress $NODE_JS_VERSION
   nvm alias default $NODE_JS_VERSION
-  npm install -g npm@6
 fi
 
 . "$BASEDIR/.setup_env"


### PR DESCRIPTION
Both Node.js 12 and Node.js 14 ship with npm@6.x out of the box,
and [this failed recently on an s390x machine](https://evergreen.mongodb.com/task_log_raw/mongosh_linux_ppc64le_build_compile_artifact_patch_504e9cc2fd486b88c253d911cd3699e1fa5c4c55_60918a33850e611944cf9e27_21_05_04_17_53_56/0?type=T) where it tried to
write to the already-present Node.js 8 installation, so let’s
skip this for now unless that’s a problem too.

    [2021/05/04 19:24:59.963] ++ npm install -g npm@6
    [2021/05/04 19:24:59.963] npm WARN checkPermissions Missing write access to /opt/node-v8.11.3-linux-ppc64le/lib/node_modules/npm/node_modules/ansi-regex
    [2021/05/04 19:24:59.963] npm WARN checkPermissions Missing write access to /opt/node-v8.11.3-linux-ppc64le/lib/node_modules/npm/node_modules/aproba
    [2021/05/04 19:24:59.963] npm WARN checkPermissions Missing write access to /opt/node-v8.11.3-linux-ppc64le/lib/node_modules/npm/node_modules/bluebird
    <...>
    [2021/05/04 19:25:00.019] npm ERR! Error: EACCES: permission denied, access '/opt/node-v8.11.3-linux-ppc64le/lib/node_modules/npm/node_modules/ansi-regex'