### PR TITLE
fix(test): flaky snippet manager tests

### DIFF
--- a/packages/snippet-manager/src/snippet-manager.spec.ts
+++ b/packages/snippet-manager/src/snippet-manager.spec.ts
@@ -386,6 +386,7 @@ describe('SnippetManager', () => {
   });
 
   it('will fail when the index URI is inaccessible', async() => {
+    await snippetManager.inflightFetchIndexPromise;
     try {
       indexURL = `${baseURL}/404`;
       await snippetManager.runSnippetCommand(['refresh']);
@@ -396,6 +397,7 @@ describe('SnippetManager', () => {
   });
 
   it('will fail when the index URI returns data in the wrong format (not .br)', async() => {
+    await snippetManager.inflightFetchIndexPromise;
     try {
       indexURL = `${baseURL}/notindexfile`;
       await snippetManager.runSnippetCommand(['refresh']);
@@ -406,6 +408,7 @@ describe('SnippetManager', () => {
   });
 
   it('will fail when the index URI returns data in the wrong format (not .bson.br)', async() => {
+    await snippetManager.inflightFetchIndexPromise;
     try {
       indexURL = `${baseURL}/notindexfile2`;
       await snippetManager.runSnippetCommand(['refresh']);
@@ -537,6 +540,7 @@ describe('SnippetManager', () => {
   });
 
   it('can install from a tarball', async() => {
+    await snippetManager.inflightFetchIndexPromise;
     indexURL = `${baseURL}/index.bson.br;${baseURL}/index2.bson.br;`;
     (evaluationListener.onPrompt as any).resolves('yes');
     await snippetManager.runSnippetCommand(['install', 'tarballed-example']);
@@ -544,6 +548,7 @@ describe('SnippetManager', () => {
   });
 
   it('reports back errors if npm fails', async() => {
+    await snippetManager.inflightFetchIndexPromise;
     indexURL = `${baseURL}/index.bson.br;${baseURL}/index2.bson.br;`;
     (evaluationListener.onPrompt as any).resolves('yes');
     try {
@@ -724,6 +729,7 @@ describe('SnippetManager', () => {
 
   describe('interruption support', () => {
     it('commands methods like load-all perform interruption checkpoints', async() => {
+      await snippetManager.inflightFetchIndexPromise;
       indexURL = `${baseURL}/index.bson.br;${baseURL}/index2.bson.br;`;
       await snippetManager.runSnippetCommand(['refresh']);
 

--- a/packages/snippet-manager/src/snippet-manager.ts
+++ b/packages/snippet-manager/src/snippet-manager.ts
@@ -414,10 +414,13 @@ export class SnippetManager implements ShellPlugin {
         } else {
           output = await this.runNpm(args[0]);
         }
+
+        const firstLineEnd = output.indexOf('\n');
+        let packages = output.substr(firstLineEnd + 1);
         for (const { name, snippetName } of this.snippets) {
-          output = output.replace(new RegExp(escapeRegexp(name), 'g'), `mongosh:${snippetName}`);
+          packages = packages.replace(new RegExp(escapeRegexp(name), 'g'), `mongosh:${snippetName}`);
         }
-        return output;
+        return (firstLineEnd < 0 ? output : output.substr(0, firstLineEnd + 1)) + packages;
       }
       case 'search':
         return await this.search();


### PR DESCRIPTION
I added the await for the fetch index promise when we change the index URL in the test. This potentially caused a race condition with a stale index in a recent test case: https://evergreen.mongodb.com/task/mongosh_linux_test_m42xc_n12_d201e37cbe4f627a07a4754d56d6a63f83fd9fb7_21_06_15_21_06_57.

I also changed the logic of replacing the snippet names on `ls` / `outdated` since the first line is the directory path. Mine contains `mongodb` and got replaced with `mongosh:mongodb-example`.