### PR TITLE
fix(shell-api): call tryNext on new change stream cursors MONGOSH-889

### DIFF
--- a/packages/shell-api/src/change-stream-cursor.spec.ts
+++ b/packages/shell-api/src/change-stream-cursor.spec.ts
@@ -127,8 +127,7 @@ describe('ChangeStreamCursor', () => {
 
     describe('collection watch', () => {
       beforeEach(async() => {
-        cursor = coll.watch([{ '$match': { 'operationType': 'insert' } }]);
-        await cursor.tryNext(); // first one always fails?
+        cursor = await coll.watch([{ '$match': { 'operationType': 'insert' } }]);
       });
       it('tryNext returns null when there is nothing', async() => {
         const result = await cursor.tryNext();
@@ -199,8 +198,7 @@ describe('ChangeStreamCursor', () => {
     });
     describe('database watch', () => {
       beforeEach(async() => {
-        cursor = db.watch([{ '$match': { 'operationType': 'insert' } }]);
-        await cursor.tryNext(); // first one always fails?
+        cursor = await db.watch([{ '$match': { 'operationType': 'insert' } }]);
       });
       it('tryNext returns null when there is nothing', async() => {
         const result = await cursor.tryNext();
@@ -235,8 +233,7 @@ describe('ChangeStreamCursor', () => {
     });
     describe('mongo watch', () => {
       beforeEach(async() => {
-        cursor = mongo.watch([{ '$match': { 'operationType': 'insert' } }]);
-        await cursor.tryNext(); // first one always fails?
+        cursor = await mongo.watch([{ '$match': { 'operationType': 'insert' } }]);
       });
       it('tryNext returns null when there is nothing', async() => {
         const result = await cursor.tryNext();

--- a/packages/shell-api/src/collection.spec.ts
+++ b/packages/shell-api/src/collection.spec.ts
@@ -1784,36 +1784,42 @@ describe('Collection', () => {
       });
     });
     describe('watch', () => {
-      it('calls serviceProvider.watch when given no args', () => {
-        collection.watch();
+      let fakeSpCursor: any;
+      beforeEach(() => {
+        fakeSpCursor = {
+          closed: false,
+          tryNext: async() => {}
+        };
+        serviceProvider.watch.returns(fakeSpCursor);
+      });
+      it('calls serviceProvider.watch when given no args', async() => {
+        await collection.watch();
         expect(serviceProvider.watch).to.have.been.calledWith([], {}, {}, collection._database._name, collection._name);
       });
-      it('calls serviceProvider.watch when given pipeline arg', () => {
+      it('calls serviceProvider.watch when given pipeline arg', async() => {
         const pipeline = [{ $match: { operationType: 'insertOne' } }];
-        collection.watch(pipeline);
+        await collection.watch(pipeline);
         expect(serviceProvider.watch).to.have.been.calledWith(pipeline, {}, {}, collection._database._name, collection._name);
       });
-      it('calls serviceProvider.watch when given no args', () => {
+      it('calls serviceProvider.watch when given no args', async() => {
         const pipeline = [{ $match: { operationType: 'insertOne' } }];
         const ops = { batchSize: 1 };
-        collection.watch(pipeline, ops);
+        await collection.watch(pipeline, ops);
         expect(serviceProvider.watch).to.have.been.calledWith(pipeline, ops, {}, collection._database._name, collection._name);
       });
 
-      it('returns whatever serviceProvider.watch returns', () => {
-        const expectedResult = { ChangeStreamCursor: 1 } as any;
-        const expectedCursor = new ChangeStreamCursor(expectedResult, collection._name, mongo);
-        serviceProvider.watch.returns(expectedResult);
-        const result = collection.watch();
+      it('returns whatever serviceProvider.watch returns', async() => {
+        const expectedCursor = new ChangeStreamCursor(fakeSpCursor, collection._name, mongo);
+        const result = await collection.watch();
         expect(result).to.deep.equal(expectedCursor);
         expect(collection._mongo._internalState.currentCursor).to.equal(result);
       });
 
-      it('throws if serviceProvider.watch throws', () => {
+      it('throws if serviceProvider.watch throws', async() => {
         const expectedError = new Error();
         serviceProvider.watch.throws(expectedError);
         try {
-          collection.watch();
+          await collection.watch();
         } catch (e) {
           expect(e).to.equal(expectedError);
           return;

--- a/packages/shell-api/src/collection.spec.ts
+++ b/packages/shell-api/src/collection.spec.ts
@@ -1873,6 +1873,7 @@ describe('Collection', () => {
       hideIndex: { m: 'runCommandWithCheck', i: 2 },
       unhideIndex: { m: 'runCommandWithCheck', i: 2 },
       remove: { m: 'deleteMany' },
+      watch: { i: 1 }
     };
     const ignore = [ 'getShardDistribution', 'stats', 'isCapped', 'save' ];
     const args = [ { query: {} }, {}, { out: 'coll' } ];
@@ -1889,6 +1890,7 @@ describe('Collection', () => {
       serviceProvider.createIndexes.resolves(['index_1']);
       serviceProvider.stats.resolves({ storageSize: 1, totalIndexSize: 1 });
       serviceProvider.listCollections.resolves([]);
+      serviceProvider.watch.returns({ closed: false, tryNext: async() => {} } as any);
       serviceProvider.countDocuments.resolves(1);
 
       serviceProvider.runCommandWithCheck.resolves({ ok: 1, version: 1, bits: 1, commands: 1, users: [], roles: [], logComponentVerbosity: 1 });

--- a/packages/shell-api/src/collection.ts
+++ b/packages/shell-api/src/collection.ts
@@ -1717,7 +1717,10 @@ export default class Collection extends ShellApiWithMongoClass {
   async watch(pipeline: Document[] = [], options: ChangeStreamOptions = {}): Promise<ChangeStreamCursor> {
     this._emitCollectionApiCall('watch', { pipeline, options });
     const cursor = new ChangeStreamCursor(
-      this._mongo._serviceProvider.watch(pipeline, options, {}, this._database._name, this._name),
+      this._mongo._serviceProvider.watch(pipeline, {
+        ...this._database._baseOptions,
+        ...options
+      }, {}, this._database._name, this._name),
       this._name,
       this._mongo
     );

--- a/packages/shell-api/src/collection.ts
+++ b/packages/shell-api/src/collection.ts
@@ -1713,13 +1713,29 @@ export default class Collection extends ShellApiWithMongoClass {
   @serverVersions(['3.1.0', ServerVersions.latest])
   @topologies([Topologies.ReplSet, Topologies.Sharded])
   @apiVersions([1])
-  watch(pipeline: Document[] = [], options: ChangeStreamOptions = {}): ChangeStreamCursor {
+  @returnsPromise
+  async watch(pipeline: Document[] = [], options: ChangeStreamOptions = {}): Promise<ChangeStreamCursor> {
     this._emitCollectionApiCall('watch', { pipeline, options });
     const cursor = new ChangeStreamCursor(
       this._mongo._serviceProvider.watch(pipeline, options, {}, this._database._name, this._name),
       this._name,
       this._mongo
     );
+    // Cursors are not actually initialized in the driver until we try to read
+    // from them. However, in the legacy shell as well as here the expectation
+    // is that the change stream cursor will include all events starting from
+    // the .watch() call itself. Therefore, we call .tryNext() here (and in the
+    // .watch() methods of the Database and Mongo classes).
+    // This should be fine, even though it means potentially ignoring one item
+    // from the cursor, because:
+    // - No events caused by this shell/connection can be missed, because it
+    //   immediately follows the service provider .watch() call
+    // - Events from another connection might be missed, but that is fine,
+    //   because an event that is observed to occur after the service provider
+    //   .watch() call and before the .tryNext() call could also have been
+    //   observed before the .watch() call, i.e. there is a race condition
+    //   here either way and we can use that to our advantage.
+    await cursor.tryNext();
     this._mongo._internalState.currentCursor = cursor;
     return cursor;
   }

--- a/packages/shell-api/src/database.spec.ts
+++ b/packages/shell-api/src/database.spec.ts
@@ -2492,6 +2492,7 @@ describe('Database', () => {
       serviceProvider.runCommandWithCheck.resolves({ ok: 1, version: 1, bits: 1, commands: 1, users: [], roles: [], logComponentVerbosity: 1, help: 'blah' });
       serviceProvider.runCommand.resolves({ ok: 1 });
       serviceProvider.listCollections.resolves([]);
+      serviceProvider.watch.returns({ closed: false, tryNext: async() => {} } as any);
       const internalState = new ShellInternalState(serviceProvider, bus);
       const mongo = new Mongo(internalState, undefined, undefined, undefined, serviceProvider);
       const session = mongo.startSession();

--- a/packages/shell-api/src/database.spec.ts
+++ b/packages/shell-api/src/database.spec.ts
@@ -2399,35 +2399,41 @@ describe('Database', () => {
       });
     });
     describe('watch', () => {
-      it('calls serviceProvider.watch when given no args', () => {
-        database.watch();
+      let fakeSpCursor: any;
+      beforeEach(() => {
+        fakeSpCursor = {
+          closed: false,
+          tryNext: async() => {}
+        };
+        serviceProvider.watch.returns(fakeSpCursor);
+      });
+      it('calls serviceProvider.watch when given no args', async() => {
+        await database.watch();
         expect(serviceProvider.watch).to.have.been.calledWith([], {}, {}, database._name);
       });
-      it('calls serviceProvider.watch when given pipeline arg', () => {
+      it('calls serviceProvider.watch when given pipeline arg', async() => {
         const pipeline = [{ $match: { operationType: 'insertOne' } }];
-        database.watch(pipeline);
+        await database.watch(pipeline);
         expect(serviceProvider.watch).to.have.been.calledWith(pipeline, {}, {}, database._name);
       });
-      it('calls serviceProvider.watch when given no args', () => {
+      it('calls serviceProvider.watch when given no args', async() => {
         const pipeline = [{ $match: { operationType: 'insertOne' } }];
         const ops = { batchSize: 1 };
-        database.watch(pipeline, ops);
+        await database.watch(pipeline, ops);
         expect(serviceProvider.watch).to.have.been.calledWith(pipeline, ops, {}, database._name);
       });
 
-      it('returns whatever serviceProvider.watch returns', () => {
-        const expectedResult = { ChangeStreamCursor: 1 } as any;
-        serviceProvider.watch.returns(expectedResult);
-        const result = database.watch();
-        expect(result).to.deep.equal(new ChangeStreamCursor(expectedResult, database._name, mongo));
+      it('returns whatever serviceProvider.watch returns', async() => {
+        const result = await database.watch();
+        expect(result).to.deep.equal(new ChangeStreamCursor(fakeSpCursor, database._name, mongo));
         expect(database._mongo._internalState.currentCursor).to.equal(result);
       });
 
-      it('throws if serviceProvider.watch throws', () => {
+      it('throws if serviceProvider.watch throws', async() => {
         const expectedError = new Error();
         serviceProvider.watch.throws(expectedError);
         try {
-          database.watch();
+          await database.watch();
         } catch (e) {
           expect(e).to.equal(expectedError);
           return;

--- a/packages/shell-api/src/database.ts
+++ b/packages/shell-api/src/database.ts
@@ -1402,13 +1402,15 @@ export default class Database extends ShellApiWithMongoClass {
   @serverVersions(['3.1.0', ServerVersions.latest])
   @topologies([Topologies.ReplSet, Topologies.Sharded])
   @apiVersions([1])
-  watch(pipeline: Document[] = [], options: ChangeStreamOptions = {}): ChangeStreamCursor {
+  @returnsPromise
+  async watch(pipeline: Document[] = [], options: ChangeStreamOptions = {}): Promise<ChangeStreamCursor> {
     this._emitDatabaseApiCall('watch', { pipeline, options });
     const cursor = new ChangeStreamCursor(
       this._mongo._serviceProvider.watch(pipeline, options, {}, this._name),
       this._name,
       this._mongo
     );
+    await cursor.tryNext(); // See comment in coll.watch().
     this._mongo._internalState.currentCursor = cursor;
     return cursor;
   }

--- a/packages/shell-api/src/database.ts
+++ b/packages/shell-api/src/database.ts
@@ -1406,7 +1406,10 @@ export default class Database extends ShellApiWithMongoClass {
   async watch(pipeline: Document[] = [], options: ChangeStreamOptions = {}): Promise<ChangeStreamCursor> {
     this._emitDatabaseApiCall('watch', { pipeline, options });
     const cursor = new ChangeStreamCursor(
-      this._mongo._serviceProvider.watch(pipeline, options, {}, this._name),
+      this._mongo._serviceProvider.watch(pipeline, {
+        ...this._baseOptions,
+        ...options
+      }, {}, this._name),
       this._name,
       this._mongo
     );

--- a/packages/shell-api/src/mongo.spec.ts
+++ b/packages/shell-api/src/mongo.spec.ts
@@ -623,35 +623,41 @@ describe('Mongo', () => {
       });
     });
     describe('watch', () => {
-      it('calls serviceProvider.watch when given no args', () => {
-        mongo.watch();
+      let fakeSpCursor: any;
+      beforeEach(() => {
+        fakeSpCursor = {
+          closed: false,
+          tryNext: async() => {}
+        };
+        serviceProvider.watch.returns(fakeSpCursor);
+      });
+      it('calls serviceProvider.watch when given no args', async() => {
+        await mongo.watch();
         expect(serviceProvider.watch).to.have.been.calledWith([], {});
       });
-      it('calls serviceProvider.watch when given pipeline arg', () => {
+      it('calls serviceProvider.watch when given pipeline arg', async() => {
         const pipeline = [{ $match: { operationType: 'insertOne' } }];
-        mongo.watch(pipeline);
+        await mongo.watch(pipeline);
         expect(serviceProvider.watch).to.have.been.calledWith(pipeline, {});
       });
-      it('calls serviceProvider.watch when given no args', () => {
+      it('calls serviceProvider.watch when given no args', async() => {
         const pipeline = [{ $match: { operationType: 'insertOne' } }];
         const ops = { batchSize: 1 };
-        mongo.watch(pipeline, ops);
+        await mongo.watch(pipeline, ops);
         expect(serviceProvider.watch).to.have.been.calledWith(pipeline, ops);
       });
 
-      it('returns whatever serviceProvider.watch returns', () => {
-        const expectedResult = { ChangeStreamCursor: 1 } as any;
-        serviceProvider.watch.returns(expectedResult);
-        const result = mongo.watch();
-        expect(result).to.deep.equal(new ChangeStreamCursor(expectedResult, 'mongodb://localhost/?directConnection=true&serverSelectionTimeoutMS=2000', mongo));
+      it('returns whatever serviceProvider.watch returns', async() => {
+        const result = await mongo.watch();
+        expect(result).to.deep.equal(new ChangeStreamCursor(fakeSpCursor, 'mongodb://localhost/?directConnection=true&serverSelectionTimeoutMS=2000', mongo));
         expect(mongo._internalState.currentCursor).to.equal(result);
       });
 
-      it('throws if serviceProvider.watch throws', () => {
+      it('throws if serviceProvider.watch throws', async() => {
         const expectedError = new Error();
         serviceProvider.watch.throws(expectedError);
         try {
-          mongo.watch();
+          await mongo.watch();
         } catch (e) {
           expect(e).to.equal(expectedError);
           return;

--- a/packages/shell-api/src/mongo.ts
+++ b/packages/shell-api/src/mongo.ts
@@ -495,13 +495,15 @@ export default class Mongo extends ShellApiClass {
   @serverVersions(['3.1.0', ServerVersions.latest])
   @topologies([Topologies.ReplSet, Topologies.Sharded])
   @apiVersions([1])
-  watch(pipeline: Document[] = [], options: ChangeStreamOptions = {}): ChangeStreamCursor {
+  @returnsPromise
+  async watch(pipeline: Document[] = [], options: ChangeStreamOptions = {}): Promise<ChangeStreamCursor> {
     this._emitMongoApiCall('watch', { pipeline, options });
     const cursor = new ChangeStreamCursor(
       this._serviceProvider.watch(pipeline, options),
       redactCredentials(this._uri),
       this
     );
+    await cursor.tryNext(); // See comment in coll.watch().
     this._internalState.currentCursor = cursor;
     return cursor;
   }


### PR DESCRIPTION
Call `.tryNext()` on each change stream cursor after its creation,
in order to initialize the cursor on the driver side and make it
start listening for events immediately.