### PR TITLE
chore(build): enable signing MSIs with notary service MONGOSH-567

### DIFF
--- a/packages/build/src/packaging/run-package.ts
+++ b/packages/build/src/packaging/run-package.ts
@@ -1,8 +1,9 @@
 import { constants as fsConstants, promises as fs } from 'fs';
 import os from 'os';
-import { Config, Platform } from '../config';
+import { BuildVariant, Config, Platform } from '../config';
 import { downloadMongocrypt } from './download-mongocryptd';
 import { macOSSignAndNotarize } from './macos-sign';
+import { notarizeMsi } from './msi-sign';
 import { createPackage, PackageFile } from './package';
 
 export async function runPackage(
@@ -36,17 +37,16 @@ export async function runPackage(
 
   const packaged = await runCreatePackage();
 
-  // TODO: uncomment to ensure signing when we have the appropriate keys (BUILD-13072)
-  // if (distributionBuildVariant === BuildVariant.WindowsMSI) {
-  //   await notarizeMsi(
-  //     packaged.path,
-  //     {
-  //       signingKeyName: config.notarySigningKeyName || '',
-  //       authToken: config.notaryAuthToken || '',
-  //       signingComment: 'Evergreen Automatic Signing (mongosh)'
-  //     }
-  //   );
-  // }
+  if (distributionBuildVariant === BuildVariant.WindowsMSI) {
+    await notarizeMsi(
+      packaged.path,
+      {
+        signingKeyName: config.notarySigningKeyName || '',
+        authToken: config.notaryAuthToken || '',
+        signingComment: 'Evergreen Automatic Signing (mongosh)'
+      }
+    );
+  }
 
   return packaged;
 }


### PR DESCRIPTION
Since the required properties are now configured in evergreen we can activate signing:

<img width="453" alt="mongosh-msi-signed" src="https://user-images.githubusercontent.com/4354632/117446977-2b583900-af3d-11eb-8dbb-0f1e7d47a620.png">

https://user-images.githubusercontent.com/4354632/117446981-2dba9300-af3d-11eb-9724-29afbfd50899.mov

