### PR TITLE
fix(service-provider-core): allow non-hostname chars in DB name MONGOSH-792

### DIFF
--- a/packages/cli-repl/test/e2e-direct.spec.ts
+++ b/packages/cli-repl/test/e2e-direct.spec.ts
@@ -185,7 +185,7 @@ describe('e2e direct connection', () => {
         });
         it('when specifying multiple seeds through --host with a wrong replsetid', async() => {
           const hostlist = 'wrongreplset/' + await rs2.hostport() + ',' + await rs1.hostport() + ',' + await rs0.hostport();
-          const shell = TestShell.start({ args: ['--host', hostlist, 'admin?serverSelectionTimeoutMS=2000'] });
+          const shell = TestShell.start({ args: ['--host', hostlist, 'admin'] });
           await shell.waitForExit();
           shell.assertContainsOutput('MongoServerSelectionError');
         });


### PR DESCRIPTION
This also means that e.g. `host:port?option=value` is not allowed,
and instead any optional part after the port in the non-URL variant
needs to be separated by a slash (which was also the case in
the legacy shell).