### PR TITLE
feat(cli-repl): aggregate .editor multiline input MONGOSH-518

### DIFF
--- a/packages/cli-repl/package-lock.json
+++ b/packages/cli-repl/package-lock.json
@@ -12,30 +12,26 @@
 				"@babel/highlight": "^7.12.13"
 			}
 		},
-		"@babel/compat-data": {
-			"version": "7.14.0",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.14.0.tgz",
-			"integrity": "sha512-vu9V3uMM/1o5Hl5OekMUowo3FqXLJSw+s+66nt0fSWVWTtmosdzn45JHOB3cPtZoe6CTBDzvSw0RdOY85Q37+Q=="
-		},
 		"@babel/core": {
-			"version": "7.14.0",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.14.0.tgz",
-			"integrity": "sha512-8YqpRig5NmIHlMLw09zMlPTvUVMILjqCOtVgu+TVNWEBvy9b5I3RRyhqnrV4hjgEK7n8P9OqvkWJAFmEL6Wwfw==",
+			"version": "7.9.0",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.9.0.tgz",
+			"integrity": "sha512-kWc7L0fw1xwvI0zi8OKVBuxRVefwGOrKSQMvrQ3dW+bIIavBY3/NpXmpjMy7bQnLgwgzWQZ8TlM57YHpHNHz4w==",
 			"requires": {
-				"@babel/code-frame": "^7.12.13",
-				"@babel/generator": "^7.14.0",
-				"@babel/helper-compilation-targets": "^7.13.16",
-				"@babel/helper-module-transforms": "^7.14.0",
-				"@babel/helpers": "^7.14.0",
-				"@babel/parser": "^7.14.0",
-				"@babel/template": "^7.12.13",
-				"@babel/traverse": "^7.14.0",
-				"@babel/types": "^7.14.0",
+				"@babel/code-frame": "^7.8.3",
+				"@babel/generator": "^7.9.0",
+				"@babel/helper-module-transforms": "^7.9.0",
+				"@babel/helpers": "^7.9.0",
+				"@babel/parser": "^7.9.0",
+				"@babel/template": "^7.8.6",
+				"@babel/traverse": "^7.9.0",
+				"@babel/types": "^7.9.0",
 				"convert-source-map": "^1.7.0",
 				"debug": "^4.1.0",
-				"gensync": "^1.0.0-beta.2",
+				"gensync": "^1.0.0-beta.1",
 				"json5": "^2.1.2",
-				"semver": "^6.3.0",
+				"lodash": "^4.17.13",
+				"resolve": "^1.3.2",
+				"semver": "^5.4.1",
 				"source-map": "^0.5.0"
 			},
 			"dependencies": {
@@ -48,9 +44,9 @@
 					}
 				},
 				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+					"version": "5.7.1",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-5.7.1.tgz",
+					"integrity": "sha512-sauaDf/PZdVgrLTNYHRtpXa1iRiKcaebiKQ1BJdpQlWH2lCvexQdX55snPFyK7QzpudqbCI0qXFfOasHdyNDGQ=="
 				}
 			}
 		},
@@ -62,24 +58,6 @@
 				"@babel/types": "^7.14.1",
 				"jsesc": "^2.5.1",
 				"source-map": "^0.5.0"
-			}
-		},
-		"@babel/helper-compilation-targets": {
-			"version": "7.13.16",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.16.tgz",
-			"integrity": "sha512-3gmkYIrpqsLlieFwjkGgLaSHmhnvlAYzZLlYVjlW+QwI+1zE17kGxuJGmIqDQdYp56XdmGeD+Bswx0UTyG18xA==",
-			"requires": {
-				"@babel/compat-data": "^7.13.15",
-				"@babel/helper-validator-option": "^7.12.17",
-				"browserslist": "^4.14.5",
-				"semver": "^6.3.0"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
-				}
 			}
 		},
 		"@babel/helper-function-name": {
@@ -170,11 +148,6 @@
 			"version": "7.14.0",
 			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.0.tgz",
 			"integrity": "sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A=="
-		},
-		"@babel/helper-validator-option": {
-			"version": "7.12.17",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.17.tgz",
-			"integrity": "sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw=="
 		},
 		"@babel/helpers": {
 			"version": "7.14.0",
@@ -559,23 +532,6 @@
 				"file-uri-to-path": "1.0.0"
 			}
 		},
-		"browserslist": {
-			"version": "4.16.6",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
-			"integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
-			"requires": {
-				"caniuse-lite": "^1.0.30001219",
-				"colorette": "^1.2.2",
-				"electron-to-chromium": "^1.3.723",
-				"escalade": "^3.1.1",
-				"node-releases": "^1.1.71"
-			}
-		},
-		"caniuse-lite": {
-			"version": "1.0.30001227",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001227.tgz",
-			"integrity": "sha512-HHZT4QpUw4Pf45IE3xxKAPgAN3q2aRai/x5TSHP8lrrKzARoH0IeBviwStcRi5lsFlscTkBbXC7gXyms43151A=="
-		},
 		"chai-as-promised": {
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
@@ -618,11 +574,6 @@
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
 		},
-		"colorette": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
-			"integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w=="
-		},
 		"component-type": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/component-type/-/component-type-1.2.1.tgz",
@@ -656,11 +607,6 @@
 				}
 			}
 		},
-		"electron-to-chromium": {
-			"version": "1.3.727",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.727.tgz",
-			"integrity": "sha512-Mfz4FIB4FSvEwBpDfdipRIrwd6uo8gUDoRDF4QEYb4h4tSuI3ov594OrjU6on042UlFHouIJpClDODGkPcBSbg=="
-		},
 		"emphasize": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/emphasize/-/emphasize-3.0.0.tgz",
@@ -681,11 +627,6 @@
 					}
 				}
 			}
-		},
-		"escalade": {
-			"version": "3.1.1",
-			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
-			"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
 		},
 		"escape-string-regexp": {
 			"version": "1.0.5",
@@ -734,6 +675,11 @@
 			"resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
 			"integrity": "sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs="
 		},
+		"function-bind": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.1.tgz",
+			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A=="
+		},
 		"gensync": {
 			"version": "1.0.0-beta.2",
 			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
@@ -743,6 +689,14 @@
 			"version": "11.12.0",
 			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
 			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
+		},
+		"has": {
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
+			"integrity": "sha512-f2dvO0VU6Oej7RkWJGrehjbzMAjFp5/VKPp5tTpWIV4JHHZK1/BxbFRtf/siA2SWTe09caDmVtYYzWEIbBS4zw==",
+			"requires": {
+				"function-bind": "^1.1.1"
+			}
 		},
 		"has-flag": {
 			"version": "4.0.0",
@@ -758,6 +712,14 @@
 			"version": "2.0.4",
 			"resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-2.0.4.tgz",
 			"integrity": "sha512-Kq1rokWXOPXWuaMAqZiJW4XxsmD9zGx9q4aePabbn3qCRGedtH7Cm+zV8WETitMfu1wdh+Rvd6w5egwSngUX2A=="
+		},
+		"is-core-module": {
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.4.0.tgz",
+			"integrity": "sha512-6A2fkfq1rfeQZjxrZJGerpLCTHRNEBiSgnu0+obeJpEPZRUooHgsizvzv0ZjJwOz3iWIHdJtVWJ/tmPr3D21/A==",
+			"requires": {
+				"has": "^1.0.3"
+			}
 		},
 		"is-recoverable-error": {
 			"version": "1.0.2",
@@ -933,10 +895,10 @@
 			"integrity": "sha512-flmrDNB06LIl5lywUz7YlNGZH/5p0M7W28k8hzd9Lshtdh1wshD2Y+U4h9LD6KObOy1f+fEVdgprPrEymjM5uw==",
 			"optional": true
 		},
-		"node-releases": {
-			"version": "1.1.71",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.71.tgz",
-			"integrity": "sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg=="
+		"path-parse": {
+			"version": "1.0.6",
+			"resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+			"integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw=="
 		},
 		"pino": {
 			"version": "5.17.0",
@@ -986,6 +948,15 @@
 			"version": "0.1.0",
 			"resolved": "https://registry.npmjs.org/remove-trailing-slash/-/remove-trailing-slash-0.1.0.tgz",
 			"integrity": "sha1-FJjl3wmEwn5Jt26/Boh8otARUNI="
+		},
+		"resolve": {
+			"version": "1.20.0",
+			"resolved": "https://registry.npmjs.org/resolve/-/resolve-1.20.0.tgz",
+			"integrity": "sha512-wENBPt4ySzg4ybFQW2TT1zMQucPK95HSh/nq2CFTZVOGut2+pQvSsgtda4d26YrYcr067wjbmzOG8byDPBX63A==",
+			"requires": {
+				"is-core-module": "^2.2.0",
+				"path-parse": "^1.0.6"
+			}
 		},
 		"safe-buffer": {
 			"version": "5.1.2",

--- a/packages/cli-repl/package-lock.json
+++ b/packages/cli-repl/package-lock.json
@@ -4,6 +4,293 @@
 	"lockfileVersion": 1,
 	"requires": true,
 	"dependencies": {
+		"@babel/code-frame": {
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.12.13.tgz",
+			"integrity": "sha512-HV1Cm0Q3ZrpCR93tkWOYiuYIgLxZXZFVG2VgK+MBWjUqZTundupbfx2aXarXuw5Ko5aMcjtJgbSs4vUGBS5v6g==",
+			"requires": {
+				"@babel/highlight": "^7.12.13"
+			}
+		},
+		"@babel/compat-data": {
+			"version": "7.14.0",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.14.0.tgz",
+			"integrity": "sha512-vu9V3uMM/1o5Hl5OekMUowo3FqXLJSw+s+66nt0fSWVWTtmosdzn45JHOB3cPtZoe6CTBDzvSw0RdOY85Q37+Q=="
+		},
+		"@babel/core": {
+			"version": "7.14.0",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.14.0.tgz",
+			"integrity": "sha512-8YqpRig5NmIHlMLw09zMlPTvUVMILjqCOtVgu+TVNWEBvy9b5I3RRyhqnrV4hjgEK7n8P9OqvkWJAFmEL6Wwfw==",
+			"requires": {
+				"@babel/code-frame": "^7.12.13",
+				"@babel/generator": "^7.14.0",
+				"@babel/helper-compilation-targets": "^7.13.16",
+				"@babel/helper-module-transforms": "^7.14.0",
+				"@babel/helpers": "^7.14.0",
+				"@babel/parser": "^7.14.0",
+				"@babel/template": "^7.12.13",
+				"@babel/traverse": "^7.14.0",
+				"@babel/types": "^7.14.0",
+				"convert-source-map": "^1.7.0",
+				"debug": "^4.1.0",
+				"gensync": "^1.0.0-beta.2",
+				"json5": "^2.1.2",
+				"semver": "^6.3.0",
+				"source-map": "^0.5.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.3.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+					"requires": {
+						"ms": "2.1.2"
+					}
+				},
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+				}
+			}
+		},
+		"@babel/generator": {
+			"version": "7.14.1",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.1.tgz",
+			"integrity": "sha512-TMGhsXMXCP/O1WtQmZjpEYDhCYC9vFhayWZPJSZCGkPJgUqX0rF0wwtrYvnzVxIjcF80tkUertXVk5cwqi5cAQ==",
+			"requires": {
+				"@babel/types": "^7.14.1",
+				"jsesc": "^2.5.1",
+				"source-map": "^0.5.0"
+			}
+		},
+		"@babel/helper-compilation-targets": {
+			"version": "7.13.16",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.13.16.tgz",
+			"integrity": "sha512-3gmkYIrpqsLlieFwjkGgLaSHmhnvlAYzZLlYVjlW+QwI+1zE17kGxuJGmIqDQdYp56XdmGeD+Bswx0UTyG18xA==",
+			"requires": {
+				"@babel/compat-data": "^7.13.15",
+				"@babel/helper-validator-option": "^7.12.17",
+				"browserslist": "^4.14.5",
+				"semver": "^6.3.0"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "6.3.0",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
+					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw=="
+				}
+			}
+		},
+		"@babel/helper-function-name": {
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.12.13.tgz",
+			"integrity": "sha512-TZvmPn0UOqmvi5G4vvw0qZTpVptGkB1GL61R6lKvrSdIxGm5Pky7Q3fpKiIkQCAtRCBUwB0PaThlx9vebCDSwA==",
+			"requires": {
+				"@babel/helper-get-function-arity": "^7.12.13",
+				"@babel/template": "^7.12.13",
+				"@babel/types": "^7.12.13"
+			}
+		},
+		"@babel/helper-get-function-arity": {
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.12.13.tgz",
+			"integrity": "sha512-DjEVzQNz5LICkzN0REdpD5prGoidvbdYk1BVgRUOINaWJP2t6avB27X1guXK1kXNrX0WMfsrm1A/ZBthYuIMQg==",
+			"requires": {
+				"@babel/types": "^7.12.13"
+			}
+		},
+		"@babel/helper-member-expression-to-functions": {
+			"version": "7.13.12",
+			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.13.12.tgz",
+			"integrity": "sha512-48ql1CLL59aKbU94Y88Xgb2VFy7a95ykGRbJJaaVv+LX5U8wFpLfiGXJJGUozsmA1oEh/o5Bp60Voq7ACyA/Sw==",
+			"requires": {
+				"@babel/types": "^7.13.12"
+			}
+		},
+		"@babel/helper-module-imports": {
+			"version": "7.13.12",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.13.12.tgz",
+			"integrity": "sha512-4cVvR2/1B693IuOvSI20xqqa/+bl7lqAMR59R4iu39R9aOX8/JoYY1sFaNvUMyMBGnHdwvJgUrzNLoUZxXypxA==",
+			"requires": {
+				"@babel/types": "^7.13.12"
+			}
+		},
+		"@babel/helper-module-transforms": {
+			"version": "7.14.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.14.0.tgz",
+			"integrity": "sha512-L40t9bxIuGOfpIGA3HNkJhU9qYrf4y5A5LUSw7rGMSn+pcG8dfJ0g6Zval6YJGd2nEjI7oP00fRdnhLKndx6bw==",
+			"requires": {
+				"@babel/helper-module-imports": "^7.13.12",
+				"@babel/helper-replace-supers": "^7.13.12",
+				"@babel/helper-simple-access": "^7.13.12",
+				"@babel/helper-split-export-declaration": "^7.12.13",
+				"@babel/helper-validator-identifier": "^7.14.0",
+				"@babel/template": "^7.12.13",
+				"@babel/traverse": "^7.14.0",
+				"@babel/types": "^7.14.0"
+			}
+		},
+		"@babel/helper-optimise-call-expression": {
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.12.13.tgz",
+			"integrity": "sha512-BdWQhoVJkp6nVjB7nkFWcn43dkprYauqtk++Py2eaf/GRDFm5BxRqEIZCiHlZUGAVmtwKcsVL1dC68WmzeFmiA==",
+			"requires": {
+				"@babel/types": "^7.12.13"
+			}
+		},
+		"@babel/helper-replace-supers": {
+			"version": "7.13.12",
+			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.13.12.tgz",
+			"integrity": "sha512-Gz1eiX+4yDO8mT+heB94aLVNCL+rbuT2xy4YfyNqu8F+OI6vMvJK891qGBTqL9Uc8wxEvRW92Id6G7sDen3fFw==",
+			"requires": {
+				"@babel/helper-member-expression-to-functions": "^7.13.12",
+				"@babel/helper-optimise-call-expression": "^7.12.13",
+				"@babel/traverse": "^7.13.0",
+				"@babel/types": "^7.13.12"
+			}
+		},
+		"@babel/helper-simple-access": {
+			"version": "7.13.12",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.13.12.tgz",
+			"integrity": "sha512-7FEjbrx5SL9cWvXioDbnlYTppcZGuCY6ow3/D5vMggb2Ywgu4dMrpTJX0JdQAIcRRUElOIxF3yEooa9gUb9ZbA==",
+			"requires": {
+				"@babel/types": "^7.13.12"
+			}
+		},
+		"@babel/helper-split-export-declaration": {
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.12.13.tgz",
+			"integrity": "sha512-tCJDltF83htUtXx5NLcaDqRmknv652ZWCHyoTETf1CXYJdPC7nohZohjUgieXhv0hTJdRf2FjDueFehdNucpzg==",
+			"requires": {
+				"@babel/types": "^7.12.13"
+			}
+		},
+		"@babel/helper-validator-identifier": {
+			"version": "7.14.0",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.0.tgz",
+			"integrity": "sha512-V3ts7zMSu5lfiwWDVWzRDGIN+lnCEUdaXgtVHJgLb1rGaA6jMrtB9EmE7L18foXJIE8Un/A/h6NJfGQp/e1J4A=="
+		},
+		"@babel/helper-validator-option": {
+			"version": "7.12.17",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.12.17.tgz",
+			"integrity": "sha512-TopkMDmLzq8ngChwRlyjR6raKD6gMSae4JdYDB8bByKreQgG0RBTuKe9LRxW3wFtUnjxOPRKBDwEH6Mg5KeDfw=="
+		},
+		"@babel/helpers": {
+			"version": "7.14.0",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.14.0.tgz",
+			"integrity": "sha512-+ufuXprtQ1D1iZTO/K9+EBRn+qPWMJjZSw/S0KlFrxCw4tkrzv9grgpDHkY9MeQTjTY8i2sp7Jep8DfU6tN9Mg==",
+			"requires": {
+				"@babel/template": "^7.12.13",
+				"@babel/traverse": "^7.14.0",
+				"@babel/types": "^7.14.0"
+			}
+		},
+		"@babel/highlight": {
+			"version": "7.14.0",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.0.tgz",
+			"integrity": "sha512-YSCOwxvTYEIMSGaBQb5kDDsCopDdiUGsqpatp3fOlI4+2HQSkTmEVWnVuySdAC5EWCqSWWTv0ib63RjR7dTBdg==",
+			"requires": {
+				"@babel/helper-validator-identifier": "^7.14.0",
+				"chalk": "^2.0.0",
+				"js-tokens": "^4.0.0"
+			},
+			"dependencies": {
+				"ansi-styles": {
+					"version": "3.2.1",
+					"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+					"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+					"requires": {
+						"color-convert": "^1.9.0"
+					}
+				},
+				"chalk": {
+					"version": "2.4.2",
+					"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+					"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+					"requires": {
+						"ansi-styles": "^3.2.1",
+						"escape-string-regexp": "^1.0.5",
+						"supports-color": "^5.3.0"
+					}
+				},
+				"color-convert": {
+					"version": "1.9.3",
+					"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+					"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+					"requires": {
+						"color-name": "1.1.3"
+					}
+				},
+				"color-name": {
+					"version": "1.1.3",
+					"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+					"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
+				},
+				"has-flag": {
+					"version": "3.0.0",
+					"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+					"integrity": "sha1-tdRU3CGZriJWmfNGfloH87lVuv0="
+				},
+				"supports-color": {
+					"version": "5.5.0",
+					"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+					"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+					"requires": {
+						"has-flag": "^3.0.0"
+					}
+				}
+			}
+		},
+		"@babel/parser": {
+			"version": "7.14.1",
+			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.1.tgz",
+			"integrity": "sha512-muUGEKu8E/ftMTPlNp+mc6zL3E9zKWmF5sDHZ5MSsoTP9Wyz64AhEf9kD08xYJ7w6Hdcu8H550ircnPyWSIF0Q=="
+		},
+		"@babel/template": {
+			"version": "7.12.13",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.12.13.tgz",
+			"integrity": "sha512-/7xxiGA57xMo/P2GVvdEumr8ONhFOhfgq2ihK3h1e6THqzTAkHbkXgB0xI9yeTfIUoH3+oAeHhqm/I43OTbbjA==",
+			"requires": {
+				"@babel/code-frame": "^7.12.13",
+				"@babel/parser": "^7.12.13",
+				"@babel/types": "^7.12.13"
+			}
+		},
+		"@babel/traverse": {
+			"version": "7.14.0",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.0.tgz",
+			"integrity": "sha512-dZ/a371EE5XNhTHomvtuLTUyx6UEoJmYX+DT5zBCQN3McHemsuIaKKYqsc/fs26BEkHs/lBZy0J571LP5z9kQA==",
+			"requires": {
+				"@babel/code-frame": "^7.12.13",
+				"@babel/generator": "^7.14.0",
+				"@babel/helper-function-name": "^7.12.13",
+				"@babel/helper-split-export-declaration": "^7.12.13",
+				"@babel/parser": "^7.14.0",
+				"@babel/types": "^7.14.0",
+				"debug": "^4.1.0",
+				"globals": "^11.1.0"
+			},
+			"dependencies": {
+				"debug": {
+					"version": "4.3.1",
+					"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.1.tgz",
+					"integrity": "sha512-doEwdvm4PCeK4K3RQN2ZC2BYUBaxwLARCqZmMjtF8a51J2Rb0xpVloFRnCODwqjpwnAoao4pelN8l3RJdv3gRQ==",
+					"requires": {
+						"ms": "2.1.2"
+					}
+				}
+			}
+		},
+		"@babel/types": {
+			"version": "7.14.1",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.1.tgz",
+			"integrity": "sha512-S13Qe85fzLs3gYRUnrpyeIrBJIMYv33qSTg1qoBwiG6nPKwUWAD9odSzWhEedpwOIzSEI6gbdQIWEMiCI42iBA==",
+			"requires": {
+				"@babel/helper-validator-identifier": "^7.14.0",
+				"to-fast-properties": "^2.0.0"
+			}
+		},
 		"@segment/loosely-validate-event": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/@segment/loosely-validate-event/-/loosely-validate-event-2.0.0.tgz",
@@ -24,6 +311,47 @@
 			"resolved": "https://registry.npmjs.org/@types/ansi-escape-sequences/-/ansi-escape-sequences-4.0.0.tgz",
 			"integrity": "sha512-y9KJUf19SBowoaqhWdQNnErxFMNsKbuair2i3SGv5Su1ExLPAJz37iPXLHKIFQGYkHGxsSe45rNt8ZekXxJwUw==",
 			"dev": true
+		},
+		"@types/babel__core": {
+			"version": "7.1.14",
+			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.14.tgz",
+			"integrity": "sha512-zGZJzzBUVDo/eV6KgbE0f0ZI7dInEYvo12Rb70uNQDshC3SkRMb67ja0GgRHZgAX3Za6rhaWlvbDO8rrGyAb1g==",
+			"dev": true,
+			"requires": {
+				"@babel/parser": "^7.1.0",
+				"@babel/types": "^7.0.0",
+				"@types/babel__generator": "*",
+				"@types/babel__template": "*",
+				"@types/babel__traverse": "*"
+			}
+		},
+		"@types/babel__generator": {
+			"version": "7.6.2",
+			"resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.2.tgz",
+			"integrity": "sha512-MdSJnBjl+bdwkLskZ3NGFp9YcXGx5ggLpQQPqtgakVhsWK0hTtNYhjpZLlWQTviGTvF8at+Bvli3jV7faPdgeQ==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@types/babel__template": {
+			"version": "7.4.0",
+			"resolved": "https://registry.npmjs.org/@types/babel__template/-/babel__template-7.4.0.tgz",
+			"integrity": "sha512-NTPErx4/FiPCGScH7foPyr+/1Dkzkni+rHiYHHoTjvwou7AQzJkNeD60A9CXRy+ZEN2B1bggmkTMCDb+Mv5k+A==",
+			"dev": true,
+			"requires": {
+				"@babel/parser": "^7.1.0",
+				"@babel/types": "^7.0.0"
+			}
+		},
+		"@types/babel__traverse": {
+			"version": "7.11.1",
+			"resolved": "https://registry.npmjs.org/@types/babel__traverse/-/babel__traverse-7.11.1.tgz",
+			"integrity": "sha512-Vs0hm0vPahPMYi9tDjtP66llufgO3ST16WXaSTtDGEl9cewAl3AibmxWw6TINOqHPT9z0uABKAYjT9jNSg4npw==",
+			"dev": true,
+			"requires": {
+				"@babel/types": "^7.3.0"
+			}
 		},
 		"@types/chai": {
 			"version": "4.2.14",
@@ -231,6 +559,23 @@
 				"file-uri-to-path": "1.0.0"
 			}
 		},
+		"browserslist": {
+			"version": "4.16.6",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
+			"integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
+			"requires": {
+				"caniuse-lite": "^1.0.30001219",
+				"colorette": "^1.2.2",
+				"electron-to-chromium": "^1.3.723",
+				"escalade": "^3.1.1",
+				"node-releases": "^1.1.71"
+			}
+		},
+		"caniuse-lite": {
+			"version": "1.0.30001227",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001227.tgz",
+			"integrity": "sha512-HHZT4QpUw4Pf45IE3xxKAPgAN3q2aRai/x5TSHP8lrrKzARoH0IeBviwStcRi5lsFlscTkBbXC7gXyms43151A=="
+		},
 		"chai-as-promised": {
 			"version": "7.1.1",
 			"resolved": "https://registry.npmjs.org/chai-as-promised/-/chai-as-promised-7.1.1.tgz",
@@ -273,10 +618,23 @@
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
 			"integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA=="
 		},
+		"colorette": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
+			"integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w=="
+		},
 		"component-type": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/component-type/-/component-type-1.2.1.tgz",
 			"integrity": "sha1-ikeQFwAjjk/DIml3EjAibyS0Fak="
+		},
+		"convert-source-map": {
+			"version": "1.7.0",
+			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.7.0.tgz",
+			"integrity": "sha512-4FJkXzKXEDB1snCFZlLP4gpC3JILicCpGbzG9f9G7tGqGCzETQ2hWPrcinA9oU4wtf2biUaEH5065UnMeR33oA==",
+			"requires": {
+				"safe-buffer": "~5.1.1"
+			}
 		},
 		"crypt": {
 			"version": "0.0.2",
@@ -298,6 +656,11 @@
 				}
 			}
 		},
+		"electron-to-chromium": {
+			"version": "1.3.727",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.727.tgz",
+			"integrity": "sha512-Mfz4FIB4FSvEwBpDfdipRIrwd6uo8gUDoRDF4QEYb4h4tSuI3ov594OrjU6on042UlFHouIJpClDODGkPcBSbg=="
+		},
 		"emphasize": {
 			"version": "3.0.0",
 			"resolved": "https://registry.npmjs.org/emphasize/-/emphasize-3.0.0.tgz",
@@ -318,6 +681,16 @@
 					}
 				}
 			}
+		},
+		"escalade": {
+			"version": "3.1.1",
+			"resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.1.tgz",
+			"integrity": "sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw=="
+		},
+		"escape-string-regexp": {
+			"version": "1.0.5",
+			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+			"integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
 		},
 		"fast-redact": {
 			"version": "2.0.0",
@@ -361,6 +734,16 @@
 			"resolved": "https://registry.npmjs.org/format/-/format-0.2.2.tgz",
 			"integrity": "sha1-1hcBB+nv3E7TDJ3DkBbflCtctYs="
 		},
+		"gensync": {
+			"version": "1.0.0-beta.2",
+			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
+			"integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg=="
+		},
+		"globals": {
+			"version": "11.12.0",
+			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
+			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA=="
+		},
 		"has-flag": {
 			"version": "4.0.0",
 			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
@@ -397,6 +780,24 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/join-component/-/join-component-1.1.0.tgz",
 			"integrity": "sha1-uEF7dQZho5K+4sJTfGiyqdSXfNU="
+		},
+		"js-tokens": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
+			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ=="
+		},
+		"jsesc": {
+			"version": "2.5.2",
+			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
+			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA=="
+		},
+		"json5": {
+			"version": "2.2.0",
+			"resolved": "https://registry.npmjs.org/json5/-/json5-2.2.0.tgz",
+			"integrity": "sha512-f+8cldu7X/y7RAJurMEJmdoKXGB/X550w2Nr3tTbezL6RwEE/iMcm+tZnXeoZtKuOq6ft8+CqzEkrIgx1fPoQA==",
+			"requires": {
+				"minimist": "^1.2.5"
+			}
 		},
 		"lodash": {
 			"version": "4.17.21",
@@ -456,6 +857,11 @@
 					"integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
 				}
 			}
+		},
+		"minimist": {
+			"version": "1.2.5",
+			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.5.tgz",
+			"integrity": "sha512-FM9nNUYrRBAELZQT3xeZQ7fmMOBg6nWNmJKTcgsJeaLstP/UODVpGsr5OhXhhXg6f+qtJ8uiZ+PUxkDWcgIXLw=="
 		},
 		"moment": {
 			"version": "2.29.1",
@@ -527,6 +933,11 @@
 			"integrity": "sha512-flmrDNB06LIl5lywUz7YlNGZH/5p0M7W28k8hzd9Lshtdh1wshD2Y+U4h9LD6KObOy1f+fEVdgprPrEymjM5uw==",
 			"optional": true
 		},
+		"node-releases": {
+			"version": "1.1.71",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.71.tgz",
+			"integrity": "sha512-zR6HoT6LrLCRBwukmrVbHv0EpEQjksO6GmFcZQQuCAy139BEsoVKPYnf3jongYW83fAa1torLGYwxxky/p28sg=="
+		},
 		"pino": {
 			"version": "5.17.0",
 			"resolved": "https://registry.npmjs.org/pino/-/pino-5.17.0.tgz",
@@ -576,6 +987,11 @@
 			"resolved": "https://registry.npmjs.org/remove-trailing-slash/-/remove-trailing-slash-0.1.0.tgz",
 			"integrity": "sha1-FJjl3wmEwn5Jt26/Boh8otARUNI="
 		},
+		"safe-buffer": {
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
+			"integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g=="
+		},
 		"semver": {
 			"version": "7.3.2",
 			"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.2.tgz",
@@ -589,6 +1005,11 @@
 				"atomic-sleep": "^1.0.0",
 				"flatstr": "^1.0.12"
 			}
+		},
+		"source-map": {
+			"version": "0.5.7",
+			"resolved": "https://registry.npmjs.org/source-map/-/source-map-0.5.7.tgz",
+			"integrity": "sha1-igOdLRAh0i0eoUyA2OpGi6LvP8w="
 		},
 		"strip-ansi": {
 			"version": "6.0.0",
@@ -610,6 +1031,11 @@
 			"version": "0.2.0",
 			"resolved": "https://registry.npmjs.org/text-table/-/text-table-0.2.0.tgz",
 			"integrity": "sha1-f17oI66AUgfACvLfSoTsP8+lcLQ="
+		},
+		"to-fast-properties": {
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
+			"integrity": "sha1-3F5pjL0HkmW8c+A3doGk5Og/YW4="
 		},
 		"win-export-certificate-and-key": {
 			"version": "1.0.2",

--- a/packages/cli-repl/package.json
+++ b/packages/cli-repl/package.json
@@ -39,6 +39,7 @@
     "node": ">=14.15.0"
   },
   "dependencies": {
+    "@babel/core": "^7.14.0",
     "@mongosh/autocomplete": "0.0.0-dev.0",
     "@mongosh/errors": "0.0.0-dev.0",
     "@mongosh/history": "0.0.0-dev.0",
@@ -68,6 +69,7 @@
   "devDependencies": {
     "@types/analytics-node": "^3.1.3",
     "@types/ansi-escape-sequences": "^4.0.0",
+    "@types/babel__core": "^7.1.6",
     "@types/chai-as-promised": "^7.1.3",
     "@types/lodash.set": "^4.3.6",
     "@types/node": "^14.14.5",

--- a/packages/cli-repl/package.json
+++ b/packages/cli-repl/package.json
@@ -39,7 +39,7 @@
     "node": ">=14.15.0"
   },
   "dependencies": {
-    "@babel/core": "^7.14.0",
+    "@babel/core": "^7.9.0",
     "@mongosh/autocomplete": "0.0.0-dev.0",
     "@mongosh/errors": "0.0.0-dev.0",
     "@mongosh/history": "0.0.0-dev.0",

--- a/packages/cli-repl/src/js-multiline-to-singleline.spec.ts
+++ b/packages/cli-repl/src/js-multiline-to-singleline.spec.ts
@@ -1,0 +1,18 @@
+import { expect } from 'chai';
+import { makeMultilineJSIntoSingleLine as toSingleLine } from './js-multiline-to-singleline';
+
+describe('makeMultilineJSIntoSingleLine', () => {
+  it('handles simple input well', () => {
+    expect(toSingleLine('1\n2\n3\n')).to.equal('1; 2; 3');
+    expect(toSingleLine('1\n2\n3;')).to.equal('1; 2; 3;');
+  });
+
+  it('performs ASI as necessary', () => {
+    // Note that without ASI the semantics here would change
+    expect(toSingleLine('() => { return\n42\n }')).to.equal('() => {return; 42; }');
+  });
+
+  it('treats comments propertly', () => {
+    expect(toSingleLine('a // comment\n b')).to.equal('a; b');
+  });
+});

--- a/packages/cli-repl/src/js-multiline-to-singleline.ts
+++ b/packages/cli-repl/src/js-multiline-to-singleline.ts
@@ -1,0 +1,24 @@
+import { transformSync } from '@babel/core';
+
+export function makeMultilineJSIntoSingleLine(src: string): string {
+  // We use babel without any actual transofmration steps, and only for ASI
+  // effects here, e.g. turning `return\n42` into `return;\n42;`
+  // since without the added semicolons semantics would be different.
+  // This unfortunately modifies the code in some other ways as well, e.g.
+  // removing unnecessary parentheses, but correctness seems to be more
+  // important here than keeping aesthetics intact.
+  // It would be nice to have a dedicated package at some point that does
+  // ASI and *only* ASI and leaves the source intact otherwise.
+  const postASI = transformSync(src, {
+    retainLines: true,
+    compact: false,
+    code: true,
+    comments: false
+  })?.code ?? src;
+  const asSingleLine = postASI.split(/[\r\n]+/g)
+    .map(line => line.trim())
+    .join(' ')
+    .trim();
+  // Remove a trailing semicolon if the input also did not have one.
+  return src.trim().endsWith(';') ? asSingleLine : asSingleLine.replace(/;$/, '');
+}

--- a/packages/cli-repl/src/mongosh-repl.spec.ts
+++ b/packages/cli-repl/src/mongosh-repl.spec.ts
@@ -427,13 +427,38 @@ describe('MongoshNodeRepl', () => {
             await tick();
             expect(mongoshRepl.runtimeState().repl.context.obj).to.deep.equal({ foo: 'bar' });
             expect(output).not.to.include('obj = ({ foo: "bar" })');
+            expect(output).not.to.include('obj = { foo: "bar" }');
 
             output = '';
             input.write(`${arrowUp}\n`);
             await tick();
-            expect(output).to.include('obj = ({ foo: "bar" })');
+            expect(output).to.include('obj = { foo: "bar" }');
             expect(getHistory()).to.deep.equal([
-              'obj = ({ foo: "bar" })'
+              'obj = { foo: "bar" }'
+            ]);
+          });
+
+          it('works for multi-line input from .editor', async() => {
+            output = '';
+            input.write('.editor\n');
+            await tick();
+            input.write('obj = ({ foo: \n');
+            await tick();
+            input.write('"baz" })\n');
+            await tick();
+            input.write('\u0004'); // Ctrl+D
+            await tick();
+            expect(mongoshRepl.runtimeState().repl.context.obj).to.deep.equal({ foo: 'baz' });
+            expect(output).not.to.include('obj = ({ foo: "baz" })');
+            expect(output).not.to.include('obj = { foo: "baz" }');
+
+            output = '';
+            input.write(`${arrowUp}\n`);
+            await tick();
+            expect(output).to.include('obj = { foo: "baz" }');
+            expect(getHistory()).to.deep.equal([
+              'obj = { foo: "baz" }',
+              '.editor'
             ]);
           });
 
@@ -448,13 +473,14 @@ describe('MongoshNodeRepl', () => {
             await tick();
             expect(mongoshRepl.runtimeState().repl.context.obj).to.deep.equal({ foo: 'bar' });
             expect(output).not.to.include('obj = ({ foo: "bar" })');
+            expect(output).not.to.include('obj = { foo: "bar" }');
 
             output = '';
             input.write(`${arrowUp}\n`);
             await tick();
-            expect(output).to.include('obj = ({ foo: "bar" })');
+            expect(output).to.include('obj = { foo: "bar" }');
             expect(getHistory()).to.deep.equal([
-              'obj = ({ foo: "bar" })',
+              'obj = { foo: "bar" }',
               'prompt = () => "abc> "'
             ]);
           });


### PR DESCRIPTION
The changes for this feature are fairly self-contained, however,
.editor support relies a lot more strongly on automated semicolon
insertion (ASI) than the previous multi-line input handling,
so the bigger part of the changes here is getting the semantics for
that right. (This would also have affected the original multi-line
aggregating functionality, e.g. `() => { 1\n2 }` would have resulted
in a broken `() => { 1 2 }` history entry.)