### PR TITLE
fix(service-provider-core): print DBRef properly MONGOSH-875

### DIFF
--- a/packages/browser-repl/src/components/utils/inspect.ts
+++ b/packages/browser-repl/src/components/utils/inspect.ts
@@ -14,15 +14,15 @@ import { bsonStringifiers } from '@mongosh/service-provider-core';
 const customInspect = utilInspect.custom || 'inspect';
 const visitedObjects = new WeakSet();
 
-function tryAddInspect(obj: any, stringifier: (this: any) => string): void {
+function tryAddInspect(obj: any, stringifier: (this: any, depth: any, options: any) => string): void {
   try {
     Object.defineProperty(obj, customInspect, {
       writable: true,
       configurable: true,
       enumerable: false,
-      value: function() {
+      value: function(...args: [any, any]) {
         try {
-          return stringifier.call(this);
+          return stringifier.call(this, ...args);
         } catch (err) {
           console.warn('Could not inspect bson object', { obj: this, err });
           return utilInspect(this, { customInspect: false });

--- a/packages/cli-repl/test/e2e-bson.spec.ts
+++ b/packages/cli-repl/test/e2e-bson.spec.ts
@@ -38,7 +38,9 @@ describe('BSON e2e', function() {
   describe('printed BSON', () => {
     const outputDoc = {
       ObjectId: 'ObjectId("5f16b8bebe434dc98cdfc9ca")',
-      DBRef: 'DBRef("a", "5f16b8bebe434dc98cdfc9cb", "db")',
+      DBRef1: 'DBRef("a", ObjectId("5f16b8bebe434dc98cdfc9cb"), "db")',
+      DBRef2: 'DBRef("a", \'5f16b8bebe434dc98cdfc9cb\', "db")',
+      DBRef3: 'DBRef("a", { x: \'5f16b8bebe434dc98cdfc9cb\' }, "db")',
       MinKey: 'MinKey()',
       MaxKey: 'MaxKey()',
       NumberInt: 'Int32(32)',
@@ -55,7 +57,9 @@ describe('BSON e2e', function() {
       const buffer = Buffer.from('MTIzNA==', 'base64');
       const inputDoc = {
         ObjectId: new bson.ObjectId('5f16b8bebe434dc98cdfc9ca'),
-        DBRef: new bson.DBRef('a', new bson.ObjectId('5f16b8bebe434dc98cdfc9cb'), 'db'),
+        DBRef1: new bson.DBRef('a', new bson.ObjectId('5f16b8bebe434dc98cdfc9cb'), 'db'),
+        DBRef2: new bson.DBRef('a', '5f16b8bebe434dc98cdfc9cb' as any, 'db'),
+        DBRef3: new bson.DBRef('a', { x: '5f16b8bebe434dc98cdfc9cb' } as any, 'db'),
         MinKey: new bson.MinKey(),
         MaxKey: new bson.MaxKey(),
         Timestamp: new bson.Timestamp(1, 100),
@@ -71,7 +75,9 @@ describe('BSON e2e', function() {
       await shell.writeInputLine('db.test.findOne()');
       await eventually(() => {
         shell.assertContainsOutput(outputDoc.ObjectId);
-        shell.assertContainsOutput(outputDoc.DBRef);
+        shell.assertContainsOutput(outputDoc.DBRef1);
+        shell.assertContainsOutput(outputDoc.DBRef2);
+        shell.assertContainsOutput(outputDoc.DBRef3);
         shell.assertContainsOutput(outputDoc.MinKey);
         shell.assertContainsOutput(outputDoc.MaxKey);
         shell.assertContainsOutput(outputDoc.Timestamp);
@@ -87,7 +93,9 @@ describe('BSON e2e', function() {
     it('Entire doc prints when created by user', async() => {
       const value = `doc = {
         ObjectId: new ObjectId('5f16b8bebe434dc98cdfc9ca'),
-        DBRef: new DBRef('a', '5f16b8bebe434dc98cdfc9cb', 'db'),
+        DBRef1: new DBRef('a', new ObjectId('5f16b8bebe434dc98cdfc9cb'), 'db'),
+        DBRef2: new DBRef('a', '5f16b8bebe434dc98cdfc9cb', 'db'),
+        DBRef3: new DBRef('a', { x: '5f16b8bebe434dc98cdfc9cb' }, 'db'),
         MinKey: new MinKey(),
         MaxKey: new MaxKey(),
         NumberInt: NumberInt("32"),
@@ -103,7 +111,9 @@ describe('BSON e2e', function() {
       await shell.writeInputLine(value);
       await eventually(() => {
         shell.assertContainsOutput(outputDoc.ObjectId);
-        shell.assertContainsOutput(outputDoc.DBRef);
+        shell.assertContainsOutput(outputDoc.DBRef1);
+        shell.assertContainsOutput(outputDoc.DBRef2);
+        shell.assertContainsOutput(outputDoc.DBRef3);
         shell.assertContainsOutput(outputDoc.MinKey);
         shell.assertContainsOutput(outputDoc.MaxKey);
         shell.assertContainsOutput(outputDoc.Timestamp);
@@ -132,7 +142,7 @@ describe('BSON e2e', function() {
       await db.collection('test').insertOne({ value: value });
       await shell.writeInputLine('db.test.findOne().value');
       await eventually(() => {
-        shell.assertContainsOutput('DBRef("coll", "5f16b8bebe434dc98cdfc9ca")');
+        shell.assertContainsOutput('DBRef("coll", ObjectId("5f16b8bebe434dc98cdfc9ca"))');
       });
       shell.assertNoErrors();
     });
@@ -256,7 +266,7 @@ describe('BSON e2e', function() {
       shell.assertNoErrors();
     });
     it('DBRef prints when created by user', async() => {
-      const value = 'DBRef("coll", "5f16b8bebe434dc98cdfc9ca")';
+      const value = 'DBRef("coll", ObjectId("5f16b8bebe434dc98cdfc9ca"))';
       await shell.writeInputLine(value);
       await eventually(() => {
         shell.assertContainsOutput(value);

--- a/packages/service-provider-core/src/printable-bson.spec.ts
+++ b/packages/service-provider-core/src/printable-bson.spec.ts
@@ -15,7 +15,11 @@ describe('BSON printers', function() {
 
   it('formats DBRefs correctly', function() {
     expect(inspect(new bson.DBRef('a', new bson.ObjectId('5f16b8bebe434dc98cdfc9cb'), 'db')))
-      .to.equal('DBRef("a", "5f16b8bebe434dc98cdfc9cb", "db")');
+      .to.equal('DBRef("a", ObjectId("5f16b8bebe434dc98cdfc9cb"), "db")');
+    expect(inspect(new bson.DBRef('a', 'foo' as any, 'db')))
+      .to.equal('DBRef("a", \'foo\', "db")');
+    expect(inspect(new bson.DBRef('a', { x: 1 } as any, 'db')))
+      .to.equal('DBRef("a", { x: 1 }, "db")');
   });
 
   it('formats MinKey and MaxKey correctly', function() {

--- a/packages/service-provider-core/src/printable-bson.ts
+++ b/packages/service-provider-core/src/printable-bson.ts
@@ -2,7 +2,7 @@ import { bson as BSON } from './index';
 import { inspect } from 'util';
 const inspectCustom = Symbol.for('nodejs.util.inspect.custom');
 
-export const bsonStringifiers: Record<string, (this: any) => string> = {
+export const bsonStringifiers: Record<string, (this: any, depth: any, options: any) => string> = {
   ObjectId: function(): string {
     return `ObjectId("${this.toHexString()}")`;
   },

--- a/packages/service-provider-core/src/printable-bson.ts
+++ b/packages/service-provider-core/src/printable-bson.ts
@@ -1,4 +1,5 @@
 import { bson as BSON } from './index';
+import { inspect } from 'util';
 const inspectCustom = Symbol.for('nodejs.util.inspect.custom');
 
 export const bsonStringifiers: Record<string, (this: any) => string> = {
@@ -6,13 +7,11 @@ export const bsonStringifiers: Record<string, (this: any) => string> = {
     return `ObjectId("${this.toHexString()}")`;
   },
 
-  DBRef: function(): string {
-    // NOTE: if OID is an ObjectId class it will just print the oid string.
-    return `DBRef("${this.namespace}", "${
-      this.oid === undefined || this.oid.toString === undefined ?
-        this.oid :
-        this.oid.toString()
-    }"${this.db ? `, "${this.db}"` : ''})`;
+  DBRef: function(depth: any, options: any): string {
+    return `DBRef("${this.namespace}", ` +
+      inspect(this.oid, options) +
+      (this.db ? `, "${this.db}"` : '') +
+      ')';
   },
 
   MaxKey: function(): string {


### PR DESCRIPTION
`DBRef` object id values can be anything (just as the `_id` field
of a document can be anything), so we should not act as if it
is always an `ObjectId`, and in particular, we should print it out
in a way that allows for re-evaluation.