### PR TITLE
MONGOSH-692 Rename package to mongodb-mongosh

### DIFF
--- a/config/build.conf.js
+++ b/config/build.conf.js
@@ -147,6 +147,7 @@ module.exports = {
       rpmName: 'mongodb-mongosh',
       debName: 'mongodb-mongosh',
       providesName: 'mongodb-shell',
+      providesVersion: '2.0',
       fullName: 'MongoDB Shell',
       version: CLI_REPL_PACKAGE_JSON.version,
       description: CLI_REPL_PACKAGE_JSON.description,

--- a/config/build.conf.js
+++ b/config/build.conf.js
@@ -143,7 +143,8 @@ module.exports = {
       }
     ],
     metadata: {
-      name: 'mongosh',
+      name: 'mongodb-mongosh',
+      providesName: 'mongodb-shell',
       fullName: 'MongoDB Shell',
       version: CLI_REPL_PACKAGE_JSON.version,
       description: CLI_REPL_PACKAGE_JSON.description,

--- a/config/build.conf.js
+++ b/config/build.conf.js
@@ -143,7 +143,9 @@ module.exports = {
       }
     ],
     metadata: {
-      name: 'mongodb-mongosh',
+      name: 'mongosh',
+      rpmName: 'mongodb-mongosh',
+      debName: 'mongodb-mongosh',
       providesName: 'mongodb-shell',
       fullName: 'MongoDB Shell',
       version: CLI_REPL_PACKAGE_JSON.version,

--- a/packages/build/src/barque.spec.ts
+++ b/packages/build/src/barque.spec.ts
@@ -53,18 +53,18 @@ describe('Barque', () => {
         [
           {
             variant: BuildVariant.Debian,
-            url: 'https://s3.amazonaws.com/mciuploads/mongosh/5ed7ee5d8683818eb28d9d3b5c65837cde4a08f5/mongosh_0.1.0_amd64.deb',
+            url: 'https://s3.amazonaws.com/mciuploads/mongosh/5ed7ee5d8683818eb28d9d3b5c65837cde4a08f5/mongodb-mongosh_0.1.0_amd64.deb',
             publishedUrls: [
-              `${Barque.PPA_REPO_BASE_URL}/apt/debian/dists/buster/mongodb-org/4.4/main/binary-amd64/mongosh_0.1.0_amd64.deb`,
-              `${Barque.PPA_REPO_BASE_URL}/apt/ubuntu/dists/bionic/mongodb-org/4.4/multiverse/binary-amd64/mongosh_0.1.0_amd64.deb`,
-              `${Barque.PPA_REPO_BASE_URL}/apt/ubuntu/dists/focal/mongodb-org/4.4/multiverse/binary-amd64/mongosh_0.1.0_amd64.deb`,
+              `${Barque.PPA_REPO_BASE_URL}/apt/debian/dists/buster/mongodb-org/4.4/main/binary-amd64/mongodb-mongosh_0.1.0_amd64.deb`,
+              `${Barque.PPA_REPO_BASE_URL}/apt/ubuntu/dists/bionic/mongodb-org/4.4/multiverse/binary-amd64/mongodb-mongosh_0.1.0_amd64.deb`,
+              `${Barque.PPA_REPO_BASE_URL}/apt/ubuntu/dists/focal/mongodb-org/4.4/multiverse/binary-amd64/mongodb-mongosh_0.1.0_amd64.deb`,
             ]
           },
           {
             variant: BuildVariant.Redhat,
-            url: 'https://s3.amazonaws.com/mciuploads/mongosh/5ed7ee5d8683818eb28d9d3b5c65837cde4a08f5/mongosh-0.1.0-x86_64.rpm',
+            url: 'https://s3.amazonaws.com/mciuploads/mongosh/5ed7ee5d8683818eb28d9d3b5c65837cde4a08f5/mongodb-mongosh-0.1.0-x86_64.rpm',
             publishedUrls: [
-              `${Barque.PPA_REPO_BASE_URL}/yum/redhat/8/mongodb-org/4.4/x86_64/RPMS/mongosh-0.1.0-x86_64.rpm`,
+              `${Barque.PPA_REPO_BASE_URL}/yum/redhat/8/mongodb-org/4.4/x86_64/RPMS/mongodb-mongosh-0.1.0-x86_64.rpm`,
             ]
           }
         ].forEach(({ variant, url, publishedUrls }) => {
@@ -88,7 +88,7 @@ describe('Barque', () => {
         barque.createCuratorDir = sinon.stub().returns(Promise.resolve('./'));
         barque.extractLatestCurator = sinon.stub().returns(Promise.resolve(true));
 
-        const debUrl = 'https://s3.amazonaws.com/mciuploads/mongosh/5ed7ee5d8683818eb28d9d3b5c65837cde4a08f5/mongosh_0.1.0_amd64.deb';
+        const debUrl = 'https://s3.amazonaws.com/mciuploads/mongosh/5ed7ee5d8683818eb28d9d3b5c65837cde4a08f5/mongodb-mongosh_0.1.0_amd64.deb';
 
         try {
           await barque.releaseToBarque(BuildVariant.Debian, debUrl);

--- a/packages/build/src/download-center/config.spec.ts
+++ b/packages/build/src/download-center/config.spec.ts
@@ -44,14 +44,14 @@ describe('DownloadCenter config', () => {
       const [version] = config.versions;
       const platforms = version.platform.filter(p => p.os === 'rhel');
       expect(platforms).to.have.length(1);
-      expect(platforms[0].download_link).to.include('mongosh-1.2.2-x86_64.rpm');
+      expect(platforms[0].download_link).to.include('mongodb-mongosh-1.2.2-x86_64.rpm');
     });
 
     it('has an artifact for debian', () => {
       const [version] = config.versions;
       const platforms = version.platform.filter(p => p.os === 'debian');
       expect(platforms).to.have.length(1);
-      expect(platforms[0].download_link).to.include('mongosh_1.2.2_amd64.deb');
+      expect(platforms[0].download_link).to.include('mongodb-mongosh_1.2.2_amd64.deb');
     });
   });
 

--- a/packages/build/src/download-center/config.ts
+++ b/packages/build/src/download-center/config.ts
@@ -48,13 +48,13 @@ export function createDownloadCenterConfig(version: string): DownloadCenterConfi
             'arch': 'x64',
             'os': 'debian',
             'name': 'Debian 64-bit',
-            'download_link': `https://downloads.mongodb.com/compass/mongosh_${version}_amd64.deb`
+            'download_link': `https://downloads.mongodb.com/compass/mongodb-mongosh_${version}_amd64.deb`
           },
           {
             'arch': 'x64',
             'os': 'rhel',
             'name': 'Redhat / CentOS / SUSE / Amazon Linux 64-bit',
-            'download_link': `https://downloads.mongodb.com/compass/mongosh-${version}-x86_64.rpm`
+            'download_link': `https://downloads.mongodb.com/compass/mongodb-mongosh-${version}-x86_64.rpm`
           }
         ]
       }

--- a/packages/build/src/packaging/package/create-package.ts
+++ b/packages/build/src/packaging/package/create-package.ts
@@ -21,7 +21,7 @@ export async function createPackage(
   createMsiPackage: typeof createMsiPackageFn = createMsiPackageFn,
   createZipPackage: typeof createZipPackageFn = createZipPackageFn
 ): Promise<PackageFile> {
-  const tarballFile = getPackageFile(buildVariant, packageInformation.metadata.version, packageInformation.metadata.name);
+  const tarballFile = getPackageFile(buildVariant, packageInformation);
   const fullTarballFilePath = path.join(outputDir, tarballFile.path);
   console.info('mongosh: gzipping:', fullTarballFilePath);
 

--- a/packages/build/src/packaging/package/debian.ts
+++ b/packages/build/src/packaging/package/debian.ts
@@ -48,7 +48,7 @@ export async function createDebianPackage(
     cwd: path.dirname(dir)
   });
 
-  await fs.rename(path.join(dir, `${pkg.metadata.name}.deb`), outFile);
+  await fs.rename(path.join(dir, `${pkg.metadata.debName}.deb`), outFile);
 
   await promisify(rimraf)(dir);
 }

--- a/packages/build/src/packaging/package/debian.ts
+++ b/packages/build/src/packaging/package/debian.ts
@@ -27,7 +27,7 @@ export async function createDebianPackage(
     ...pkg.binaries.map(({ license }) => license)
   ];
   // Put documentation files in /usr/share/doc/.
-  const docdir = path.join(dir, pkg.metadata.name, 'usr', 'share', 'doc', pkg.metadata.name);
+  const docdir = path.join(dir, pkg.metadata.debName, 'usr', 'share', 'doc', pkg.metadata.debName);
   await fs.mkdir(docdir, { recursive: true });
   for (const { sourceFilePath, packagedFilePath } of docFiles) {
     await fs.copyFile(sourceFilePath, path.join(docdir, packagedFilePath), COPYFILE_FICLONE);
@@ -36,7 +36,7 @@ export async function createDebianPackage(
   // https://www.debian.org/doc/debian-policy/ch-archive.html#s-pkgcopyright
   await fs.writeFile(path.join(docdir, 'copyright'), await generateDebianCopyright(pkg));
   for (const { sourceFilePath, category } of pkg.binaries) {
-    const targetDir = path.join(dir, pkg.metadata.name, 'usr', category);
+    const targetDir = path.join(dir, pkg.metadata.debName, 'usr', category);
     await fs.mkdir(targetDir, { recursive: true });
     await fs.copyFile(sourceFilePath, path.join(targetDir, path.basename(sourceFilePath)), COPYFILE_FICLONE);
   }

--- a/packages/build/src/packaging/package/debian.ts
+++ b/packages/build/src/packaging/package/debian.ts
@@ -43,7 +43,7 @@ export async function createDebianPackage(
 
   // Create the package.
   await execFile('dpkg', [
-    '--build', path.join(dir, pkg.metadata.name)
+    '--build', path.join(dir, pkg.metadata.debName)
   ], {
     cwd: path.dirname(dir)
   });

--- a/packages/build/src/packaging/package/get-package-file.spec.ts
+++ b/packages/build/src/packaging/package/get-package-file.spec.ts
@@ -6,7 +6,7 @@ describe('tarball getPackageFile', () => {
   context('when the build variant is windows', () => {
     it('returns the windows tarball name', () => {
       expect(
-        getPackageFile(BuildVariant.Windows, '1.0.0', 'mongosh')
+        getPackageFile(BuildVariant.Windows, { metadata: { version: '1.0.0', name: 'mongosh' } } as any)
       ).to.deep.equal({
         path: 'mongosh-1.0.0-win32.zip',
         contentType: 'application/zip'
@@ -17,7 +17,7 @@ describe('tarball getPackageFile', () => {
   context('when the build variant is macos', () => {
     it('returns the tarball details', () => {
       expect(
-        getPackageFile(BuildVariant.MacOs, '1.0.0', 'mongosh')
+        getPackageFile(BuildVariant.MacOs, { metadata: { version: '1.0.0', name: 'mongosh' } } as any)
       ).to.deep.equal({
         path: 'mongosh-1.0.0-darwin.zip',
         contentType: 'application/zip'
@@ -28,7 +28,7 @@ describe('tarball getPackageFile', () => {
   context('when the build variant is linux', () => {
     it('returns the tarball details', () => {
       expect(
-        getPackageFile(BuildVariant.Linux, '1.0.0', 'mongosh')
+        getPackageFile(BuildVariant.Linux, { metadata: { version: '1.0.0', name: 'mongosh' } } as any)
       ).to.deep.equal({
         path: 'mongosh-1.0.0-linux.tgz',
         contentType: 'application/gzip'
@@ -39,9 +39,9 @@ describe('tarball getPackageFile', () => {
   context('when the build variant is debian', () => {
     it('returns the tarball details', () => {
       expect(
-        getPackageFile(BuildVariant.Debian, '1.0.0', 'mongosh')
+        getPackageFile(BuildVariant.Debian, { metadata: { version: '1.0.0', debName: 'mongodb-mongosh' } } as any)
       ).to.deep.equal({
-        path: 'mongosh_1.0.0_amd64.deb',
+        path: 'mongodb-mongosh_1.0.0_amd64.deb',
         contentType: 'application/vnd.debian.binary-package'
       });
     });
@@ -50,9 +50,9 @@ describe('tarball getPackageFile', () => {
   context('when the build variant is rhel', () => {
     it('returns the tarball details', () => {
       expect(
-        getPackageFile(BuildVariant.Redhat, '1.0.0', 'mongosh')
+        getPackageFile(BuildVariant.Redhat, { metadata: { version: '1.0.0', rpmName: 'mongodb-mongosh' } } as any)
       ).to.deep.equal({
-        path: 'mongosh-1.0.0-x86_64.rpm',
+        path: 'mongodb-mongosh-1.0.0-x86_64.rpm',
         contentType: 'application/x-rpm'
       });
     });

--- a/packages/build/src/packaging/package/get-package-file.ts
+++ b/packages/build/src/packaging/package/get-package-file.ts
@@ -1,11 +1,13 @@
 import { BuildVariant } from '../../config';
+import type { PackageInformation } from './package-information';
 
 export interface PackageFile {
   path: string;
   contentType: string;
 }
 
-export function getPackageFile(buildVariant: BuildVariant, version: string, name: string): PackageFile {
+export function getPackageFile(buildVariant: BuildVariant, packageInformation: PackageInformation): PackageFile {
+  const { version, name, debName, rpmName } = packageInformation.metadata;
   switch (buildVariant) {
     case BuildVariant.Linux:
       return {
@@ -14,7 +16,7 @@ export function getPackageFile(buildVariant: BuildVariant, version: string, name
       };
     case BuildVariant.Redhat:
       return {
-        path: `${name}-${version}-x86_64.rpm`,
+        path: `${rpmName}-${version}-x86_64.rpm`,
         contentType: 'application/x-rpm'
       };
     case BuildVariant.Debian:
@@ -22,7 +24,7 @@ export function getPackageFile(buildVariant: BuildVariant, version: string, name
       // name: https://www.debian.org/doc/manuals/debian-faq/pkg-basics.en.html
       // sometimes there is also revision number, but we can add that later.
       return {
-        path: `${name}_${version}_amd64.deb`,
+        path: `${debName}_${version}_amd64.deb`,
         contentType: 'application/vnd.debian.binary-package'
       };
     case BuildVariant.MacOs:

--- a/packages/build/src/packaging/package/package-information.ts
+++ b/packages/build/src/packaging/package/package-information.ts
@@ -19,6 +19,8 @@ export interface PackageInformation {
     otherDocFilePaths: DocumentationFile[];
     metadata: {
         name: string;
+        debName: string;
+        rpmName: string;
         version: string;
         description: string;
         homepage: string;

--- a/packages/build/src/packaging/package/redhat.ts
+++ b/packages/build/src/packaging/package/redhat.ts
@@ -43,7 +43,7 @@ export async function createRedhatPackage(
     filelistRpm,
     version
   });
-    // Copy all files that we want to ship into the BUILD directory.
+  // Copy all files that we want to ship into the BUILD directory.
   for (const { sourceFilePath } of pkg.binaries) {
     await fs.copyFile(sourceFilePath, path.join(dir, 'BUILD', path.basename(sourceFilePath)), COPYFILE_FICLONE);
   }

--- a/packages/build/src/packaging/package/redhat.ts
+++ b/packages/build/src/packaging/package/redhat.ts
@@ -57,7 +57,7 @@ export async function createRedhatPackage(
   // Create the package.
   const arch = 'x86_64';
   await execFile('rpmbuild', [
-    '-bb', path.join(dir, 'SPECS', `${pkg.metadata.name}.spec`),
+    '-bb', path.join(dir, 'SPECS', `${pkg.metadata.rpmName}.spec`),
     '--target', arch,
     '--define', `_topdir ${dir}`
   ], {

--- a/packages/build/src/run-draft.ts
+++ b/packages/build/src/run-draft.ts
@@ -32,7 +32,7 @@ export async function runDraft(
   await fs.mkdir(tmpDir, { recursive: true });
 
   for await (const variant of ALL_BUILD_VARIANTS) {
-    const tarballFile = getPackageFile(variant, config.packageInformation.metadata.version, config.packageInformation.metadata.name);
+    const tarballFile = getPackageFile(variant, config.packageInformation);
     console.info(`mongosh: processing artifact for ${variant} - ${tarballFile.path}`);
 
     const downloadedArtifact = await downloadArtifactFromEvergreen(

--- a/packages/build/src/run-publish.spec.ts
+++ b/packages/build/src/run-publish.spec.ts
@@ -63,6 +63,8 @@ describe('publish', () => {
       packageInformation: {
         metadata: {
           name: 'mongosh',
+          rpmName: 'mongodb-mongosh',
+          debName: 'mongodb-mongosh',
           version: 'packageVersion',
           description: 'The best shell you ever had.',
           homepage: 'https://mongodb.com',
@@ -179,11 +181,11 @@ describe('publish', () => {
       expect(barque.releaseToBarque).to.have.been.callCount(2);
       expect(barque.releaseToBarque).to.have.been.calledWith(
         BuildVariant.Redhat,
-        'https://s3.amazonaws.com/mciuploads/project/v0.7.0-draft.42/mongosh-0.7.0-x86_64.rpm'
+        'https://s3.amazonaws.com/mciuploads/project/v0.7.0-draft.42/mongodb-mongosh-0.7.0-x86_64.rpm'
       );
       expect(barque.releaseToBarque).to.have.been.calledWith(
         BuildVariant.Debian,
-        'https://s3.amazonaws.com/mciuploads/project/v0.7.0-draft.42/mongosh_0.7.0_amd64.deb'
+        'https://s3.amazonaws.com/mciuploads/project/v0.7.0-draft.42/mongodb-mongosh_0.7.0_amd64.deb'
       );
       expect(barque.waitUntilPackagesAreAvailable).to.have.been.called;
     });

--- a/packages/build/test/fixtures/pkgconf.js
+++ b/packages/build/test/fixtures/pkgconf.js
@@ -38,6 +38,8 @@ module.exports = {
     homepage: 'https://example.org',
     maintainer: 'Somebody <somebody@example.org>',
     name: 'foobar',
+    debName: 'foobar',
+    rpmName: 'foobar',
     manufacturer: 'Some Random Company Inc.'
   },
   debTemplateDir: path.resolve(__dirname, 'deb-template'),

--- a/packaging/deb-template/mongodb-mongosh/DEBIAN/control
+++ b/packaging/deb-template/mongodb-mongosh/DEBIAN/control
@@ -1,5 +1,5 @@
 Package: {{debName}}
-Provides: {{providesName}}
+Provides: {{providesName}} (= {{providesVersion}})
 Version: {{version}}
 Section: utils
 Priority: optional

--- a/packaging/deb-template/mongodb-mongosh/DEBIAN/control
+++ b/packaging/deb-template/mongodb-mongosh/DEBIAN/control
@@ -1,4 +1,4 @@
-Package: {{name}}
+Package: {{debName}}
 Provides: {{providesName}}
 Version: {{version}}
 Section: utils

--- a/packaging/deb-template/mongodb-mongosh/DEBIAN/control
+++ b/packaging/deb-template/mongodb-mongosh/DEBIAN/control
@@ -1,4 +1,5 @@
 Package: {{name}}
+Provides: {{providesName}}
 Version: {{version}}
 Section: utils
 Priority: optional

--- a/packaging/rpm-template/SPECS/mongodb-mongosh.spec
+++ b/packaging/rpm-template/SPECS/mongodb-mongosh.spec
@@ -6,7 +6,7 @@
 %define _libexecdir %{_exec_prefix}/libexec
 
 Name: {{rpmName}}
-Provides: {{providesName}}
+Provides: {{providesName}} = {{providesVersion}}
 Version: {{version}}
 Release: 1%{?dist}
 Group: Development/Tools

--- a/packaging/rpm-template/SPECS/mongodb-mongosh.spec
+++ b/packaging/rpm-template/SPECS/mongodb-mongosh.spec
@@ -6,6 +6,7 @@
 %define _libexecdir %{_exec_prefix}/libexec
 
 Name: {{name}}
+Provides: {{providesName}}
 Version: {{version}}
 Release: 1%{?dist}
 Group: Development/Tools

--- a/packaging/rpm-template/SPECS/mongodb-mongosh.spec
+++ b/packaging/rpm-template/SPECS/mongodb-mongosh.spec
@@ -5,7 +5,7 @@
 %undefine _libexecdir
 %define _libexecdir %{_exec_prefix}/libexec
 
-Name: {{name}}
+Name: {{rpmName}}
 Provides: {{providesName}}
 Version: {{version}}
 Release: 1%{?dist}

--- a/scripts/docker/centos7-rpm.Dockerfile
+++ b/scripts/docker/centos7-rpm.Dockerfile
@@ -3,5 +3,5 @@ FROM centos:7
 ARG artifact_url=""
 ADD ${artifact_url} /tmp
 RUN yum repolist
-RUN yum install -y /tmp/mongosh-*-x86_64.rpm
+RUN yum install -y /tmp/*mongosh-*-x86_64.rpm
 ENTRYPOINT [ "mongosh" ]

--- a/scripts/docker/centos8-rpm.Dockerfile
+++ b/scripts/docker/centos8-rpm.Dockerfile
@@ -3,5 +3,5 @@ FROM centos:8
 ARG artifact_url=""
 ADD ${artifact_url} /tmp
 RUN yum repolist
-RUN yum install -y /tmp/mongosh-*-x86_64.rpm
+RUN yum install -y /tmp/*mongosh-*-x86_64.rpm
 ENTRYPOINT [ "mongosh" ]

--- a/scripts/docker/ubuntu16.04-deb.Dockerfile
+++ b/scripts/docker/ubuntu16.04-deb.Dockerfile
@@ -3,6 +3,6 @@ FROM ubuntu:16.04
 ARG artifact_url=""
 ADD ${artifact_url} /tmp
 RUN apt-get update
-RUN apt-get install -y /tmp/mongosh_*_amd64.deb
+RUN apt-get install -y /tmp/*mongosh_*_amd64.deb
 RUN /usr/bin/mongosh --version
 ENTRYPOINT [ "mongosh" ]

--- a/scripts/docker/ubuntu18.04-deb.Dockerfile
+++ b/scripts/docker/ubuntu18.04-deb.Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:18.04
 ARG artifact_url=""
 ADD ${artifact_url} /tmp
 RUN apt-get update
-RUN apt-get install -y /tmp/mongosh_*_amd64.deb
+RUN apt-get install -y /tmp/*mongosh_*_amd64.deb
 RUN /usr/bin/mongosh --version
 RUN /usr/libexec/mongocryptd-mongosh --version
 ENTRYPOINT [ "mongosh" ]

--- a/scripts/docker/ubuntu20.04-deb.Dockerfile
+++ b/scripts/docker/ubuntu20.04-deb.Dockerfile
@@ -3,7 +3,7 @@ FROM ubuntu:20.04
 ARG artifact_url=""
 ADD ${artifact_url} /tmp
 RUN apt-get update
-RUN apt-get install -y /tmp/mongosh_*_amd64.deb
+RUN apt-get install -y /tmp/*mongosh_*_amd64.deb
 RUN /usr/bin/mongosh --version
 RUN /usr/libexec/mongocryptd-mongosh --version
 ENTRYPOINT [ "mongosh" ]


### PR DESCRIPTION
The RPM and Debian packages are renamed to mongodb-mongosh to fit a
common Linux package naming convention which allows users to locate
software more easily. A Provides: tag is also added to the packages to
provide a stable naming alias in case we ever decide to rename packages
again.