### PR TITLE
chore(cli-repl): wait longer in ENOTFOUND fail-fast test

### DIFF
--- a/packages/cli-repl/test/e2e.spec.ts
+++ b/packages/cli-repl/test/e2e.spec.ts
@@ -950,8 +950,8 @@ describe('e2e', function() {
       const shell = TestShell.start({ args: [
         'mongodb://' + 'verymuchnonexistentdomainname'.repeat(10) + '.mongodb.net/'
       ] });
-      const result = await shell.waitForPromptOrExit();
-      expect(result).to.deep.equal({ state: 'exit', exitCode: 1 });
+      const exitCode = await shell.waitForExit();
+      expect(exitCode).to.equal(1);
     });
 
     it('fails fast for ECONNREFUSED errors', async() => {


### PR DESCRIPTION
(Because waiting for the prompt has a timeout of 10s, waiting for exit has a timeout of 60ms. This has been flaky on Windows.)