### PR TITLE
feat(shell-api): add mongo.getDBs() and .getDBNames() MONGOSH-766

### DIFF
--- a/packages/i18n/src/locales/en_US.ts
+++ b/packages/i18n/src/locales/en_US.ts
@@ -1660,6 +1660,15 @@ const translations: Catalog = {
               link: 'https://docs.mongodb.com/manual/reference/method/Mongo.getDB',
               description: 'Returns the specified Database of the Mongo object.'
             },
+            getDBs: {
+              link: 'https://docs.mongodb.com/manual/reference/method/Mongo.getDBs',
+              description: 'Returns information about all databases. Uses the listDatabases command.'
+            },
+            getDBNames: {
+              link: 'https://docs.mongodb.com/manual/reference/method/Mongo.getDBs',
+              description: 'Returns an array of all database names. Uses the listDatabases command.',
+              example: 'db.getMongo().getDBNames().map(name => db.getSiblingDB(name).getCollectionNames())'
+            },
             connect: {
               link: 'https://docs.mongodb.com/manual/reference/method/connect',
               description: 'Creates a connection to a MongoDB instance and returns the reference to the database.'

--- a/packages/shell-api/src/integration.spec.ts
+++ b/packages/shell-api/src/integration.spec.ts
@@ -1744,6 +1744,18 @@ describe('Shell API (integration)', function() {
         expect(internalState.mongos).to.deep.equal([mongo]);
       });
     });
+    describe('getDBs', () => {
+      it('lists all databases', async() => {
+        const result = await mongo.getDBs();
+        expect(result.ok).to.equal(1);
+        expect(result.databases.find(db => db.name === 'admin').sizeOnDisk).to.be.a('number');
+      });
+    });
+    describe('getDBNames', () => {
+      it('lists all database names', async() => {
+        expect(await mongo.getDBNames()).to.include('admin');
+      });
+    });
   });
   describe('PlanCache', () => {
     describe('list', () => {


### PR DESCRIPTION
These were present in the legacy shell, and while they were
undocumented, I feel like they are obvious candidates for inclusion
in the API, so I’m just going ahead and opening a PR.