### PR TITLE
chore(cli-repl): use eventually in e2e snippet test

### DIFF
--- a/packages/cli-repl/test/e2e-snippet.spec.ts
+++ b/packages/cli-repl/test/e2e-snippet.spec.ts
@@ -88,7 +88,8 @@ describe('snippet integration tests', function() {
   });
 
   it('informs about the mongocompat snippet', async() => {
-    await shell.executeLine('sleep(2000)'); // "Ensure" index is up to date...
-    expect(await shell.executeLine('Date.timeFunc()')).to.match(/Date.timeFunc is not a function.+Try running `snippet install mongocompat`/);
+    await eventually(() => {
+      expect(await shell.executeLine('Date.timeFunc()')).to.match(/Date.timeFunc is not a function.+Try running `snippet install mongocompat`/);
+    }, { timeout: 30_000 });
   });
 });

--- a/packages/cli-repl/test/e2e-snippet.spec.ts
+++ b/packages/cli-repl/test/e2e-snippet.spec.ts
@@ -88,7 +88,7 @@ describe('snippet integration tests', function() {
   });
 
   it('informs about the mongocompat snippet', async() => {
-    await eventually(() => {
+    await eventually(async() => {
       expect(await shell.executeLine('Date.timeFunc()')).to.match(/Date.timeFunc is not a function.+Try running `snippet install mongocompat`/);
     }, { timeout: 30_000 });
   });


### PR DESCRIPTION
This is hopefully noticeably less flaky.