### PR TITLE
fix(cli-repl): stop mongocryptd search once successful MONGOSH-775

### DIFF
--- a/packages/cli-repl/src/mongocryptd-manager.ts
+++ b/packages/cli-repl/src/mongocryptd-manager.ts
@@ -168,6 +168,7 @@ export class MongocryptdManager {
 
       // No UNIX socket means we're on Windows, where we have to use networking.
       uri = !socket ? `mongodb://localhost:${port}` : `mongodb://${encodeURIComponent(socket)}`;
+      break;
     }
     if (!proc || !uri) {
       throw lastError ?? new MongoshInternalError('Could not successfully spawn mongocryptd');


### PR DESCRIPTION
We should not keep searching the mongocryptd search path once we have
spawned a functional mongocryptd process.