### PR TITLE
[DNM] buggy-but-available LB support to create test binaries

### DIFF
--- a/packages/service-provider-server/package-lock.json
+++ b/packages/service-provider-server/package-lock.json
@@ -70,9 +70,9 @@
 			}
 		},
 		"bson": {
-			"version": "4.4.0",
-			"resolved": "https://registry.npmjs.org/bson/-/bson-4.4.0.tgz",
-			"integrity": "sha512-uX9Zqzv2DpFXJgQOWKD8nbf0dTQV57WM8eiXDXVWeJYgiu/zIRz61OGLJKwbfSEEjZJ+AgS+7TUT7Y8EloTaqQ==",
+			"version": "4.4.1",
+			"resolved": "https://registry.npmjs.org/bson/-/bson-4.4.1.tgz",
+			"integrity": "sha512-Uu4OCZa0jouQJCKOk1EmmyqtdWAP5HVLru4lQxTwzJzxT+sJ13lVpEZU/MATDxtHiekWMAL84oQY3Xn1LpJVSg==",
 			"requires": {
 				"buffer": "^5.6.0"
 			}
@@ -417,9 +417,8 @@
 			"optional": true
 		},
 		"mongodb": {
-			"version": "4.0.0-beta.6",
-			"resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.0.0-beta.6.tgz",
-			"integrity": "sha512-gV6IbnGWgHBiDgAaWCNSMymP6jIMk/zvCjUETPcFa1sUgar2XUpUXpCOdV1G7R7VrRBtpNRStbHIVx5MkbPFCA==",
+			"version": "github:addaleax/node-mongodb-native#8951e199777bb78bc3241345550c640765cadc96",
+			"from": "github:addaleax/node-mongodb-native#8951e199777bb78bc3241345550c640765cadc96",
 			"requires": {
 				"bson": "^4.4.0",
 				"denque": "^1.5.0",

--- a/packages/service-provider-server/package.json
+++ b/packages/service-provider-server/package.json
@@ -42,7 +42,7 @@
     "@mongosh/service-provider-core": "0.0.0-dev.0",
     "@mongosh/types": "0.0.0-dev.0",
     "@types/sinon-chai": "^3.2.3",
-    "mongodb": "4.0.0-beta.6",
+    "mongodb": "addaleax/node-mongodb-native#8951e199777bb78bc3241345550c640765cadc96",
     "saslprep": "mongodb-js/saslprep#v1.0.4",
     "mongodb-connection-string-url": "^1.0.0"
   },


### PR DESCRIPTION
This is only to create test binaries, because they have been requested by the serverless team. The referenced git hash is the current state of the NODE-3011 work rebased against the 4.0 branch.