### PR TITLE
fix(cli-repl): ctrl-c terminates running DB operations MONGOSH-640

### DIFF
--- a/packages/async-rewriter2/README.md
+++ b/packages/async-rewriter2/README.md
@@ -33,7 +33,7 @@ they reach their first `await` expression, and the fact that we can determine
 which `Promise`s need `await`ing by marking them as such using decorators
 on the API surface.
 
-The transformation takes place in two main steps.
+The transformation takes place in three main steps.
 
 ### Step one: IIFE wrapping
 
@@ -63,7 +63,64 @@ function foo() {
 Note how identifiers remain accessible in the outside environment, including
 top-level functions being hoisted to the outside.
 
-### Step two: Async function wrapping
+### Step two: Making certain exceptions uncatchable
+
+In order to support Ctrl+C properly, we add a type of exception that is not
+catchable by userland code.
+
+For example,
+
+```js
+try {
+  foo3();
+} catch {
+  bar3();
+}
+```
+
+is transformed into
+
+```js
+try {
+  foo3();
+} catch (_err) {
+  if (!err || !_err[Symbol.for('@@mongosh.uncatchable')]) {
+    bar3();
+  } else {
+    throw _err;
+  }
+}
+```
+
+and
+
+```js
+try {
+  foo1();
+} catch (err) {
+  bar1(err);
+} finally {
+  baz();
+}
+```
+
+into
+
+```js
+let _isCatchable;
+
+try {
+  foo1();
+} catch (err) {
+  _isCatchable = !err || !err[Symbol.for('@@mongosh.uncatchable')];
+
+  if (_isCatchable) bar1(err); else throw err;
+} finally {
+  if (_isCatchable) baz();
+}
+```
+
+### Step three: Async function wrapping
 
 We perform three operations:
 

--- a/packages/async-rewriter2/src/async-writer-babel.ts
+++ b/packages/async-rewriter2/src/async-writer-babel.ts
@@ -2,13 +2,14 @@
 import * as babel from '@babel/core';
 import runtimeSupport from './runtime-support.nocov';
 import wrapAsFunctionPlugin from './stages/wrap-as-iife';
+import uncatchableExceptionPlugin from './stages/uncatchable-exceptions';
 import makeMaybeAsyncFunctionPlugin from './stages/transform-maybe-await';
 import { AsyncRewriterErrors } from './error-codes';
 
 /**
  * General notes for this package:
  *
- * This package contains two babel plugins used in async rewriting, plus a helper
+ * This package contains three babel plugins used in async rewriting, plus a helper
  * to apply these plugins to plain code.
  *
  * If you have not worked with babel plugins,
@@ -51,6 +52,7 @@ export default class AsyncWriter {
         require('@babel/plugin-transform-destructuring').default
       ]);
       code = this.step(code, [wrapAsFunctionPlugin]);
+      code = this.step(code, [uncatchableExceptionPlugin]);
       code = this.step(code, [
         [
           makeMaybeAsyncFunctionPlugin,

--- a/packages/async-rewriter2/src/stages/uncatchable-exceptions.ts
+++ b/packages/async-rewriter2/src/stages/uncatchable-exceptions.ts
@@ -1,0 +1,106 @@
+import * as babel from '@babel/core';
+import * as BabelTypes from '@babel/types';
+
+/**
+ * In this step, we transform try/catch statements so that there are specific
+ * types of exceptions that they cannot catch (marked by
+ * Symbol.for('@@mongosh.uncatchable')) or run finally blocks for.
+ */
+export default ({ types: t }: { types: typeof BabelTypes }): babel.PluginObj<{}> => {
+  // We mark already-visited try/catch statements using these symbols.
+  function asNodeKey(v: any): keyof babel.types.Node { return v; }
+  const isGeneratedTryCatch = asNodeKey(Symbol('isGeneratedTryCatch'));
+  const notUncatchableCheck = babel.template.expression(`
+    (!ERR_IDENTIFIER || !ERR_IDENTIFIER[Symbol.for('@@mongosh.uncatchable')])
+  `);
+
+  return {
+    visitor: {
+      TryStatement(path) {
+        if (path.node[isGeneratedTryCatch]) return;
+        const { block, finalizer } = path.node;
+        let catchParam: babel.types.Identifier;
+        let handler: babel.types.CatchClause;
+        const fallbackCatchParam = path.scope.generateUidIdentifier('err');
+
+        if (path.node.handler) {
+          if (path.node.handler.param?.type === 'Identifier') {
+            // Classic catch(err) { ... }. We're good, no need to change anything.
+            catchParam = path.node.handler.param;
+            handler = path.node.handler;
+          } else if (path.node.handler.param) {
+            // Destructuring catch({ ... }) { ... body ... }. Transform to
+            // catch(err) { let ... = err; ... body ... }.
+            catchParam = fallbackCatchParam;
+            handler = t.catchClause(catchParam, t.blockStatement([
+              t.variableDeclaration('let', [
+                t.variableDeclarator(path.node.handler.param, catchParam)
+              ]),
+              path.node.handler.body
+            ]));
+          } else {
+            //
+            catchParam = fallbackCatchParam;
+            handler = path.node.handler;
+          }
+        } else {
+          // try {} finally {} without 'catch' is valid -- if we encounter that,
+          // pretend that there is a dummy catch (err) { throw err; }
+          catchParam = fallbackCatchParam;
+          handler = t.catchClause(catchParam, t.blockStatement([
+            t.throwStatement(catchParam)
+          ]));
+        }
+
+        if (!finalizer) {
+          // No finalizer -> no need to keep track of state outside the catch {}
+          // block itself. This is a bit simpler.
+          path.replaceWith(Object.assign(
+            t.tryStatement(
+              block,
+              t.catchClause(
+                catchParam,
+                t.blockStatement([
+                  // if (!err[isUncatchableSymbol]) { ... } else throw err;
+                  t.ifStatement(
+                    notUncatchableCheck({ ERR_IDENTIFIER: catchParam }),
+                    handler.body,
+                    t.throwStatement(catchParam))
+                ])
+              )
+            ),
+            { [isGeneratedTryCatch]: true }));
+        } else {
+          // finalizer -> need to store whether the exception was catchable
+          // (i.e. whether the finalizer is allowed to run) outside of the
+          // try/catch/finally block.
+          const isCatchable = path.scope.generateUidIdentifier('_isCatchable');
+          path.replaceWithMultiple([
+            t.variableDeclaration('let', [t.variableDeclarator(isCatchable)]),
+            Object.assign(
+              t.tryStatement(
+                block,
+                t.catchClause(
+                  catchParam,
+                  t.blockStatement([
+                  // isCatchable = !err[isUncatchableSymbol]
+                    t.expressionStatement(
+                      t.assignmentExpression('=',
+                        isCatchable,
+                        notUncatchableCheck({ ERR_IDENTIFIER: catchParam }))),
+                    // if (isCatchable) { ... } else throw err;
+                    t.ifStatement(isCatchable, handler.body, t.throwStatement(catchParam))
+                  ]),
+                ),
+                t.blockStatement([
+                // if (isCatchable) { ... }
+                  t.ifStatement(isCatchable, finalizer)
+                ])
+              ),
+              { [isGeneratedTryCatch]: true })
+          ]);
+        }
+      }
+    }
+  };
+};

--- a/packages/cli-repl/src/async-repl.spec.ts
+++ b/packages/cli-repl/src/async-repl.spec.ts
@@ -68,10 +68,9 @@ describe('AsyncRepl', () => {
   it('allows sync interruption through SIGINT', async function() {
     if (process.platform === 'win32') {
       this.skip(); // No SIGINT on Windows.
-      return;
     }
 
-    const { input, output } = createDefaultAsyncRepl({ breakEvalOnSigint: true });
+    const { input, output } = createDefaultAsyncRepl({ onAsyncSigint: () => false });
 
     input.write('while (true) { process.kill(process.pid, "SIGINT"); }\n');
     await expectInStream(output, 'execution was interrupted');
@@ -80,15 +79,16 @@ describe('AsyncRepl', () => {
   it('allows async interruption through SIGINT', async function() {
     if (process.platform === 'win32') {
       this.skip(); // No SIGINT on Windows.
-      return;
     }
 
-    const { input, output } = createDefaultAsyncRepl({ breakEvalOnSigint: true });
+    const onAsyncSigint = sinon.stub().resolves(false);
+    const { input, output } = createDefaultAsyncRepl({ onAsyncSigint: onAsyncSigint });
 
     input.write('new Promise(oopsIdontResolve => 0)\n');
     await delay(100);
     process.kill(process.pid, 'SIGINT');
     await expectInStream(output, 'execution was interrupted');
+    expect(onAsyncSigint).to.have.been.calledOnce;
   });
 
   it('handles synchronous exceptions well', async() => {

--- a/packages/cli-repl/src/async-repl.spec.ts
+++ b/packages/cli-repl/src/async-repl.spec.ts
@@ -67,7 +67,7 @@ describe('AsyncRepl', () => {
 
   it('allows sync interruption through SIGINT', async function() {
     if (process.platform === 'win32') {
-      this.skip(); // No SIGINT on Windows.
+      return this.skip(); // No SIGINT on Windows.
     }
 
     const { input, output } = createDefaultAsyncRepl({ onAsyncSigint: () => false });
@@ -78,7 +78,7 @@ describe('AsyncRepl', () => {
 
   it('allows async interruption through SIGINT', async function() {
     if (process.platform === 'win32') {
-      this.skip(); // No SIGINT on Windows.
+      return this.skip(); // No SIGINT on Windows.
     }
 
     const onAsyncSigint = sinon.stub().resolves(false);

--- a/packages/cli-repl/src/async-repl.ts
+++ b/packages/cli-repl/src/async-repl.ts
@@ -1,11 +1,11 @@
 /* eslint-disable chai-friendly/no-unused-expressions */
-import type { REPLServer, ReplOptions } from 'repl';
-import { Interface, ReadLineOptions } from 'readline';
-import type { EventEmitter } from 'events';
-import { Recoverable, start as originalStart } from 'repl';
-import isRecoverableError from 'is-recoverable-error';
-import { promisify } from 'util';
 import { Domain } from 'domain';
+import type { EventEmitter } from 'events';
+import isRecoverableError from 'is-recoverable-error';
+import { Interface, ReadLineOptions } from 'readline';
+import type { ReplOptions, REPLServer } from 'repl';
+import { Recoverable, start as originalStart } from 'repl';
+import { promisify } from 'util';
 
 // Utility, inverse of Readonly<T>
 type Mutable<T> = {

--- a/packages/cli-repl/src/async-repl.ts
+++ b/packages/cli-repl/src/async-repl.ts
@@ -15,10 +15,11 @@ type Mutable<T> = {
 export type OriginalEvalFunction = (input: string, context: any, filename: string) => Promise<any>;
 export type AsyncEvalFunction = (originalEval: OriginalEvalFunction, input: string, context: any, filename: string) => Promise<any>;
 
-export type AsyncREPLOptions = ReadLineOptions & Omit<ReplOptions, 'eval'> & {
+export type AsyncREPLOptions = ReadLineOptions & Omit<ReplOptions, 'eval' | 'breakEvalOnSigint'> & {
   start?: typeof originalStart,
   wrapCallbackError?: (err: Error) => Error;
   asyncEval: AsyncEvalFunction;
+  onAsyncSigint?: () => Promise<boolean> | boolean;
 };
 
 export type EvalStartEvent = {
@@ -57,8 +58,16 @@ function getPrompt(repl: any): string {
 // Start a REPLServer that supports asynchronous evaluation, rather than just
 // synchronous, and integrates nicely with Ctrl+C handling in that respect.
 export function start(opts: AsyncREPLOptions): REPLServer {
+  const {
+    asyncEval,
+    wrapCallbackError = err => err,
+    onAsyncSigint
+  } = opts;
+  if (onAsyncSigint) {
+    (opts as ReplOptions).breakEvalOnSigint = true;
+  }
+
   const repl = (opts.start ?? originalStart)(opts);
-  const { asyncEval, wrapCallbackError = err => err, breakEvalOnSigint } = opts;
   const originalEval = promisify(wrapNoSyncDomainError(repl.eval.bind(repl)));
 
   (repl as Mutable<typeof repl>).eval = async(
@@ -97,14 +106,22 @@ export function start(opts: AsyncREPLOptions): REPLServer {
 
       try {
         result = await new Promise((resolve, reject) => {
-          if (breakEvalOnSigint) {
+          if (onAsyncSigint) {
             // Handle SIGINT (Ctrl+C) that occurs while we are stuck in `await`
             // by racing a listener for 'SIGINT' against the evalResult Promise.
             // We remove all 'SIGINT' listeners and install our own.
-            sigintListener = (): void => {
-              // Reject with an exception similar to one thrown by Node.js
-              // itself if the `customEval` itself is interrupted.
-              reject(new Error('Asynchronous execution was interrupted by `SIGINT`'));
+            sigintListener = async(): Promise<void> => {
+              let interruptHandled = false;
+              try {
+                interruptHandled = await onAsyncSigint();
+              } catch (e) {
+                // ignore
+              } finally {
+                // Reject with an exception similar to one thrown by Node.js
+                // itself if the `customEval` itself is interrupted
+                // and the asyncSigint handler did not deal with it
+                reject(interruptHandled ? undefined : new Error('Asynchronous execution was interrupted by `SIGINT`'));
+              }
             };
 
             replSigint = disableEvent(repl, 'SIGINT');

--- a/packages/cli-repl/src/cli-repl.spec.ts
+++ b/packages/cli-repl/src/cli-repl.spec.ts
@@ -179,6 +179,7 @@ describe('CliRepl', () => {
           const filenameA = path.resolve(__dirname, '..', 'test', 'fixtures', 'load', 'a.js');
           input.write(`load(${JSON.stringify(filenameA)})\n`);
           await waitEval(cliRepl.bus);
+          expect(output).to.contain('Hi!');
           input.write('variableFromA\n');
           await waitEval(cliRepl.bus);
           expect(output).to.include('yes from A');
@@ -188,6 +189,7 @@ describe('CliRepl', () => {
           const filenameB = path.resolve(__dirname, '..', 'test', 'fixtures', 'load', 'b.js');
           input.write(`load(${JSON.stringify(filenameB)})\n`);
           await waitEval(cliRepl.bus);
+          expect(output).to.contain('Hi!');
           input.write('variableFromA + " " + variableFromB\n');
           await waitEval(cliRepl.bus);
           expect(output).to.include('yes from A yes from A from B');

--- a/packages/cli-repl/src/cli-repl.spec.ts
+++ b/packages/cli-repl/src/cli-repl.spec.ts
@@ -838,12 +838,9 @@ describe('CliRepl', () => {
       it('does not reconnect until the evaluation finishes', async() => {
         input.write('sleep(500); print(db.ctrlc.find({}));\n');
         await tick();
-        process.kill(process.pid, 'SIGINT');
 
         output = '';
-        await waitBus(cliRepl.bus, 'mongosh:eval-complete');
-        expect(output).to.match(/^Stopping execution.../m);
-        expect(output).to.not.match(/>\s+$/);
+        process.kill(process.pid, 'SIGINT');
 
         await waitBus(cliRepl.bus, 'mongosh:interrupt-complete');
         expect(output).to.match(/^Stopping execution.../m);
@@ -855,6 +852,10 @@ describe('CliRepl', () => {
         output = '';
         await delay(1000);
         expect(output).to.be.empty;
+
+        input.write('db.ctrlc.find({})\n');
+        await waitEval(cliRepl.bus);
+        expect(output).to.contain('hello');
       });
 
       it('cancels shell API commands that do not use the server', async() => {

--- a/packages/cli-repl/src/cli-repl.spec.ts
+++ b/packages/cli-repl/src/cli-repl.spec.ts
@@ -862,12 +862,22 @@ describe('CliRepl', () => {
       // it('cancels shell API commands that do not use the server', async() => {
       //   input.write('while(true) { print("I am alive") };\n');
       //   await tick();
+      //   console.log('Sending SIGINT...');
       //   process.kill(process.pid, 'SIGINT');
-      //   await once(cliRepl.mongoshRepl._repl, evalFinish);
-      //   expect(output).to.include('execution was interrupted');
 
       //   output = '';
+      //   await waitBus(cliRepl.bus, 'mongosh:eval-complete');
+      //   expect(output).to.include('execution was interrupted');
+      //   expect(output).to.not.match(/>\s+$/);
+
+      //   await waitBus(cliRepl.bus, 'mongosh:interrupt-complete');
+      //   output = '';
+
       //   await delay(100);
+      //   expect(output).to.include('execution was interrupted');
+      //   expect(output).to.not.include('MongoError');
+      //   expect(output).to.not.include('Mongosh');
+      //   expect(output).to.match(/>\s+$/);
       //   expect(output).to.not.include('alive');
       // }).timeout(5000);
     });

--- a/packages/cli-repl/src/cli-repl.spec.ts
+++ b/packages/cli-repl/src/cli-repl.spec.ts
@@ -803,15 +803,19 @@ describe('CliRepl', () => {
       //   await tick();
       //   process.kill(process.pid, 'SIGINT');
       //   await waitBus(cliRepl.bus, 'mongosh:interrupt-complete');
-      //   expect(output).to.match(/^Stopping execution.../m);
+      //   expect(output).to.match(/Stopping execution.../m);
 
       //   input.write('use admin\n');
       //   await waitEval(cliRepl.bus);
-      //   input.write('db.aggregate([ {$currentOp: {} }, { $match: { \'command.find\': \'ctrlc\' } }, { $project: { command: 1 } } ])\n');
-      //   await waitEval(cliRepl.bus);
 
-      //   expect(output).to.not.include('MongoError');
-      //   expect(output).to.not.include('loop1');
+      //   await eventually(async() => {
+      //     output = '';
+      //     input.write('db.aggregate([ {$currentOp: {} }, { $match: { \'command.find\': \'ctrlc\' } }, { $project: { command: 1 } } ])\n');
+      //     await waitEval(cliRepl.bus);
+
+      //     expect(output).to.not.include('MongoError');
+      //     expect(output).to.not.include('loop1');
+      //   });
       // });
 
       // it('terminates operations also for explicitly created Mongo instances', async() => {
@@ -826,13 +830,16 @@ describe('CliRepl', () => {
       //   await tick();
       //   process.kill(process.pid, 'SIGINT');
       //   await waitBus(cliRepl.bus, 'mongosh:interrupt-complete');
-      //   expect(output).to.match(/^Stopping execution.../m);
+      //   expect(output).to.match(/Stopping execution.../m);
 
-      //   input.write('clientAdminDb.aggregate([ {$currentOp: {} }, { $match: { \'command.find\': \'ctrlc\' } }, { $project: { command: 1 } } ])\n');
-      //   await waitEval(cliRepl.bus);
+      //   await eventually(async() => {
+      //     output = '';
+      //     input.write('clientAdminDb.aggregate([ {$currentOp: {} }, { $match: { \'command.find\': \'ctrlc\' } }, { $project: { command: 1 } } ])\n');
+      //     await waitEval(cliRepl.bus);
 
-      //   expect(output).to.not.include('MongoError');
-      //   expect(output).to.not.include('loop2');
+      //     expect(output).to.not.include('MongoError');
+      //     expect(output).to.not.include('loop2');
+      //   });
       // });
 
       it('does not reconnect until the evaluation finishes', async() => {

--- a/packages/cli-repl/src/cli-repl.spec.ts
+++ b/packages/cli-repl/src/cli-repl.spec.ts
@@ -880,6 +880,24 @@ describe('CliRepl', () => {
         await delay(100);
         expect(output).to.not.include('alive');
       });
+
+      it('ensures user code cannot catch the interrupt exception', async() => {
+        output = '';
+        input.write('nope = false; while(true) { try { print("I am alive"); } catch { nope = true; } };\n');
+        await tick();
+        process.kill(process.pid, 'SIGINT');
+
+        await waitBus(cliRepl.bus, 'mongosh:interrupt-complete');
+        expect(output).to.match(/^Stopping execution.../m);
+        expect(output).to.not.include('MongoError');
+        expect(output).to.not.include('Mongosh');
+        expect(output).to.match(/>\s+$/);
+
+        output = '';
+        input.write('nope\n');
+        await waitEval(cliRepl.bus);
+        expect(output).to.not.contain(true);
+      });
     });
   });
 

--- a/packages/cli-repl/src/mongosh-repl.ts
+++ b/packages/cli-repl/src/mongosh-repl.ts
@@ -390,6 +390,7 @@ class MongoshNodeRepl implements EvaluationListener {
       return shellResult.type !== null ? null : shellResult.rawValue;
     } catch (err) {
       if (this.runtimeState().internalState.interrupted) {
+        this.bus.emit('mongosh:eval-interrupt');
         // The shell is interrupted by CTRL-C - so we ignore any errors
         // that happened during evaluation.
         const result: ShellResult = {
@@ -436,14 +437,20 @@ class MongoshNodeRepl implements EvaluationListener {
   }
 
   async onAsyncSigint(): Promise<boolean> {
+    const evalInterrupt = new Promise<void>(resolve => {
+      this.bus.once('mongosh:eval-interrupt', () => {
+        // We have to write the message immediate inside the event handler
+        // to prevent the REPL from printing the prompt before the message
+        this.output.write('Stopping execution...');
+        resolve();
+      });
+    });
     const { internalState } = this.runtimeState();
     const fullyInterrupted = await internalState.onInterruptExecution();
 
-    this.output.write(this.formatError(new Error('Asynchronous execution was interrupted by `SIGINT`')));
-
     // this is an async interrupt - the evaluation is still running in the background
     // we wait until it finally completes
-    await once(this.bus, 'mongosh:eval-complete');
+    await evalInterrupt;
 
     const fullyResumed = await internalState.onResumeExecution();
     if (!fullyInterrupted || !fullyResumed) {

--- a/packages/cli-repl/src/mongosh-repl.ts
+++ b/packages/cli-repl/src/mongosh-repl.ts
@@ -454,6 +454,13 @@ class MongoshNodeRepl implements EvaluationListener {
     }
     this.output.write('Stopping execution...');
 
+    const mongodVersion: string = internalState.connectionInfo.buildInfo?.version;
+    if (mongodVersion.match(/^(4\.0\.|3\.)\d+/)) {
+      this.output.write(
+        this.clr('\nWARNING: Operations running on the server cannot be killed automatically.\n         Please make sure to kill them manually.', ['bold', 'yellow'])
+      );
+    }
+
     const fullyInterrupted = await internalState.onInterruptExecution();
     // this is an async interrupt - the evaluation is still running in the background
     // we wait until it finally completes (which should happen immediately)

--- a/packages/cli-repl/src/mongosh-repl.ts
+++ b/packages/cli-repl/src/mongosh-repl.ts
@@ -477,9 +477,10 @@ class MongoshNodeRepl implements EvaluationListener {
     return this.formatOutput({ type: result.type, value: result.printable });
   }
 
-  onPrint(values: ShellResult[]): void {
+  async onPrint(values: ShellResult[]): Promise<void> {
     const joined = values.map((value) => this.writer(value)).join(' ');
     this.output.write(joined + '\n');
+    await new Promise(resolve => setImmediate(resolve));
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/cli-repl/src/mongosh-repl.ts
+++ b/packages/cli-repl/src/mongosh-repl.ts
@@ -483,10 +483,9 @@ class MongoshNodeRepl implements EvaluationListener {
     return this.formatOutput({ type: result.type, value: result.printable });
   }
 
-  async onPrint(values: ShellResult[]): Promise<void> {
+  onPrint(values: ShellResult[]): void {
     const joined = values.map((value) => this.writer(value)).join(' ');
     this.output.write(joined + '\n');
-    await new Promise(resolve => setImmediate(resolve));
   }
 
   // eslint-disable-next-line @typescript-eslint/no-unused-vars

--- a/packages/cli-repl/src/mongosh-repl.ts
+++ b/packages/cli-repl/src/mongosh-repl.ts
@@ -456,9 +456,11 @@ class MongoshNodeRepl implements EvaluationListener {
 
     const mongodVersion: string = internalState.connectionInfo.buildInfo?.version;
     if (mongodVersion.match(/^(4\.0\.|3\.)\d+/)) {
-      this.output.write(
-        this.clr('\nWARNING: Operations running on the server cannot be killed automatically.\n         Please make sure to kill them manually.', ['bold', 'yellow'])
-      );
+      this.output.write(this.clr(
+        `\nWARNING: Operations running on the server cannot be killed automatically for MongoDB ${mongodVersion}.` +
+        '\n         Please make sure to kill them manually. Killing operations is supported starting with MongoDB 4.1.',
+        ['bold', 'yellow']
+      ));
     }
 
     const fullyInterrupted = await internalState.onInterruptExecution();

--- a/packages/cli-repl/src/mongosh-repl.ts
+++ b/packages/cli-repl/src/mongosh-repl.ts
@@ -96,6 +96,8 @@ function fixupReplForNodeBug38314(repl: REPLServer): void {
  */
 class MongoshNodeRepl implements EvaluationListener {
   _runtimeState: MongoshRuntimeState | null;
+  _repl: REPLServer | undefined;
+
   input: Readable;
   lineByLineInput: LineByLineInput;
   output: Writable;
@@ -108,6 +110,7 @@ class MongoshNodeRepl implements EvaluationListener {
   inspectDepth = 0;
   started = false;
   showStackTraces = false;
+
 
   constructor(options: MongoshNodeReplOptions) {
     this.input = options.input;
@@ -294,6 +297,8 @@ class MongoshNodeRepl implements EvaluationListener {
         await this.onExit();
       } catch { /* ... */ }
     });
+
+    this._repl = repl;
 
     internalState.setCtx(repl.context);
     return { __initialized: 'yes' };

--- a/packages/cli-repl/test/e2e.spec.ts
+++ b/packages/cli-repl/test/e2e.spec.ts
@@ -429,7 +429,7 @@ describe('e2e', function() {
   describe('Ctrl+C aka SIGINT', () => {
     before(function() {
       if (process.platform === 'win32') {
-        this.skip(); // Cannot trigger SIGINT programmatically on Windows
+        return this.skip(); // Cannot trigger SIGINT programmatically on Windows
       }
     });
 
@@ -850,7 +850,7 @@ describe('e2e', function() {
 
       it('keeps working when the config file is present but not writable', async function() {
         if (process.platform === 'win32' || process.getuid() === 0 || process.geteuid() === 0) {
-          this.skip(); // There is no meaningful chmod on Windows, and root can ignore permissions.
+          return this.skip(); // There is no meaningful chmod on Windows, and root can ignore permissions.
         }
         await fs.mkdir(path.dirname(configPath), { recursive: true });
         await fs.writeFile(configPath, '{}');

--- a/packages/cli-repl/test/e2e.spec.ts
+++ b/packages/cli-repl/test/e2e.spec.ts
@@ -429,16 +429,17 @@ describe('e2e', function() {
   describe('Ctrl+C aka SIGINT', () => {
     before(function() {
       if (process.platform === 'win32') {
-        this.skip(); // There is no SIGINT on Windows.
+        this.skip(); // Cannot trigger SIGINT programmatically on Windows
       }
     });
 
-    let shell;
+    let shell: TestShell;
     beforeEach(async() => {
       shell = TestShell.start({ args: [ '--nodb' ], removeSigintListeners: true });
       await shell.waitForPrompt();
       shell.assertNoErrors();
     });
+
     it('interrupts sync execution', async() => {
       await shell.executeLine('void process.removeAllListeners("SIGINT")');
       const result = shell.executeLine('while(true);');
@@ -450,13 +451,14 @@ describe('e2e', function() {
       const result = shell.executeLine('new Promise(() => {});');
       setTimeout(() => shell.kill('SIGINT'), 3000);
       await result;
-      shell.assertContainsError('interrupted');
+      shell.assertContainsOutput('Stopping execution...');
     });
     it('interrupts load()', async() => {
       const filename = path.resolve(__dirname, 'fixtures', 'load', 'infinite-loop.js');
       const result = shell.executeLine(`load(${JSON.stringify(filename)})`);
       setTimeout(() => shell.kill('SIGINT'), 3000);
       await result;
+      // The while loop in the script is run as "sync" code
       shell.assertContainsError('interrupted');
     });
     it('behaves normally after an exception', async() => {
@@ -466,6 +468,7 @@ describe('e2e', function() {
       await shell.waitForPrompt();
       await new Promise((resolve) => setTimeout(resolve, 100));
       shell.assertNotContainsOutput('interrupted');
+      shell.assertNotContainsOutput('Stopping execution');
     });
   });
 
@@ -848,7 +851,6 @@ describe('e2e', function() {
       it('keeps working when the config file is present but not writable', async function() {
         if (process.platform === 'win32' || process.getuid() === 0 || process.geteuid() === 0) {
           this.skip(); // There is no meaningful chmod on Windows, and root can ignore permissions.
-          return;
         }
         await fs.mkdir(path.dirname(configPath), { recursive: true });
         await fs.writeFile(configPath, '{}');

--- a/packages/node-runtime-worker-thread/src/child-process-mongosh-bus.ts
+++ b/packages/node-runtime-worker-thread/src/child-process-mongosh-bus.ts
@@ -13,6 +13,9 @@ export class ChildProcessMongoshBus {
         },
         on() {
           throw new Error("Can't use `on` method on ChildProcessMongoshBus");
+        },
+        once() {
+          throw new Error("Can't use `once` method on ChildProcessMongoshBus");
         }
       },
       childProcess

--- a/packages/node-runtime-worker-thread/src/worker-runtime.ts
+++ b/packages/node-runtime-worker-thread/src/worker-runtime.ts
@@ -61,6 +61,9 @@ const messageBus: MongoshBus = Object.assign(
   {
     on() {
       throw new Error("Can't call `on` method on worker runtime MongoshBus");
+    },
+    once() {
+      throw new Error("Can't call `once` method on worker runtime MongoshBus");
     }
   }
 );

--- a/packages/service-provider-core/src/closable.ts
+++ b/packages/service-provider-core/src/closable.ts
@@ -5,4 +5,10 @@ export default interface Closable {
    * @param {boolean} force - Whether to force close.
    */
   close(force: boolean): Promise<void>;
+
+  /**
+   * Suspends the connection, i.e. temporarily force-closes it
+   * and returns a function that will re-open the connection.
+   */
+  suspend(): Promise<() => Promise<void>>;
 }

--- a/packages/service-provider-server/src/cli-service-provider.ts
+++ b/packages/service-provider-server/src/cli-service-provider.ts
@@ -239,7 +239,7 @@ class CliServiceProvider extends ServiceProviderCore implements ServiceProvider 
    */
   constructor(mongoClient: MongoClient, clientOptions: MongoClientOptions = {}, uri?: ConnectionString) {
     super(bsonlib);
-    ensureMongoNodeNativePatchesAreApplied(mongoClient);
+    ensureMongoNodeNativePatchesAreApplied();
 
     this.mongoClient = mongoClient;
     this.uri = uri;

--- a/packages/service-provider-server/src/cli-service-provider.ts
+++ b/packages/service-provider-server/src/cli-service-provider.ts
@@ -454,6 +454,13 @@ class CliServiceProvider extends ServiceProviderCore implements ServiceProvider 
     return this.mongoClient.close(force);
   }
 
+  async suspend(): Promise<() => Promise<void>> {
+    await this.close(true);
+    return async() => {
+      await this.resetConnectionOptions({});
+    };
+  }
+
   /**
    * Deprecated count command.
    *

--- a/packages/service-provider-server/src/cli-service-provider.ts
+++ b/packages/service-provider-server/src/cli-service-provider.ts
@@ -81,6 +81,7 @@ import {
 } from '@mongosh/service-provider-core';
 
 import { MongoshCommandFailed, MongoshInternalError, MongoshRuntimeError } from '@mongosh/errors';
+import { ensureMongoNodeNativePatchesAreApplied } from './mongodb-patches';
 
 const bsonlib = {
   Binary,
@@ -238,6 +239,8 @@ class CliServiceProvider extends ServiceProviderCore implements ServiceProvider 
    */
   constructor(mongoClient: MongoClient, clientOptions: MongoClientOptions = {}, uri?: ConnectionString) {
     super(bsonlib);
+    ensureMongoNodeNativePatchesAreApplied(mongoClient);
+
     this.mongoClient = mongoClient;
     this.uri = uri;
     this.platform = ReplPlatform.CLI;

--- a/packages/service-provider-server/src/mongodb-patches.ts
+++ b/packages/service-provider-server/src/mongodb-patches.ts
@@ -17,7 +17,7 @@ export function ensureMongoNodeNativePatchesAreApplied(): void {
 const poolToConnections = new Map<ConnectionPool, Set<Connection>>();
 
 function patchConnectionPoolTracking(): void {
-  const connectionPoolPrototype: ConnectionPool = Object.getPrototypeOf(require('mongodb/lib/cmap/connection_pool').ConnectionPool);
+  const connectionPoolPrototype: ConnectionPool = require('mongodb/lib/cmap/connection_pool').ConnectionPool.prototype;
   if (!connectionPoolPrototype) {
     throw new MongoshInternalError('Failed to setup connection handling');
   }

--- a/packages/service-provider-server/src/mongodb-patches.ts
+++ b/packages/service-provider-server/src/mongodb-patches.ts
@@ -1,0 +1,89 @@
+import { MongoshInternalError } from '@mongosh/errors';
+import { Callback, CloseOptions, Connection, ConnectionPool, MongoClient, Server } from 'mongodb';
+
+let alreadyPatched = false;
+
+// TODO: revisit whether we still need monkey patching in light of NODE-3263
+export function ensureMongoNodeNativePatchesAreApplied(mongoClient: MongoClient): void {
+  if (alreadyPatched) {
+    return;
+  }
+
+  patchConnectionPoolTracking(mongoClient);
+
+  alreadyPatched = true;
+}
+
+const poolToConnections = new Map<ConnectionPool, Set<Connection>>();
+
+function patchConnectionPoolTracking(mongoClient: MongoClient): void {
+  const connectionPoolPrototype = getConnectionPoolPrototype(mongoClient);
+  if (!connectionPoolPrototype) {
+    if (Object.getPrototypeOf(mongoClient).constructor.name !== 'MongoClient') {
+      // this happens in tests with mocks - we ignore these cases
+      return;
+    }
+    throw new MongoshInternalError('Failed to setup connection handling');
+  }
+
+  const originalCheckOut = connectionPoolPrototype.checkOut;
+  const newCheckOut: typeof originalCheckOut = function(this: ConnectionPool, cb: Callback<Connection>): void {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    const pool = this;
+    originalCheckOut.call(this, function(this: any, error, connection) {
+      if (connection) {
+        let connections = poolToConnections.get(pool);
+        if (!connections) {
+          connections = new Set<Connection>();
+          poolToConnections.set(pool, connections);
+        }
+        connections.add(connection);
+      }
+
+      cb.call(this, error, connection);
+    });
+  };
+  connectionPoolPrototype.checkOut = newCheckOut;
+
+  const originalCheckIn = connectionPoolPrototype.checkIn;
+  const newCheckIn: typeof originalCheckIn = function(this: ConnectionPool, connection: Connection): void {
+    if (connection) {
+      const connections = poolToConnections.get(this);
+      if (connections) {
+        connections.delete(connection);
+      }
+    }
+    originalCheckIn.call(this, connection);
+  };
+  connectionPoolPrototype.checkIn = newCheckIn;
+
+  const originalClose = connectionPoolPrototype.close;
+  const newClose: typeof originalClose = function(this: ConnectionPool, options: CloseOptions | Callback<void>, cb?: Callback<void>): void {
+    // eslint-disable-next-line @typescript-eslint/no-this-alias
+    const pool = this;
+    const connections = poolToConnections.get(pool);
+    if (!pool.closed && connections && typeof options === 'object' && options.force) {
+      const originalCallback = cb;
+      cb = function(this: any, error: any, result: any) {
+        poolToConnections.delete(pool);
+        [...connections].forEach(c => c.destroy({ force: true }));
+
+        if (originalCallback) {
+          originalCallback.call(this, error, result);
+        }
+      };
+    }
+
+    originalClose.call(this, options as any, cb as any);
+  };
+  connectionPoolPrototype.close = newClose;
+}
+
+function getConnectionPoolPrototype(mongoClient: MongoClient): ConnectionPool | undefined {
+  const servers: Map<string, Server> | undefined = (mongoClient.topology as any)?.s.servers;
+  if (!servers) {
+    return undefined;
+  }
+  const aServer = [...servers.values()][0];
+  return Object.getPrototypeOf((aServer as any).s.pool);
+}

--- a/packages/shell-api/src/abstract-cursor.ts
+++ b/packages/shell-api/src/abstract-cursor.ts
@@ -1,9 +1,9 @@
 import {
   shellApiClassNoHelp,
-  ShellApiClass,
-  returnsPromise,
   toShellResult,
-  returnType
+  returnType,
+  ShellApiWithMongoClass,
+  returnsPromise
 } from './decorators';
 import type Mongo from './mongo';
 import type {
@@ -17,7 +17,7 @@ import { CursorIterationResult } from './result';
 import { iterate, validateExplainableVerbosity, markAsExplainOutput } from './helpers';
 
 @shellApiClassNoHelp
-export abstract class AbstractCursor extends ShellApiClass {
+export abstract class AbstractCursor extends ShellApiWithMongoClass {
   _mongo: Mongo;
   abstract _cursor: ServiceProviderAggregationCursor | ServiceProviderCursor;
   _currentIterationResult: CursorIterationResult | null = null;

--- a/packages/shell-api/src/bulk.spec.ts
+++ b/packages/shell-api/src/bulk.spec.ts
@@ -4,7 +4,7 @@ import { fail } from 'assert';
 import chai, { expect } from 'chai';
 import sinonChai from 'sinon-chai';
 import { EventEmitter } from 'events';
-import sinon, { StubbedInstance, stubInterface } from 'ts-sinon';
+import { StubbedInstance, stubInterface } from 'ts-sinon';
 import Bulk, { BulkFindOp } from './bulk';
 import Collection from './collection';
 import { ALL_PLATFORMS, ALL_SERVER_VERSIONS, ALL_TOPOLOGIES } from './enums';
@@ -47,8 +47,8 @@ describe('Bulk API', () => {
     });
     describe('Metadata', () => {
       describe('toShellResult', () => {
-        const mongo = sinon.spy();
-        const b = new Bulk(mongo, {
+        const collection = stubInterface<Collection>();
+        const b = new Bulk(collection, {
           batches: [1, 2, 3, 4]
         } as any);
         it('value', async() => {

--- a/packages/shell-api/src/bulk.ts
+++ b/packages/shell-api/src/bulk.ts
@@ -1,4 +1,4 @@
-import { returnsPromise, ShellApiClass, shellApiClassDefault, returnType, deprecated } from './decorators';
+import { returnsPromise, shellApiClassDefault, returnType, deprecated, ShellApiWithMongoClass } from './decorators';
 import Mongo from './mongo';
 import { CommonErrors, MongoshInvalidInputError, MongoshUnimplementedError } from '@mongosh/errors';
 import {
@@ -17,7 +17,7 @@ import { BulkWriteResult } from './result';
 import type Collection from './collection';
 
 @shellApiClassDefault
-export class BulkFindOp extends ShellApiClass {
+export class BulkFindOp extends ShellApiWithMongoClass {
   _serviceProviderBulkFindOp: FindOperators;
   _parentBulk: Bulk;
   _hint: Document | undefined;
@@ -26,6 +26,10 @@ export class BulkFindOp extends ShellApiClass {
     super();
     this._serviceProviderBulkFindOp = innerFind;
     this._parentBulk = parentBulk;
+  }
+
+  get _mongo(): Mongo {
+    return this._parentBulk._mongo;
   }
 
   [asPrintable](): string {
@@ -131,7 +135,7 @@ export class BulkFindOp extends ShellApiClass {
 
 
 @shellApiClassDefault
-export default class Bulk extends ShellApiClass {
+export default class Bulk extends ShellApiWithMongoClass {
   _mongo: Mongo;
   _collection: Collection;
   _batchCounts: any;
@@ -139,7 +143,7 @@ export default class Bulk extends ShellApiClass {
   _serviceProviderBulkOp: OrderedBulkOperation | UnorderedBulkOperation;
   _ordered: boolean;
 
-  constructor(collection: any, innerBulk: OrderedBulkOperation | UnorderedBulkOperation, ordered = false) {
+  constructor(collection: Collection, innerBulk: OrderedBulkOperation | UnorderedBulkOperation, ordered = false) {
     super();
     this._collection = collection;
     this._mongo = collection._mongo;

--- a/packages/shell-api/src/change-stream-cursor.ts
+++ b/packages/shell-api/src/change-stream-cursor.ts
@@ -2,8 +2,8 @@ import {
   shellApiClassDefault,
   returnsPromise,
   returnType,
-  ShellApiClass,
-  deprecated
+  deprecated,
+  ShellApiWithMongoClass
 } from './decorators';
 import {
   ChangeStream,
@@ -22,7 +22,7 @@ import { printWarning } from './deprecation-warning';
 import Mongo from './mongo';
 
 @shellApiClassDefault
-export default class ChangeStreamCursor extends ShellApiClass {
+export default class ChangeStreamCursor extends ShellApiWithMongoClass {
   _mongo: Mongo;
   _cursor: ChangeStream;
   _currentIterationResult: CursorIterationResult | null = null;

--- a/packages/shell-api/src/collection.ts
+++ b/packages/shell-api/src/collection.ts
@@ -6,10 +6,10 @@ import {
   returnsPromise,
   returnType,
   serverVersions,
-  ShellApiClass,
   shellApiClassDefault,
   topologies,
-  deprecated
+  deprecated,
+  ShellApiWithMongoClass
 } from './decorators';
 import { ADMIN_DB, asPrintable, namespaceInfo, ServerVersions, Topologies } from './enums';
 import {
@@ -79,7 +79,7 @@ type CollStatsShellOptions = CollStatsOptions & {
 
 @shellApiClassDefault
 @addSourceToResults
-export default class Collection extends ShellApiClass {
+export default class Collection extends ShellApiWithMongoClass {
   _mongo: Mongo;
   _database: Database;
   _name: string;

--- a/packages/shell-api/src/database.ts
+++ b/packages/shell-api/src/database.ts
@@ -5,10 +5,10 @@ import {
   returnsPromise,
   returnType,
   serverVersions,
-  ShellApiClass,
   shellApiClassDefault,
   topologies,
-  deprecated
+  deprecated,
+  ShellApiWithMongoClass
 } from './decorators';
 import { ADMIN_DB, asPrintable, ServerVersions, Topologies } from './enums';
 import {
@@ -46,7 +46,7 @@ import { ShellApiErrors } from './error-codes';
 type AuthDoc = {user: string, pwd: string, authDb?: string, mechanism?: string};
 
 @shellApiClassDefault
-export default class Database extends ShellApiClass {
+export default class Database extends ShellApiWithMongoClass {
   _mongo: Mongo;
   _name: string;
   _collections: Record<string, Collection>;

--- a/packages/shell-api/src/decorators.ts
+++ b/packages/shell-api/src/decorators.ts
@@ -359,11 +359,11 @@ export function topologies(topologiesArray: Topologies[]): Function {
 }
 export const nonAsyncFunctionsReturningPromises: string[] = []; // For testing.
 export function returnsPromise(_target: any, _propertyKey: string, descriptor: PropertyDescriptor): void {
-  const orig = descriptor.value;
-  orig.returnsPromise = true;
-  descriptor.value = markImplicitlyAwaited(descriptor.value);
-  if (orig.constructor.name !== 'AsyncFunction') {
-    nonAsyncFunctionsReturningPromises.push(orig.name);
+  const originalFunction = descriptor.value;
+  originalFunction.returnsPromise = true;
+  descriptor.value = markImplicitlyAwaited(originalFunction);
+  if (originalFunction.constructor.name !== 'AsyncFunction') {
+    nonAsyncFunctionsReturningPromises.push(originalFunction.name);
   }
 }
 // This is use to mark functions that are executable in the shell in a POSIX-shell-like

--- a/packages/shell-api/src/decorators.ts
+++ b/packages/shell-api/src/decorators.ts
@@ -410,10 +410,10 @@ export function returnsPromise(_target: any, _propertyKey: string, descriptor: P
     try {
       return await originalFunction.call(this, ...args);
     } finally {
-       if (typeof setImmediate === 'function') {
-         // Not all JS environments have setImmediate
-         await new Promise(setImmediate);
-       }
+      if (typeof setImmediate === 'function') {
+        // Not all JS environments have setImmediate
+        await new Promise(setImmediate);
+      }
     }
   }
   Object.setPrototypeOf(wrapper, Object.getPrototypeOf(originalFunction));

--- a/packages/shell-api/src/decorators.ts
+++ b/packages/shell-api/src/decorators.ts
@@ -410,7 +410,7 @@ export function returnsPromise(_target: any, _propertyKey: string, descriptor: P
     try {
       return await originalFunction.call(this, ...args);
     } finally {
-      if (typeof setImmediate === 'function') {
+      if (typeof setTimeout === 'function' && typeof setImmediate === 'function') {
         // Not all JS environments have setImmediate
         await new Promise(setImmediate);
       }

--- a/packages/shell-api/src/decorators.ts
+++ b/packages/shell-api/src/decorators.ts
@@ -407,9 +407,14 @@ export function returnsPromise(_target: any, _propertyKey: string, descriptor: P
   originalFunction.returnsPromise = true;
 
   async function wrapper(this: any, ...args: any[]) {
-    const result = await originalFunction.call(this, ...args);
-    await new Promise(setImmediate);
-    return result;
+    try {
+      return await originalFunction.call(this, ...args);
+    } finally {
+       if (typeof setImmediate === 'function') {
+         // Not all JS environments have setImmediate
+         await new Promise(setImmediate);
+       }
+    }
   }
   Object.setPrototypeOf(wrapper, Object.getPrototypeOf(originalFunction));
   Object.defineProperties(wrapper, Object.getOwnPropertyDescriptors(originalFunction));

--- a/packages/shell-api/src/decorators.ts
+++ b/packages/shell-api/src/decorators.ts
@@ -82,11 +82,11 @@ export abstract class ShellApiWithMongoClass extends ShellApiClass {
 
 export abstract class ShellApiValueClass extends ShellApiClass {
   get _mongo(): Mongo {
-    throw new Error('Not supported on this value class');
+    throw new MongoshInternalError('Not supported on this value class');
   }
 
   get _internalState(): ShellInternalState {
-    throw new Error('Not supported on this value class');
+    throw new MongoshInternalError('Not supported on this value class');
   }
 }
 

--- a/packages/shell-api/src/explainable.ts
+++ b/packages/shell-api/src/explainable.ts
@@ -4,9 +4,9 @@ import ExplainableCursor from './explainable-cursor';
 import {
   returnsPromise,
   returnType,
-  ShellApiClass,
   shellApiClassDefault,
-  serverVersions
+  serverVersions,
+  ShellApiWithMongoClass
 } from './decorators';
 import { asPrintable, ServerVersions } from './enums';
 import {
@@ -29,7 +29,7 @@ import type {
 } from '@mongosh/service-provider-core';
 
 @shellApiClassDefault
-export default class Explainable extends ShellApiClass {
+export default class Explainable extends ShellApiWithMongoClass {
   _mongo: Mongo;
   _collection: Collection;
   _verbosity: ExplainVerbosityLike;

--- a/packages/shell-api/src/field-level-encryption.ts
+++ b/packages/shell-api/src/field-level-encryption.ts
@@ -2,8 +2,8 @@ import {
   classPlatforms,
   returnsPromise,
   returnType,
-  ShellApiClass,
-  shellApiClassDefault
+  shellApiClassDefault,
+  ShellApiWithMongoClass
 } from './decorators';
 import {
   ClientEncryption as MongoCryptClientEncryption,
@@ -44,7 +44,7 @@ export interface ClientSideFieldLevelEncryptionOptions {
 
 @shellApiClassDefault
 @classPlatforms([ ReplPlatform.CLI ] )
-export class ClientEncryption extends ShellApiClass {
+export class ClientEncryption extends ShellApiWithMongoClass {
   public _mongo: Mongo;
   public _libmongocrypt: MongoCryptClientEncryption;
 
@@ -96,7 +96,7 @@ export class ClientEncryption extends ShellApiClass {
 
 @shellApiClassDefault
 @classPlatforms([ ReplPlatform.CLI ] )
-export class KeyVault extends ShellApiClass {
+export class KeyVault extends ShellApiWithMongoClass {
   public _mongo: Mongo;
   public _clientEncryption: ClientEncryption;
   private _keyColl: Collection;

--- a/packages/shell-api/src/interruptor.spec.ts
+++ b/packages/shell-api/src/interruptor.spec.ts
@@ -1,0 +1,64 @@
+import { bson, ServiceProvider } from '@mongosh/service-provider-core';
+import { expect } from 'chai';
+import { EventEmitter } from 'events';
+import { StubbedInstance, stubInterface } from 'ts-sinon';
+import Database from './database';
+import Mongo from './mongo';
+import ShellInternalState from './shell-internal-state';
+
+describe('interruptor', () => {
+  describe('with Shell API functions', () => {
+    let mongo: Mongo;
+    let serviceProvider: StubbedInstance<ServiceProvider>;
+    let database: Database;
+    let bus: StubbedInstance<EventEmitter>;
+    let internalState: ShellInternalState;
+
+    beforeEach(() => {
+      bus = stubInterface<EventEmitter>();
+      serviceProvider = stubInterface<ServiceProvider>();
+      serviceProvider.initialDb = 'test';
+      serviceProvider.bsonLibrary = bson;
+      serviceProvider.runCommand.resolves({ ok: 1 });
+      serviceProvider.runCommandWithCheck.resolves({ ok: 1 });
+      internalState = new ShellInternalState(serviceProvider, bus);
+      mongo = new Mongo(internalState, undefined, undefined, undefined, serviceProvider);
+      database = new Database(mongo, 'db1');
+    });
+
+    it('causes an interrupt error to be thrown on entry', async() => {
+      internalState.interrupted = true;
+      try {
+        await database.runCommand({ some: 1 });
+      } catch (e) {
+        expect(e.name).to.equal('MongoshInterruptedError');
+        expect(serviceProvider.runCommand).to.not.have.been.called;
+        expect(serviceProvider.runCommandWithCheck).to.not.have.been.called;
+        return;
+      }
+      expect.fail('Expected error');
+    });
+
+    it('causes an interrupt error to be thrown on exit', async() => {
+      let resolveCall: (result: any) => void;
+      serviceProvider.runCommandWithCheck.callsFake(() => {
+        return new Promise(resolve => {
+          resolveCall = resolve;
+        });
+      });
+
+      const runCommand = database.runCommand({ some: 1 });
+      internalState.interrupted = true;
+      resolveCall({ ok: 1 });
+
+      try {
+        await runCommand;
+      } catch (e) {
+        expect(e.name).to.equal('MongoshInterruptedError');
+        expect(serviceProvider.runCommandWithCheck).to.have.been.called;
+        return;
+      }
+      expect.fail('Expected error');
+    });
+  });
+});

--- a/packages/shell-api/src/interruptor.spec.ts
+++ b/packages/shell-api/src/interruptor.spec.ts
@@ -27,7 +27,7 @@ describe('interruptor', () => {
     });
 
     it('causes an interrupt error to be thrown on entry', async() => {
-      internalState.interrupted = true;
+      internalState.interrupted.set();
       try {
         await database.runCommand({ some: 1 });
       } catch (e) {
@@ -48,7 +48,7 @@ describe('interruptor', () => {
       });
 
       const runCommand = database.runCommand({ some: 1 });
-      internalState.interrupted = true;
+      internalState.interrupted.set();
       resolveCall({ ok: 1 });
 
       try {

--- a/packages/shell-api/src/interruptor.ts
+++ b/packages/shell-api/src/interruptor.ts
@@ -1,0 +1,19 @@
+import { MongoshBaseError, MongoshInternalError } from '@mongosh/errors';
+import { ShellApiClass } from './decorators';
+import { shellApiType } from './enums';
+
+export class MongoshInterruptedError extends MongoshBaseError {
+  constructor() {
+    super('MongoshInterruptedError', 'execution was interrupted');
+  }
+}
+
+export function checkInterrupted(apiClass: any): void {
+  if (!apiClass[shellApiType]) {
+    throw new MongoshInternalError('checkInterrupted can only be called for functions from shell API classes');
+  }
+  // internalState can be undefined in tests
+  if ((apiClass as ShellApiClass)._internalState?.interrupted) {
+    throw new MongoshInterruptedError();
+  }
+}

--- a/packages/shell-api/src/interruptor.ts
+++ b/packages/shell-api/src/interruptor.ts
@@ -2,7 +2,11 @@ import { MongoshBaseError, MongoshInternalError } from '@mongosh/errors';
 import { ShellApiClass } from './decorators';
 import { shellApiType } from './enums';
 
+const kUncatchable = Symbol.for('@@mongosh.uncatchable');
+
 export class MongoshInterruptedError extends MongoshBaseError {
+  [kUncatchable] = true;
+
   constructor() {
     super('MongoshInterruptedError', 'execution was interrupted');
   }

--- a/packages/shell-api/src/interruptor.ts
+++ b/packages/shell-api/src/interruptor.ts
@@ -1,7 +1,6 @@
 import { MongoshBaseError, MongoshInternalError } from '@mongosh/errors';
 import { ShellApiClass } from './decorators';
 import { shellApiType } from './enums';
-import type ShellInternalState from './shell-internal-state';
 
 export class MongoshInterruptedError extends MongoshBaseError {
   constructor() {
@@ -58,14 +57,14 @@ export class InterruptFlag {
   }
 }
 
-export function checkInterrupted(apiClass: any): ShellInternalState | undefined {
+export function checkInterrupted(apiClass: any): InterruptFlag | undefined {
   if (!apiClass[shellApiType]) {
     throw new MongoshInternalError('checkInterrupted can only be called for functions from shell API classes');
   }
   // internalState can be undefined in tests
   const internalState = (apiClass as ShellApiClass)._internalState;
-  if (internalState?.interrupted.isSet()) {
+  if (internalState?.interrupted?.isSet()) {
     throw new MongoshInterruptedError();
   }
-  return internalState;
+  return internalState?.interrupted;
 }

--- a/packages/shell-api/src/interruptor.ts
+++ b/packages/shell-api/src/interruptor.ts
@@ -1,6 +1,7 @@
 import { MongoshBaseError, MongoshInternalError } from '@mongosh/errors';
 import { ShellApiClass } from './decorators';
 import { shellApiType } from './enums';
+import type ShellInternalState from './shell-internal-state';
 
 export class MongoshInterruptedError extends MongoshBaseError {
   constructor() {
@@ -8,12 +9,63 @@ export class MongoshInterruptedError extends MongoshBaseError {
   }
 }
 
-export function checkInterrupted(apiClass: any): void {
+export class InterruptFlag {
+  private interrupted = false;
+  private deferred: {
+    reject: (e: MongoshInterruptedError) => void;
+    promise: Promise<never>;
+  };
+
+  constructor() {
+    this.deferred = this.defer();
+  }
+
+  public isSet(): boolean {
+    return this.interrupted;
+  }
+
+  /**
+   * The returned promise will never be resolved but is rejected
+   * when the interrupt is set. The rejection happens with an
+   * instance of `MongoshInterruptedError`.
+   * @returns Promise that is rejected when the interrupt is set
+   */
+  public asPromise(): Promise<never> {
+    return this.deferred.promise;
+  }
+
+  public set(): void {
+    this.interrupted = true;
+    this.deferred.reject(new MongoshInterruptedError());
+  }
+
+  public reset(): void {
+    this.interrupted = false;
+    this.deferred = this.defer();
+  }
+
+  private defer(): { reject: (e: MongoshInterruptedError) => void; promise: Promise<never>; } {
+    const result: any = {};
+    result.promise = new Promise<never>((_, reject) => {
+      result.reject = reject;
+    });
+    result.promise.catch(() => {
+      // we ignore the error here - all others should be notified
+      // we just have to ensure there's at least one handler for it
+      // to prevent an UnhandledPromiseRejection
+    });
+    return result;
+  }
+}
+
+export function checkInterrupted(apiClass: any): ShellInternalState | undefined {
   if (!apiClass[shellApiType]) {
     throw new MongoshInternalError('checkInterrupted can only be called for functions from shell API classes');
   }
   // internalState can be undefined in tests
-  if ((apiClass as ShellApiClass)._internalState?.interrupted) {
+  const internalState = (apiClass as ShellApiClass)._internalState;
+  if (internalState?.interrupted.isSet()) {
     throw new MongoshInterruptedError();
   }
+  return internalState;
 }

--- a/packages/shell-api/src/mongo.ts
+++ b/packages/shell-api/src/mongo.ts
@@ -309,6 +309,10 @@ export default class Mongo extends ShellApiClass {
     await this._serviceProvider.close(force);
   }
 
+  async _suspend(): Promise<() => Promise<void>> {
+    return await this._serviceProvider.suspend();
+  }
+
   getReadPrefMode(): ReadPreferenceModeId {
     return this._serviceProvider.getReadPreference().mode;
   }

--- a/packages/shell-api/src/plan-cache.ts
+++ b/packages/shell-api/src/plan-cache.ts
@@ -1,22 +1,27 @@
 import {
   returnsPromise,
   serverVersions,
-  ShellApiClass,
   shellApiClassDefault,
-  deprecated
+  deprecated,
+  ShellApiWithMongoClass
 } from './decorators';
 import { Document } from '@mongosh/service-provider-core';
 import Collection from './collection';
 import { asPrintable, ServerVersions } from './enums';
 import { MongoshDeprecatedError } from '@mongosh/errors';
+import Mongo from './mongo';
 
 @shellApiClassDefault
-export default class PlanCache extends ShellApiClass {
+export default class PlanCache extends ShellApiWithMongoClass {
   _collection: Collection;
 
   constructor(collection: Collection) {
     super();
     this._collection = collection;
+  }
+
+  get _mongo(): Mongo {
+    return this._collection._mongo;
   }
 
   /**

--- a/packages/shell-api/src/replica-set.ts
+++ b/packages/shell-api/src/replica-set.ts
@@ -1,9 +1,9 @@
 import Database from './database';
 import {
   shellApiClassDefault,
-  ShellApiClass,
   returnsPromise,
-  deprecated
+  deprecated,
+  ShellApiWithMongoClass
 } from './decorators';
 import {
   Document
@@ -13,14 +13,19 @@ import { assertArgsDefinedType } from './helpers';
 import { CommonErrors, MongoshDeprecatedError, MongoshInvalidInputError, MongoshRuntimeError } from '@mongosh/errors';
 import { CommandResult } from './result';
 import { redactCredentials } from '@mongosh/history';
+import { Mongo } from '.';
 
 @shellApiClassDefault
-export default class ReplicaSet extends ShellApiClass {
+export default class ReplicaSet extends ShellApiWithMongoClass {
   _database: Database;
 
   constructor(database: Database) {
     super();
     this._database = database;
+  }
+
+  get _mongo(): Mongo {
+    return this._database._mongo;
   }
 
   /**

--- a/packages/shell-api/src/result.ts
+++ b/packages/shell-api/src/result.ts
@@ -1,9 +1,9 @@
-import { ShellApiClass, shellApiClassDefault } from './decorators';
+import { shellApiClassDefault, ShellApiValueClass } from './decorators';
 import { shellApiType, asPrintable } from './enums';
 import { Document, ObjectIdType } from '@mongosh/service-provider-core';
 
 @shellApiClassDefault
-export class CommandResult extends ShellApiClass {
+export class CommandResult extends ShellApiValueClass {
   value: unknown;
   type: string;
   constructor(type: string, value: unknown) {
@@ -22,7 +22,7 @@ export class CommandResult extends ShellApiClass {
 }
 
 @shellApiClassDefault
-export class BulkWriteResult extends ShellApiClass {
+export class BulkWriteResult extends ShellApiValueClass {
   acknowledged: boolean;
   insertedCount: number;
   insertedIds: {[index: number]: ObjectIdType};
@@ -53,7 +53,7 @@ export class BulkWriteResult extends ShellApiClass {
 }
 
 @shellApiClassDefault
-export class InsertManyResult extends ShellApiClass {
+export class InsertManyResult extends ShellApiValueClass {
   acknowledged: boolean;
   insertedIds: { [key: number]: ObjectIdType };
   constructor(acknowledged: boolean, insertedIds: { [key: number]: ObjectIdType }) {
@@ -64,7 +64,7 @@ export class InsertManyResult extends ShellApiClass {
 }
 
 @shellApiClassDefault
-export class InsertOneResult extends ShellApiClass {
+export class InsertOneResult extends ShellApiValueClass {
   acknowledged: boolean;
   insertedId: ObjectIdType | undefined;
   constructor(acknowledged: boolean, insertedId?: ObjectIdType) {
@@ -75,7 +75,7 @@ export class InsertOneResult extends ShellApiClass {
 }
 
 @shellApiClassDefault
-export class UpdateResult extends ShellApiClass {
+export class UpdateResult extends ShellApiValueClass {
   acknowledged: boolean;
   insertedId: ObjectIdType;
   matchedCount: number;
@@ -97,7 +97,7 @@ export class UpdateResult extends ShellApiClass {
 }
 
 @shellApiClassDefault
-export class DeleteResult extends ShellApiClass {
+export class DeleteResult extends ShellApiValueClass {
   acknowledged: boolean;
   deletedCount: number | undefined;
   constructor(acknowledged: boolean, deletedCount: number | undefined) {
@@ -108,7 +108,7 @@ export class DeleteResult extends ShellApiClass {
 }
 
 @shellApiClassDefault
-export class CursorIterationResult extends ShellApiClass {
+export class CursorIterationResult extends ShellApiValueClass {
   cursorHasMore: boolean;
   documents: Document[];
 

--- a/packages/shell-api/src/session.ts
+++ b/packages/shell-api/src/session.ts
@@ -2,8 +2,8 @@ import {
   classPlatforms,
   classReturnsPromise,
   returnsPromise,
-  ShellApiClass,
-  shellApiClassDefault
+  shellApiClassDefault,
+  ShellApiWithMongoClass
 } from './decorators';
 import {
   Document,
@@ -25,11 +25,11 @@ import { assertArgsDefinedType } from './helpers';
 @shellApiClassDefault
 @classReturnsPromise
 @classPlatforms([ ReplPlatform.CLI ] )
-export default class Session extends ShellApiClass {
+export default class Session extends ShellApiWithMongoClass {
   public id: ServerSessionId | undefined;
   public _session: ClientSession;
   public _options: ClientSessionOptions;
-  private _mongo: Mongo;
+  public _mongo: Mongo;
   private _databases: Record<string, Database>;
 
   constructor(mongo: Mongo, options: ClientSessionOptions, session: ClientSession) {

--- a/packages/shell-api/src/shard.ts
+++ b/packages/shell-api/src/shard.ts
@@ -1,7 +1,7 @@
 import Database from './database';
 import {
   shellApiClassDefault,
-  ShellApiClass, returnsPromise, serverVersions
+  returnsPromise, serverVersions, ShellApiWithMongoClass
 } from './decorators';
 
 import type { Document } from '@mongosh/service-provider-core';
@@ -9,14 +9,19 @@ import { assertArgsDefinedType, getConfigDB, getPrintableShardStatus } from './h
 import { ServerVersions, asPrintable } from './enums';
 import { CommandResult, UpdateResult } from './result';
 import { redactCredentials } from '@mongosh/history';
+import Mongo from './mongo';
 
 @shellApiClassDefault
-export default class Shard extends ShellApiClass {
+export default class Shard extends ShellApiWithMongoClass {
   _database: Database;
 
   constructor(database: Database) {
     super();
     this._database = database;
+  }
+
+  get _mongo(): Mongo {
+    return this._database._mongo;
   }
 
   /**

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -92,7 +92,7 @@ export interface MongoshBusEventsMap {
   'mongosh:mongoshrc-load': () => void;
   'mongosh:mongoshrc-mongorc-warn': () => void;
   'mongosh:eval-cli-script': () => void;
-  'mongosh:eval-interrupt': () => void;
+  'mongosh:eval-interrupted': () => void;
   'mongosh:mongocryptd-tryspawn': (ev: MongocryptdTrySpawnEvent) => void;
   'mongosh:mongocryptd-error': (ev: MongocryptdErrorEvent) => void;
   'mongosh:mongocryptd-log': (ev: MongocryptdLogEvent) => void;

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -98,11 +98,13 @@ export interface MongoshBusEventsMap {
   'mongosh:closed': () => void; // For testing.
   'mongosh:eval-complete': () => void; // For testing.
   'mongosh:autocompletion-complete': () => void; // For testing.
+  'mongosh:interrupt-complete': () => void; // For testing.
 }
 
 export interface MongoshBus {
   // TypeScript uses something like this itself for its EventTarget definitions.
   on<K extends keyof MongoshBusEventsMap>(event: K, listener: MongoshBusEventsMap[K]): this;
+  once<K extends keyof MongoshBusEventsMap>(event: K, listener: MongoshBusEventsMap[K]): this;
   emit<K extends keyof MongoshBusEventsMap>(event: K, ...args: MongoshBusEventsMap[K] extends (...args: infer P) => any ? P : never): unknown;
 }
 

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -92,6 +92,7 @@ export interface MongoshBusEventsMap {
   'mongosh:mongoshrc-load': () => void;
   'mongosh:mongoshrc-mongorc-warn': () => void;
   'mongosh:eval-cli-script': () => void;
+  'mongosh:eval-interrupt': () => void;
   'mongosh:mongocryptd-tryspawn': (ev: MongocryptdTrySpawnEvent) => void;
   'mongosh:mongocryptd-error': (ev: MongocryptdErrorEvent) => void;
   'mongosh:mongocryptd-log': (ev: MongocryptdLogEvent) => void;


### PR DESCRIPTION
Still a work in progress - but already implements a large deal of CTRL-C handling. The process is as follows:

1. CTRL-C is caught for an async execution
2. All MongoClients are closed
3. We print the "Error: Asynchronous execution was interrupted" message (no prompt)
3. We wait until the async execution finishes (since it is running in the background CTRL-C doesn't kill it) and silently catch any errors
4. We reconnect all MongoClients
5. The prompt returns and allows the user to enter new commands

The following needs to be completed:

* [x] Adapt the API decorators to check for interruption and immediately throw an internal error
* [x] Adapt the `async-writer` to ensure that the internal interrupt errors are not caught by user code

And here a quick demo how it looks like for a simple command:

![mongosh-ctrlc](https://user-images.githubusercontent.com/4354632/117281634-26738680-ae64-11eb-85af-b71107ac77f8.gif)

