### PR TITLE
chore(shell-api): deprecate collection.mapReduce for 5.0+ MONGOSH-854

### DIFF
--- a/packages/autocomplete/index.spec.ts
+++ b/packages/autocomplete/index.spec.ts
@@ -46,6 +46,17 @@ const standalone300 = {
   getCollectionCompletionsForCurrentDb: () => collections,
   getDatabaseCompletions: () => databases
 };
+const standalone500 = {
+  topology: () => Topologies.Standalone,
+  apiVersionInfo: () => undefined,
+  connectionInfo: () => ({
+    is_atlas: false,
+    is_data_lake: false,
+    server_version: '5.0.0'
+  }),
+  getCollectionCompletionsForCurrentDb: () => collections,
+  getDatabaseCompletions: () => databases
+};
 const datalake440 = {
   topology: () => Topologies.Sharded,
   apiVersionInfo: () => undefined,
@@ -258,6 +269,11 @@ describe('completer.completer', () => {
       const adjusted = collComplete.filter(c => !['count', 'update', 'remove', 'insert', 'save', 'findAndModify', 'reIndex'].includes(c)).map(c => `${i}${c}`);
 
       expect(await completer(sharded440, i)).to.deep.equal([adjusted, i]);
+    });
+
+    it('does not include a deprecated command for server version >= deprecation', async() => {
+      const i = 'db.shipwrecks.';
+      expect(await completer(standalone500, i)).to.not.include('mapReduce');
     });
 
     it('matches several collection commands', async() => {

--- a/packages/shell-api/src/bulk.ts
+++ b/packages/shell-api/src/bulk.ts
@@ -79,14 +79,14 @@ export class BulkFindOp extends ShellApiWithMongoClass {
 
   @returnType('Bulk')
   @apiVersions([1])
-  @deprecated
+  @deprecated()
   remove(): Bulk {
     return this.delete();
   }
 
   @returnType('Bulk')
   @apiVersions([1])
-  @deprecated
+  @deprecated()
   removeOne(): Bulk {
     return this.deleteOne();
   }

--- a/packages/shell-api/src/change-stream-cursor.ts
+++ b/packages/shell-api/src/change-stream-cursor.ts
@@ -57,7 +57,7 @@ export default class ChangeStreamCursor extends ShellApiWithMongoClass {
   }
 
   @returnsPromise
-  @deprecated
+  @deprecated()
   async hasNext(): Promise<void> {
     printWarning(
       'If there are no documents in the batch, hasNext will block. Use tryNext if you want to check if there ' +

--- a/packages/shell-api/src/collection.ts
+++ b/packages/shell-api/src/collection.ts
@@ -241,7 +241,7 @@ export default class Collection extends ShellApiWithMongoClass {
    * @returns {Integer} The promise of the count.
    */
   @returnsPromise
-  @deprecated
+  @deprecated()
   @serverVersions([ServerVersions.earliest, '4.0.0'])
   @apiVersions([])
   async count(query = {}, options: CountOptions = {}): Promise<number> {
@@ -423,7 +423,7 @@ export default class Collection extends ShellApiWithMongoClass {
   }
 
   @returnsPromise
-  @deprecated
+  @deprecated()
   @apiVersions([1])
   async findAndModify(options: FindAndModifyMethodShellOptions): Promise<Document> {
     assertArgsDefinedType([options], [true], 'Collection.findAndModify');
@@ -630,7 +630,7 @@ export default class Collection extends ShellApiWithMongoClass {
    * @return {InsertManyResult}
    */
   @returnsPromise
-  @deprecated
+  @deprecated()
   @serverVersions([ServerVersions.earliest, '3.6.0'])
   @apiVersions([1])
   async insert(docs: Document | Document[], options: BulkWriteOptions = {}): Promise<InsertManyResult> {
@@ -752,7 +752,7 @@ export default class Collection extends ShellApiWithMongoClass {
    * @return {Promise}
    */
   @returnsPromise
-  @deprecated
+  @deprecated()
   @serverVersions([ServerVersions.earliest, '3.2.0'])
   @apiVersions([1])
   async remove(query: Document, options: boolean | RemoveShellOptions = {}): Promise<DeleteResult | Document> {
@@ -781,7 +781,7 @@ export default class Collection extends ShellApiWithMongoClass {
     );
   }
 
-  @deprecated
+  @deprecated()
   save(): never {
     throw new MongoshInvalidInputError(
       'Collection.save() is deprecated. Use insertOne, insertMany, updateOne, or updateMany.'
@@ -827,7 +827,7 @@ export default class Collection extends ShellApiWithMongoClass {
   }
 
   @returnsPromise
-  @deprecated
+  @deprecated()
   @serverVersions([ServerVersions.earliest, '3.2.0'])
   @apiVersions([1])
   async update(filter: Document, update: Document, options: UpdateOptions & { multi?: boolean } = {}): Promise<UpdateResult | Document> {
@@ -1533,6 +1533,10 @@ export default class Collection extends ShellApiWithMongoClass {
   }
 
   @returnsPromise
+  @deprecated({
+    since: '5.0.0',
+    msg: 'Collection.mapReduce() is deprecated. Use an aggregation instead.\nSee https://docs.mongodb.com/manual/core/map-reduce for details.'
+  })
   @apiVersions([])
   async mapReduce(map: Function | string, reduce: Function | string, optionsOrOutString: MapReduceShellOptions): Promise<Document> {
     assertArgsDefinedType([map, reduce, optionsOrOutString], [true, true, true], 'Collection.mapReduce');

--- a/packages/shell-api/src/cursor.ts
+++ b/packages/shell-api/src/cursor.ts
@@ -211,7 +211,7 @@ export default class Cursor extends AbstractCursor {
     return this;
   }
 
-  @deprecated
+  @deprecated()
   @serverVersions([ServerVersions.earliest, '4.0.0'])
   maxScan(): void {
     throw new MongoshDeprecatedError(

--- a/packages/shell-api/src/database.ts
+++ b/packages/shell-api/src/database.ts
@@ -1143,17 +1143,17 @@ export default class Database extends ShellApiWithMongoClass {
     return result.logComponentVerbosity;
   }
 
-  @deprecated
+  @deprecated()
   cloneDatabase(): void {
     throw new MongoshDeprecatedError('`cloneDatabase()` was removed because it was deprecated in MongoDB 4.0');
   }
 
-  @deprecated
+  @deprecated()
   cloneCollection(): void {
     throw new MongoshDeprecatedError('`cloneCollection()` was removed because it was deprecated in MongoDB 4.0');
   }
 
-  @deprecated
+  @deprecated()
   copyDatabase(): void {
     throw new MongoshDeprecatedError('`copyDatabase()` was removed because it was deprecated in MongoDB 4.0');
   }
@@ -1391,7 +1391,7 @@ export default class Database extends ShellApiWithMongoClass {
     return new CommandResult('StatsResult', result);
   }
 
-  @deprecated
+  @deprecated()
   @returnsPromise
   async printSlaveReplicationInfo(): Promise<CommandResult> {
     throw new MongoshDeprecatedError('Method deprecated, use db.printSecondaryReplicationInfo instead');

--- a/packages/shell-api/src/deprecation-warning.ts
+++ b/packages/shell-api/src/deprecation-warning.ts
@@ -25,3 +25,7 @@ export function printWarning(
     warn(`Warning: ${message}`);
   }
 }
+
+export function clearWarningsForTest(): void {
+  warningShown.clear();
+}

--- a/packages/shell-api/src/mongo.ts
+++ b/packages/shell-api/src/mongo.ts
@@ -484,12 +484,12 @@ export default class Mongo extends ShellApiClass {
     );
   }
 
-  @deprecated
+  @deprecated()
   setSlaveOk(): void {
     throw new MongoshDeprecatedError('Setting slaveOk is deprecated, use setReadPref instead.');
   }
 
-  @deprecated
+  @deprecated()
   setSecondaryOk(): void {
     throw new MongoshDeprecatedError('Setting secondaryOk is deprecated, use setReadPref instead.');
   }

--- a/packages/shell-api/src/plan-cache.ts
+++ b/packages/shell-api/src/plan-cache.ts
@@ -60,12 +60,12 @@ export default class PlanCache extends ShellApiWithMongoClass {
     return await agg.toArray();
   }
 
-  @deprecated
+  @deprecated()
   planCacheQueryShapes(): void {
     throw new MongoshDeprecatedError('PlanCache.listQueryShapes was deprecated, please use PlanCache.list instead');
   }
 
-  @deprecated
+  @deprecated()
   getPlansByQuery(): void {
     throw new MongoshDeprecatedError('PlanCache.getPlansByQuery was deprecated, please use PlanCache.list instead');
   }

--- a/packages/shell-api/src/replica-set.ts
+++ b/packages/shell-api/src/replica-set.ts
@@ -250,7 +250,7 @@ export default class ReplicaSet extends ShellApiWithMongoClass {
     return this._database.printSecondaryReplicationInfo();
   }
 
-  @deprecated
+  @deprecated()
   @returnsPromise
   @apiVersions([])
   async printSlaveReplicationInfo(): Promise<CommandResult> {


### PR DESCRIPTION
Changes the `@deprecate` decorator to take a parameter to allow to specify a version `since` that method is deprecated and include a message that should be printed as deprecation message.

Using `@deprecate()` will be equivalent to the old behavior (always deprecated) and will _not_ automatically print a deprecation message.

Deprecated methods will not be included in autocompletion (depending on the `since` value compared to server version).