### PR TITLE
fix(async-rewriter2): fix `delete` behavior MONGOSH-817

### DIFF
--- a/packages/async-rewriter2/src/async-writer-babel.spec.ts
+++ b/packages/async-rewriter2/src/async-writer-babel.spec.ts
@@ -370,8 +370,20 @@ describe('AsyncWriter', () => {
       expect(obj).to.deep.equal({});
     });
 
+    it('supports delete for implicitly awaited values (indexed)', async() => {
+      const obj = { foo: 'bar' };
+      implicitlyAsyncFn.resolves(obj);
+      expect(await runTranspiledCode('delete implicitlyAsyncFn()["foo"]')).to.equal(true);
+      expect(obj).to.deep.equal({});
+    });
+
     it('supports delete for plain values', async() => {
       expect(runTranspiledCode('const obj = { x: "x", y: "y" }; delete obj.x; obj'))
+        .to.deep.equal({ y: 'y' });
+    });
+
+    it('supports delete for plain values (idnexed)', async() => {
+      expect(runTranspiledCode('const obj = { x: "x", y: "y" }; delete obj["x"]; obj'))
         .to.deep.equal({ y: 'y' });
     });
 

--- a/packages/async-rewriter2/src/async-writer-babel.spec.ts
+++ b/packages/async-rewriter2/src/async-writer-babel.spec.ts
@@ -363,6 +363,18 @@ describe('AsyncWriter', () => {
       expect(await runTranspiledCode('typeof implicitlyAsyncValue')).to.equal('string');
     });
 
+    it('supports delete for implicitly awaited values', async() => {
+      const obj = { foo: 'bar' };
+      implicitlyAsyncFn.resolves(obj);
+      expect(await runTranspiledCode('delete implicitlyAsyncFn().foo')).to.equal(true);
+      expect(obj).to.deep.equal({});
+    });
+
+    it('supports delete for plain values', async() => {
+      expect(runTranspiledCode('const obj = { x: "x", y: "y" }; delete obj.x; obj'))
+        .to.deep.equal({ y: 'y' });
+    });
+
     context('invalid implicit awaits', () => {
       beforeEach(() => {
         runUntranspiledCode(asyncWriter.runtimeSupportCode());

--- a/packages/async-rewriter2/src/stages/transform-maybe-await.ts
+++ b/packages/async-rewriter2/src/stages/transform-maybe-await.ts
@@ -429,6 +429,8 @@ export default ({ types: t }: { types: typeof BabelTypes }): babel.PluginObj<{ f
           if (path.parentPath.isForXStatement() && path.key === 'left') return;
           // ++ and -- count as assignments for our purposes.
           if (path.parentPath.isUpdateExpression()) return;
+          // So does `delete x.y`.
+          if (path.parentPath.isUnaryExpression() && path.parentPath.node.operator === 'delete') return;
 
           // There are a few types of expressions that we can skip.
           // We use this opt-out-list approach so that we don't miss any important


### PR DESCRIPTION
I did check the babel AST definitions for `LValue`s, so that we can
skip transformation for them, but it turns out `delete x.y` is actually
a UnaryExpression and doesn’t even need an `LValue` argument,
which is how this was missed.