### PR TITLE
feat(shell-api): reset current cursor when db changes or auths MONGOSH-13

### DIFF
--- a/packages/shell-api/src/database.ts
+++ b/packages/shell-api/src/database.ts
@@ -452,6 +452,7 @@ export default class Database extends ShellApiWithMongoClass {
   @apiVersions([])
   async logout(): Promise<Document> {
     this._emitDatabaseApiCall('logout', {});
+    this._mongo._internalState.currentCursor = null;
     return await this._runCommand({ logout: 1 });
   }
 
@@ -516,6 +517,7 @@ export default class Database extends ShellApiWithMongoClass {
       );
     }
     authDoc.authDb = this._name;
+    this._mongo._internalState.currentCursor = null;
     return await this._mongo._serviceProvider.authenticate(authDoc);
   }
 

--- a/packages/shell-api/src/shell-internal-state.ts
+++ b/packages/shell-api/src/shell-internal-state.ts
@@ -174,6 +174,7 @@ export default class ShellInternalState {
     // Pre-fetch for autocompletion.
     this.currentDb._getCollectionNamesForCompletion().catch(err => this.messageBus.emit('mongosh:error', err));
     this.currentDb._mongo._getDatabaseNamesForCompletion().catch(err => this.messageBus.emit('mongosh:error', err));
+    this.currentCursor = null;
     return newDb;
   }
 


### PR DESCRIPTION
Reset the current cursor on:
- Assignment to `db`
- `db.auth()`
- `db.logout()`