### PR TITLE
fix(java-shell): allow console.warn and console.info

### DIFF
--- a/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/ConsoleLogSupport.kt
+++ b/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/ConsoleLogSupport.kt
@@ -14,7 +14,9 @@ internal class ConsoleLogSupport(context: MongoShellContext, converter: MongoShe
         @Suppress("JSPrimitiveTypeWrapperUsage")
         val console = context.eval("new Object()")
         console["log"] = print
+        console["warn"] = print
         console["error"] = print
+        console["info"] = print
         context.bindings["console"] = console
     }
 


### PR DESCRIPTION
eea5cd667d9b40 broke the waterfall tests, because BSON uses
console.warn() when applied to the java shell as no secure random
number generator is available, and the change upgraded the
resulting error from a silent unhandled promise rejection to a full
exception.

Solve this by adding warn and info to the java-shell console
for parity with the shell-api code.