### PR TITLE
fix(shell-api): use hello instead of isMaster for internal calls MONG…

### DIFF
--- a/packages/i18n/src/locales/en_US.ts
+++ b/packages/i18n/src/locales/en_US.ts
@@ -1420,6 +1420,11 @@ const translations: Catalog = {
               description: 'Calls isMaster',
               example: 'rs.isMaster()',
             },
+            hello: {
+              link: 'https://docs.mongodb.com/manual/reference/method/rs.hello',
+              description: 'Calls hello',
+              example: 'rs.hello()',
+            },
             printSecondaryReplicationInfo: {
               link: 'https://docs.mongodb.com/manual/reference/method/rs.printSecondaryReplicationInfo',
               description: 'Calls db.printSecondaryReplicationInfo',

--- a/packages/shell-api/src/database.ts
+++ b/packages/shell-api/src/database.ts
@@ -968,8 +968,8 @@ export default class Database extends ShellApiWithMongoClass {
   @returnsPromise
   async enableFreeMonitoring(): Promise<Document | string> {
     this._emitDatabaseApiCall('enableFreeMonitoring', {});
-    const isMaster = await this._mongo._serviceProvider.runCommand(this._name, { isMaster: 1 }, this._baseOptions);
-    if (!isMaster.ismaster) {
+    const helloResult = await this.hello();
+    if (!helloResult.isWritablePrimary) {
       throw new MongoshInvalidInputError(
         'db.enableFreeMonitoring() may only be run on a primary',
         CommonErrors.InvalidOperation
@@ -1312,10 +1312,10 @@ export default class Database extends ShellApiWithMongoClass {
     try {
       replInfo = await this.getReplicationInfo();
     } catch (error) {
-      const isMaster = await this._runCommand({ isMaster: 1 });
-      if (isMaster.arbiterOnly) {
+      const helloResult = await this.hello();
+      if (helloResult.arbiterOnly) {
         return new CommandResult('StatsResult', { message: 'cannot provide replication status from an arbiter' });
-      } else if (!isMaster.ismaster) {
+      } else if (!helloResult.isWritablePrimary) {
         const secondaryInfo = await this.printSecondaryReplicationInfo();
         return new CommandResult('StatsResult', {
           message: 'this is a secondary, printing secondary replication info.',

--- a/packages/shell-api/src/helpers.spec.ts
+++ b/packages/shell-api/src/helpers.spec.ts
@@ -96,7 +96,7 @@ describe('getPrintableShardStatus', () => {
 
     const origRunCommandWithCheck = serviceProvider.runCommandWithCheck;
     serviceProvider.runCommandWithCheck = async(db, cmd) => {
-      if (db === 'admin' && cmd.isMaster) {
+      if (cmd.hello) {
         return { ok: 1, msg: 'isdbgrid' };
       }
       if (db === 'admin' && cmd.balancerStatus) {

--- a/packages/shell-api/src/helpers.ts
+++ b/packages/shell-api/src/helpers.ts
@@ -487,8 +487,8 @@ export async function getPrintableShardStatus(db: Database, verbose: boolean): P
 }
 
 export async function getConfigDB(db: Database): Promise<Database> {
-  const isM = await db._runAdminCommand({ isMaster: 1 });
-  if (isM.msg !== 'isdbgrid') {
+  const helloResult = await db.hello();
+  if (helloResult.msg !== 'isdbgrid') {
     throw new MongoshInvalidInputError('Not connected to a mongos', ShellApiErrors.NotConnectedToMongos);
   }
   return db.getSiblingDB('config');

--- a/packages/shell-api/src/replica-set.spec.ts
+++ b/packages/shell-api/src/replica-set.spec.ts
@@ -355,6 +355,33 @@ describe('ReplicaSet', () => {
         expect(catchedError).to.equal(expectedError);
       });
     });
+    describe('hello', () => {
+      it('calls serviceProvider.runCommandWithCheck', async() => {
+        await rs.hello();
+
+        expect(serviceProvider.runCommandWithCheck).to.have.been.calledWith(
+          ADMIN_DB,
+          {
+            hello: 1
+          }
+        );
+      });
+
+      it('returns whatever serviceProvider.runCommandWithCheck returns', async() => {
+        const expectedResult = { ok: 1 };
+        serviceProvider.runCommandWithCheck.resolves(expectedResult);
+        const result = await rs.hello();
+        expect(result).to.deep.equal(expectedResult);
+      });
+
+      it('throws if serviceProvider.runCommandWithCheck rejects', async() => {
+        const expectedError = new Error();
+        serviceProvider.runCommandWithCheck.rejects(expectedError);
+        const catchedError = await rs.hello()
+          .catch(e => e);
+        expect(catchedError).to.equal(expectedError);
+      });
+    });
     describe('add', () => {
       it('calls serviceProvider.runCommandWithCheck with no arb and string hostport', async() => {
         const configDoc = { version: 1, members: [{ _id: 0 }, { _id: 1 }] };

--- a/packages/shell-api/src/replica-set.ts
+++ b/packages/shell-api/src/replica-set.ts
@@ -226,11 +226,13 @@ export default class ReplicaSet extends ShellApiWithMongoClass {
   @returnsPromise
   async isMaster(): Promise<Document> {
     this._emitReplicaSetApiCall('isMaster', {});
-    return this._database._runAdminCommand(
-      {
-        isMaster: 1,
-      }
-    );
+    return this._database.getSiblingDB('admin').isMaster();
+  }
+
+  @returnsPromise
+  async hello(): Promise<Document> {
+    this._emitReplicaSetApiCall('hello', {});
+    return this._database.getSiblingDB('admin').hello();
   }
 
   @returnsPromise

--- a/packages/shell-api/src/shard.spec.ts
+++ b/packages/shell-api/src/shard.spec.ts
@@ -1240,6 +1240,24 @@ describe('Shard', () => {
           Object.keys(result.value).includes('active mongoses') ||
           Object.keys(result.value).includes('most recently active mongoses')).to.be.true;
       });
+      context('with 5.0+ server', () => {
+        skipIfServerVersion(mongos, '<= 4.4');
+
+        it('returns the status when used with apiStrict', async() => {
+          await serviceProvider.close(true);
+          serviceProvider = await CliServiceProvider.connect(await mongos.connectionString(), {
+            serverApi: { version: '1', strict: true }
+          });
+          internalState = new ShellInternalState(serviceProvider);
+          sh = new Shard(internalState.currentDb);
+
+          const result = await sh.status();
+          expect(result.type).to.equal('StatsResult');
+          expect(Object.keys(result.value)).to.include.members([
+            'shardingVersion', 'shards', 'autosplit', 'balancer', 'databases'
+          ]);
+        });
+      });
     });
     describe('turn on sharding', () => {
       it('enableSharding for a db', async() => {

--- a/packages/shell-api/src/shard.spec.ts
+++ b/packages/shell-api/src/shard.spec.ts
@@ -1242,14 +1242,21 @@ describe('Shard', () => {
       });
       context('with 5.0+ server', () => {
         skipIfServerVersion(mongos, '<= 4.4');
+        let apiStrictServiceProvider;
 
-        it('returns the status when used with apiStrict', async() => {
-          await serviceProvider.close(true);
-          serviceProvider = await CliServiceProvider.connect(await mongos.connectionString(), {
+        before(async() => {
+          apiStrictServiceProvider = await CliServiceProvider.connect(await mongos.connectionString(), {
             serverApi: { version: '1', strict: true }
           });
-          internalState = new ShellInternalState(serviceProvider);
-          sh = new Shard(internalState.currentDb);
+        });
+
+        after(async() => {
+          await apiStrictServiceProvider.close(true);
+        });
+
+        it('returns the status when used with apiStrict', async() => {
+          const internalState = new ShellInternalState(apiStrictServiceProvider);
+          const sh = new Shard(internalState.currentDb);
 
           const result = await sh.status();
           expect(result.type).to.equal('StatsResult');


### PR DESCRIPTION
…OSH-816

Otherwise commands like `sh.status()` unnecessarily fail when run
under the versioned API.