### PR TITLE
fix: clean up history pkg interfaces and use them properly MONGOSH-921

### DIFF
--- a/packages/browser-repl/src/components/shell.tsx
+++ b/packages/browser-repl/src/components/shell.tsx
@@ -181,7 +181,9 @@ export class Shell extends Component<ShellProps, ShellState> {
       ...this.state.history
     ];
 
-    changeHistory(history, this.props.redactInfo);
+    changeHistory(
+      history,
+      this.props.redactInfo ? 'redact-sensitive-data' : 'keep-sensitive-data');
     history.splice(this.props.maxHistoryLength);
 
     Object.freeze(history);

--- a/packages/cli-repl/src/cli-repl.ts
+++ b/packages/cli-repl/src/cli-repl.ts
@@ -1,5 +1,5 @@
 import { MongoshInternalError, MongoshRuntimeError, MongoshWarning } from '@mongosh/errors';
-import { redactCredentials } from '@mongosh/history';
+import { redactURICredentials } from '@mongosh/history';
 import i18n from '@mongosh/i18n';
 import { bson, AutoEncryptionOptions } from '@mongosh/service-provider-core';
 import { CliOptions, CliServiceProvider, MongoClientOptions } from '@mongosh/service-provider-server';
@@ -341,7 +341,7 @@ class CliRepl {
    */
   async connect(driverUri: string, driverOptions: MongoClientOptions): Promise<CliServiceProvider> {
     if (!this.cliOptions.nodb && !this.cliOptions.quiet) {
-      this.output.write(i18n.__(CONNECTING) + '\t\t' + this.clr(redactCredentials(driverUri), ['bold', 'green']) + '\n');
+      this.output.write(i18n.__(CONNECTING) + '\t\t' + this.clr(redactURICredentials(driverUri), ['bold', 'green']) + '\n');
     }
     const provider = await CliServiceProvider.connect(driverUri, driverOptions, this.cliOptions, this.bus);
     this.bus.emit('mongosh:driver-initialized', provider.driverMetadata);

--- a/packages/cli-repl/src/mongosh-repl.ts
+++ b/packages/cli-repl/src/mongosh-repl.ts
@@ -270,7 +270,9 @@ class MongoshNodeRepl implements EvaluationListener {
       repl.on('flushHistory', () => {
         if (this.redactHistory !== 'keep') {
           const history: string[] = (repl as any).history;
-          changeHistory(history, this.redactHistory === 'remove-redact');
+          changeHistory(
+            history,
+            this.redactHistory === 'remove-redact' ? 'redact-sensitive-data' : 'keep-sensitive-data');
         }
       });
       // We also want to group multiline history entries and .editor input into

--- a/packages/cli-repl/src/run.ts
+++ b/packages/cli-repl/src/run.ts
@@ -1,6 +1,6 @@
 import { CliRepl, parseCliArgs, mapCliToDriver, getStoragePaths, getMongocryptdPaths, runSmokeTests, USAGE, buildInfo } from './index';
 import { generateUri } from '@mongosh/service-provider-server';
-import { redactCredentials } from '@mongosh/history';
+import { redactURICredentials } from '@mongosh/history';
 import { runMain } from 'module';
 
 // eslint-disable-next-line complexity
@@ -56,7 +56,7 @@ import { runMain } from 'module';
       const driverOptions = await mapCliToDriver(options);
       const driverUri = generateUri(options);
 
-      const title = `mongosh ${redactCredentials(driverUri)}`;
+      const title = `mongosh ${redactURICredentials(driverUri)}`;
       process.title = title;
       setTerminalWindowTitle(title);
 

--- a/packages/cli-repl/src/setup-logger-and-telemetry.ts
+++ b/packages/cli-repl/src/setup-logger-and-telemetry.ts
@@ -1,6 +1,6 @@
 /* eslint-disable camelcase */
 import redactInfo from 'mongodb-redact';
-import { redactCredentials } from '@mongosh/history';
+import { redactURICredentials } from '@mongosh/history';
 import type { Logger } from 'pino';
 import type {
   MongoshBus,
@@ -116,7 +116,7 @@ export default function setupLoggerAndTelemetry(
   });
 
   bus.on('mongosh:connect', function(args: ConnectEvent) {
-    const connectionUri = redactCredentials(args.uri);
+    const connectionUri = redactURICredentials(args.uri);
     const { uri: _uri, ...argsWithoutUri } = args; // eslint-disable-line @typescript-eslint/no-unused-vars
     const params = { session_id: logId, userId, connectionUri, ...argsWithoutUri };
     log.info('mongosh:connect', jsonClone(params));
@@ -392,7 +392,7 @@ export default function setupLoggerAndTelemetry(
 
   bus.on('mongosh-sp:resolve-srv-error', function(ev: SpResolveSrvErrorEvent) {
     log.info('mongosh-sp:resolve-srv-error', {
-      from: redactCredentials(ev.from),
+      from: redactURICredentials(ev.from),
       error: ev.error?.message,
       duringLoad: ev.duringLoad
     });
@@ -400,8 +400,8 @@ export default function setupLoggerAndTelemetry(
 
   bus.on('mongosh-sp:resolve-srv-succeeded', function(ev: SpResolveSrvSucceededEvent) {
     log.info('mongosh-sp:resolve-srv-succeeded', {
-      from: redactCredentials(ev.from),
-      to: redactCredentials(ev.to)
+      from: redactURICredentials(ev.from),
+      to: redactURICredentials(ev.to)
     });
   });
 

--- a/packages/cli-repl/src/smoke-tests.ts
+++ b/packages/cli-repl/src/smoke-tests.ts
@@ -2,7 +2,7 @@
 import { spawn } from 'child_process';
 import assert from 'assert';
 import { once } from 'events';
-import { redactCredentials } from '@mongosh/history';
+import { redactURICredentials } from '@mongosh/history';
 import fleSmokeTestScript from './smoke-tests-fle';
 
 // Run smoke tests on a executable, e.g.
@@ -49,9 +49,9 @@ async function runSmokeTest(executable: string, args: string[], input: string, o
   await once(proc.stdout, 'end');
   try {
     assert.match(stdout, output);
-    console.error({ status: 'success', input, output, stdout, executable, args: args.map(redactCredentials) });
+    console.error({ status: 'success', input, output, stdout, executable, args: args.map(redactURICredentials) });
   } catch (err) {
-    console.error({ status: 'failure', input, output, stdout, executable, args: args.map(redactCredentials) });
+    console.error({ status: 'failure', input, output, stdout, executable, args: args.map(redactURICredentials) });
     throw err;
   }
 }

--- a/packages/history/src/history.spec.ts
+++ b/packages/history/src/history.spec.ts
@@ -1,92 +1,76 @@
 import { changeHistory } from './history';
-
 import { expect } from 'chai';
 
 describe('changeHistory', () => {
   const history = ['db.shipwrecks.findOne()', 'use ships'];
 
-  context('when redact option is not used', () => {
+  context('when redact option is keep-sensitive-data', () => {
     it('removes sensitive commands from history', () => {
       const i = ['db.createUser({ user: "reportUser256" })', 'db.shipwrecks.findOne()', 'use ships'];
-      changeHistory(i);
+      changeHistory(i, 'keep-sensitive-data');
       expect(i).to.deep.equal(history);
     });
     it('removes connect commands from history', () => {
       const i = ['db = connect(\'uri\', \'u\', \'p\')', 'db.shipwrecks.findOne()', 'use ships'];
-      changeHistory(i);
+      changeHistory(i, 'keep-sensitive-data');
       expect(i).to.deep.equal(history);
     });
     it('removes URI having Mongo from history', () => {
       const i = ['m = new Mongo(\'mongodb://anna:anna@127.0.0.1:27017/test\')', 'db.shipwrecks.findOne()', 'use ships'];
-      changeHistory(i);
+      changeHistory(i, 'keep-sensitive-data');
       expect(i).to.deep.equal(history);
     });
     it('removes URI having Mongo from history for srv', () => {
       const i = ['m = new Mongo(\'mongodb+srv://admin:catscat3ca1s@cats-data-sets-e08dy.mongodb.net/admin\')', 'db.shipwrecks.findOne()', 'use ships'];
-      changeHistory(i);
+      changeHistory(i, 'keep-sensitive-data');
       expect(i).to.deep.equal(history);
     });
 
     it('leaves history as is if command is not sensitive', () => {
       const i = ['db.shipwrecks.find({quasou: "depth unknown"})', 'db.shipwrecks.findOne()', 'use ships'];
       const cloned = Array.from(i);
-      changeHistory(cloned);
+      changeHistory(cloned, 'keep-sensitive-data');
       expect(cloned).to.deep.equal(i);
     });
 
     it('does not modify an empty history', () => {
       const i: string[] = [];
-      changeHistory(i);
+      changeHistory(i, 'keep-sensitive-data');
       expect(i).to.deep.equal([]);
-    });
-  });
-
-  context('when redact option is false', () => {
-    it('removes sensitive commands from history', () => {
-      const i = ['db.createUser({ user: "reportUser256" })', 'db.shipwrecks.findOne()', 'use ships'];
-      changeHistory(i, false);
-      expect(i).to.deep.equal(history);
-    });
-
-    it('leaves history as is if command is not sensitive', () => {
-      const i = ['db.shipwrecks.find({quasou: "depth unknown"})', 'db.shipwrecks.findOne()', 'use ships'];
-      const cloned = Array.from(i);
-      changeHistory(cloned, false);
-      expect(cloned).to.deep.equal(i);
     });
   });
 
   context('when redact option is true', () => {
     it('removes sensitive commands from history', () => {
       const i = ['db.createUser({ user: "reportUser256" })', 'db.shipwrecks.findOne()', 'use ships'];
-      changeHistory(i, true);
+      changeHistory(i, 'redact-sensitive-data');
       expect(i).to.deep.equal(history);
     });
 
     it('removes sensitive raw commands from history', () => {
       const i = ['db.runCommand({createUser: "reportUser256", pwd: "pwd", roles: {] })', 'db.shipwrecks.findOne()', 'use ships'];
-      changeHistory(i, true);
+      changeHistory(i, 'redact-sensitive-data');
       expect(i).to.deep.equal(history);
     });
 
     it('leaves history as is if command is not sensitive', () => {
       const i = ['db.shipwrecks.find({quasou: "depth unknown"})', 'db.shipwrecks.findOne()', 'use ships'];
       const cloned = Array.from(i);
-      changeHistory(cloned, true);
+      changeHistory(cloned, 'redact-sensitive-data');
       expect(cloned).to.deep.equal(i);
     });
 
     it('leaves history as is if command is not sensitive but contains sensitive substrings', () => {
       const i = ['db.shipwrecks.find({quasou: "connectionId"})', 'db.shipwrecks.findOne()', 'use ships'];
       const cloned = Array.from(i);
-      changeHistory(cloned, true);
+      changeHistory(cloned, 'redact-sensitive-data');
       expect(cloned).to.deep.equal(i);
     });
 
     it('removes command from history and does not redact even if info in command is redactable', () => {
       const i = ['db.createUser( { user: "restricted", pwd: passwordPrompt(),      // Or  "<cleartext password>" roles: [ { role: "readWrite", db: "reporting" } ], authenticationRestrictions: [ { clientSource: ["192.0.2.0"], serverAddress: ["198.51.100.0"] } ] })',
         'db.shipwrecks.findOne()', 'use ships'];
-      changeHistory(i, true);
+      changeHistory(i, 'redact-sensitive-data');
       expect(i).to.deep.equal(history);
     });
 
@@ -96,7 +80,7 @@ describe('changeHistory', () => {
       const redacted = ['db.supplies.find({email: "<email>"})',
         'db.supplies.findOne()', 'use sales'];
       const cloned = Array.from(i);
-      changeHistory(cloned, true);
+      changeHistory(cloned, 'redact-sensitive-data');
       expect(cloned).to.deep.equal(redacted);
     });
   });

--- a/packages/history/src/history.ts
+++ b/packages/history/src/history.ts
@@ -1,28 +1,23 @@
-import redactInfo from 'mongodb-redact';
+import redactSensitiveData from 'mongodb-redact';
 
 export const HIDDEN_COMMANDS = String.raw `\b(createUser|auth|updateUser|changeUserPassword|connect|Mongo)\b`;
 
-export function removeCommand(history: string, redact = false): string {
-  if (redact) {
-    return redactInfo(history);
-  }
-  return history;
-}
-
 /**
- * Modifies the history based on sensitive information.
+ * Modifies the most recent command in history based on sensitive information.
  * If redact option is passed, also redacts sensitive info.
  *
  * @param {String} history - Command string.
  * @param {boolean} redact - Option to redact sensitive info.
  */
-export function changeHistory(history: string[], redact = false): void {
+export function changeHistory(history: string[], redact: 'redact-sensitive-data' | 'keep-sensitive-data'): void {
   if (history.length === 0) return;
   const hiddenCommands = new RegExp(HIDDEN_COMMANDS, 'g');
 
   if (hiddenCommands.test(history[0])) {
     history.shift();
-  } else {
-    history[0] = removeCommand(history[0], redact);
+  } else if (redact === 'redact-sensitive-data') {
+    history[0] = redactSensitiveData(history[0]);
   }
 }
+
+export { redactSensitiveData };

--- a/packages/history/src/index.ts
+++ b/packages/history/src/index.ts
@@ -1,3 +1,2 @@
-import { changeHistory, removeCommand, HIDDEN_COMMANDS } from './history';
-import redactCredentials from './redact-credentials';
-export { redactCredentials, changeHistory, removeCommand, HIDDEN_COMMANDS };
+export { changeHistory, redactSensitiveData, HIDDEN_COMMANDS } from './history';
+export { redactURICredentials } from './redact-credentials';

--- a/packages/history/src/redact-credentials.spec.ts
+++ b/packages/history/src/redact-credentials.spec.ts
@@ -1,31 +1,31 @@
-import redactCredentials from './redact-credentials';
+import { redactURICredentials } from './redact-credentials';
 import { expect } from 'chai';
 
 describe('redact credentials', () => {
   context('when url contains credentials', () => {
     it('returns the <credentials> in output instead of password', () => {
-      expect(redactCredentials('mongodb+srv://admin:catsc@tscat3ca1s@cats-data-sets-e08dy.mongodb.net/admin'))
+      expect(redactURICredentials('mongodb+srv://admin:catsc@tscat3ca1s@cats-data-sets-e08dy.mongodb.net/admin'))
         .to.equal('mongodb+srv://<credentials>@cats-data-sets-e08dy.mongodb.net/admin');
     });
 
     it('returns the <credentials> in output instead of IAM session token', () => {
-      expect(redactCredentials('mongodb+srv://cats-data-sets-e08dy.mongodb.net/admin?authMechanism=MONGODB-AWS&authMechanismProperties=AWS_SESSION_TOKEN%3Asampletoken,else%3Amiau&param=true'))
+      expect(redactURICredentials('mongodb+srv://cats-data-sets-e08dy.mongodb.net/admin?authMechanism=MONGODB-AWS&authMechanismProperties=AWS_SESSION_TOKEN%3Asampletoken,else%3Amiau&param=true'))
         .to.equal('mongodb+srv://cats-data-sets-e08dy.mongodb.net/admin?authMechanism=MONGODB-AWS&authMechanismProperties=AWS_SESSION_TOKEN%3A<credentials>,else%3Amiau&param=true');
-      expect(redactCredentials('mongodb+srv://cats-data-sets-e08dy.mongodb.net/admin?authMechanism=MONGODB-AWS&authMechanismProperties=AWS_SESSION_TOKEN%3Asampletoken&param=true'))
+      expect(redactURICredentials('mongodb+srv://cats-data-sets-e08dy.mongodb.net/admin?authMechanism=MONGODB-AWS&authMechanismProperties=AWS_SESSION_TOKEN%3Asampletoken&param=true'))
         .to.equal('mongodb+srv://cats-data-sets-e08dy.mongodb.net/admin?authMechanism=MONGODB-AWS&authMechanismProperties=AWS_SESSION_TOKEN%3A<credentials>&param=true');
-      expect(redactCredentials('mongodb+srv://cats-data-sets-e08dy.mongodb.net/admin?authMechanism=MONGODB-AWS&authMechanismProperties=AWS_SESSION_TOKEN%3Asampletoken'))
+      expect(redactURICredentials('mongodb+srv://cats-data-sets-e08dy.mongodb.net/admin?authMechanism=MONGODB-AWS&authMechanismProperties=AWS_SESSION_TOKEN%3Asampletoken'))
         .to.equal('mongodb+srv://cats-data-sets-e08dy.mongodb.net/admin?authMechanism=MONGODB-AWS&authMechanismProperties=AWS_SESSION_TOKEN%3A<credentials>');
     });
 
     it('returns the <credentials> in output instead of password and IAM session token', () => {
-      expect(redactCredentials('mongodb+srv://admin:tscat3ca1s@cats-data-sets-e08dy.mongodb.net/admin?authMechanism=MONGODB-AWS&authMechanismProperties=AWS_SESSION_TOKEN%3Asampletoken&param=true'))
+      expect(redactURICredentials('mongodb+srv://admin:tscat3ca1s@cats-data-sets-e08dy.mongodb.net/admin?authMechanism=MONGODB-AWS&authMechanismProperties=AWS_SESSION_TOKEN%3Asampletoken&param=true'))
         .to.equal('mongodb+srv://<credentials>@cats-data-sets-e08dy.mongodb.net/admin?authMechanism=MONGODB-AWS&authMechanismProperties=AWS_SESSION_TOKEN%3A<credentials>&param=true');
     });
   });
 
   context('when url contains no credentials', () => {
     it('does not alter input', () => {
-      expect(redactCredentials('mongodb://127.0.0.1:27017')).to.equal('mongodb://127.0.0.1:27017');
+      expect(redactURICredentials('mongodb://127.0.0.1:27017')).to.equal('mongodb://127.0.0.1:27017');
     });
   });
 });

--- a/packages/history/src/redact-credentials.ts
+++ b/packages/history/src/redact-credentials.ts
@@ -1,4 +1,4 @@
-export default function redactCredentials(uri: string): string {
+export function redactURICredentials(uri: string): string {
   const regexes = [
     // Username and password
     /(?<=\/\/)(.*)(?=\@)/g,

--- a/packages/shell-api/src/field-level-encryption.ts
+++ b/packages/shell-api/src/field-level-encryption.ts
@@ -24,7 +24,7 @@ import Cursor from './cursor';
 import { DeleteResult } from './result';
 import { assertArgsDefinedType } from './helpers';
 import { asPrintable } from './enums';
-import { redactCredentials } from '@mongosh/history';
+import { redactURICredentials } from '@mongosh/history';
 import type Mongo from './mongo';
 import { CommonErrors, MongoshInvalidInputError, MongoshRuntimeError } from '@mongosh/errors';
 
@@ -67,7 +67,7 @@ export class ClientEncryption extends ShellApiWithMongoClass {
   }
 
   [asPrintable](): string {
-    return `ClientEncryption class for ${redactCredentials(this._mongo._uri)}`;
+    return `ClientEncryption class for ${redactURICredentials(this._mongo._uri)}`;
   }
 
   @returnsPromise
@@ -113,7 +113,7 @@ export class KeyVault extends ShellApiWithMongoClass {
   }
 
   [asPrintable](): string {
-    return `KeyVault class for ${redactCredentials(this._mongo._uri)}`;
+    return `KeyVault class for ${redactURICredentials(this._mongo._uri)}`;
   }
 
   createKey(kms: 'local', keyAltNames?: string[]): Promise<Document>

--- a/packages/shell-api/src/mongo.ts
+++ b/packages/shell-api/src/mongo.ts
@@ -41,7 +41,7 @@ import type Collection from './collection';
 import Database from './database';
 import ShellInternalState from './shell-internal-state';
 import { CommandResult } from './result';
-import { redactCredentials } from '@mongosh/history';
+import { redactURICredentials } from '@mongosh/history';
 import { asPrintable, ServerVersions, Topologies } from './enums';
 import Session from './session';
 import { assertArgsDefinedType, processFLEOptions, isValidDatabaseName } from './helpers';
@@ -138,7 +138,7 @@ export default class Mongo extends ShellApiClass {
    * Internal method to determine what is printed for this class.
    */
   [asPrintable](): string {
-    return redactCredentials(this._uri);
+    return redactURICredentials(this._uri);
   }
 
   /**
@@ -500,7 +500,7 @@ export default class Mongo extends ShellApiClass {
     this._emitMongoApiCall('watch', { pipeline, options });
     const cursor = new ChangeStreamCursor(
       this._serviceProvider.watch(pipeline, options),
-      redactCredentials(this._uri),
+      redactURICredentials(this._uri),
       this
     );
     await cursor.tryNext(); // See comment in coll.watch().

--- a/packages/shell-api/src/replica-set.ts
+++ b/packages/shell-api/src/replica-set.ts
@@ -1,5 +1,5 @@
 import { CommonErrors, MongoshDeprecatedError, MongoshInvalidInputError, MongoshRuntimeError } from '@mongosh/errors';
-import { redactCredentials } from '@mongosh/history';
+import { redactURICredentials } from '@mongosh/history';
 import { Document } from '@mongosh/service-provider-core';
 import Mongo from './mongo';
 import Database from './database';
@@ -376,7 +376,7 @@ export default class ReplicaSet extends ShellApiWithMongoClass {
    * Internal method to determine what is printed for this class.
    */
   [asPrintable](): string {
-    return `ReplicaSet class connected to ${redactCredentials(this._database._mongo._uri)} via db ${this._database._name}`;
+    return `ReplicaSet class connected to ${redactURICredentials(this._database._mongo._uri)} via db ${this._database._name}`;
   }
 
   /**

--- a/packages/shell-api/src/shard.ts
+++ b/packages/shell-api/src/shard.ts
@@ -8,7 +8,7 @@ import type { Document } from '@mongosh/service-provider-core';
 import { assertArgsDefinedType, getConfigDB, getPrintableShardStatus } from './helpers';
 import { ServerVersions, asPrintable } from './enums';
 import { CommandResult, UpdateResult } from './result';
-import { redactCredentials } from '@mongosh/history';
+import { redactURICredentials } from '@mongosh/history';
 import Mongo from './mongo';
 
 @shellApiClassDefault
@@ -28,7 +28,7 @@ export default class Shard extends ShellApiWithMongoClass {
    * Internal method to determine what is printed for this class.
    */
   [asPrintable](): string {
-    return `Shard class connected to ${redactCredentials(this._database._mongo._uri)} via db ${this._database._name}`;
+    return `Shard class connected to ${redactURICredentials(this._database._mongo._uri)} via db ${this._database._name}`;
   }
 
   /**

--- a/packages/shell-evaluator/src/shell-evaluator.ts
+++ b/packages/shell-evaluator/src/shell-evaluator.ts
@@ -8,7 +8,7 @@ import AsyncWriter from '@mongosh/async-rewriter2';
 
 type EvaluationFunction = (input: string, context: object, filename: string) => Promise<any>;
 
-import { HIDDEN_COMMANDS, removeCommand } from '@mongosh/history';
+import { HIDDEN_COMMANDS, redactSensitiveData } from '@mongosh/history';
 
 type ResultHandler<EvaluationResultType> = (value: any) => EvaluationResultType | Promise<EvaluationResultType>;
 class ShellEvaluator<EvaluationResultType = ShellResult> {
@@ -46,7 +46,7 @@ class ShellEvaluator<EvaluationResultType = ShellResult> {
     if (!hiddenCommands.test(input) && !hiddenCommands.test(rewrittenInput)) {
       this.internalState.messageBus.emit(
         'mongosh:evaluate-input',
-        { input: removeCommand(input.trim()) }
+        { input: redactSensitiveData(input.trim()) }
       );
     }
 


### PR DESCRIPTION
- Rename `redactCredentials` to `redactURICredentials` to indicate
  that this does not redact credentials in general, but rather
  specifically the credentials of connection strings (and it expects
  a connection string as an input)
- Remove the optional second parameter of `changeHistory` and require
  all call sites to be explicit about which behavior they want
- Do not export `removeCommand` because it is a footgun when used
  on its own as it is a no-op when called with default arguments.
  Rather, re-export the function exposed by `mongodb-redact` directly
  and name it appropriately. This fixes usage of it in the
  shell-evaluator package.