### PR TITLE
fix(cli-repl): store config using EJSON MONGOSH-850

### DIFF
--- a/packages/cli-repl/src/config-directory.spec.ts
+++ b/packages/cli-repl/src/config-directory.spec.ts
@@ -6,10 +6,13 @@ import { promisify } from 'util';
 import chai, { expect } from 'chai';
 import sinon from 'ts-sinon';
 import sinonChai from 'sinon-chai';
+import { bson } from '@mongosh/service-provider-core';
+const { EJSON } = bson;
 chai.use(sinonChai);
 
 class ExampleConfig {
   someProperty = 42;
+  someOtherProperty?: number = Infinity;
 }
 
 describe('home directory management', () => {
@@ -62,7 +65,7 @@ describe('home directory management', () => {
       const configPath = manager.path();
       await manager.writeConfigFile(new ExampleConfig());
       const contents = await fs.readFile(configPath, { encoding: 'utf8' });
-      expect(JSON.parse(contents)).to.deep.equal(new ExampleConfig());
+      expect(EJSON.parse(contents)).to.deep.equal(new ExampleConfig());
 
       expect(onError).to.not.have.been.called;
       expect(onNewConfig).to.not.have.been.called;

--- a/packages/cli-repl/test/e2e.spec.ts
+++ b/packages/cli-repl/test/e2e.spec.ts
@@ -9,6 +9,8 @@ import { promisify } from 'util';
 import rimraf from 'rimraf';
 import path from 'path';
 import { readReplLogfile } from './repl-helpers';
+import { bson } from '@mongosh/service-provider-core';
+const { EJSON } = bson;
 
 describe('e2e', function() {
   const testServer = startTestServer('shared');
@@ -682,7 +684,7 @@ describe('e2e', function() {
         configPath = path.resolve(homedir, '.mongodb', 'mongosh', 'config');
         historyPath = path.resolve(homedir, '.mongodb', 'mongosh', 'mongosh_repl_history');
       }
-      readConfig = async() => JSON.parse(await fs.readFile(configPath, 'utf8'));
+      readConfig = async() => EJSON.parse(await fs.readFile(configPath, 'utf8'));
       readLogfile = async() => readReplLogfile(logPath);
       startTestShell = async(...extraArgs: string[]) => {
         const shell = TestShell.start({


### PR DESCRIPTION
EJSON comes with support for values like `Infinity`, unlike
plain JSON.