### PR TITLE
feat(shell-api): provide bulk.find().delete() instead of .remove() MONGOSH-752

### DIFF
--- a/packages/i18n/src/locales/en_US.ts
+++ b/packages/i18n/src/locales/en_US.ts
@@ -1979,6 +1979,16 @@ const translations: Catalog = {
               description: 'Adds an removeOne to the bulk operation.',
               example: 'bulkOp.find(...).removeOne()',
             },
+            'delete': {
+              link: 'https://docs.mongodb.com/manual/reference/method/Bulk.find.delete/',
+              description: 'Adds an delete to the bulk operation.',
+              example: 'bulkOp.find(...).delete()',
+            },
+            'deleteOne': {
+              link: 'https://docs.mongodb.com/manual/reference/method/Bulk.find.deleteOne/',
+              description: 'Adds an deleteOne to the bulk operation.',
+              example: 'bulkOp.find(...).deleteOne()',
+            },
             'replaceOne': {
               link: 'https://docs.mongodb.com/manual/reference/method/Bulk.find.replaceOne/',
               description: 'Adds an replaceOne to the bulk operation.',

--- a/packages/shell-api/src/bulk.spec.ts
+++ b/packages/shell-api/src/bulk.spec.ts
@@ -280,9 +280,9 @@ describe('Bulk API', () => {
 
       });
       describe('remove', () => {
-        it('calls serviceProviderBulkOp.remove and returns parent', () => {
+        it('calls serviceProviderBulkOp.delete and returns parent', () => {
           bulkFindOp.remove();
-          expect(innerStub.remove).to.have.been.calledWith();
+          expect(innerStub.delete).to.have.been.calledWith();
           expect(bulk._batchCounts.nRemoveOps).to.equal(1);
         });
 
@@ -290,27 +290,61 @@ describe('Bulk API', () => {
           expect(bulkFindOp.remove()).to.equal(bulk);
         });
 
-        it('throws if serviceProviderBulkOp.remove throws', async() => {
+        it('throws if serviceProviderBulkOp.delete throws', async() => {
           const expectedError = new Error();
-          innerStub.remove.throws(expectedError);
+          innerStub.delete.throws(expectedError);
           expect(() => bulkFindOp.remove()).to.throw(expectedError);
         });
       });
       describe('removeOne', () => {
-        it('calls serviceProviderBulkOp.removeOne and returns parent', () => {
+        it('calls serviceProviderBulkOp.deleteOne and returns parent', () => {
           bulkFindOp.removeOne();
-          expect(innerStub.removeOne).to.have.been.calledWith();
+          expect(innerStub.deleteOne).to.have.been.calledWith();
           expect(bulk._batchCounts.nRemoveOps).to.equal(1);
         });
 
         it('returns self', () => {
-          expect(bulkFindOp.removeOne()).to.equal(bulk);
+          expect(bulkFindOp.deleteOne()).to.equal(bulk);
         });
 
-        it('throws if serviceProviderBulkOp.removeOne throws', async() => {
+        it('throws if serviceProviderBulkOp.deleteOne throws', async() => {
           const expectedError = new Error();
           innerStub.removeOne.throws(expectedError);
-          expect(() => bulkFindOp.removeOne()).to.throw(expectedError);
+          expect(() => bulkFindOp.deleteOne()).to.throw(expectedError);
+        });
+      });
+      describe('delete', () => {
+        it('calls serviceProviderBulkOp.delete and returns parent', () => {
+          bulkFindOp.delete();
+          expect(innerStub.delete).to.have.been.calledWith();
+          expect(bulk._batchCounts.ndeleteOps).to.equal(1);
+        });
+
+        it('returns self', () => {
+          expect(bulkFindOp.delete()).to.equal(bulk);
+        });
+
+        it('throws if serviceProviderBulkOp.delete throws', async() => {
+          const expectedError = new Error();
+          innerStub.delete.throws(expectedError);
+          expect(() => bulkFindOp.delete()).to.throw(expectedError);
+        });
+      });
+      describe('deleteOne', () => {
+        it('calls serviceProviderBulkOp.deleteOne and returns parent', () => {
+          bulkFindOp.deleteOne();
+          expect(innerStub.deleteOne).to.have.been.calledWith();
+          expect(bulk._batchCounts.ndeleteOps).to.equal(1);
+        });
+
+        it('returns self', () => {
+          expect(bulkFindOp.deleteOne()).to.equal(bulk);
+        });
+
+        it('throws if serviceProviderBulkOp.deleteOne throws', async() => {
+          const expectedError = new Error();
+          innerStub.deleteOne.throws(expectedError);
+          expect(() => bulkFindOp.deleteOne()).to.throw(expectedError);
         });
       });
       describe('upsert', () => {

--- a/packages/shell-api/src/bulk.spec.ts
+++ b/packages/shell-api/src/bulk.spec.ts
@@ -309,15 +309,15 @@ describe('Bulk API', () => {
 
         it('throws if serviceProviderBulkOp.deleteOne throws', async() => {
           const expectedError = new Error();
-          innerStub.removeOne.throws(expectedError);
-          expect(() => bulkFindOp.deleteOne()).to.throw(expectedError);
+          innerStub.deleteOne.throws(expectedError);
+          expect(() => bulkFindOp.removeOne()).to.throw(expectedError);
         });
       });
       describe('delete', () => {
         it('calls serviceProviderBulkOp.delete and returns parent', () => {
           bulkFindOp.delete();
           expect(innerStub.delete).to.have.been.calledWith();
-          expect(bulk._batchCounts.ndeleteOps).to.equal(1);
+          expect(bulk._batchCounts.nRemoveOps).to.equal(1);
         });
 
         it('returns self', () => {
@@ -334,7 +334,7 @@ describe('Bulk API', () => {
         it('calls serviceProviderBulkOp.deleteOne and returns parent', () => {
           bulkFindOp.deleteOne();
           expect(innerStub.deleteOne).to.have.been.calledWith();
-          expect(bulk._batchCounts.ndeleteOps).to.equal(1);
+          expect(bulk._batchCounts.nRemoveOps).to.equal(1);
         });
 
         it('returns self', () => {

--- a/packages/shell-api/src/bulk.ts
+++ b/packages/shell-api/src/bulk.ts
@@ -1,4 +1,4 @@
-import { hasAsyncChild, returnsPromise, ShellApiClass, shellApiClassDefault, returnType } from './decorators';
+import { hasAsyncChild, returnsPromise, ShellApiClass, shellApiClassDefault, returnType, deprecated } from './decorators';
 import Mongo from './mongo';
 import { CommonErrors, MongoshInvalidInputError, MongoshUnimplementedError } from '@mongosh/errors';
 import {
@@ -55,17 +55,29 @@ export class BulkFindOp extends ShellApiClass {
   }
 
   @returnType('Bulk')
-  remove(): Bulk {
+  delete(): Bulk {
     this._parentBulk._batchCounts.nRemoveOps++;
-    this._serviceProviderBulkFindOp.remove();
+    this._serviceProviderBulkFindOp.delete();
     return this._parentBulk;
   }
 
   @returnType('Bulk')
-  removeOne(): Bulk {
+  deleteOne(): Bulk {
     this._parentBulk._batchCounts.nRemoveOps++;
-    this._serviceProviderBulkFindOp.removeOne();
+    this._serviceProviderBulkFindOp.deleteOne();
     return this._parentBulk;
+  }
+
+  @returnType('Bulk')
+  @deprecated
+  remove(): Bulk {
+    return this.delete();
+  }
+
+  @returnType('Bulk')
+  @deprecated
+  removeOne(): Bulk {
+    return this.deleteOne();
   }
 
   @returnType('Bulk')


### PR DESCRIPTION
This happens to account for the changes made in NODE-2978 (https://github.com/mongodb/node-mongodb-native/commit/c3a183938289).

The old names are kept as deprecated aliases.

MONGOSH-752