### PR TITLE
fix(build): use latest upstream master for Homebrew PR MONGOSH-874

### DIFF
--- a/packages/build/src/github-repo.spec.ts
+++ b/packages/build/src/github-repo.spec.ts
@@ -484,25 +484,13 @@ describe('GithubRepo', () => {
     });
 
     it('creates the branch based on the given base', async() => {
-      getRef.withArgs({
-        ...githubRepo.repo,
-        ref: 'heads/base'
-      }).resolves({
-        data: {
-          object: {
-            sha: 'sha'
-          }
-        }
-      });
-
       createRef.withArgs({
         ...githubRepo.repo,
         ref: 'refs/heads/newBranch',
-        sha: 'sha'
+        sha: 'baseSha'
       }).resolves();
 
-      await githubRepo.createBranch('newBranch', 'base');
-      expect(getRef).to.have.been.called;
+      await githubRepo.createBranch('newBranch', 'baseSha');
       expect(createRef).to.have.been.called;
     });
   });

--- a/packages/build/src/github-repo.ts
+++ b/packages/build/src/github-repo.ts
@@ -40,6 +40,16 @@ type ReleaseAsset = {
   url: string;
 };
 
+type Branch = {
+  ref: string;
+  url: string;
+  object: {
+    sha: string;
+    type: string;
+    url: string;
+  }
+};
+
 export class GithubRepo {
   private octokit: Octokit;
   readonly repo: Readonly<Repo>;
@@ -202,19 +212,26 @@ export class GithubRepo {
   /**
    * Creates a new branch pointing to the latest commit of the given source branch.
    * @param branchName The name of the branch (not including refs/heads/)
-   * @param sourceBranch The name of the branch to branch off from (not including refs/heads/)
+   * @param sourceSha The SHA hash of the commit to branch off from
    */
-  async createBranch(branchName: string, sourceBranch: string): Promise<void> {
-    const result = await this.octokit.git.getRef({
-      ...this.repo,
-      ref: `heads/${sourceBranch}`
-    });
-
+  async createBranch(branchName: string, sourceSha: string): Promise<void> {
     await this.octokit.git.createRef({
       ...this.repo,
       ref: `refs/heads/${branchName}`,
-      sha: result.data.object.sha
+      sha: sourceSha
     });
+  }
+
+  /**
+   * Retrieves the details of the given branch.
+   * @param branchName The name of the branch (not including refs/heads/)
+   */
+  async getBranchDetails(branchName: string): Promise<Branch> {
+    const result = await this.octokit.git.getRef({
+      ...this.repo,
+      ref: `heads/${branchName}`
+    });
+    return result.data;
   }
 
   /**

--- a/packages/build/src/homebrew/publish-to-homebrew.spec.ts
+++ b/packages/build/src/homebrew/publish-to-homebrew.spec.ts
@@ -7,7 +7,7 @@ chai.use(require('sinon-chai'));
 
 describe('Homebrew publish-to-homebrew', () => {
   let homebrewCore: GithubRepo;
-  let homebrewFork: GithubRepo;
+  let homebrewCoreFork: GithubRepo;
   let createPullRequest: sinon.SinonStub;
   let httpsSha256: sinon.SinonStub;
   let generateFormula: sinon.SinonStub;
@@ -26,7 +26,7 @@ describe('Homebrew publish-to-homebrew', () => {
       },
       createPullRequest: createPullRequest as any
     } as unknown as GithubRepo;
-    homebrewFork = {
+    homebrewCoreFork = {
       repo: {
         owner: 'mongodb-js',
         repo: 'homebrew-core'
@@ -51,7 +51,8 @@ describe('Homebrew publish-to-homebrew', () => {
         packageVersion: '1.0.0',
         packageSha: 'sha',
         homebrewFormula: 'new formula',
-        homebrewCoreFork: homebrewFork
+        homebrewCore,
+        homebrewCoreFork
       })
       .resolves('new-branch');
 
@@ -62,7 +63,7 @@ describe('Homebrew publish-to-homebrew', () => {
 
     await publishToHomebrew(
       homebrewCore,
-      homebrewFork,
+      homebrewCoreFork,
       '1.0.0',
       'githubRelease',
       httpsSha256,
@@ -93,13 +94,14 @@ describe('Homebrew publish-to-homebrew', () => {
         packageVersion: '1.0.0',
         packageSha: 'sha',
         homebrewFormula: 'formula',
-        homebrewCoreFork: homebrewFork
+        homebrewCore,
+        homebrewCoreFork
       })
       .resolves(undefined);
 
     await publishToHomebrew(
       homebrewCore,
-      homebrewFork,
+      homebrewCoreFork,
       '1.0.0',
       'githubRelease',
       httpsSha256,
@@ -130,7 +132,8 @@ describe('Homebrew publish-to-homebrew', () => {
         packageVersion: '1.0.0',
         packageSha: 'sha',
         homebrewFormula: 'new formula',
-        homebrewCoreFork: homebrewFork
+        homebrewCore,
+        homebrewCoreFork
       })
       .resolves('new-branch');
 
@@ -141,7 +144,7 @@ describe('Homebrew publish-to-homebrew', () => {
 
     await publishToHomebrew(
       homebrewCore,
-      homebrewFork,
+      homebrewCoreFork,
       '1.0.0',
       'githubRelease',
       httpsSha256,

--- a/packages/build/src/homebrew/publish-to-homebrew.ts
+++ b/packages/build/src/homebrew/publish-to-homebrew.ts
@@ -26,7 +26,7 @@ export async function publishToHomebrew(
   }
 
   const forkBranch = await updateHomebrewForkFn({
-    packageVersion, packageSha, homebrewFormula, homebrewCoreFork
+    packageVersion, packageSha, homebrewFormula, homebrewCore, homebrewCoreFork
   });
   if (!forkBranch) {
     console.warn('There are no changes to the homebrew formula');

--- a/packages/build/src/run-publish.spec.ts
+++ b/packages/build/src/run-publish.spec.ts
@@ -97,6 +97,12 @@ describe('publish', () => {
       githubRepo = createStubRepo({
         getMostRecentDraftTagForRelease: sinon.stub().resolves({ name: 'v0.7.0-draft.42', sha: 'revision' })
       });
+      Object.assign(githubRepo, {
+        repo: {
+          owner: 'mongodb-js',
+          repo: 'mongosh'
+        }
+      });
     });
 
     context('validates configuration', () => {

--- a/packages/build/src/run-publish.ts
+++ b/packages/build/src/run-publish.ts
@@ -62,7 +62,7 @@ export async function runPublish(
     config.downloadCenterAwsSecret || ''
   );
 
-  const releaseUrl = await mongoshGithubRepo.promoteRelease(config);
+  await mongoshGithubRepo.promoteRelease(config);
 
   // ensures the segment api key to be present in the published packages
   await writeAnalyticsConfig(
@@ -76,7 +76,7 @@ export async function runPublish(
     homebrewCoreGithubRepo,
     mongodbHomebrewForkGithubRepo,
     config.version,
-    releaseUrl
+    `https://github.com/${mongoshGithubRepo.repo.owner}/${mongoshGithubRepo.repo.repo}/releases/tag/v${config.version}`
   );
 
   console.info('mongosh: finished release process.');


### PR DESCRIPTION
This should fix the issue observed in https://github.com/Homebrew/homebrew-core/pull/80462. I've also replaced the release URL with a ordinary string template as it turned out to be rendered very awkwardly in the PRs...