### PR TITLE
fix(shell-api): add toJSON for CommandResult MONGOSH-905

### DIFF
--- a/packages/cli-repl/test/e2e.spec.ts
+++ b/packages/cli-repl/test/e2e.spec.ts
@@ -409,6 +409,11 @@ describe('e2e', function() {
       expect(await shell.executeLine('explainOutput')).to.match(/g:\s*\{\s*h:\s*\{\s*i:\s*\{\s*j:/);
     });
 
+    it('allows toJSON on results of db operations', async() => {
+      expect(await shell.executeLine('typeof JSON.parse(JSON.stringify(db.listCommands())).ping.help')).to.include('string');
+      expect(await shell.executeLine('typeof JSON.parse(JSON.stringify(db.test.insertOne({}))).insertedId')).to.include('string');
+    });
+
     describe('document validation errors', () => {
       context('post-4.4', () => {
         skipIfServerVersion(testServer, '<= 4.4');

--- a/packages/cli-repl/test/e2e.spec.ts
+++ b/packages/cli-repl/test/e2e.spec.ts
@@ -409,7 +409,10 @@ describe('e2e', function() {
       expect(await shell.executeLine('explainOutput')).to.match(/g:\s*\{\s*h:\s*\{\s*i:\s*\{\s*j:/);
     });
 
-    it('allows toJSON on results of db operations', async() => {
+    it('allows toJSON on results of db operations', async function() {
+      if (process.env.MONGOSH_TEST_FORCE_API_STRICT) {
+        return this.skip(); // listCommands is unversioned
+      }
       expect(await shell.executeLine('typeof JSON.parse(JSON.stringify(db.listCommands())).ping.help')).to.include('string');
       expect(await shell.executeLine('typeof JSON.parse(JSON.stringify(db.test.insertOne({}))).insertedId')).to.include('string');
     });

--- a/packages/shell-api/src/bulk.spec.ts
+++ b/packages/shell-api/src/bulk.spec.ts
@@ -115,9 +115,9 @@ describe('Bulk API', () => {
               expect(() => bulk.insert({})).to.throw(expectedError);
             });
           });
-          describe('tojson', () => {
+          describe('toJSON', () => {
             it('returns the batches length + currentInsert/Update/RemoveBatch?', () => {
-              expect(bulk.tojson()).to.deep.equal({
+              expect(bulk.toJSON()).to.deep.equal({
                 nInsertOps: 0, nUpdateOps: 0, nRemoveOps: 0, nBatches: 4
               });
             });

--- a/packages/shell-api/src/bulk.ts
+++ b/packages/shell-api/src/bulk.ts
@@ -170,7 +170,7 @@ export default class Bulk extends ShellApiWithMongoClass {
    * Internal method to determine what is printed for this class.
    */
   [asPrintable](): any {
-    return this.tojson();
+    return this.toJSON();
   }
 
   /**
@@ -224,7 +224,7 @@ export default class Bulk extends ShellApiWithMongoClass {
     return this;
   }
 
-  tojson(): Record<'nInsertOps' | 'nUpdateOps' | 'nRemoveOps' | 'nBatches', number> {
+  toJSON(): Record<'nInsertOps' | 'nUpdateOps' | 'nRemoveOps' | 'nBatches', number> {
     const batches = this._serviceProviderBulkOp.batches.length;
 
     return {
@@ -234,7 +234,7 @@ export default class Bulk extends ShellApiWithMongoClass {
   }
 
   toString(): string {
-    return JSON.stringify(this.tojson());
+    return JSON.stringify(this.toJSON());
   }
 
   getOperations(): Pick<Batch, 'originalZeroIndex' | 'batchType' | 'operations'>[] {

--- a/packages/shell-api/src/database.spec.ts
+++ b/packages/shell-api/src/database.spec.ts
@@ -2352,6 +2352,7 @@ describe('Database', () => {
         serviceProvider.runCommandWithCheck.resolves(expectedResult);
         const result = await database.listCommands();
         expect(result.value).to.deep.equal(expectedResult.commands);
+        expect(result.toJSON()).to.deep.equal(expectedResult.commands);
         expect(result.type).to.equal('ListCommandsResult');
       });
 

--- a/packages/shell-api/src/decorators.ts
+++ b/packages/shell-api/src/decorators.ts
@@ -278,7 +278,7 @@ type ClassHelp = {
   attr: { name: string; description: string }[];
 };
 
-export const toIgnore = ['constructor', 'help'];
+export const toIgnore = ['constructor', 'help', 'toJSON'];
 function shellApiClassGeneric(constructor: Function, hasHelp: boolean): void {
   const className = constructor.name;
   const classHelpKeyPrefix = `shell-api.classes.${className}.help`;

--- a/packages/shell-api/src/integration.spec.ts
+++ b/packages/shell-api/src/integration.spec.ts
@@ -1511,8 +1511,8 @@ describe('Shell API (integration)', function() {
             expect(await collection.countDocuments()).to.equal(0);
             await bulk.execute();
           });
-          it('tojson returns correctly', async() => {
-            expect(bulk.tojson()).to.deep.equal({ nInsertOps: size, nUpdateOps: 0, nRemoveOps: 0, nBatches: 1 });
+          it('toJSON returns correctly', async() => {
+            expect(bulk.toJSON()).to.deep.equal({ nInsertOps: size, nUpdateOps: 0, nRemoveOps: 0, nBatches: 1 });
           });
           it('executes', async() => {
             expect(await collection.countDocuments()).to.equal(size);
@@ -1537,8 +1537,8 @@ describe('Shell API (integration)', function() {
             bulk.find({ x: { $mod: [ 2, 0 ] } }).remove();
             await bulk.execute();
           });
-          it('tojson returns correctly', async() => {
-            expect(bulk.tojson()).to.deep.equal({ nInsertOps: 0, nUpdateOps: 0, nRemoveOps: 1, nBatches: 1 });
+          it('toJSON returns correctly', async() => {
+            expect(bulk.toJSON()).to.deep.equal({ nInsertOps: 0, nUpdateOps: 0, nRemoveOps: 1, nBatches: 1 });
           });
           it('executes', async() => {
             expect(await collection.countDocuments()).to.equal(size / 2);
@@ -1562,8 +1562,8 @@ describe('Shell API (integration)', function() {
             bulk.find({ x: { $mod: [ 2, 0 ] } }).removeOne();
             await bulk.execute();
           });
-          it('tojson returns correctly', async() => {
-            expect(bulk.tojson()).to.deep.equal({ nInsertOps: 0, nUpdateOps: 0, nRemoveOps: 1, nBatches: 1 });
+          it('toJSON returns correctly', async() => {
+            expect(bulk.toJSON()).to.deep.equal({ nInsertOps: 0, nUpdateOps: 0, nRemoveOps: 1, nBatches: 1 });
           });
           it('executes', async() => {
             expect(await collection.countDocuments()).to.equal(size - 1);
@@ -1587,8 +1587,8 @@ describe('Shell API (integration)', function() {
             bulk.find({ x: 2 }).replaceOne({ x: 1 });
             await bulk.execute();
           });
-          it('tojson returns correctly', async() => {
-            expect(bulk.tojson()).to.deep.equal({ nInsertOps: 0, nUpdateOps: 1, nRemoveOps: 0, nBatches: 1 });
+          it('toJSON returns correctly', async() => {
+            expect(bulk.toJSON()).to.deep.equal({ nInsertOps: 0, nUpdateOps: 1, nRemoveOps: 0, nBatches: 1 });
           });
           it('executes', async() => {
             expect(await collection.countDocuments({ x: 1 })).to.equal(2);
@@ -1614,8 +1614,8 @@ describe('Shell API (integration)', function() {
             bulk.find({ x: 2 }).updateOne({ $inc: { x: -1 } });
             await bulk.execute();
           });
-          it('tojson returns correctly', async() => {
-            expect(bulk.tojson()).to.deep.equal({ nInsertOps: 0, nUpdateOps: 1, nRemoveOps: 0, nBatches: 1 });
+          it('toJSON returns correctly', async() => {
+            expect(bulk.toJSON()).to.deep.equal({ nInsertOps: 0, nUpdateOps: 1, nRemoveOps: 0, nBatches: 1 });
           });
           it('executes', async() => {
             expect(await collection.countDocuments({ x: 1 })).to.equal(2);
@@ -1641,8 +1641,8 @@ describe('Shell API (integration)', function() {
             bulk.find({ x: { $mod: [ 2, 0 ] } }).update({ $inc: { x: 1 } });
             await bulk.execute();
           });
-          it('tojson returns correctly', async() => {
-            expect(bulk.tojson()).to.deep.equal({ nInsertOps: 0, nUpdateOps: 1, nRemoveOps: 0, nBatches: 1 });
+          it('toJSON returns correctly', async() => {
+            expect(bulk.toJSON()).to.deep.equal({ nInsertOps: 0, nUpdateOps: 1, nRemoveOps: 0, nBatches: 1 });
           });
           it('executes', async() => {
             expect(await collection.countDocuments()).to.equal(size);
@@ -1671,8 +1671,8 @@ describe('Shell API (integration)', function() {
           afterEach(async() => {
             await collection.drop();
           });
-          it('tojson returns correctly', async() => {
-            expect(bulk.tojson()).to.deep.equal({ nInsertOps: 0, nUpdateOps: 1, nRemoveOps: 0, nBatches: 1 });
+          it('toJSON returns correctly', async() => {
+            expect(bulk.toJSON()).to.deep.equal({ nInsertOps: 0, nUpdateOps: 1, nRemoveOps: 0, nBatches: 1 });
           });
           it('executes', async() => {
             expect(await collection.countDocuments()).to.equal(size + 1);
@@ -1698,8 +1698,8 @@ describe('Shell API (integration)', function() {
             bulk.find({ y: 0 }).upsert().updateOne({ $set: { y: 1 } });
             await bulk.execute();
           });
-          it('tojson returns correctly', async() => {
-            expect(bulk.tojson()).to.deep.equal({ nInsertOps: 0, nUpdateOps: 1, nRemoveOps: 0, nBatches: 1 });
+          it('toJSON returns correctly', async() => {
+            expect(bulk.toJSON()).to.deep.equal({ nInsertOps: 0, nUpdateOps: 1, nRemoveOps: 0, nBatches: 1 });
           });
           it('executes', async() => {
             expect(await collection.countDocuments()).to.equal(size + 1);
@@ -1736,17 +1736,17 @@ describe('Shell API (integration)', function() {
             for (let i = 0; i < size; i++) {
               bulk.insert({ x: 1 });
             }
-            expect(bulk.tojson().nBatches).to.equal(1);
+            expect(bulk.toJSON().nBatches).to.equal(1);
             bulk.find({ x: 1 }).remove();
-            expect(bulk.tojson().nBatches).to.equal(2);
+            expect(bulk.toJSON().nBatches).to.equal(2);
             bulk.find({ x: 2 }).update({ $inc: { x: 1 } });
-            expect(bulk.tojson().nBatches).to.equal(3);
+            expect(bulk.toJSON().nBatches).to.equal(3);
             for (let i = 0; i < size; i++) {
               bulk.insert({ x: 1 });
             }
           });
           it('updates count depending on ordered or not', () => {
-            expect(bulk.tojson().nBatches).to.equal(m === 'initializeUnorderedBulkOp' ? 3 : 4);
+            expect(bulk.toJSON().nBatches).to.equal(m === 'initializeUnorderedBulkOp' ? 3 : 4);
           });
         });
         describe('collation', () => {
@@ -1777,8 +1777,8 @@ describe('Shell API (integration)', function() {
         //   afterEach(async() => {
         //     await collection.drop();
         //   });
-        //   it('tojson returns correctly', async() => {
-        //     expect(bulk.tojson()).to.deep.equal({ nInsertOps: 0, nUpdateOps: 1, nRemoveOps: 0, nBatches: 1 });
+        //   it('toJSON returns correctly', async() => {
+        //     expect(bulk.toJSON()).to.deep.equal({ nInsertOps: 0, nUpdateOps: 1, nRemoveOps: 0, nBatches: 1 });
         //   });
         //   it('executes', async() => {
         //     expect(await collection.countDocuments()).to.equal(10);

--- a/packages/shell-api/src/result.ts
+++ b/packages/shell-api/src/result.ts
@@ -19,6 +19,10 @@ export class CommandResult extends ShellApiValueClass {
   [asPrintable](): unknown {
     return this.value;
   }
+
+  toJSON(): unknown {
+    return this.value;
+  }
 }
 
 @shellApiClassDefault


### PR DESCRIPTION
And also rename the `tojson` method of the `Bulk` class, which had
only been cased that way for compatibility with the legacy shell’s
`tojson()`/`tojsononeline()` methods, which are not present by
default in mongosh.