### PR TITLE
chore: support Kerberos-specific CLI arguments MONGOSH-838

### DIFF
--- a/packages/cli-repl/src/arg-mapper.spec.ts
+++ b/packages/cli-repl/src/arg-mapper.spec.ts
@@ -208,6 +208,66 @@ describe('arg-mapper.mapCliToDriver', () => {
     });
   });
 
+  context('when the cli args have gssapiServiceName', () => {
+    const cliOptions: CliOptions = { gssapiServiceName: 'alternate' };
+
+    it('maps to authMechanismProperties.SERVICE_NAME', async() => {
+      expect(await mapCliToDriver(cliOptions)).to.deep.equal({
+        authMechanismProperties: {
+          SERVICE_NAME: 'alternate'
+        }
+      });
+    });
+  });
+
+  context('when the cli args have sspiRealmOverride', () => {
+    const cliOptions: CliOptions = { sspiRealmOverride: 'REALM.COM' };
+
+    it('maps to authMechanismProperties.SERVICE_REALM', async() => {
+      expect(await mapCliToDriver(cliOptions)).to.deep.equal({
+        authMechanismProperties: {
+          SERVICE_REALM: 'REALM.COM'
+        }
+      });
+    });
+  });
+
+  context('when the cli args have sspiHostnameCanonicalization', () => {
+    context('with a value of none', () => {
+      const cliOptions: CliOptions = { sspiHostnameCanonicalization: 'none' };
+
+      it('is not mapped to authMechanismProperties', async() => {
+        expect(await mapCliToDriver(cliOptions)).to.deep.equal({});
+      });
+    });
+
+    context('with a value of forward', () => {
+      const cliOptions: CliOptions = { sspiHostnameCanonicalization: 'forward' };
+
+      it('is mapped to authMechanismProperties', async() => {
+        expect(await mapCliToDriver(cliOptions)).to.deep.equal({
+          authMechanismProperties: {
+            gssapiCanonicalizeHostName: 'true'
+          }
+        });
+      });
+    });
+
+    context('with a value of forwardAndReverse', () => {
+      const cliOptions: CliOptions = { sspiHostnameCanonicalization: 'forwardAndReverse' };
+
+      it('is mapped to authMechanismProperties', async() => {
+        try {
+          await mapCliToDriver(cliOptions);
+        } catch (e) {
+          expect(e.message).to.contain('forwardAndReverse is not supported');
+          return;
+        }
+        expect.fail('expected error');
+      });
+    });
+  });
+
   context('when the cli args have keyVaultNamespace', () => {
     const cliOptions: CliOptions = { keyVaultNamespace: 'db.datakeys' };
 

--- a/packages/cli-repl/src/arg-parser.spec.ts
+++ b/packages/cli-repl/src/arg-parser.spec.ts
@@ -322,12 +322,47 @@ describe('arg-parser', () => {
         context('when providing --gssapiHostName', () => {
           const argv = [ ...baseArgv, uri, '--gssapiHostName', 'example.com' ];
 
+          it('throws an error since it is not yet supported', () => {
+            try {
+              parseCliArgs(argv);
+            } catch (e) {
+              expect(e).to.be.instanceOf(MongoshUnimplementedError);
+              expect(e.message).to.include('Argument --gssapiHostName is not yet supported in mongosh');
+              return;
+            }
+            expect.fail('Expected error');
+          });
+
+          // it('returns the URI in the object', () => {
+          //   expect(parseCliArgs(argv).connectionSpecifier).to.equal(uri);
+          // });
+
+          // it('sets the gssapiHostName in the object', () => {
+          //   expect(parseCliArgs(argv).gssapiHostName).to.equal('example.com');
+          // });
+        });
+
+        context('when providing --sspiHostnameCanonicalization', () => {
+          const argv = [ ...baseArgv, uri, '--sspiHostnameCanonicalization', 'forward' ];
+
           it('returns the URI in the object', () => {
             expect(parseCliArgs(argv).connectionSpecifier).to.equal(uri);
           });
 
           it('sets the gssapiHostName in the object', () => {
-            expect(parseCliArgs(argv).gssapiHostName).to.equal('example.com');
+            expect(parseCliArgs(argv).sspiHostnameCanonicalization).to.equal('forward');
+          });
+        });
+
+        context('when providing --sspiRealmOverride', () => {
+          const argv = [ ...baseArgv, uri, '--sspiRealmOverride', 'example2.com' ];
+
+          it('returns the URI in the object', () => {
+            expect(parseCliArgs(argv).connectionSpecifier).to.equal(uri);
+          });
+
+          it('sets the gssapiHostName in the object', () => {
+            expect(parseCliArgs(argv).sspiRealmOverride).to.equal('example2.com');
           });
         });
 

--- a/packages/cli-repl/src/arg-parser.ts
+++ b/packages/cli-repl/src/arg-parser.ts
@@ -27,6 +27,8 @@ const OPTIONS = {
     'eval',
     'gssapiHostName',
     'gssapiServiceName',
+    'sspiHostnameCanonicalization',
+    'sspiRealmOverride',
     'host',
     'keyVaultNamespace',
     'kmsURL',
@@ -108,7 +110,8 @@ const DEPRECATED_ARGS_WITH_REPLACEMENT: Record<string, keyof CliOptions> = {
  */
 const UNSUPPORTED_ARGS: Readonly<string[]> = [
   'sslFIPSMode',
-  'tlsFIPSMode'
+  'tlsFIPSMode',
+  'gssapiHostName'
 ];
 
 /**

--- a/packages/cli-repl/src/constants.ts
+++ b/packages/cli-repl/src/constants.ts
@@ -38,6 +38,9 @@ export const USAGE = `
         --authenticationDatabase [arg]         ${i18n.__('cli-repl.args.authenticationDatabase')}
         --authenticationMechanism [arg]        ${i18n.__('cli-repl.args.authenticationMechanism')}
         --awsIamSessionToken [arg]             ${i18n.__('cli-repl.args.awsIamSessionToken')}
+        --gssapiServiceName [arg]              ${i18n.__('cli-repl.args.gssapiServiceName')}
+        --sspiHostnameCanonicalization [arg]   ${i18n.__('cli-repl.args.sspiHostnameCanonicalization')}
+        --sspiRealmOverride [arg]              ${i18n.__('cli-repl.args.sspiRealmOverride')}
 
   ${clr(i18n.__('cli-repl.args.tlsOptions'), ['bold', 'yellow'])}
 

--- a/packages/i18n/src/locales/en_US.ts
+++ b/packages/i18n/src/locales/en_US.ts
@@ -31,6 +31,8 @@ const translations: Catalog = {
       awsIamSessionToken: 'AWS IAM Temporary Session Token ID',
       gssapiServiceName: 'Service name to use when authenticating using GSSAPI/Kerberos',
       gssapiHostName: 'Remote host name to use for purpose of GSSAPI/Kerberos authentication',
+      sspiHostnameCanonicalization: 'Specify the SSPI hostname canonicalization (none or forward, available on Windows)',
+      sspiRealmOverride: 'Specify the SSPI server realm (available on Windows)',
       tlsOptions: 'TLS Options:',
       tls: 'Use TLS for all connections',
       tlsCertificateKeyFile: 'PEM certificate/key file for TLS',
@@ -82,7 +84,9 @@ const translations: Catalog = {
     },
     'uri-generator': {
       'no-host-port': 'If a full URI is provided, you cannot also specify --host or --port',
-      'invalid-host': 'The --host argument contains an invalid character'
+      'invalid-host': 'The --host argument contains an invalid character',
+      'diverging-service-name': 'Either the --gssapiServiceName parameter or the SERVICE_NAME authentication mechanism property in the connection string can be used but not both.',
+      'gssapi-service-name-unsupported': 'The gssapiServiceName query parameter is not supported anymore. Please use the --gssapiServiceName argument or the SERVICE_NAME authentication mechanism property (e.g. ?authMechanismProperties=SERVICE_NAME:<value>).',
     }
   },
   'service-provider-browser': {},

--- a/packages/service-provider-core/src/cli-options.ts
+++ b/packages/service-provider-core/src/cli-options.ts
@@ -18,8 +18,9 @@ export default interface CliOptions {
   awsSessionToken?: string;
   db?: string;
   eval?: string;
-  gssapiHostName?: string;
   gssapiServiceName?: string;
+  sspiHostnameCanonicalization?: string;
+  sspiRealmOverride?: string;
   help?: boolean;
   host?: string;
   ipv6?: boolean;


### PR DESCRIPTION
Adds support for handling:
* `--gssapiServiceName`
* `--sspiHostnameCanonicalization=none|forward`
* `--sspiRealmOverride`
* throws an error when `gssapiServiceName` is used as a query parameter

`gssapiServiceName` and `sspiRealmOverride` will only work properly when a new driver version is available.