### PR TITLE
feat(cli-repl): add inspectCompact option MONGOSH-684

### DIFF
--- a/packages/cli-repl/src/cli-repl.spec.ts
+++ b/packages/cli-repl/src/cli-repl.spec.ts
@@ -158,7 +158,7 @@ describe('CliRepl', () => {
 
       it('returns the list of available config options when asked to', () => {
         expect(cliRepl.listConfigOptions()).to.deep.equal([
-          'batchSize', 'enableTelemetry', 'inspectDepth', 'historyLength', 'showStackTraces'
+          'batchSize', 'enableTelemetry', 'inspectCompact', 'inspectDepth', 'historyLength', 'showStackTraces'
         ]);
       });
 

--- a/packages/cli-repl/src/format-output.ts
+++ b/packages/cli-repl/src/format-output.ts
@@ -15,6 +15,7 @@ type EvaluationResult = {
 
 type FormatOptions = {
   colors: boolean;
+  compact?: boolean | number;
   depth?: number;
   maxArrayLength?: number;
   maxStringLength?: number;
@@ -201,7 +202,8 @@ function inspect(output: any, options: FormatOptions): any {
       colors: options.colors ?? true,
       depth: options.depth ?? 6,
       maxArrayLength: options.maxArrayLength,
-      maxStringLength: options.maxStringLength
+      maxStringLength: options.maxStringLength,
+      compact: options.compact
     }));
   } finally {
     delete (Date.prototype as any)[util.inspect.custom];

--- a/packages/cli-repl/src/mongosh-repl.spec.ts
+++ b/packages/cli-repl/src/mongosh-repl.spec.ts
@@ -520,6 +520,17 @@ describe('MongoshNodeRepl', () => {
     });
 
     context('with modified config values', () => {
+      it('controls inspect compact option', async() => {
+        input.write('config.set("inspectCompact", false)\n');
+        await waitEval(bus);
+        expect(output).to.include('Setting "inspectCompact" has been changed');
+
+        output = '';
+        input.write('({a:{b:{}}})\n');
+        await waitEval(bus);
+        expect(stripAnsi(output)).to.include('{\n  a: {\n    b: {}\n  }\n}\n');
+      });
+
       it('controls inspect depth', async() => {
         input.write('config.set("inspectDepth", 2)\n');
         await waitEval(bus);

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -142,17 +142,24 @@ export class ShellUserConfigValidator {
 export class CliUserConfig extends ShellUserConfig {
   userId = '';
   disableGreetingMessage = false;
+  inspectCompact: number | boolean = 3;
   inspectDepth = 6;
   historyLength = 1000;
   showStackTraces = false;
 }
 
 export class CliUserConfigValidator extends ShellUserConfigValidator {
+  // eslint-disable-next-line complexity
   static async validate<K extends keyof CliUserConfig>(key: K, value: CliUserConfig[K]): Promise<string | null> {
     switch (key) {
       case 'userId':
       case 'disableGreetingMessage':
         return null; // Not modifiable by the user anyway.
+      case 'inspectCompact':
+        if (typeof value !== 'boolean' && (typeof value !== 'number' || value < 0)) {
+          return `${key} must be a boolean or a positive integer`;
+        }
+        return null;
       case 'inspectDepth':
       case 'historyLength':
         if (typeof value !== 'number' || value < 0) {


### PR DESCRIPTION
Some people prefer to have a very verbose, single-line-per-property
output. Node.js supports that, so we add a config options for those
who want it.