### PR TITLE
fix(cli-repl): aggregate regular characters in LineByLineInput MONGOS…

### DIFF
--- a/packages/cli-repl/src/line-by-line-input.spec.ts
+++ b/packages/cli-repl/src/line-by-line-input.spec.ts
@@ -27,7 +27,7 @@ describe('LineByLineInput', () => {
   context('when block on newline is enabled (default)', () => {
     it('does not forward characters after newline', () => {
       stdinMock.emit('data', Buffer.from('ab\nc'));
-      expect(forwardedChunks).to.deep.equal(['a', 'b', '\n']);
+      expect(forwardedChunks).to.deep.equal(['ab', '\n']);
     });
 
     it('forwards CTRL-C anyway and as soon as is received', () => {
@@ -43,7 +43,7 @@ describe('LineByLineInput', () => {
     it('unblocks on nextline', () => {
       stdinMock.emit('data', Buffer.from('ab\nc'));
       lineByLineInput.nextLine();
-      expect(forwardedChunks).to.deep.equal(['a', 'b', '\n', 'c']);
+      expect(forwardedChunks).to.deep.equal(['ab', '\n', 'c']);
     });
   });
 
@@ -60,7 +60,7 @@ describe('LineByLineInput', () => {
       lineByLineInput.disableBlockOnNewline();
       lineByLineInput.enableBlockOnNewLine();
       stdinMock.emit('data', Buffer.from('ab\nc'));
-      expect(forwardedChunks).to.deep.equal(['a', 'b', '\n']);
+      expect(forwardedChunks).to.deep.equal(['ab', '\n']);
     });
   });
 
@@ -77,8 +77,8 @@ describe('LineByLineInput', () => {
         insideDataCalls--;
       });
       stdinMock.emit('data', Buffer.from('foo\n\u0003'));
-      expect(dataCalls).to.equal(5);
-      expect(forwardedChunks).to.deep.equal(['\u0003', 'f', 'o', 'o', '\n']);
+      expect(dataCalls).to.equal(3);
+      expect(forwardedChunks).to.deep.equal(['\u0003', 'foo', '\n']);
     });
   });
 });

--- a/packages/cli-repl/src/line-by-line-input.ts
+++ b/packages/cli-repl/src/line-by-line-input.ts
@@ -105,6 +105,11 @@ export class LineByLineInput extends Readable {
     for (const char of chars) {
       if (this._isCtrlC(char) || this._isCtrlD(char)) {
         this.push(char);
+      } else if (
+        this._isRegularCharacter(char) &&
+        this._charQueue.length > 0 &&
+        this._isRegularCharacter(this._charQueue[this._charQueue.length - 1])) {
+        (this._charQueue[this._charQueue.length - 1] as string) += char as string;
       } else {
         this._charQueue.push(char);
       }
@@ -160,6 +165,10 @@ export class LineByLineInput extends Readable {
 
       this.push(char);
     }
+  }
+
+  private _isRegularCharacter(char: string | null): boolean {
+    return char !== null && !this._isLineEnding(char) && !this._isCtrlC(char) && !this._isCtrlD(char);
   }
 
   private _isLineEnding(char: string | null): boolean {

--- a/packages/cli-repl/src/mongosh-repl.spec.ts
+++ b/packages/cli-repl/src/mongosh-repl.spec.ts
@@ -223,7 +223,14 @@ describe('MongoshNodeRepl', () => {
   });
 
   context('with terminal: true', () => {
-    const tab = '\u0009';
+    const tab = async() => {
+      await tick();
+      input.write('\u0009');
+    };
+    const tabtab = async() => {
+      await tab();
+      await tab();
+    };
 
     beforeEach(async() => {
       // Node.js uses $TERM to determine what level of functionality to provide
@@ -254,7 +261,8 @@ describe('MongoshNodeRepl', () => {
       await tick();
       expect(output).to.include('Entering editor mode');
       output = '';
-      input.write(`db.${tab}${tab}`);
+      input.write('db.');
+      await tabtab();
       await tick();
       input.write('version()\n');
       input.write('\u0004'); // Ctrl+D
@@ -298,22 +306,21 @@ describe('MongoshNodeRepl', () => {
 
     context('autocompletion', () => {
       it('autocompletes collection methods', async() => {
-        // this triggers an eval
-        input.write(`db.coll.${tab}${tab}`);
-        // first tab
-        await waitEval(bus);
-        // second tab
+        input.write('db.coll.');
+        await tabtab();
         await tick();
         expect(output).to.include('db.coll.updateOne');
       });
       it('autocompletes shell-api methods (once)', async() => {
-        input.write(`vers${tab}${tab}`);
+        input.write('vers');
+        await tabtab();
         await tick();
         expect(output).to.include('version');
         expect(output).to.not.match(/version[ \t]+version/);
       });
       it('autocompletes async shell api methods', async() => {
-        input.write(`db.coll.find().${tab}${tab}`);
+        input.write('db.coll.find().');
+        await tabtab();
         await tick();
         expect(output).to.include('db.coll.find().close');
       });
@@ -321,7 +328,8 @@ describe('MongoshNodeRepl', () => {
         input.write('let somelongvariable = 0\n');
         await waitEval(bus);
         output = '';
-        input.write(`somelong${tab}${tab}`);
+        input.write('somelong');
+        await tabtab();
         await tick();
         expect(output).to.include('somelongvariable');
       });
@@ -330,14 +338,21 @@ describe('MongoshNodeRepl', () => {
         await tick();
         output = '';
         expect((mongoshRepl.runtimeState().repl as any)._prompt).to.equal('');
-        input.write(`db.${tab}${tab}`);
+        input.write('db.');
+        await tabtab();
         await tick();
         input.write('foo\nbar\n');
         expect((mongoshRepl.runtimeState().repl as any)._prompt).to.equal('');
         input.write('\u0003'); // Ctrl+C for abort
         await tick();
         expect((mongoshRepl.runtimeState().repl as any)._prompt).to.equal('> ');
-        expect(stripAnsi(output)).to.equal('db.\tfoo\r\nbar\r\n\r\n> ');
+        expect(stripAnsi(output)).to.equal('db.foo\r\nbar\r\n\r\n> ');
+      });
+      it('does not autocomplete tab-indented code', async() => {
+        output = '';
+        input.write('\t\tfoo');
+        await tick();
+        expect(output).to.equal('\t\tfoo');
       });
     });
 

--- a/packages/cli-repl/test/e2e-direct.spec.ts
+++ b/packages/cli-repl/test/e2e-direct.spec.ts
@@ -6,6 +6,13 @@ import { TestShell } from './test-shell';
 describe('e2e direct connection', () => {
   afterEach(TestShell.cleanup);
 
+  const tabtab = async(shell: TestShell) => {
+    await new Promise(resolve => setTimeout(resolve, 400));
+    shell.writeInput('\u0009');
+    await new Promise(resolve => setTimeout(resolve, 400));
+    shell.writeInput('\u0009');
+  };
+
   context('to a replica set', async() => {
     const replSetId = 'replset';
     const [rs0, rs1, rs2] = startTestCluster(
@@ -120,7 +127,8 @@ describe('e2e direct connection', () => {
           }
           const shell = TestShell.start({ args: [`${await rs1.connectionString()}/${dbname}`], forceTerminal: true });
           await shell.waitForPrompt();
-          shell.writeInput('db.testc\u0009\u0009');
+          shell.writeInput('db.testc');
+          await tabtab(shell);
           await eventually(() => {
             shell.assertContainsOutput('db.testcollection');
           });
@@ -195,7 +203,8 @@ describe('e2e direct connection', () => {
           }
           const shell = TestShell.start({ args: [`${await rs1.connectionString()}/${dbname}`], forceTerminal: true });
           await shell.waitForPrompt();
-          shell.writeInput('db.testc\u0009\u0009');
+          shell.writeInput('db.testc');
+          await tabtab(shell);
           await eventually(() => {
             shell.assertContainsOutput('db.testcollection');
           });


### PR DESCRIPTION
…H-687

Instead of forwarding characters one-by-one to the REPL/readline
instance, group characters that do not have special meaning in a
REPL context together. This is relevant when pasting strings,
where multiple characters are read in rapid succession, and makes
the REPL behave a bit more closely to what e.g. the Node.js REPL
does in that case. There are two main advantages of this:

- This makes tab-indented code behave well, because the REPL does
  not trigger autocompletion when seeing `\tstring`, only when
  seeing `\t` and `string` separately.
- This makes input handling a bit faster, because e.g. the input
  highlighting needs to perform fewer operations for pasted code.