### PR TITLE
fix: add --tlsCRLFile option to help

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ variable. For detailed instructions for each of our supported platforms, please 
         --tlsAllowInvalidHostnames             Allow connections to servers with non-matching hostnames
         --tlsAllowInvalidCertificates          Allow connections to servers with invalid certificates
         --tlsCertificateSelector [arg]         TLS Certificate in system store (Windows and macOS only)
+        --tlsCRLFile [arg]                     Specifies the .pem file that contains the Certificate Revocation List
         --tlsDisabledProtocols [arg]           Comma separated list of TLS protocols to disable [TLS1_0,TLS1_1,TLS1_2]
 
   API version options:

--- a/packages/cli-repl/src/constants.ts
+++ b/packages/cli-repl/src/constants.ts
@@ -48,6 +48,7 @@ export const USAGE = `
         --tlsAllowInvalidHostnames             ${i18n.__('cli-repl.args.tlsAllowInvalidHostnames')}
         --tlsAllowInvalidCertificates          ${i18n.__('cli-repl.args.tlsAllowInvalidCertificates')}
         --tlsCertificateSelector [arg]         ${i18n.__('cli-repl.args.tlsCertificateSelector')}
+        --tlsCRLFile [arg]                     ${i18n.__('cli-repl.args.tlsCRLFile')}
         --tlsDisabledProtocols [arg]           ${i18n.__('cli-repl.args.tlsDisabledProtocols')}
 
   ${clr(i18n.__('cli-repl.args.apiVersionOptions'), ['bold', 'yellow'])}

--- a/packages/i18n/src/locales/en_US.ts
+++ b/packages/i18n/src/locales/en_US.ts
@@ -40,6 +40,7 @@ const translations: Catalog = {
       tlsAllowInvalidHostnames: 'Allow connections to servers with non-matching hostnames',
       tlsAllowInvalidCertificates: 'Allow connections to servers with invalid certificates',
       tlsCertificateSelector: 'TLS Certificate in system store (Windows and macOS only)',
+      tlsCRLFile: 'Specifies the .pem file that contains the Certificate Revocation List',
       tlsDisabledProtocols: 'Comma separated list of TLS protocols to disable [TLS1_0,TLS1_1,TLS1_2]',
       apiVersionOptions: 'API version options:',
       apiVersion: 'Specifies the API version to connect with',


### PR DESCRIPTION
The `--tlsCRLFile` option was missing in the output of `mongosh --help`. Now it's not anymore.

![image](https://user-images.githubusercontent.com/761042/121309967-1d625300-c903-11eb-90a1-140b44f22d08.png)
