### PR TITLE
feat(cli-repl): add redactHistory config option MONGOSH-603

### DIFF
--- a/packages/cli-repl/src/arg-parser.ts
+++ b/packages/cli-repl/src/arg-parser.ts
@@ -55,7 +55,6 @@ const OPTIONS = {
     'nodb',
     'norc',
     'quiet',
-    'redactInfo',
     'retryWrites',
     'shell',
     'smokeTests',

--- a/packages/cli-repl/src/cli-repl.spec.ts
+++ b/packages/cli-repl/src/cli-repl.spec.ts
@@ -181,7 +181,7 @@ describe('CliRepl', () => {
 
       it('returns the list of available config options when asked to', () => {
         expect(cliRepl.listConfigOptions()).to.deep.equal([
-          'batchSize', 'enableTelemetry', 'inspectCompact', 'inspectDepth', 'historyLength', 'showStackTraces'
+          'batchSize', 'enableTelemetry', 'inspectCompact', 'inspectDepth', 'historyLength', 'showStackTraces', 'redactHistory'
         ]);
       });
 

--- a/packages/service-provider-core/src/cli-options.ts
+++ b/packages/service-provider-core/src/cli-options.ts
@@ -30,7 +30,6 @@ export default interface CliOptions {
   password?: string;
   port?: string;
   quiet?: boolean;
-  redactInfo?: boolean;
   retryWrites?: boolean;
   shell?: boolean;
   tls?: boolean;

--- a/packages/types/src/index.spec.ts
+++ b/packages/types/src/index.spec.ts
@@ -20,6 +20,12 @@ describe('config validation', () => {
     expect(await validate('showStackTraces', -1)).to.equal('showStackTraces must be a boolean');
     expect(await validate('showStackTraces', false)).to.equal(null);
     expect(await validate('showStackTraces', true)).to.equal(null);
+    expect(await validate('redactHistory', 'foo')).to.equal("redactHistory must be one of 'keep', 'remove', or 'remove-redact'");
+    expect(await validate('redactHistory', -1)).to.equal("redactHistory must be one of 'keep', 'remove', or 'remove-redact'");
+    expect(await validate('redactHistory', false)).to.equal("redactHistory must be one of 'keep', 'remove', or 'remove-redact'");
+    expect(await validate('redactHistory', 'keep')).to.equal(null);
+    expect(await validate('redactHistory', 'remove')).to.equal(null);
+    expect(await validate('redactHistory', 'remove-redact')).to.equal(null);
     expect(await validate('batchSize', 'foo')).to.equal('batchSize must be a positive integer');
     expect(await validate('batchSize', -1)).to.equal('batchSize must be a positive integer');
     expect(await validate('batchSize', 0)).to.equal('batchSize must be a positive integer');

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -242,6 +242,7 @@ export class CliUserConfig extends ShellUserConfig {
   inspectDepth = 6;
   historyLength = 1000;
   showStackTraces = false;
+  redactHistory: 'keep' | 'remove' | 'remove-redact' = 'remove';
 }
 
 export class CliUserConfigValidator extends ShellUserConfigValidator {
@@ -265,6 +266,11 @@ export class CliUserConfigValidator extends ShellUserConfigValidator {
       case 'showStackTraces':
         if (typeof value !== 'boolean') {
           return `${key} must be a boolean`;
+        }
+        return null;
+      case 'redactHistory':
+        if (value !== 'keep' && value !== 'remove' && value !== 'remove-redact') {
+          return `${key} must be one of 'keep', 'remove', or 'remove-redact'`;
         }
         return null;
       default:


### PR DESCRIPTION
Remove the undocumented, untested `--redactInfo` CLI flag and offer
a config option with three possible values:

- `keep`: Retain the history as-is
- `remove`: Remove lines with sensitive commands
- `remove-redact`: `remove` + redact sensitive data from non-sensitive
   commands (e.g. email addresses)