### PR TITLE
fix(shell-api): align coll.validate() args with legacy shell MONGOSH-925

### DIFF
--- a/packages/shell-api/src/collection.spec.ts
+++ b/packages/shell-api/src/collection.spec.ts
@@ -1593,13 +1593,24 @@ describe('Collection', () => {
           }
         );
       });
-      it('calls serviceProvider.runCommand on the collection with options', async() => {
+      it('calls serviceProvider.runCommand on the collection with boolean argument', async() => {
         await collection.validate(true);
         expect(serviceProvider.runCommandWithCheck).to.have.been.calledWith(
           database._name,
           {
             validate: collection._name,
             full: true
+          }
+        );
+      });
+      it('calls serviceProvider.runCommand on the collection with options', async() => {
+        await collection.validate({ full: true, repair: true });
+        expect(serviceProvider.runCommandWithCheck).to.have.been.calledWith(
+          database._name,
+          {
+            validate: collection._name,
+            full: true,
+            repair: true
           }
         );
       });

--- a/packages/shell-api/src/collection.ts
+++ b/packages/shell-api/src/collection.ts
@@ -1578,13 +1578,16 @@ export default class Collection extends ShellApiWithMongoClass {
 
   @returnsPromise
   @apiVersions([])
-  async validate(full = false): Promise<Document> {
-    this._emitCollectionApiCall('validate', { full });
+  async validate(options: boolean | Document = false): Promise<Document> {
+    this._emitCollectionApiCall('validate', { options });
+    if (typeof options === 'boolean') {
+      options = { full: options };
+    }
     return await this._mongo._serviceProvider.runCommandWithCheck(
       this._database._name,
       {
         validate: this._name,
-        full: full
+        ...options
       },
       this._database._baseOptions
     );

--- a/packages/shell-api/src/integration.spec.ts
+++ b/packages/shell-api/src/integration.spec.ts
@@ -1003,6 +1003,36 @@ describe('Shell API (integration)', function() {
         expect(await collection.findOne()).to.deep.equal({ '$x.y': 2, _id: '_id' });
       });
     });
+
+    describe('validate', () => {
+      skipIfApiStrict();
+      skipIfServerVersion(testServer, '< 5.0');
+
+      beforeEach(async() => {
+        await collection.insertOne({ foo: 'bar' });
+      });
+
+      it('validate can be used to validate a collection', async() => {
+        expect((await collection.validate({ full: true })).valid).to.equal(true);
+      });
+
+      it('validate accepts a repair option', async() => {
+        expect((await collection.validate({ full: true, repair: true })).valid).to.equal(true);
+      });
+
+      it('validate accepts a background option', async() => {
+        expect((await collection.validate({ full: false, background: true })).valid).to.equal(true);
+      });
+
+      it('validate fails with background: true and full: true', async() => {
+        try {
+          await collection.validate({ full: true, background: true });
+          expect.fail('missed exception');
+        } catch (err) {
+          expect(err.name).to.equal('MongoServerError');
+        }
+      });
+    });
   });
 
   describe('db', () => {


### PR DESCRIPTION
This is a bit looser than newer versions of the legacy shell, which
actually reject a single boolean argument, but this way we cover
the behavior across multiple legacy shell versions.