### PR TITLE
feat(cli-repl): add Node.js version to build info

### DIFF
--- a/packages/cli-repl/src/build-info.ts
+++ b/packages/cli-repl/src/build-info.ts
@@ -2,6 +2,7 @@ import os from 'os';
 
 export type BuildInfo = {
   version: string;
+  nodeVersion: string;
   distributionKind: 'unpackaged' | 'packaged' | 'compiled';
   buildArch: string;
   buildPlatform: string;
@@ -12,7 +13,7 @@ export type BuildInfo = {
 
 export function buildInfo(): BuildInfo {
   try {
-    const buildInfo = { ...require('./build-info.json') };
+    const buildInfo = { ...require('./build-info.json'), nodeVersion: process.version };
     delete buildInfo.segmentApiKey;
     return buildInfo;
   } catch {
@@ -24,7 +25,8 @@ export function buildInfo(): BuildInfo {
       buildPlatform: os.platform(),
       buildTarget: 'unknown',
       buildTime: null,
-      gitVersion: null
+      gitVersion: null,
+      nodeVersion: process.version
     };
   }
 }

--- a/packages/cli-repl/test/e2e.spec.ts
+++ b/packages/cli-repl/test/e2e.spec.ts
@@ -38,9 +38,10 @@ describe('e2e', function() {
       const data = JSON.parse(shell.output);
       expect(Object.keys(data)).to.deep.equal([
         'version', 'distributionKind', 'buildArch', 'buildPlatform',
-        'buildTarget', 'buildTime', 'gitVersion'
+        'buildTarget', 'buildTime', 'gitVersion', 'nodeVersion'
       ]);
       expect(data.version).to.be.a('string');
+      expect(data.nodeVersion).to.be.a('string');
       expect(data.distributionKind).to.be.a('string');
       expect(['unpackaged', 'packaged', 'compiled'].includes(data.distributionKind)).to.be.true;
       expect(data.buildArch).to.be.a('string');


### PR DESCRIPTION
This is not strictly a piece of *build* information, but in cases
where we ask for the `--build-info` output, we most likely also
want to know the Node.js version (in particular, if this is in
“packaged” mode, i.e. homebrew or npm, then the exact Node.js version
used can vary).