### PR TITLE
feat(cli-repl): add build info to log file

### DIFF
--- a/packages/cli-repl/src/build-info.ts
+++ b/packages/cli-repl/src/build-info.ts
@@ -1,0 +1,30 @@
+import os from 'os';
+
+export type BuildInfo = {
+  version: string;
+  distributionKind: 'unpackaged' | 'packaged' | 'compiled';
+  buildArch: string;
+  buildPlatform: string;
+  buildTarget: string;
+  buildTime: string | null;
+  gitVersion: string | null;
+};
+
+export function buildInfo(): BuildInfo {
+  try {
+    const buildInfo = { ...require('./build-info.json') };
+    delete buildInfo.segmentApiKey;
+    return buildInfo;
+  } catch {
+    const { version } = require('../package.json');
+    return {
+      version,
+      distributionKind: 'unpackaged',
+      buildArch: os.arch(),
+      buildPlatform: os.platform(),
+      buildTarget: 'unknown',
+      buildTime: null,
+      gitVersion: null
+    };
+  }
+}

--- a/packages/cli-repl/src/index.ts
+++ b/packages/cli-repl/src/index.ts
@@ -6,6 +6,7 @@ import { getStoragePaths } from './config-directory';
 import { MONGOSH_WIKI, TELEMETRY_GREETING_MESSAGE, USAGE } from './constants';
 import { getMongocryptdPaths } from './mongocryptd-manager';
 import { runSmokeTests } from './smoke-tests';
+import { buildInfo } from './build-info';
 
 export default CliRepl;
 
@@ -19,5 +20,6 @@ export {
   mapCliToDriver,
   getStoragePaths,
   getMongocryptdPaths,
-  runSmokeTests
+  runSmokeTests,
+  buildInfo
 };

--- a/packages/cli-repl/src/run.ts
+++ b/packages/cli-repl/src/run.ts
@@ -1,8 +1,7 @@
-import { CliRepl, parseCliArgs, mapCliToDriver, getStoragePaths, getMongocryptdPaths, runSmokeTests, USAGE } from './index';
+import { CliRepl, parseCliArgs, mapCliToDriver, getStoragePaths, getMongocryptdPaths, runSmokeTests, USAGE, buildInfo } from './index';
 import { generateUri } from '@mongosh/service-provider-server';
 import { redactCredentials } from '@mongosh/history';
 import { runMain } from 'module';
-import os from 'os';
 
 // eslint-disable-next-line complexity
 (async() => {
@@ -27,23 +26,8 @@ import os from 'os';
       // eslint-disable-next-line no-console
       console.log(version);
     } else if (options.buildInfo) {
-      try {
-        const buildInfo = require('./build-info.json');
-        delete buildInfo.segmentApiKey;
-        // eslint-disable-next-line no-console
-        console.log(JSON.stringify(buildInfo, null, '  '));
-      } catch {
-        // eslint-disable-next-line no-console
-        console.log(JSON.stringify({
-          version,
-          distributionKind: 'unpackaged',
-          buildArch: os.arch(),
-          buildPlatform: os.platform(),
-          buildTarget: 'unknown',
-          buildTime: null,
-          gitVersion: null
-        }, null, '  '));
-      }
+      // eslint-disable-next-line no-console
+      console.log(JSON.stringify(buildInfo(), null, '  '));
     } else if (options.smokeTests) {
       const smokeTestServer = process.env.MONGOSH_SMOKE_TEST_SERVER;
       if (process.execPath === process.argv[1]) {

--- a/packages/cli-repl/src/setup-logger-and-telemetry.spec.ts
+++ b/packages/cli-repl/src/setup-logger-and-telemetry.spec.ts
@@ -94,7 +94,7 @@ describe('setupLoggerAndTelemetry', () => {
     bus.emit('mongosh-sp:missing-optional-dependency', { name: 'kerberos', error: new Error('no kerberos') });
 
     let i = 0;
-    expect(logOutput[i++].msg).to.match(/^mongosh:start-logging \{"version":".+","execPath":".+","isCompiledBinary":.+\}$/);
+    expect(logOutput[i++].msg).to.match(/^mongosh:start-logging \{"execPath":".+","version":".+","distributionKind":.+\}$/);
     expect(logOutput[i++].msg).to.equal('mongosh:update-user {"enableTelemetry":false}');
     expect(logOutput[i].msg).to.match(/^mongosh:connect/);
     expect(logOutput[i].msg).to.match(/"session_id":"5fb3c20ee1507e894e5340f3"/);

--- a/packages/cli-repl/src/setup-logger-and-telemetry.ts
+++ b/packages/cli-repl/src/setup-logger-and-telemetry.ts
@@ -33,6 +33,7 @@ import type {
   SpMissingOptionalDependencyEvent
 } from '@mongosh/types';
 import { inspect } from 'util';
+import { buildInfo } from './build-info';
 
 interface MongoshAnalytics {
   identify(message: {
@@ -87,9 +88,8 @@ export default function setupLoggerAndTelemetry(
   };
 
   log.info('mongosh:start-logging', {
-    version: mongosh_version,
     execPath: process.execPath,
-    isCompiledBinary: process.execPath === process.argv[1]
+    ...buildInfo()
   });
 
   let analytics: MongoshAnalytics = new NoopAnalytics();


### PR DESCRIPTION
This just occurred to me -- we should probably just include the
full build info in the log file, because it doesn’t hurt to include
it and it’s in line with the things that are already in the initial
event.