### PR TITLE
chore(ci): try setting PATH to include NVM_BIN explicitly

### DIFF
--- a/.evergreen/.setup_env
+++ b/.evergreen/.setup_env
@@ -12,6 +12,7 @@ if [ "$OS" != "Windows_NT" ]; then
   echo "Setting NVM environment home: $NVM_DIR"
   [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
   nvm use $NODE_JS_VERSION
+  export PATH="$NVM_BIN:$PATH"
 
   export CC=gcc
   export CXX=c++
@@ -28,6 +29,9 @@ export EVERGREEN_EXPANSIONS_PATH="$BASEDIR/../../tmp/expansions.yaml"
 if [ "$OS" == "Windows_NT" ]; then
   export EVERGREEN_EXPANSIONS_PATH="$(cygpath -w "$EVERGREEN_EXPANSIONS_PATH")"
 fi
+
+echo "Full path:"
+echo $PATH
 
 echo "Using node version:"
 node --version


### PR DESCRIPTION
Waterfall builds for ppc64le are currently failing because nvm
somehow doesn’t modify `$PATH` as it should:

    [2021/05/06 12:02:21.433] Now using node v14.15.1 (npm v5.6.0)
    <...>
    [2021/05/06 12:02:21.680] Using node version:
    [2021/05/06 12:02:21.680] v8.11.3
    [2021/05/06 12:02:21.680] Using npm version:
    [2021/05/06 12:02:21.680] 5.6.0
    <...>
    [2021/05/06 12:02:21.984] > npm ci
    [2021/05/06 12:02:22.288] Usage: npm <command>

Try this to see if it helps.