### PR TITLE
fix(ci): always set npm registry to main registry

### DIFF
--- a/.evergreen/evergreen.yml.in
+++ b/.evergreen/evergreen.yml.in
@@ -505,8 +505,7 @@ functions:
           export NODE_JS_VERSION=${node_js_version}
           source .evergreen/setup-env.sh
           export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD="true"
-          echo "registry=https://registry.npmjs.org/" > .npmrc
-          echo "//registry.npmjs.org/:_authToken=${devtoolsbot_npm_token}" >> .npmrc
+          echo "//registry.npmjs.org/:_authToken=${devtoolsbot_npm_token}" > .npmrc
           npm --unsafe-perm=true run bootstrap-ci -- --ignore-prepublish
           npm run evergreen-release publish
           }

--- a/.evergreen/setup-env.sh
+++ b/.evergreen/setup-env.sh
@@ -39,6 +39,8 @@ if [ `uname` = Linux ]; then
   export npm_config_unsafe_perm=true
 fi
 
+export npm_config_registry=https://registry.npmjs.org/
+
 echo "Full path:"
 echo $PATH
 


### PR DESCRIPTION
This should address CI build failures we are seeing right now.