### PR TITLE
fix(cli-repl): fix query operator completion MONGOSH-793

### DIFF
--- a/packages/cli-repl/src/cli-repl.spec.ts
+++ b/packages/cli-repl/src/cli-repl.spec.ts
@@ -1177,6 +1177,13 @@ describe('CliRepl', () => {
         await waitCompletion(cliRepl.bus);
         expect(output).to.include('use admin');
       });
+
+      it('completes query operators', async() => {
+        input.write('db.movies.find({year: {$g');
+        await tabtab();
+        await waitCompletion(cliRepl.bus);
+        expect(output).to.include('db.movies.find({year: {$gte');
+      });
     });
   }
 });


### PR DESCRIPTION
My previous fix for REPL command completion in 720728d721e was wrong,
this fixes the integraion of the Node.js and mongosh autocompleters
properly.