### PR TITLE
fix(shell-evaluator): treat cmd whose arg starts with `(` as fn call …

### DIFF
--- a/packages/shell-evaluator/src/shell-evaluator.spec.ts
+++ b/packages/shell-evaluator/src/shell-evaluator.spec.ts
@@ -44,6 +44,13 @@ describe('ShellEvaluator', () => {
       expect(useSpy).to.have.been.calledWith('somedb');
     });
 
+    it('does not apply special handling for commands when the first argument starts with (', async() => {
+      const originalEval = sinon.spy();
+      await shellEvaluator.customEval(originalEval, 'use   (somedb);', {}, '');
+      expect(originalEval.firstCall.args[0]).to.include('somedb');
+      expect(useSpy).to.have.callCount(0);
+    });
+
     it('forwards show commands', async() => {
       const dontCallEval = () => { throw new Error('unreachable'); };
       await shellEvaluator.customEval(dontCallEval, 'show dbs;', {}, '');

--- a/packages/shell-evaluator/src/shell-evaluator.ts
+++ b/packages/shell-evaluator/src/shell-evaluator.ts
@@ -36,7 +36,7 @@ class ShellEvaluator<EvaluationResultType = ShellResult> {
     const { shellApi } = this.internalState;
     const argv = input.trim().replace(/;$/, '').split(/\s+/g);
     const cmd = argv.shift() as keyof typeof shellApi;
-    if (shellApi[cmd]?.isDirectShellCommand) {
+    if (shellApi[cmd]?.isDirectShellCommand && !(argv[0] ?? '').startsWith('(')) {
       return shellApi[cmd](...argv);
     }
 


### PR DESCRIPTION
…MONGOSH-858

If the argument to a shell command starts with `(`, we treat it as
a function call, since that is probably the intended usage here.