### PR TITLE
fix(shell-api): improve rs.reconfig helper for 5.0 changes MONGOSH-785

### DIFF
--- a/testing/integration-testing-hooks.ts
+++ b/testing/integration-testing-hooks.ts
@@ -461,9 +461,7 @@ export function startTestCluster(...argLists: string[][]): MongodSetup[] {
 }
 
 function skipIfVersion(test: any, testServerVersion: string, semverCondition: string): void {
-  // Strip -rc.0, -alpha, etc. from the server version because semver rejects those otherwise.
-  testServerVersion = testServerVersion.replace(/-.*$/, '');
-  if (semver.satisfies(testServerVersion, semverCondition)) {
+  if (semver.satisfies(testServerVersion, semverCondition, { includePrerelease: true })) {
     test.skip();
   }
 }


### PR DESCRIPTION
I'll adjust the tests so that the `reconfig` methods gets the full tests on backoff etc. that are currently on the `reconfigPSASet`.