### PR TITLE
fix(async-rewriter2): fix 'use strict' handling MONGOSH-890

### DIFF
--- a/packages/async-rewriter2/src/async-writer-babel.spec.ts
+++ b/packages/async-rewriter2/src/async-writer-babel.spec.ts
@@ -96,6 +96,32 @@ describe('AsyncWriter', () => {
     });
   });
 
+  context('use strict', () => {
+    it('parses a plain "use strict"; as a string literal', () => {
+      expect(runTranspiledCode('"use strict"')).to.equal('use strict');
+      expect(runTranspiledCode('"use strict";')).to.equal('use strict');
+      expect(runTranspiledCode("'use strict'")).to.equal('use strict');
+      expect(runTranspiledCode("'use strict';")).to.equal('use strict');
+    });
+
+    it('runs code that starts with "use strict"', () => {
+      expect(runTranspiledCode("'use strict'; 144 + 233;")).to.equal(377);
+    });
+
+    it('fails to run invalid strict-mode code', () => {
+      try {
+        runTranspiledCode("'use strict'; delete Object.prototype");
+        expect.fail('missed exception');
+      } catch (err) {
+        expect(err.name).to.equal('TypeError');
+      }
+    });
+
+    it('runs code in sloppy mode by default', () => {
+      expect(runTranspiledCode('delete Object.prototype')).to.equal(false);
+    });
+  });
+
   context('scoping', () => {
     it('adds functions to the global scope as expected', () => {
       const f = runTranspiledCode('function f() {}');


### PR DESCRIPTION
- Fix dumb bug where I forgot to check whether the program
  actually contains a body before assuming that the presence of
  a single directive would indicate that the program consisted
  only of that
- Make sure that 'use strict' actually gets propagated into
  the transpiled result