### PR TITLE
feat(shell-api): disable line breaks in sh.status chunks MONGOSH-802

### DIFF
--- a/packages/shell-api/src/helpers.ts
+++ b/packages/shell-api/src/helpers.ts
@@ -23,6 +23,7 @@ import { AutoEncryptionOptions } from 'mongodb';
 import { shellApiType } from './enums';
 import type { AbstractCursor } from './abstract-cursor';
 import type ChangeStreamCursor from './change-stream-cursor';
+import { inspect } from 'util';
 
 /**
  * Helper method to adapt aggregation pipeline options.
@@ -458,6 +459,17 @@ export async function getPrintableShardStatus(db: Database, verbose: boolean): P
                 'on shard': chunk.shard,
                 'last modified': chunk.lastmod
               } as any;
+              // Displaying a full, multi-line output for each chunk is a bit verbose,
+              // even if there are only a few chunks. Where supported, we use a custom
+              // inspection function to inspect a copy of this object with an unlimited
+              // line break length (i.e. all objects on a single line).
+              Object.defineProperty(c, Symbol.for('nodejs.util.inspect.custom'), {
+                value: function(depth: number, options: any): string {
+                  return inspect({ ...this }, { ...options, breakLength: Infinity });
+                },
+                writable: true,
+                configurable: true
+              });
               if (chunk.jumbo) c.jumbo = 'yes';
               chunksRes.push(c);
             });

--- a/packages/shell-api/src/shard.spec.ts
+++ b/packages/shell-api/src/shard.spec.ts
@@ -11,7 +11,7 @@ import { UpdateResult } from './result';
 import { CliServiceProvider } from '../../service-provider-server';
 import { startTestCluster, skipIfServerVersion, skipIfApiStrict } from '../../../testing/integration-testing-hooks';
 import Database from './database';
-import { ObjectId } from 'mongodb';
+import { inspect } from 'util';
 
 describe('Shard', () => {
   skipIfApiStrict();
@@ -685,7 +685,7 @@ describe('Shard', () => {
 
       it('returns whatever serviceProvider.updateOne returns', async() => {
         serviceProvider.runCommandWithCheck.resolves({ ok: 1, msg: 'isdbgrid' });
-        const oid = new ObjectId();
+        const oid = new bson.ObjectId();
         const expectedResult = {
           matchedCount: 1,
           modifiedCount: 1,
@@ -744,7 +744,7 @@ describe('Shard', () => {
 
       it('returns whatever serviceProvider.updateOne returns', async() => {
         serviceProvider.runCommandWithCheck.resolves({ ok: 1, msg: 'isdbgrid' });
-        const oid = new ObjectId();
+        const oid = new bson.ObjectId();
         const expectedResult = {
           matchedCount: 1,
           modifiedCount: 1,
@@ -919,7 +919,7 @@ describe('Shard', () => {
 
       it('returns whatever serviceProvider.updateOne returns', async() => {
         serviceProvider.runCommandWithCheck.resolves({ ok: 1, msg: 'isdbgrid' });
-        const oid = new ObjectId();
+        const oid = new bson.ObjectId();
         const expectedResult = {
           matchedCount: 1,
           modifiedCount: 1,
@@ -977,7 +977,7 @@ describe('Shard', () => {
 
       it('returns whatever serviceProvider.updateOne returns', async() => {
         serviceProvider.runCommandWithCheck.resolves({ ok: 1, msg: 'isdbgrid' });
-        const oid = new ObjectId();
+        const oid = new bson.ObjectId();
         const expectedResult = {
           matchedCount: 1,
           modifiedCount: 1,
@@ -1285,7 +1285,14 @@ describe('Shard', () => {
         expect(original.key).to.equal('A');
         expect(original.value).to.equal(10);
 
-        expect((await sh.status()).value.databases[1].collections[ns].chunkMetadata).to.have.lengthOf(1);
+        const collectionInfo = (await sh.status()).value.databases[1].collections[ns];
+        expect(collectionInfo.chunkMetadata).to.have.lengthOf(1);
+        const inspectedCollectionInfo = inspect(collectionInfo);
+        // Make sure that each individual chunk in the output is on a single line
+        expect(inspectedCollectionInfo).to.include('chunks: [\n' +
+          '    { min: { key: MinKey() }, max: { key: MaxKey() }, ' +
+          `'on shard': '${collectionInfo.chunks[0]['on shard']}', 'last modified': Timestamp(0, 1) }\n` +
+          '  ],\n');
       });
     });
     describe('autosplit', () => {


### PR DESCRIPTION
This only works for environments using the Node.js `util.inspect()`,
but most likely those environments are also the main issue here.