### PR TITLE
fix(ci): build git 2.x if not present on host

### DIFF
--- a/.evergreen/.install_node
+++ b/.evergreen/.install_node
@@ -18,6 +18,13 @@ else
 
   nvm install --no-progress $NODE_JS_VERSION
   nvm alias default $NODE_JS_VERSION
+
+  if git --version | grep -q 'git version 1.'; then
+    (cd "$BASEDIR" &&
+      curl -sSfL https://github.com/git/git/archive/refs/tags/v2.31.1.tar.gz | tar -xvz &&
+      cd git-2.31.1 &&
+      make -j8)
+  fi
 fi
 
 . "$BASEDIR/.setup_env"

--- a/.evergreen/.install_node
+++ b/.evergreen/.install_node
@@ -19,10 +19,11 @@ else
   nvm install --no-progress $NODE_JS_VERSION
   nvm alias default $NODE_JS_VERSION
 
-  if git --version | grep -q 'git version 1.'; then
+  if env PATH="/opt/chefdk/gitbin:$PATH" git --version | grep -q 'git version 1.'; then
     (cd "$BASEDIR" &&
       curl -sSfL https://github.com/git/git/archive/refs/tags/v2.31.1.tar.gz | tar -xvz &&
-      cd git-2.31.1 &&
+      mv git-2.31.1 git-2 &&
+      cd git-2 &&
       make -j8 NO_EXPAT=1)
   fi
 fi

--- a/.evergreen/.install_node
+++ b/.evergreen/.install_node
@@ -23,7 +23,7 @@ else
     (cd "$BASEDIR" &&
       curl -sSfL https://github.com/git/git/archive/refs/tags/v2.31.1.tar.gz | tar -xvz &&
       cd git-2.31.1 &&
-      make -j8)
+      make -j8 NO_EXPAT=1)
   fi
 fi
 

--- a/.evergreen/.setup_env
+++ b/.evergreen/.setup_env
@@ -1,7 +1,7 @@
 set -e
 set -x
 export BASEDIR="$PWD/.evergreen"
-export PATH="$BASEDIR/node-v$NODE_JS_VERSION-win-x64:/opt/python/3.6/bin:/opt/chefdk/gitbin:/cygdrive/c/Program Files/Git/bin:/cygdrive/c/Program Files/Git/mingw32/libexec/git-core:/cygdrive/c/Python39/Scripts:/cygdrive/c/Python39:/cygdrive/c/cmake/bin:/opt/mongodbtoolchain/v3/bin:$PATH"
+export PATH="$BASEDIR/git-2.31.1:$BASEDIR/node-v$NODE_JS_VERSION-win-x64:/opt/python/3.6/bin:/opt/chefdk/gitbin:/cygdrive/c/Program Files/Git/bin:/cygdrive/c/Program Files/Git/mingw32/libexec/git-core:/cygdrive/c/Python39/Scripts:/cygdrive/c/Python39:/cygdrive/c/cmake/bin:/opt/mongodbtoolchain/v3/bin:$PATH"
 export IS_MONGOSH_EVERGREEN_CI=1
 
 if [ "$OS" != "Windows_NT" ]; then

--- a/.evergreen/.setup_env
+++ b/.evergreen/.setup_env
@@ -1,7 +1,7 @@
 set -e
 set -x
 export BASEDIR="$PWD/.evergreen"
-export PATH="$BASEDIR/git-2.31.1:$BASEDIR/node-v$NODE_JS_VERSION-win-x64:/opt/python/3.6/bin:/opt/chefdk/gitbin:/cygdrive/c/Program Files/Git/bin:/cygdrive/c/Program Files/Git/mingw32/libexec/git-core:/cygdrive/c/Python39/Scripts:/cygdrive/c/Python39:/cygdrive/c/cmake/bin:/opt/mongodbtoolchain/v3/bin:$PATH"
+export PATH="$BASEDIR/git-2:$BASEDIR/node-v$NODE_JS_VERSION-win-x64:/opt/python/3.6/bin:/opt/chefdk/gitbin:/cygdrive/c/Program Files/Git/bin:/cygdrive/c/Program Files/Git/mingw32/libexec/git-core:/cygdrive/c/Python39/Scripts:/cygdrive/c/Python39:/cygdrive/c/cmake/bin:/opt/mongodbtoolchain/v3/bin:$PATH"
 export IS_MONGOSH_EVERGREEN_CI=1
 
 if [ "$OS" != "Windows_NT" ]; then
@@ -22,6 +22,10 @@ if [ "$OS" != "Windows_NT" ]; then
 
   echo "Using g++ version:"
   g++ --version
+
+  if [ -x "$BASEDIR/git-2/git" ]; then
+    export GIT_EXEC_PATH="$BASEDIR/git-2"
+  fi
 fi
 
 export EVERGREEN_EXPANSIONS_PATH="$BASEDIR/../../tmp/expansions.yaml"


### PR DESCRIPTION
There is no git 2.x on the s390x hosts. Lerna needs git 2.x.
Consequentially, we build it before running our tasks.