### PR TITLE
fix(shell-api): allow ShellApi methods to be called with new MONGOSH-786

### DIFF
--- a/packages/shell-api/src/shell-api.spec.ts
+++ b/packages/shell-api/src/shell-api.spec.ts
@@ -484,6 +484,11 @@ describe('ShellApi', () => {
         expect((await toShellResult(m)).type).to.equal('Mongo');
         expect(m._uri).to.equal('mongodb://127.0.0.1:27017/?directConnection=true&serverSelectionTimeoutMS=2000');
       });
+      it('returns a new Mongo object with new', async() => {
+        const m = await new internalState.context.Mongo('mongodb://127.0.0.1:27017');
+        expect((await toShellResult(m)).type).to.equal('Mongo');
+        expect(m._uri).to.equal('mongodb://127.0.0.1:27017/?directConnection=true&serverSelectionTimeoutMS=2000');
+      });
       it('fails for non-CLI', async() => {
         serviceProvider.platform = ReplPlatform.Browser;
         try {

--- a/packages/shell-api/src/shell-internal-state.ts
+++ b/packages/shell-api/src/shell-internal-state.ts
@@ -181,14 +181,15 @@ export default class ShellInternalState {
     this.context = contextObject;
     Object.assign(contextObject, this.shellApi);
     for (const name of Object.getOwnPropertyNames(ShellApi.prototype)) {
+      const { shellApi } = this;
       if (toIgnore.concat(['help']).includes(name) ||
-        typeof (this.shellApi as any)[name] !== 'function') {
+        typeof (shellApi as any)[name] !== 'function') {
         continue;
       }
-      contextObject[name] = (...args: any[]): any => {
-        return (this.shellApi as any)[name](...args);
+      contextObject[name] = function(...args: any[]): any {
+        return (shellApi as any)[name](...args);
       };
-      contextObject[name].help = (this.shellApi as any)[name].help;
+      contextObject[name].help = (shellApi as any)[name].help;
     }
     contextObject.help = this.shellApi.help;
     Object.assign(contextObject, this.shellBson);


### PR DESCRIPTION
Use plain functions instead of arrow functions so that they can be used
with new as well.