### PR TITLE
fix(service-provider-server): fix change stream .next() interrupt 

### DIFF
--- a/packages/service-provider-server/src/mongodb-patches.ts
+++ b/packages/service-provider-server/src/mongodb-patches.ts
@@ -66,7 +66,18 @@ function patchConnectionPoolTracking(): void {
       const originalCallback = cb;
       cb = function(this: any, error: any, result: any) {
         poolToConnections.delete(pool);
-        [...connections].forEach(c => c.destroy({ force: true }));
+        for (const c of connections) {
+          c.destroy({ force: true });
+          // Immediately after destroying, act as if the close had happened,
+          // but *not* as an actual 'close' event on the socket itself --
+          // a close on the socket is communicated as a network error, which
+          // is considered an retryable error by operations which are currently
+          // running on this connection, but the whole point here is that these
+          // operations should *not* be retried. So, we just act as if something
+          // had happened that interrupts all ongoing operations and also is
+          // supposed to destroy the connection (which is a no-op at this point).
+          c.handleIssue({ destroy: true });
+        }
 
         if (originalCallback) {
           originalCallback.call(this, error, result);

--- a/packages/service-provider-server/src/mongodb-patches.ts
+++ b/packages/service-provider-server/src/mongodb-patches.ts
@@ -76,7 +76,7 @@ function patchConnectionPoolTracking(): void {
           // operations should *not* be retried. So, we just act as if something
           // had happened that interrupts all ongoing operations and also is
           // supposed to destroy the connection (which is a no-op at this point).
-          c.handleIssue({ destroy: true });
+          c.handleIssue({ destroy: new Error('connection canceled by force close') });
         }
 
         if (originalCallback) {


### PR DESCRIPTION
MONGOSH-888

When a user interrupts running code while a change stream `.next()`
call is running, that closes the network connection. However,
network errors are considered retryable by the driver (in line
with the spec); this makes the change stream cursor `.next()`
operation attempt to re-try itself, which fails because the
MongoClient is already unusable at that point.

In order to address this, we call the driver-internal
`Connection.handleIssue()` method (which should be okay, since the
relevant code here is concerned only with driver internals anyway)
with a non-network-error state, which still closes ongoing operations.