### PR TITLE
chore(java-shell): skip executionStats validation in tests

### DIFF
--- a/packages/java-shell/src/test/resources/cursor/explain.expected.txt
+++ b/packages/java-shell/src/test/resources/cursor/explain.expected.txt
@@ -3,6 +3,3 @@
 "admin.coll"
 true
 false
-42
-{ "name": { "$eq": "Vasya" } }
-{ "_id": -1 }

--- a/packages/java-shell/src/test/resources/cursor/explain.js
+++ b/packages/java-shell/src/test/resources/cursor/explain.js
@@ -13,11 +13,5 @@ db.coll.find().explain();
 db.coll.find().explain("executionStats");
 // command containsProperty=executionStats
 db.coll.find().explain("queryPlanner");
-// command extractProperty=executionStats extractProperty=executionStages extractProperty=limitAmount
-db.coll.find().limit(42).explain("executionStats");
-// command extractProperty=executionStats extractProperty=executionStages extractProperty=filter
-db.coll.find({name: "Vasya"}).explain("executionStats");
-// command extractProperty=executionStats extractProperty=executionStages extractProperty=transformBy
-db.coll.find({}, {_id: -1}).explain("executionStats");
 // clear
 db.coll.drop();


### PR DESCRIPTION
The SBE engine has been turned on by default in the latest server
versions, which returns a different explain output in executionStats.
Therefore, skip validation in the java-shell tests, which currently
expect the pre-5.0 format.