### PR TITLE
chore(ci): test s390x builds on RHEL 8.0 MONGOSH-768

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -1457,8 +1457,8 @@ buildvariants:
     tasks:
       - name: compile_artifact
   - name: linux_s390x_build
-    display_name: "RHEL 8.0 s390x (build)"
-    run_on: rhel72-zseries-small # TODO: Bump to rhel80-zseries-small once available
+    display_name: "RHEL 7.2 s390x (build)"
+    run_on: rhel72-zseries-small
     expansions:
       executable_os_id: linux-s390x
     tasks:
@@ -1539,9 +1539,14 @@ buildvariants:
     run_on: rhel81-power8-small
     tasks:
       - name: e2e_tests_linux_ppc64le
+  - name: e2e_rhel72_s390x
+    display_name: "RHEL 7.2 s390x (E2E Tests)"
+    run_on: rhel72-zseries-small
+    tasks:
+      - name: e2e_tests_linux_s390x
   - name: e2e_rhel80_s390x
     display_name: "RHEL 8.0 s390x (E2E Tests)"
-    run_on: rhel72-zseries-small # TODO: Bump to rhel80-zseries-small once available
+    run_on: rhel80-zseries-small
     tasks:
       - name: e2e_tests_linux_s390x
 
@@ -1630,9 +1635,14 @@ buildvariants:
     run_on: amazon2-arm64-small
     tasks:
       - name: pkg_test_amzn2_arm64_rpm
+  - name: pkg_smoke_tests_rhel72_s390x
+    display_name: "package smoke tests (RHEL 7.2 s390x)"
+    run_on: rhel72-zseries-small
+    tasks:
+      - name: pkg_test_s390x_rpm
   - name: pkg_smoke_tests_rhel80_s390x
     display_name: "package smoke tests (RHEL 8.0 s390x)"
-    run_on: rhel72-zseries-small # TODO: Bump to rhel80-zseries-small once available
+    run_on: rhel80-zseries-small
     tasks:
       - name: pkg_test_s390x_rpm
   - name: pkg_smoke_tests_rhel81_ppc64le

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -1544,11 +1544,14 @@ buildvariants:
     run_on: rhel72-zseries-small
     tasks:
       - name: e2e_tests_linux_s390x
-  - name: e2e_rhel80_s390x
-    display_name: "RHEL 8.0 s390x (E2E Tests)"
-    run_on: rhel80-zseries-small
-    tasks:
-      - name: e2e_tests_linux_s390x
+# TODO: reenable once /opt/mongodbtoolchain/v3 contains executables that
+# are actually compatible with the OS/architecture:
+# https://jira.mongodb.org/browse/BUILD-13551
+#  - name: e2e_rhel80_s390x
+#    display_name: "RHEL 8.0 s390x (E2E Tests)"
+#    run_on: rhel80-zseries-small
+#    tasks:
+#      - name: e2e_tests_linux_s390x
 
   - name: win32
     display_name: "Windows VS 2019"

--- a/.evergreen/.setup_env
+++ b/.evergreen/.setup_env
@@ -48,3 +48,9 @@ git --version
 
 echo "Using python version:"
 python --version
+
+echo "Node.js OS info:"
+node -p '[os.arch(), os.platform(), os.endianness(), os.type(), os.release()]'
+
+echo "/etc/os-release contents:"
+cat /etc/os-release || true

--- a/packages/cli-repl/src/smoke-tests-fle.ts
+++ b/packages/cli-repl/src/smoke-tests-fle.ts
@@ -12,7 +12,7 @@ const assert = function(value, message) {
 };
 // There is no mongocryptd binary for darwin-x64 or rhel80-s390x yet.
 if ((os.platform() === 'darwin' && os.arch() === 'arm64') ||
-    (os.platform() === 'linux' && os.arch() === 's390x' && fs.readFileSync('/etc/os-release', 'utf8').includes('VERSION_ID="8"'))) {
+    (os.platform() === 'linux' && os.arch() === 's390x' && fs.readFileSync('/etc/os-release', 'utf8').includes('VERSION_ID="8'))) {
   print('Test skipped')
   process.exit(0);
 }

--- a/packages/cli-repl/src/smoke-tests-fle.ts
+++ b/packages/cli-repl/src/smoke-tests-fle.ts
@@ -10,8 +10,9 @@ const assert = function(value, message) {
     process.exit(1);
   }
 };
-// There is no mongocryptd binary for darwin-x64 yet.
-if (os.platform() === 'darwin' && os.arch() === 'arm64') {
+// There is no mongocryptd binary for darwin-x64 or rhel80-s390x yet.
+if ((os.platform() === 'darwin' && os.arch() === 'arm64') ||
+    (os.platform() === 'linux' && os.arch() === 's390x' && fs.readFileSync('/etc/os-release', 'utf8').includes('VERSION_ID="8"'))) {
   print('Test skipped')
   process.exit(0);
 }


### PR DESCRIPTION
The platform support matrix for the 5.0 server now indicates that
RHEL 8 will be supported in addition to, not instead of, RHEL 7
on the zSeries/s390x platform.

This is the optimistic approach, where we build the same executable
for both targets. If this fails in CI, we may need to start
building separate binaries.