### PR TITLE
fix(async-rewriter2): handle var decls properly for completion records

### DIFF
--- a/packages/async-rewriter2/src/async-writer-babel.spec.ts
+++ b/packages/async-rewriter2/src/async-writer-babel.spec.ts
@@ -131,8 +131,8 @@ describe('AsyncWriter', () => {
 
     it('adds var declarations to the global scope as expected', () => {
       const a = runTranspiledCode('var a = 10;');
-      expect(a).to.equal(10);
-      expect(ctx.a).to.equal(a);
+      expect(a).to.equal(undefined);
+      expect(ctx.a).to.equal(10);
     });
 
     it('adds let declarations to the global scope as expected (unlike regular JS)', () => {
@@ -155,8 +155,8 @@ describe('AsyncWriter', () => {
 
     it('adds block-scoped var declarations to the global scope as expected', () => {
       const a = runTranspiledCode('{ var a = 10; }');
-      expect(a).to.equal(10);
-      expect(ctx.a).to.equal(a);
+      expect(a).to.equal(undefined);
+      expect(ctx.a).to.equal(10);
     });
 
     it('does not add block-scoped let declarations to the global scope', () => {
@@ -176,6 +176,11 @@ describe('AsyncWriter', () => {
       expect(a).to.equal(undefined);
       expect(ctx.a).to.equal(undefined);
     });
+
+    // enable after https://github.com/babel/babel/pull/13596
+    // it('ignores variable declarations for completion records', () => {
+    //   expect(runTranspiledCode('"foo" + "bar"; var a = 10;')).to.equal('foobar');
+    // });
 
     it('moves top-level classes into the top-level scope', () => {
       const A = runTranspiledCode('class A {}');


### PR DESCRIPTION
MONGOSH-916

Handle variable declarations properly for completion records.
Instead of ignoring the assignment expressions we sometimes turn
them into when they show up as completion records, we assign
these assignment expressions to another dummy variable so that
we faithfully replace variable declarations with other variable
declarations and don’t affect completion record computation.

This doesn’t fully fix the referenced issue, but for that a babel
change is necessary. This commit does everything we can do on our side.