### PR TITLE
fix(cli-repl): always autocomplete own enumerable properties MONGOSH-808

### DIFF
--- a/packages/cli-repl/src/cli-repl.spec.ts
+++ b/packages/cli-repl/src/cli-repl.spec.ts
@@ -1207,6 +1207,23 @@ describe('CliRepl', () => {
         await waitCompletion(cliRepl.bus);
         expect(output).to.include('db.movies.find({year: {$gte');
       });
+
+      it('completes properties of shell API result types', async() => {
+        if (!hasCollectionNames) return;
+        input.write('res = db.autocompleteTestColl.deleteMany({ deletetestdummykey: 1 })\n');
+        await waitEval(cliRepl.bus);
+
+        // Consitency check: The result actually has a shell API type tag:
+        output = '';
+        input.write('res[Symbol.for("@@mongosh.shellApiType")]\n');
+        await waitEval(cliRepl.bus);
+        expect(output).to.include('DeleteResult');
+
+        input.write('res.a');
+        await tabtab();
+        await waitCompletion(cliRepl.bus);
+        expect(output).to.include('res.acknowledged');
+      });
     });
   }
 });

--- a/packages/cli-repl/src/mongosh-repl.ts
+++ b/packages/cli-repl/src/mongosh-repl.ts
@@ -412,9 +412,15 @@ class MongoshNodeRepl implements EvaluationListener {
       // The Node.js auto completion needs to access the raw values in order
       // to be able to autocomplete their properties properly. One catch is
       // that we peform some filtering of mongosh methods depending on
-      // topology, server version, etc., so for those, we do not autocomplete
-      // at all and instead leave that to the @mongosh/autocomplete package.
-      return shellResult.type !== null ? null : shellResult.rawValue;
+      // topology, server version, etc., so for those, we only autocomplete
+      // own, enumerable, non-underscore-prefixed properties and instead leave
+      // the rest to the @mongosh/autocomplete package.
+      if (shellResult.type === null) {
+        return shellResult.rawValue;
+      }
+      return Object.fromEntries(
+        Object.entries(shellResult.rawValue)
+          .filter(([key]) => !key.startsWith('_')));
     } catch (err) {
       if (this.runtimeState().internalState.interrupted.isSet()) {
         this.bus.emit('mongosh:eval-interrupted');


### PR DESCRIPTION
This is also not the cleanest approach in the world, but aside from
a full refactor of the autocomplete implementation (which would be
coming in MONGOSH-538), this seems like a decent tradeoff between
implementation complexity and result accuracy.