### PR TITLE
feat(shell-api): allow options in find() and findOne() MONGOSH-857

### DIFF
--- a/packages/shell-api/src/collection.ts
+++ b/packages/shell-api/src/collection.ts
@@ -406,8 +406,7 @@ export default class Collection extends ShellApiWithMongoClass {
    */
   @returnType('Cursor')
   @apiVersions([1])
-  find(query?: Document, projection?: Document): Cursor {
-    const options: FindOptions = {};
+  find(query?: Document, projection?: Document, options: FindOptions = {}): Cursor {
     if (projection) {
       options.projection = projection;
     }
@@ -463,8 +462,7 @@ export default class Collection extends ShellApiWithMongoClass {
   @returnsPromise
   @returnType('Document')
   @apiVersions([1])
-  async findOne(query: Document = {}, projection?: Document): Promise<Document | null> {
-    const options: any = {};
+  async findOne(query: Document = {}, projection?: Document, options: FindOptions = {}): Promise<Document | null> {
     if (projection) {
       options.projection = projection;
     }

--- a/packages/shell-api/src/integration.spec.ts
+++ b/packages/shell-api/src/integration.spec.ts
@@ -933,6 +933,44 @@ describe('Shell API (integration)', function() {
         });
       });
     });
+
+    describe('find', () => {
+      it('uses default options for the driver (find)', async() => {
+        const longOne = new serviceProvider.bsonLibrary.Long('1');
+        await serviceProvider.insertOne(dbName, collectionName, { longOne, _id: 0 });
+
+        const cursor = await collection.find({});
+
+        expect(await cursor.toArray()).to.deep.equal([{ longOne, _id: 0 }]);
+      });
+
+      it('passes through options to the driver (find)', async() => {
+        const longOne = new serviceProvider.bsonLibrary.Long('1');
+        await serviceProvider.insertOne(dbName, collectionName, { longOne, _id: 0 });
+
+        const cursor = await collection.find({}, {}, { promoteLongs: true });
+
+        expect(await cursor.toArray()).to.deep.equal([{ longOne: 1, _id: 0 }]);
+      });
+
+      it('uses default options for the driver (findOne)', async() => {
+        const longOne = new serviceProvider.bsonLibrary.Long('1');
+        await serviceProvider.insertOne(dbName, collectionName, { longOne, _id: 0 });
+
+        const doc = await collection.findOne({});
+
+        expect(doc).to.deep.equal({ longOne, _id: 0 });
+      });
+
+      it('passes through options to the driver (findOne)', async() => {
+        const longOne = new serviceProvider.bsonLibrary.Long('1');
+        await serviceProvider.insertOne(dbName, collectionName, { longOne, _id: 0 });
+
+        const doc = await collection.findOne({}, {}, { promoteLongs: true });
+
+        expect(doc).to.deep.equal({ longOne: 1, _id: 0 });
+      });
+    });
   });
 
   describe('db', () => {


### PR DESCRIPTION
Allow passing options through to the driver for `coll.find()`
and `coll.findOne()`.