### PR TITLE
chore(cli-repl): do not use encryption db name for smoke tests

### DIFF
--- a/packages/cli-repl/src/smoke-tests-fle.ts
+++ b/packages/cli-repl/src/smoke-tests-fle.ts
@@ -35,7 +35,7 @@ assert(db.getName() === dbname, 'db name must match');
 const local = { key: Buffer.from('kh4Gv2N8qopZQMQYMEtww/AkPsIrXNmEMxTrs3tUoTQZbZu4msdRUaR8U5fXD7A7QXYHcEvuu4WctJLoT+NvvV3eeIg3MD+K8H9SR794m/safgRHdIfy6PD+rFpvmFbY', 'base64') };
 
 const keyMongo = Mongo(db.getMongo()._uri, {
-  keyVaultNamespace: 'encryption.__keyVault',
+  keyVaultNamespace: dbname + '.__keyVault',
   kmsProviders: { local }
 });
 
@@ -60,7 +60,7 @@ schemaMap[dbname + '.employees'] = {
 console.log('Using schema map', schemaMap);
 
 const autoMongo = Mongo(db.getMongo()._uri, {
-  keyVaultNamespace: 'encryption.__keyVault',
+  keyVaultNamespace: dbname + '.__keyVault',
   kmsProviders: { local },
   schemaMap
 });


### PR DESCRIPTION
Using the local test db name is nicer because that means that we don’t
clutter up the encryption db of the test environment, and we drop
the test db at the end of the test anyway.