### PR TITLE
chore(cli-repl): fix flaky show collections test

### DIFF
--- a/packages/cli-repl/test/e2e.spec.ts
+++ b/packages/cli-repl/test/e2e.spec.ts
@@ -953,6 +953,8 @@ describe('e2e', function() {
 
     beforeEach(async() => {
       shell = TestShell.start({ args: [ await testServer.connectionString() ] });
+      await shell.waitForPrompt();
+      shell.assertNoErrors();
     });
 
     it('prints collections with their types', async() => {


### PR DESCRIPTION
This should fix

    [2021/06/08 14:26:20.478]   1 failing
    [2021/06/08 14:26:20.478]   1) e2e
    [2021/06/08 14:26:20.478]        collection names with types
    [2021/06/08 14:26:20.478]          prints collections with their types:
    [2021/06/08 14:26:20.478]      AssertionError: expected '{\n  acknowledged: true,\n  insertedId: ObjectId("60bf7e0b80872cc7f0cde639")\n}\nEnterprise > ' to include 'coll1'
    [2021/06/08 14:26:20.478]       at Context.<anonymous> (test/e2e.spec.ts:963:62)

and aligns the test here with the other sections, where we also
wait for the prompt to show up first.