### PR TITLE
chore: add apiStrict-only test to CI MONGOSH-756

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -9,6 +9,7 @@ exec_timeout_secs: 3600
 #   test - Runs all tests.
 #   test_vscode - Clones the vscode extension repository and runs its tests.
 #   test_connectivity - Runs extra connectivity tests.
+#   test_apistrict - Runs shell API and CLI tests with --apiStrict --apiDeprecationErrors.
 #   compile_artifact - Compile the release binary.
 #   package_and_upload_artifact - Upload the release binary to S3.
 #   test_linux_artifact - Test that the built artifact works where we expect it to.
@@ -109,6 +110,22 @@ functions:
           source .evergreen/.setup_env
           npm --unsafe-perm=true run bootstrap-ci
           npm run test-connectivity
+          }
+  test_apistrict:
+    - command: expansions.write
+      params:
+        file: tmp/expansions.yaml
+        redacted: true
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          {
+          export NODE_JS_VERSION=${node_js_version}
+          source .evergreen/.setup_env
+          npm run test-apistrict-ci
           }
 
   ###
@@ -379,6 +396,7 @@ functions:
 #   test_{version} - Runs all tests, against a specified mongod version.
 #   test_vscode - Run the vscode extension integration tests.
 #   test_connectivity - Runs extra connectivity tests.
+#   test_apistrict - Runs shell API and CLI tests with --apiStrict --apiDeprecationErrors.
 #   compile_artifact - Compile the release binary.
 #   package_and_upload_artifact - Upload the release binary to S3.
 #   test_linux_artifact - Test that the built artifact works where we expect it to.
@@ -628,6 +646,18 @@ tasks:
         vars:
           node_js_version: "14.17.0"
       - func: test_connectivity
+  - name: test_apistrict
+    tags: ["extra-integration-test"]
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "14.17.0"
+      - func: test_apistrict
+        vars:
+          node_js_version: "14.17.0"
+          mongosh_server_test_version: "latest-alpha"
+          mongosh_test_force_api_strict: "1"
   - name: compile_artifact
     commands:
       - func: checkout
@@ -1391,6 +1421,7 @@ buildvariants:
       - name: test_mlatest_n14
       - name: test_vscode
       - name: test_connectivity
+      - name: test_apistrict
       - name: package_and_upload_artifact_linux_x64
       - name: package_and_upload_artifact_debian_x64
       - name: package_and_upload_artifact_rhel_x64

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "test-ci-nocoverage": "lerna exec -- npm run test-ci",
     "test-e2e": "lerna run --stream test-e2e",
     "test-e2e-ci": "lerna run --stream test-e2e-ci",
+    "test-apistrict-ci": "lerna run --stream test-apistrict-ci",
     "test-connectivity": "lerna run --stream test-connectivity",
     "test-nodedriver": "node scripts/replace-package.js && npm run bootstrap -- --no-ci && npm run compile-ts && npm run test-ci-nocoverage",
     "compile-ts": "lerna run compile-ts",

--- a/packages/cli-repl/package.json
+++ b/packages/cli-repl/package.json
@@ -23,6 +23,7 @@
     "pretest": "npm run compile-ts",
     "test": "cross-env TS_NODE_PROJECT=../../config/tsconfig.test.json mocha -r \"../../scripts/import-expansions.js\" --timeout 60000 --colors -r ts-node/register \"./{src,test}/**/*.spec.ts\"",
     "test-ci": "cross-env TS_NODE_PROJECT=../../config/tsconfig.test.json mocha -r \"../../scripts/import-expansions.js\" --timeout 60000 -r ts-node/register \"./{src,test}/**/*.spec.ts\"",
+    "test-apistrict-ci": "cross-env MONGOSH_TEST_FORCE_API_STRICT=1 npm run test-ci",
     "pretest-e2e": "npm run compile-ts",
     "test-e2e": "cross-env TS_NODE_PROJECT=../../config/tsconfig.test.json mocha -r \"../../scripts/import-expansions.js\" --timeout 15000 --colors -r ts-node/register \"./test/e2e*.spec.ts\"",
     "test-e2e-ci": "cross-env TS_NODE_PROJECT=../../config/tsconfig.test.json mocha -r \"../../scripts/import-expansions.js\" --timeout 15000 --colors -r ts-node/register \"./test/e2e*.spec.ts\"",

--- a/packages/cli-repl/src/cli-repl.spec.ts
+++ b/packages/cli-repl/src/cli-repl.spec.ts
@@ -954,7 +954,10 @@ describe('CliRepl', () => {
       context('for server >= 4.1', () => {
         skipIfServerVersion(testServer, '< 4.1');
 
-        it('terminates operations on the server side', async() => {
+        it('terminates operations on the server side', async function() {
+          if (process.env.MONGOSH_TEST_FORCE_API_STRICT) {
+            return this.skip(); // $currentOp is unversioned
+          }
           input.write('db.ctrlc.find({ $where: \'while(true) { /* loop1 */ }\' })\n');
           await delay(100);
           process.kill(process.pid, 'SIGINT');
@@ -1124,7 +1127,10 @@ describe('CliRepl', () => {
         expect(output).not.to.include('listCollections requires authentication');
       });
 
-      it(`${wantWatch ? 'completes' : 'does not complete'} the watch method`, async() => {
+      it(`${wantWatch ? 'completes' : 'does not complete'} the watch method`, async function() {
+        if (process.env.MONGOSH_TEST_FORCE_API_STRICT) {
+          return this.skip();
+        }
         output = '';
         input.write('db.wat');
         await tabtab();
@@ -1136,7 +1142,10 @@ describe('CliRepl', () => {
         }
       });
 
-      it('completes the version method', async() => {
+      it('completes the version method', async function() {
+        if (process.env.MONGOSH_TEST_FORCE_API_STRICT) {
+          return this.skip();
+        }
         output = '';
         input.write('db.vers');
         await tabtab();
@@ -1144,7 +1153,10 @@ describe('CliRepl', () => {
         expect(output).to.include('db.version');
       });
 
-      it(`${wantShardDistribution ? 'completes' : 'does not complete'} the getShardDistribution method`, async() => {
+      it(`${wantShardDistribution ? 'completes' : 'does not complete'} the getShardDistribution method`, async function() {
+        if (process.env.MONGOSH_TEST_FORCE_API_STRICT) {
+          return this.skip();
+        }
         output = '';
         input.write('db.coll.getShardDis');
         await tabtab();

--- a/packages/cli-repl/test/e2e-analytics.spec.ts
+++ b/packages/cli-repl/test/e2e-analytics.spec.ts
@@ -3,7 +3,7 @@ import { startTestCluster } from '../../../testing/integration-testing-hooks';
 import { eventually } from '../../../testing/eventually';
 import { TestShell } from './test-shell';
 
-describe('e2e Analytics', () => {
+describe('e2e Analytics Node', () => {
   const replSetName = 'replicaSet';
   const [rs0, rs1, rs2, rs3] = startTestCluster(
     [ '--single', '--replSet', replSetName ],
@@ -14,7 +14,10 @@ describe('e2e Analytics', () => {
 
   after(TestShell.cleanup);
 
-  before(async() => {
+  before(async function() {
+    if (process.env.MONGOSH_TEST_FORCE_API_STRICT) {
+      return this.skip();
+    }
     const rsConfig = {
       _id: replSetName,
       members: [

--- a/packages/cli-repl/test/e2e-auth.spec.ts
+++ b/packages/cli-repl/test/e2e-auth.spec.ts
@@ -5,6 +5,7 @@ import {
 import { eventually } from '../../../testing/eventually';
 import { TestShell } from './test-shell';
 import {
+  skipIfApiStrict,
   startTestServer
 } from '../../../testing/integration-testing-hooks';
 
@@ -64,6 +65,8 @@ function createAssertUserAuth(db, connectionString, dbName): Function {
 }
 
 describe('Auth e2e', function() {
+  skipIfApiStrict(); // connectionStatus is unversioned.
+
   const testServer = startTestServer('shared');
   let assertUserExists;
   let assertUserAuth;

--- a/packages/cli-repl/test/e2e-aws.spec.ts
+++ b/packages/cli-repl/test/e2e-aws.spec.ts
@@ -3,6 +3,9 @@ import { spawnSync } from 'child_process';
 import { TestShell } from './test-shell';
 
 function assertEnvVariable(variableName: string): string {
+  if (process.env.MONGOSH_TEST_FORCE_API_STRICT) {
+    return undefined;
+  }
   const value = process.env[variableName];
   if (!value) {
     if (process.env.IS_CI) {

--- a/packages/cli-repl/test/e2e-direct.spec.ts
+++ b/packages/cli-repl/test/e2e-direct.spec.ts
@@ -1,9 +1,10 @@
-import { startTestCluster, skipIfServerVersion } from '../../../testing/integration-testing-hooks';
+import { startTestCluster, skipIfServerVersion, skipIfApiStrict } from '../../../testing/integration-testing-hooks';
 import { eventually } from '../../../testing/eventually';
 import { expect } from 'chai';
 import { TestShell } from './test-shell';
 
 describe('e2e direct connection', () => {
+  skipIfApiStrict();
   afterEach(TestShell.cleanup);
 
   const tabtab = async(shell: TestShell) => {

--- a/packages/cli-repl/test/e2e-tls.spec.ts
+++ b/packages/cli-repl/test/e2e-tls.spec.ts
@@ -180,7 +180,10 @@ describe('e2e TLS', () => {
       );
       const certUser = 'emailAddress=tester@example.com,CN=Wonderwoman,OU=DevTools Testers,O=MongoDB';
 
-      before(async() => {
+      before(async function() {
+        if (process.env.MONGOSH_TEST_FORCE_API_STRICT) {
+          return this.skip(); // createUser is unversioned
+        }
         /* connect with cert to create user */
         const shell = TestShell.start({
           args: [

--- a/packages/cli-repl/test/e2e.spec.ts
+++ b/packages/cli-repl/test/e2e.spec.ts
@@ -336,7 +336,10 @@ describe('e2e', function() {
       shell.assertNoErrors();
     });
 
-    it('rewrites async properly for mapReduce', async() => {
+    it('rewrites async properly for mapReduce', async function() {
+      if (process.env.MONGOSH_TEST_FORCE_API_STRICT) {
+        return this.skip(); // mapReduce is unversioned
+      }
       await shell.executeLine(`use ${dbName}`);
       await shell.executeLine('db.test.insertMany([{i:1},{i:2},{i:3},{i:4}]);');
       const result = await shell.executeLine(`db.test.mapReduce(function() {
@@ -525,7 +528,10 @@ describe('e2e', function() {
       });
     });
 
-    it('treats piping a script into stdin line by line', async() => {
+    it('treats piping a script into stdin line by line', async function() {
+      if (process.env.MONGOSH_TEST_FORCE_API_STRICT) {
+        return this.skip(); // collStats is unversioned
+      }
       // This script doesn't work if evaluated as a whole, only when evaluated
       // line-by-line, due to Automatic Semicolon Insertion (ASI).
       createReadStream(path.resolve(__dirname, 'fixtures', 'asi-script.js'))

--- a/packages/service-provider-server/src/cli-service-provider.ts
+++ b/packages/service-provider-server/src/cli-service-provider.ts
@@ -235,6 +235,14 @@ class CliServiceProvider extends ServiceProviderCore implements ServiceProvider 
   ): Promise<CliServiceProvider> {
     const connectionString = new ConnectionString(uri || 'mongodb://nodb/');
     const clientOptions = processDriverOptions(driverOptions);
+    if (process.env.MONGOSH_TEST_FORCE_API_STRICT) {
+      clientOptions.serverApi = {
+        version: typeof clientOptions.serverApi === 'string' ? clientOptions.serverApi :
+          (clientOptions.serverApi?.version ?? '1'),
+        strict: true,
+        deprecationErrors: true
+      };
+    }
 
     const mongoClient = !cliOptions.nodb ?
       await connectMongoClient(

--- a/packages/shell-api/package.json
+++ b/packages/shell-api/package.json
@@ -20,6 +20,7 @@
     "report-supported-api": "ts-node bin/report-supported-api.ts",
     "test": "cross-env TS_NODE_PROJECT=../../config/tsconfig.test.json mocha -r \"../../scripts/import-expansions.js\" --timeout 60000 --colors -r ts-node/register \"./src/**/*.spec.ts\"",
     "test-ci": "cross-env TS_NODE_PROJECT=../../config/tsconfig.test.json mocha -r \"../../scripts/import-expansions.js\" --timeout 60000 -r ts-node/register \"./src/**/*.spec.ts\"",
+    "test-apistrict-ci": "cross-env MONGOSH_TEST_FORCE_API_STRICT=1 npm run test-ci",
     "prepublish": "npm run compile-ts"
   },
   "license": "Apache-2.0",

--- a/packages/shell-api/src/integration.spec.ts
+++ b/packages/shell-api/src/integration.spec.ts
@@ -5,7 +5,7 @@ import Cursor from './cursor';
 import Explainable from './explainable';
 import Collection from './collection';
 import AggregationCursor from './aggregation-cursor';
-import { startTestServer, skipIfServerVersion } from '../../../testing/integration-testing-hooks';
+import { startTestServer, skipIfServerVersion, skipIfApiStrict } from '../../../testing/integration-testing-hooks';
 import { toShellResult, Topologies } from './index';
 import { Document } from '@mongosh/service-provider-core';
 import { ShellUserConfig } from '@mongosh/types';
@@ -371,6 +371,7 @@ describe('Shell API (integration)', function() {
     });
 
     describe('convertToCapped', () => {
+      skipIfApiStrict();
       let result;
 
       beforeEach(async() => {
@@ -527,6 +528,8 @@ describe('Shell API (integration)', function() {
     });
 
     describe('#reIndex', () => {
+      skipIfApiStrict();
+
       beforeEach(async() => {
         await serviceProvider.createCollection(dbName, collectionName);
       });
@@ -589,6 +592,8 @@ describe('Shell API (integration)', function() {
     });
 
     describe('totalIndexSize', () => {
+      skipIfApiStrict();
+
       beforeEach(async() => {
         await serviceProvider.createCollection(dbName, collectionName);
       });
@@ -599,6 +604,8 @@ describe('Shell API (integration)', function() {
     });
 
     describe('dataSize', () => {
+      skipIfApiStrict();
+
       beforeEach(async() => {
         await serviceProvider.createCollection(dbName, collectionName);
       });
@@ -609,6 +616,8 @@ describe('Shell API (integration)', function() {
     });
 
     describe('storageSize', () => {
+      skipIfApiStrict();
+
       beforeEach(async() => {
         await serviceProvider.createCollection(dbName, collectionName);
       });
@@ -619,6 +628,8 @@ describe('Shell API (integration)', function() {
     });
 
     describe('totalSize', () => {
+      skipIfApiStrict();
+
       beforeEach(async() => {
         await serviceProvider.createCollection(dbName, collectionName);
       });
@@ -629,6 +640,8 @@ describe('Shell API (integration)', function() {
     });
 
     describe('stats', () => {
+      skipIfApiStrict();
+
       beforeEach(async() => {
         await serviceProvider.createCollection(dbName, collectionName);
         await serviceProvider.insertOne(dbName, collectionName, { x: 1 });
@@ -712,6 +725,8 @@ describe('Shell API (integration)', function() {
     });
 
     describe('runCommand', () => {
+      skipIfApiStrict();
+
       beforeEach(async() => {
         await serviceProvider.createCollection(dbName, collectionName);
       });
@@ -822,6 +837,8 @@ describe('Shell API (integration)', function() {
     });
 
     describe('renameCollection', () => {
+      skipIfApiStrict();
+
       context('without dropTarget', () => {
         beforeEach(async() => {
           await serviceProvider.insertOne(dbName, collectionName, { doc: 1 });
@@ -953,6 +970,8 @@ describe('Shell API (integration)', function() {
     });
 
     describe('adminCommand', () => {
+      skipIfApiStrict();
+
       it('runs an adminCommand', async() => {
         const result = await database.adminCommand(
           { serverStatus: 1 }
@@ -963,6 +982,8 @@ describe('Shell API (integration)', function() {
     });
 
     describe('aggregate', () => {
+      skipIfApiStrict();
+
       it('runs an aggregate pipeline on the database', async() => {
         const cursor = await database.aggregate([{
           $listLocalSessions: {}
@@ -1014,11 +1035,14 @@ describe('Shell API (integration)', function() {
     });
 
     describe('createCollection', () => {
+      skipIfApiStrict();
+
       it('creates a collection without options', async() => {
         await database.createCollection('newcoll');
         const stats = await serviceProvider.runCommand(dbName, { collStats: 'newcoll' });
         expect(stats.nindexes).to.equal(1);
       });
+
       it('creates a collection with options', async() => {
         await database.createCollection('newcoll', {
           capped: true,
@@ -1099,6 +1123,8 @@ describe('Shell API (integration)', function() {
     });
 
     describe('listCommands', () => {
+      skipIfApiStrict();
+
       it('includes an entry for ping', async() => {
         const { ping } = (await database.listCommands()).value;
         expect(ping.help).to.be.a('string');
@@ -1830,6 +1856,8 @@ describe('Shell API (integration)', function() {
     });
   });
   describe('PlanCache', () => {
+    skipIfApiStrict();
+
     describe('list', () => {
       skipIfServerVersion(testServer, '< 4.4');
       it('lists all without args', async() => {
@@ -1882,6 +1910,8 @@ describe('Shell API (integration)', function() {
     });
   });
   describe('mapReduce', () => {
+    skipIfApiStrict();
+
     it('accepts function args and collection name as string', async() => {
       await loadMRExample(collection);
       const mapFn = `function() {
@@ -1976,6 +2006,8 @@ describe('Shell API (integration)', function() {
     });
 
     describe('fetchConnectionInfo', () => {
+      skipIfApiStrict();
+
       it('returns information about the connection', async() => {
         expect(internalState.connectionInfo.buildInfo.version).to.equal(await database.version());
       });
@@ -2009,18 +2041,24 @@ describe('Shell API (integration)', function() {
   });
 
   describe('database commands', () => {
-    it('db.isMaster() works', async() => {
-      expect((await database.isMaster()).ismaster).to.equal(true);
-      expect((await database.isMaster()).isWritablePrimary).to.equal(true);
+    context('hello as isMaster', () => {
+      skipIfApiStrict();
+      it('db.isMaster() works', async() => {
+        expect((await database.isMaster()).ismaster).to.equal(true);
+        expect((await database.isMaster()).isWritablePrimary).to.equal(true);
+      });
     });
 
-    it('db.hello() works', async() => {
-      const result = await database.hello();
-      expect(result.ismaster).to.equal(undefined);
-      expect(result.isWritablePrimary).to.equal(true);
+    context('hello as hello', () => {
+      it('db.hello() works', async() => {
+        const result = await database.hello();
+        expect(result.ismaster).to.equal(undefined);
+        expect(result.isWritablePrimary).to.equal(true);
+      });
     });
 
     context('with 5.0+ server', () => {
+      skipIfApiStrict();
       skipIfServerVersion(testServer, '<= 4.4');
 
       it('db.rotateCertificates() works', async() => {

--- a/packages/shell-api/src/replica-set.spec.ts
+++ b/packages/shell-api/src/replica-set.spec.ts
@@ -6,7 +6,7 @@ import semver from 'semver';
 import sinonChai from 'sinon-chai';
 import sinon, { StubbedInstance, stubInterface } from 'ts-sinon';
 import { ensureMaster } from '../../../testing/helpers';
-import { MongodSetup, skipIfServerVersion, startTestCluster } from '../../../testing/integration-testing-hooks';
+import { MongodSetup, skipIfServerVersion, startTestCluster, skipIfApiStrict } from '../../../testing/integration-testing-hooks';
 import { CliServiceProvider } from '../../service-provider-server';
 import Database from './database';
 import {
@@ -27,6 +27,7 @@ function deepClone<T>(value: T): T {
 }
 
 describe('ReplicaSet', () => {
+  skipIfApiStrict();
   describe('help', () => {
     const apiClass: any = new ReplicaSet({} as any);
 

--- a/packages/shell-api/src/session.spec.ts
+++ b/packages/shell-api/src/session.spec.ts
@@ -13,7 +13,7 @@ import {
   ALL_TOPOLOGIES
 } from './enums';
 import { CliServiceProvider } from '../../service-provider-server';
-import { startTestCluster } from '../../../testing/integration-testing-hooks';
+import { startTestCluster, skipIfApiStrict } from '../../../testing/integration-testing-hooks';
 import { ensureMaster, ensureSessionExists } from '../../../testing/helpers';
 import Database from './database';
 import { CommonErrors, MongoshInvalidInputError, MongoshUnimplementedError } from '@mongosh/errors';
@@ -180,6 +180,7 @@ describe('Session', () => {
     });
 
     describe('server starts and stops sessions', () => {
+      skipIfApiStrict(); // ensureSessionExists needs $listLocalSessions
       it('starts a session', async() => {
         session = mongo.startSession();
         await session.getDatabase(databaseName).getCollection('coll').insertOne({});
@@ -293,6 +294,7 @@ describe('Session', () => {
       });
     });
     describe('after resetting connection will error with expired session', () => {
+      skipIfApiStrict();
       it('reset connection options', async() => {
         session = mongo.startSession();
         await mongo.setReadConcern('majority');

--- a/packages/shell-api/src/shard.spec.ts
+++ b/packages/shell-api/src/shard.spec.ts
@@ -9,11 +9,12 @@ import { EventEmitter } from 'events';
 import ShellInternalState from './shell-internal-state';
 import { UpdateResult } from './result';
 import { CliServiceProvider } from '../../service-provider-server';
-import { startTestCluster, skipIfServerVersion } from '../../../testing/integration-testing-hooks';
+import { startTestCluster, skipIfServerVersion, skipIfApiStrict } from '../../../testing/integration-testing-hooks';
 import Database from './database';
 import { ObjectId } from 'mongodb';
 
 describe('Shard', () => {
+  skipIfApiStrict();
   describe('help', () => {
     const apiClass: any = new Shard({} as any);
     it('calls help function', async() => {

--- a/testing/helpers.ts
+++ b/testing/helpers.ts
@@ -3,9 +3,9 @@ import {expect} from 'chai';
 
 const delay = util.promisify(setTimeout);
 export const ensureMaster = async(cls, timeout, hp): Promise<void> => {
-  while (!(await cls.isMaster()).ismaster) {
+  while (!(await cls.hello()).isWritablePrimary) {
     if (timeout > 32000) {
-      return expect.fail(`Waited for ${hp} to become master, never happened`);
+      return expect.fail(`Waited for ${hp} to become primary, never happened`);
     }
     await delay(timeout);
     timeout *= 2; // try again but wait double

--- a/testing/integration-testing-hooks.ts
+++ b/testing/integration-testing-hooks.ts
@@ -496,6 +496,18 @@ export function skipIfCommunityServer(server: MongodSetup): void {
 }
 
 /**
+ * Skip tests if environment variables signal that every test runs with
+ * --apiStrict.
+ */
+export function skipIfApiStrict(): void {
+  before(function() {
+    if (process.env.MONGOSH_TEST_FORCE_API_STRICT) {
+      this.skip();
+    }
+  });
+}
+
+/**
  * Add the server tarball's bin/ directrory to the PATH for this section.
  * This enables using e.g. mongocryptd if available.
  *


### PR DESCRIPTION
Run the shell-api and cli-repl test suites with the `strict` and
`deprecationErrors` versioned API options, and skip tests where
this does not apply.