### PR TITLE
feat(cli-repl): include API version in greeting message

### DIFF
--- a/packages/cli-repl/src/mongosh-repl.ts
+++ b/packages/cli-repl/src/mongosh-repl.ts
@@ -129,7 +129,11 @@ class MongoshNodeRepl implements EvaluationListener {
     internalState.setEvaluationListener(this);
     await internalState.fetchConnectionInfo();
 
-    const mongodVersion = internalState.connectionInfo.buildInfo?.version;
+    let mongodVersion = internalState.connectionInfo.buildInfo?.version;
+    const apiVersion = serviceProvider.getRawClient()?.serverApi?.version;
+    if (apiVersion) {
+      mongodVersion = (mongodVersion ? mongodVersion + ' ' : '') + `(API Version ${apiVersion})`;
+    }
     await this.greet(mongodVersion);
     await this.printStartupLog(internalState);
 

--- a/packages/cli-repl/test/e2e.spec.ts
+++ b/packages/cli-repl/test/e2e.spec.ts
@@ -906,6 +906,22 @@ describe('e2e', function() {
           `${await testServer.connectionString()}/${dbName}`, '--apiVersion', '1'
         ] });
         await shell.waitForPrompt();
+        shell.assertContainsOutput('(API Version 1)');
+        expect(await shell.executeLine('db.coll.find().toArray()'))
+          .to.include('[]');
+        shell.assertNoErrors();
+      });
+
+      it('can specify an API version and strict mode', async function() {
+        // Disable this until https://jira.mongodb.org/browse/NODE-3183
+        // is done because the server has started requiring hello instead of
+        // isMaster.
+        return this.skip();
+        const shell = TestShell.start({ args: [
+          `${await testServer.connectionString()}/${dbName}`, '--apiVersion', '1', '--apiStrict', '--apiDeprecationErrors'
+        ] });
+        await shell.waitForPrompt();
+        shell.assertContainsOutput('(API Version 1)');
         expect(await shell.executeLine('db.coll.find().toArray()'))
           .to.include('[]');
         shell.assertNoErrors();


### PR DESCRIPTION
This is mostly so that when `--apiStrict` is used, we’ll show
the API version instead of just `Using MongoDB: undefined`
(which fits, because in that case the API version effectively
fills the role the server version currently has).