### PR TITLE
chore: bump Node.js to 14.17.0

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -389,10 +389,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.15.1"
+          node_js_version: "14.17.0"
       - func: check
         vars:
-          node_js_version: "14.15.1"
+          node_js_version: "14.17.0"
 
   ###
   # UNIT TESTS
@@ -488,77 +488,77 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.15.1"
+          node_js_version: "14.17.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.0.x-community"
-          node_js_version: "14.15.1"
+          node_js_version: "14.17.0"
   - name: test_m40xe_n14
     tags: ["unit-test"]
     commands:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.15.1"
+          node_js_version: "14.17.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.0.x"
-          node_js_version: "14.15.1"
+          node_js_version: "14.17.0"
   - name: test_m42xc_n14
     tags: ["unit-test"]
     commands:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.15.1"
+          node_js_version: "14.17.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.2.x-community"
-          node_js_version: "14.15.1"
+          node_js_version: "14.17.0"
   - name: test_m42xe_n14
     tags: ["unit-test"]
     commands:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.15.1"
+          node_js_version: "14.17.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.2.x"
-          node_js_version: "14.15.1"
+          node_js_version: "14.17.0"
   - name: test_m44xc_n14
     tags: ["unit-test"]
     commands:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.15.1"
+          node_js_version: "14.17.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.4.x-community"
-          node_js_version: "14.15.1"
+          node_js_version: "14.17.0"
   - name: test_m44xe_n14
     tags: ["unit-test"]
     commands:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.15.1"
+          node_js_version: "14.17.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.4.x"
-          node_js_version: "14.15.1"
+          node_js_version: "14.17.0"
   - name: test_mlatest_n14
     tags: ["unit-test", "mlatest"]
     commands:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.15.1"
+          node_js_version: "14.17.0"
       - func: test
         vars:
           mongosh_server_test_version: "latest-alpha"
-          node_js_version: "14.15.1"
+          node_js_version: "14.17.0"
 
   ###
   # INTEGRATION TESTS
@@ -579,17 +579,17 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.15.1"
+          node_js_version: "14.17.0"
       - func: test_connectivity
   - name: compile_artifact
     commands:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.15.1"
+          node_js_version: "14.17.0"
       - func: compile_artifact
         vars:
-          node_js_version: "14.15.1"
+          node_js_version: "14.17.0"
 
   ###
   # E2E TESTS
@@ -603,13 +603,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.15.1"
+          node_js_version: "14.17.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: darwin
       - func: run_e2e_tests
         vars:
-          node_js_version: "14.15.1"
+          node_js_version: "14.17.0"
   - name: e2e_tests_linux_x64
     tags: ["e2e-test"]
     depends_on:
@@ -619,13 +619,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.15.1"
+          node_js_version: "14.17.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64
       - func: run_e2e_tests
         vars:
-          node_js_version: "14.15.1"
+          node_js_version: "14.17.0"
   - name: e2e_tests_linux_arm64
     tags: ["e2e-test"]
     depends_on:
@@ -635,13 +635,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.15.1"
+          node_js_version: "14.17.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64
       - func: run_e2e_tests
         vars:
-          node_js_version: "14.15.1"
+          node_js_version: "14.17.0"
   - name: e2e_tests_linux_ppc64le
     tags: ["e2e-test"]
     depends_on:
@@ -651,13 +651,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.15.1"
+          node_js_version: "14.17.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-ppc64le
       - func: run_e2e_tests
         vars:
-          node_js_version: "14.15.1"
+          node_js_version: "14.17.0"
   - name: e2e_tests_linux_s390x
     tags: ["e2e-test"]
     depends_on:
@@ -667,13 +667,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.15.1"
+          node_js_version: "14.17.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-s390x
       - func: run_e2e_tests
         vars:
-          node_js_version: "14.15.1"
+          node_js_version: "14.17.0"
   - name: e2e_tests_win
     tags: ["e2e-test"]
     depends_on:
@@ -683,13 +683,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.15.1"
+          node_js_version: "14.17.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: win32
       - func: run_e2e_tests
         vars:
-          node_js_version: "14.15.1"
+          node_js_version: "14.17.0"
 
   ###
   # PACKAGING
@@ -706,10 +706,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.15.1"
+          node_js_version: "14.17.0"
       - func: package_and_upload_artifact
         vars:
-          node_js_version: "14.15.1"
+          node_js_version: "14.17.0"
           distribution_build_variant: darwin-x64
   - name: package_and_upload_artifact_linux_x64
     depends_on:
@@ -723,10 +723,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.15.1"
+          node_js_version: "14.17.0"
       - func: package_and_upload_artifact
         vars:
-          node_js_version: "14.15.1"
+          node_js_version: "14.17.0"
           distribution_build_variant: linux-x64
           executable_os_id: linux-x64
   - name: package_and_upload_artifact_debian_x64
@@ -741,10 +741,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.15.1"
+          node_js_version: "14.17.0"
       - func: package_and_upload_artifact
         vars:
-          node_js_version: "14.15.1"
+          node_js_version: "14.17.0"
           distribution_build_variant: debian-x64
           executable_os_id: linux-x64
   - name: package_and_upload_artifact_rhel_x64
@@ -759,10 +759,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.15.1"
+          node_js_version: "14.17.0"
       - func: package_and_upload_artifact
         vars:
-          node_js_version: "14.15.1"
+          node_js_version: "14.17.0"
           distribution_build_variant: rhel-x64
           executable_os_id: linux-x64
   - name: package_and_upload_artifact_linux_arm64
@@ -777,10 +777,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.15.1"
+          node_js_version: "14.17.0"
       - func: package_and_upload_artifact
         vars:
-          node_js_version: "14.15.1"
+          node_js_version: "14.17.0"
           distribution_build_variant: linux-arm64
           executable_os_id: linux-arm64
   - name: package_and_upload_artifact_debian_arm64
@@ -795,10 +795,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.15.1"
+          node_js_version: "14.17.0"
       - func: package_and_upload_artifact
         vars:
-          node_js_version: "14.15.1"
+          node_js_version: "14.17.0"
           distribution_build_variant: debian-arm64
           executable_os_id: linux-arm64
   - name: package_and_upload_artifact_rhel_arm64
@@ -813,10 +813,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.15.1"
+          node_js_version: "14.17.0"
       - func: package_and_upload_artifact
         vars:
-          node_js_version: "14.15.1"
+          node_js_version: "14.17.0"
           distribution_build_variant: rhel-arm64
           executable_os_id: linux-arm64
   - name: package_and_upload_artifact_linux_s390x
@@ -831,10 +831,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.15.1"
+          node_js_version: "14.17.0"
       - func: package_and_upload_artifact
         vars:
-          node_js_version: "14.15.1"
+          node_js_version: "14.17.0"
           distribution_build_variant: linux-s390x
           executable_os_id: linux-s390x
   - name: package_and_upload_artifact_rhel_s390x
@@ -849,10 +849,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.15.1"
+          node_js_version: "14.17.0"
       - func: package_and_upload_artifact
         vars:
-          node_js_version: "14.15.1"
+          node_js_version: "14.17.0"
           distribution_build_variant: rhel-s390x
           executable_os_id: linux-s390x
   - name: package_and_upload_artifact_linux_ppc64le
@@ -867,10 +867,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.15.1"
+          node_js_version: "14.17.0"
       - func: package_and_upload_artifact
         vars:
-          node_js_version: "14.15.1"
+          node_js_version: "14.17.0"
           distribution_build_variant: linux-ppc64le
           executable_os_id: linux-ppc64le
   - name: package_and_upload_artifact_rhel_ppc64le
@@ -885,10 +885,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.15.1"
+          node_js_version: "14.17.0"
       - func: package_and_upload_artifact
         vars:
-          node_js_version: "14.15.1"
+          node_js_version: "14.17.0"
           distribution_build_variant: rhel-ppc64le
           executable_os_id: linux-ppc64le
   - name: package_and_upload_artifact_win
@@ -903,10 +903,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.15.1"
+          node_js_version: "14.17.0"
       - func: package_and_upload_artifact
         vars:
-          node_js_version: "14.15.1"
+          node_js_version: "14.17.0"
           distribution_build_variant: win32-x64
   - name: package_and_upload_artifact_winmsi
     depends_on:
@@ -920,10 +920,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.15.1"
+          node_js_version: "14.17.0"
       - func: package_and_upload_artifact
         vars:
-          node_js_version: "14.15.1"
+          node_js_version: "14.17.0"
           distribution_build_variant: win32msi-x64
 
   ###
@@ -1123,10 +1123,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.15.1"
+          node_js_version: "14.17.0"
       - func: release_draft
         vars:
-          node_js_version: "14.15.1"
+          node_js_version: "14.17.0"
   - name: release_publish
     tags: ["publish"]
     git_tag_only: true
@@ -1134,10 +1134,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.15.1"
+          node_js_version: "14.17.0"
       - func: release_publish
         vars:
-          node_js_version: "14.15.1"
+          node_js_version: "14.17.0"
 
 # Need to run builds for every possible build variant.
 buildvariants:


### PR DESCRIPTION
This addresses MONGOSH-685 and unblocks MONGOSH-442.