### PR TITLE
feat(shell-api): add reshard collection helpers MONGOSH-754

### DIFF
--- a/packages/i18n/src/locales/en_US.ts
+++ b/packages/i18n/src/locales/en_US.ts
@@ -1474,7 +1474,22 @@ const translations: Catalog = {
             shardCollection: {
               link: 'https://docs.mongodb.com/manual/reference/method/sh.shardCollection',
               description: 'Enables sharding for a collection. Uses the shardCollection command',
-              example: 'sh.shardCollection(namesapce, key, unique?, options?)',
+              example: 'sh.shardCollection(namespace, key, unique?, options?)',
+            },
+            reshardCollection: {
+              link: 'https://docs.mongodb.com/manual/reference/method/sh.reshardCollection',
+              description: 'Enables sharding for a collection. Uses the reshardCollection command',
+              example: 'sh.reshardCollection(namespace, key, unique?, options?)',
+            },
+            commitReshardCollection: {
+              link: 'https://docs.mongodb.com/manual/reference/method/sh.commitReshardCollection',
+              description: 'Commits the current reshardCollection on a given collection',
+              example: 'sh.commitReshardCollection(namespace)',
+            },
+            abortReshardCollection: {
+              link: 'https://docs.mongodb.com/manual/reference/method/sh.abortReshardCollection',
+              description: 'Abort the current reshardCollection on a given collection',
+              example: 'sh.abortReshardCollection(namespace)',
             },
             status: {
               link: 'https://docs.mongodb.com/manual/reference/method/sh.status',

--- a/packages/shell-api/src/shard.spec.ts
+++ b/packages/shell-api/src/shard.spec.ts
@@ -155,6 +155,98 @@ describe('Shard', () => {
         expect(catchedError).to.equal(expectedError);
       });
     });
+    describe('reshardCollection', () => {
+      it('calls serviceProvider.runCommandWithCheck without optional args', async() => {
+        await shard.reshardCollection('db.coll', { key: 1 } );
+        expect(serviceProvider.runCommandWithCheck).to.have.been.calledWith(
+          ADMIN_DB,
+          {
+            reshardCollection: 'db.coll',
+            key: { key: 1 }
+          }
+        );
+      });
+
+      it('calls serviceProvider.runCommandWithCheck with optional args', async() => {
+        await shard.reshardCollection('db.coll', { key: 1 }, true, { option1: 1 });
+        expect(serviceProvider.runCommandWithCheck).to.have.been.calledWith(
+          ADMIN_DB,
+          {
+            reshardCollection: 'db.coll',
+            key: { key: 1 },
+            unique: true,
+            option1: 1
+          }
+        );
+      });
+
+      it('returns whatever serviceProvider.runCommandWithCheck returns', async() => {
+        const expectedResult = { ok: 1 };
+        serviceProvider.runCommandWithCheck.resolves(expectedResult);
+        const result = await shard.reshardCollection('db.coll', { key: 1 });
+        expect(result).to.deep.equal(expectedResult);
+      });
+
+      it('throws if serviceProvider.runCommandWithCheck rejects', async() => {
+        const expectedError = new Error();
+        serviceProvider.runCommandWithCheck.rejects(expectedError);
+        const catchedError = await shard.reshardCollection('db.coll', { key: 1 })
+          .catch(e => e);
+        expect(catchedError).to.equal(expectedError);
+      });
+    });
+    describe('commitReshardCollection', () => {
+      it('calls serviceProvider.runCommandWithCheck', async() => {
+        await shard.commitReshardCollection('db.coll');
+        expect(serviceProvider.runCommandWithCheck).to.have.been.calledWith(
+          ADMIN_DB,
+          {
+            commitReshardCollection: 'db.coll'
+          }
+        );
+      });
+
+      it('returns whatever serviceProvider.runCommandWithCheck returns', async() => {
+        const expectedResult = { ok: 1 };
+        serviceProvider.runCommandWithCheck.resolves(expectedResult);
+        const result = await shard.commitReshardCollection('db.coll');
+        expect(result).to.deep.equal(expectedResult);
+      });
+
+      it('throws if serviceProvider.runCommandWithCheck rejects', async() => {
+        const expectedError = new Error();
+        serviceProvider.runCommandWithCheck.rejects(expectedError);
+        const catchedError = await shard.commitReshardCollection('db.coll')
+          .catch(e => e);
+        expect(catchedError).to.equal(expectedError);
+      });
+    });
+    describe('abortReshardCollection', () => {
+      it('calls serviceProvider.runCommandWithCheck', async() => {
+        await shard.abortReshardCollection('db.coll');
+        expect(serviceProvider.runCommandWithCheck).to.have.been.calledWith(
+          ADMIN_DB,
+          {
+            abortReshardCollection: 'db.coll'
+          }
+        );
+      });
+
+      it('returns whatever serviceProvider.runCommandWithCheck returns', async() => {
+        const expectedResult = { ok: 1 };
+        serviceProvider.runCommandWithCheck.resolves(expectedResult);
+        const result = await shard.abortReshardCollection('db.coll');
+        expect(result).to.deep.equal(expectedResult);
+      });
+
+      it('throws if serviceProvider.runCommandWithCheck rejects', async() => {
+        const expectedError = new Error();
+        serviceProvider.runCommandWithCheck.rejects(expectedError);
+        const catchedError = await shard.abortReshardCollection('db.coll')
+          .catch(e => e);
+        expect(catchedError).to.equal(expectedError);
+      });
+    });
     describe('addShard', () => {
       it('calls serviceProvider.runCommandWithCheck with arg', async() => {
         serviceProvider.runCommandWithCheck.resolves({ ok: 1, msg: 'isdbgrid' });


### PR DESCRIPTION
Integration tests are omitted, because it seems like they would
take a fairly long time (see the conversation in the ticket).