### PR TITLE
fix(cli-repl): prevent failures in macOS certificate selector MONGOSH-762

### DIFF
--- a/packages/cli-repl/package-lock.json
+++ b/packages/cli-repl/package-lock.json
@@ -786,9 +786,9 @@
 			}
 		},
 		"macos-export-certificate-and-key": {
-			"version": "1.0.0",
-			"resolved": "https://registry.npmjs.org/macos-export-certificate-and-key/-/macos-export-certificate-and-key-1.0.0.tgz",
-			"integrity": "sha512-DUzj2vwFYYOhN5LzHGb0GVfwBjvl2IcXr1tWs7OXSQhdp0klh8muZIVfEARBkWJm4qYszG+JGtZ9jiqZ7+jbOA==",
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/macos-export-certificate-and-key/-/macos-export-certificate-and-key-1.0.1.tgz",
+			"integrity": "sha512-AMVBDbOI3lTUU5zrKiJGDo0yisdk8Uqbfnuh/TKmEYyYFUFb34uT2eE+CmpJtLFPV6yFXxkiUSBghWOVBrUxZg==",
 			"optional": true,
 			"requires": {
 				"bindings": "^1.5.0",

--- a/packages/cli-repl/package.json
+++ b/packages/cli-repl/package.json
@@ -82,7 +82,7 @@
     "moment": "^2.29.1"
   },
   "optionalDependencies": {
-    "macos-export-certificate-and-key": "^1.0.0",
+    "macos-export-certificate-and-key": "^1.0.1",
     "win-export-certificate-and-key": "^1.0.2"
   }
 }

--- a/packages/cli-repl/src/arg-mapper.spec.ts
+++ b/packages/cli-repl/src/arg-mapper.spec.ts
@@ -263,7 +263,7 @@ describe('arg-mapper.mapCliToDriver', () => {
 
 describe('arg-mapper.applyTlsCertificateSelector', () => {
   context('with fake ca provider', () => {
-    let exportCertificateAndPrivateKey;
+    let exportCertificateAndPrivateKey: sinon.SinonStub;
     beforeEach(() => {
       process.env.TEST_OS_EXPORT_CERTIFICATE_AND_KEY_PATH =
         path.resolve(__dirname, '..', 'test', 'fixtures', 'fake-os-ca-provider.js');


### PR DESCRIPTION
This brings in https://github.com/mongodb-js/macos-export-certificate-and-key/releases/tag/v1.0.1 which contains a fix to prevent crashes when we cannot get a valid subject name from a certificate.