### PR TITLE
fix(errors): direct link to JIRA project

### DIFF
--- a/packages/errors/README.md
+++ b/packages/errors/README.md
@@ -86,7 +86,7 @@ __args:__
 
 `e.message` will be appended with the following information:
 ```
-This is an error inside Mongosh. Please file a bug report for the MONGOSH project here: https://jira.mongodb.org.
+This is an error inside mongosh. Please file a bug report for the MONGOSH project here: https://jira.mongodb.org/projects/MONGOSH/issues.
 ```
 
 _Note: The error code will automatically be set to `CommonErrors.UnexpectedInternalError`._

--- a/packages/errors/index.spec.ts
+++ b/packages/errors/index.spec.ts
@@ -26,7 +26,7 @@ describe('errors', () => {
     const error = new MongoshInternalError('Something went wrong.');
     expect(error).to.be.instanceOf(MongoshBaseError);
     expect(error.name).to.be.equal('MongoshInternalError');
-    expect(error.message).to.be.equal('[COMMON-90001] Something went wrong.\nThis is an error inside Mongosh. Please file a bug report for the MONGOSH project here: https://jira.mongodb.org.');
+    expect(error.message).to.be.equal('[COMMON-90001] Something went wrong.\nThis is an error inside mongosh. Please file a bug report for the MONGOSH project here: https://jira.mongodb.org/projects/MONGOSH/issues.');
     expect(error.code).to.be.equal(CommonErrors.UnexpectedInternalError);
     expect(error.scope).to.be.equal('COMMON');
   });

--- a/packages/errors/index.ts
+++ b/packages/errors/index.ts
@@ -33,7 +33,7 @@ class MongoshInternalError extends MongoshBaseError {
     super(
       'MongoshInternalError',
       `${message}
-This is an error inside Mongosh. Please file a bug report for the MONGOSH project here: https://jira.mongodb.org.`,
+This is an error inside mongosh. Please file a bug report for the MONGOSH project here: https://jira.mongodb.org/projects/MONGOSH/issues.`,
       CommonErrors.UnexpectedInternalError,
       metadata
     );


### PR DESCRIPTION
If someone decides to create a bug when they find something
broken, we should point them directly to the JIRA project rather
than letting them figure out how to get to it.