### PR TITLE
fix: make shell run with --apiStrict

### DIFF
--- a/packages/cli-repl/src/mongosh-repl.ts
+++ b/packages/cli-repl/src/mongosh-repl.ts
@@ -127,7 +127,7 @@ class MongoshNodeRepl implements EvaluationListener {
     internalState.setEvaluationListener(this);
     await internalState.fetchConnectionInfo();
 
-    const mongodVersion = internalState.connectionInfo.buildInfo.version;
+    const mongodVersion = internalState.connectionInfo.buildInfo?.version;
     await this.greet(mongodVersion);
     await this.printStartupLog(internalState);
 

--- a/packages/service-provider-core/src/connect-info.spec.ts
+++ b/packages/service-provider-core/src/connect-info.spec.ts
@@ -158,4 +158,31 @@ describe('getConnectInfo', function() {
       null,
       TOPOLOGY_WITH_CREDENTIALS)).to.deep.equal(output);
   });
+
+  it('does not fail when buildInfo is unavailable', function() {
+    const output = {
+      is_atlas: false,
+      is_localhost: false,
+      server_version: undefined,
+      mongosh_version: '0.0.6',
+      is_enterprise: false,
+      auth_type: 'LDAP',
+      is_data_lake: false,
+      dl_version: null,
+      atlas_version: null,
+      is_genuine: true,
+      non_genuine_server_name: 'mongodb',
+      server_arch: null,
+      node_version: process.version,
+      server_os: null,
+      uri: ''
+    };
+    expect(getConnectInfo(
+      '',
+      '0.0.6',
+      null,
+      CMD_LINE_OPTS,
+      null,
+      TOPOLOGY_WITH_CREDENTIALS)).to.deep.equal(output);
+  });
 });

--- a/packages/service-provider-core/src/connect-info.ts
+++ b/packages/service-provider-core/src/connect-info.ts
@@ -22,6 +22,7 @@ export interface ConnectInfo {
 }
 
 export default function getConnectInfo(uri: string, mongoshVersion: string, buildInfo: any, cmdLineOpts: any, atlasVersion: any, topology: any): ConnectInfo {
+  buildInfo ??= {}; // We're currently not getting buildInfo with --apiStrict.
   const { isGenuine: is_genuine, serverName: non_genuine_server_name } =
     getBuildInfo.getGenuineMongoDB(buildInfo, cmdLineOpts);
   const { isDataLake: is_data_lake, dlVersion: dl_version }


### PR DESCRIPTION
This does not yet add integration tests, which is left for MONGOSH-765.