### PR TITLE
chore(test): add serverless connectivity tests MONGOSH-903

### DIFF
--- a/packages/connectivity-tests/test/atlas.sh
+++ b/packages/connectivity-tests/test/atlas.sh
@@ -8,6 +8,7 @@ echo "Exporting secrets ..."
 eval $(
   node "${MONGOSH_ROOT_DIR}/scripts/print-expansions.js" \
     connectivity_test_data_lake_hostname \
+    connectivity_test_serverless_hostname \
     connectivity_test_atlas_hostname \
     connectivity_test_atlas_username \
     connectivity_test_atlas_password
@@ -17,12 +18,14 @@ ATLAS_USERNAME="${CONNECTIVITY_TEST_ATLAS_USERNAME}"
 ATLAS_PASSWORD="${CONNECTIVITY_TEST_ATLAS_PASSWORD}"
 ATLAS_HOSTNAME="${CONNECTIVITY_TEST_ATLAS_HOSTNAME}"
 ATLAS_DATA_LAKE_HOSTNAME="${CONNECTIVITY_TEST_DATA_LAKE_HOSTNAME}"
+ATLAS_SERVERLESS_HOSTNAME="${CONNECTIVITY_TEST_SERVERLESS_HOSTNAME}"
 
 if
   [[ -z "${ATLAS_USERNAME}" ]] ||
     [[ -z "${ATLAS_PASSWORD}" ]] ||
     [[ -z "${ATLAS_HOSTNAME}" ]] ||
-    [[ -z "${ATLAS_DATA_LAKE_HOSTNAME}" ]]
+    [[ -z "${ATLAS_DATA_LAKE_HOSTNAME}" ]] ||
+    [[ -z "${ATLAS_SERVERLESS_HOSTNAME}" ]]
 then
   echo "Atlas credentials are not provided"
 
@@ -129,6 +132,21 @@ function test_data_lake() {
   check_failed
 }
 
+function test_serverless() {
+  printf "test_serverless ... "
+
+  CONNECTION_STRING="mongodb+srv://${ATLAS_SERVERLESS_HOSTNAME}/admin"
+
+  echo "${CONNECTION_STATUS_COMMAND}" |
+    mongosh "${CONNECTION_STRING}" \
+      --username "${ATLAS_USERNAME}" \
+      --password "${ATLAS_PASSWORD}" |
+    grep -Fq "${CONNECTION_STATUS_CHECK_STRING}" ||
+    FAILED="Can't connect to Serverless instance using connection string with username and password"
+
+  check_failed
+}
+
 function test_srv_without_nodejs_dns() {
   printf "test_srv_without_nodejs_dns ... "
 
@@ -147,6 +165,7 @@ test_credentials_masking
 test_cli_args
 test_password_prompt
 test_data_lake
+test_serverless
 test_srv_without_nodejs_dns
 
 echo "All Atlas tests are passing"


### PR DESCRIPTION
Already gave it a go in Evergreen in a patch: https://spruce.mongodb.com/task/mongosh_linux_test_connectivity_patch_db830b31f597682411d793462c898a6ba3c441fa_60f137e1850e614dffa57f95_21_07_16_07_40_31/logs?execution=0