### PR TITLE
feat(cli-repl): only store non-default config keys on disk MONGOSH-794

### DIFF
--- a/packages/cli-repl/src/cli-repl.spec.ts
+++ b/packages/cli-repl/src/cli-repl.spec.ts
@@ -111,6 +111,29 @@ describe('CliRepl', () => {
         expect(JSON.parse(content).enableTelemetry).to.be.false;
       });
 
+      it('does not store config options on disk that have not been changed', async() => {
+        let content = await fs.readFile(path.join(tmpdir.path, 'config'), { encoding: 'utf8' });
+        expect(Object.keys(JSON.parse(content))).to.deep.equal([
+          'userId', 'enableTelemetry', 'disableGreetingMessage'
+        ]);
+
+        input.write('config.set("inspectDepth", config.get("inspectDepth"))\n');
+
+        await waitEval(cliRepl.bus);
+        content = await fs.readFile(path.join(tmpdir.path, 'config'), { encoding: 'utf8' });
+        expect(Object.keys(JSON.parse(content))).to.deep.equal([
+          'userId', 'enableTelemetry', 'disableGreetingMessage', 'inspectDepth'
+        ]);
+
+        // When a new REPL is created:
+        cliRepl = new CliRepl(cliReplOptions);
+        await cliRepl.start('', {});
+        content = await fs.readFile(path.join(tmpdir.path, 'config'), { encoding: 'utf8' });
+        expect(Object.keys(JSON.parse(content))).to.deep.equal([
+          'userId', 'enableTelemetry', 'disableGreetingMessage', 'inspectDepth'
+        ]);
+      });
+
       it('emits exit when asked to, Node.js-style', async() => {
         input.write('.exit\n');
         await exitPromise;


### PR DESCRIPTION
For context, the original motivation here was that for snippets,
if we change the default index URL, users should receive that change
if  they have not explicitly changed the config themselves.