### PR TITLE
fix(cli-repl): use try-require instead of if-else for buildInfo

### DIFF
--- a/packages/cli-repl/src/run.ts
+++ b/packages/cli-repl/src/run.ts
@@ -27,12 +27,12 @@ import os from 'os';
       // eslint-disable-next-line no-console
       console.log(version);
     } else if (options.buildInfo) {
-      if (process.execPath === process.argv[1]) {
+      try {
         const buildInfo = require('./build-info.json');
         delete buildInfo.segmentApiKey;
         // eslint-disable-next-line no-console
         console.log(JSON.stringify(buildInfo, null, '  '));
-      } else {
+      } catch {
         // eslint-disable-next-line no-console
         console.log(JSON.stringify({
           version,


### PR DESCRIPTION
Fix for an issue I only noticed moments after merging: We should
always try to look for the build info JSON file, because that
is not just present in compiled builds, but also in npm packages.