### PR TITLE
feat: reverse and extend Timestamp constructor arguments MONGOSH-930

### DIFF
--- a/packages/cli-repl/test/e2e-bson.spec.ts
+++ b/packages/cli-repl/test/e2e-bson.spec.ts
@@ -44,7 +44,7 @@ describe('BSON e2e', function() {
       MaxKey: 'MaxKey()',
       NumberInt: 'Int32(32)',
       NumberLong: 'Long("64")',
-      Timestamp: 'Timestamp(1, 100)',
+      Timestamp: 'Timestamp({ t: 100, i: 1 })',
       Symbol: 'abc',
       Code: 'Code("abc")',
       NumberDecimal: 'Decimal128("1")',
@@ -61,7 +61,7 @@ describe('BSON e2e', function() {
         DBRef3: new bson.DBRef('a', { x: '5f16b8bebe434dc98cdfc9cb' } as any, 'db'),
         MinKey: new bson.MinKey(),
         MaxKey: new bson.MaxKey(),
-        Timestamp: new bson.Timestamp(1, 100),
+        Timestamp: new bson.Timestamp(new bson.Long(1, 100)),
         Symbol: new bson.BSONSymbol('abc'),
         Code: new bson.Code('abc'),
         NumberDecimal: new bson.Decimal128('1'),
@@ -97,7 +97,7 @@ describe('BSON e2e', function() {
         MaxKey: new MaxKey(),
         NumberInt: NumberInt("32"),
         NumberLong: NumberLong("64"),
-        Timestamp: new Timestamp(1, 100),
+        Timestamp: new Timestamp(100, 1),
         Symbol: new BSONSymbol('abc'),
         Code: new Code('abc'),
         NumberDecimal: NumberDecimal('1'),
@@ -164,10 +164,10 @@ describe('BSON e2e', function() {
       shell.assertNoErrors();
     });
     it('Timestamp prints when returned from the server', async() => {
-      const value = new bson.Timestamp(0, 100);
+      const value = new bson.Timestamp(new bson.Long(0, 100));
       await shell.executeLine(`use ${dbName}`);
       await db.collection('test').insertOne({ value: value });
-      expect(await shell.executeLine('db.test.findOne().value')).to.include('Timestamp(0, 100)');
+      expect(await shell.executeLine('db.test.findOne().value')).to.include('Timestamp({ t: 100, i: 0 })');
       shell.assertNoErrors();
     });
     it('Code prints when returned from the server', async() => {
@@ -249,8 +249,13 @@ describe('BSON e2e', function() {
       expect(await shell.executeLine(value)).to.include('Long("345678654321234561")');
       shell.assertNoErrors();
     });
-    it('Timestamp prints when created by user', async() => {
-      const value = 'Timestamp(0, 100)';
+    it('Timestamp prints when created by user (legacy)', async() => {
+      const value = 'Timestamp(100, 0)';
+      expect(await shell.executeLine(value)).to.include('Timestamp({ t: 100, i: 0 })');
+      shell.assertNoErrors();
+    });
+    it('Timestamp prints when created by user ({t, i})', async() => {
+      const value = 'Timestamp({ t: 100, i: 0 })';
       expect(await shell.executeLine(value)).to.include(value);
       shell.assertNoErrors();
     });

--- a/packages/java-shell/src/test/resources/collection/insertOne.js
+++ b/packages/java-shell/src/test/resources/collection/insertOne.js
@@ -10,7 +10,7 @@ const res = db.coll.insertOne({
     date: new Date("2012-12-19"),
     isoDate: new ISODate("2012-12-19"),
     numberInt: NumberInt("24"),
-    timestamp: new Timestamp(0, 100),
+    timestamp: new Timestamp(100, 0),
     "undefined": undefined,
     "null": null,
     uuid: new UUID('01234567-89ab-cdef-0123-456789abcdef')

--- a/packages/java-shell/src/test/resources/literal/Timestamp.js
+++ b/packages/java-shell/src/test/resources/literal/Timestamp.js
@@ -1,2 +1,2 @@
 // command checkResultClass
-new Timestamp(0, 100)
+new Timestamp(100, 0)

--- a/packages/service-provider-core/src/printable-bson.spec.ts
+++ b/packages/service-provider-core/src/printable-bson.spec.ts
@@ -44,7 +44,7 @@ describe('BSON printers', function() {
   });
 
   it('formats Timestamp correctly', function() {
-    expect(inspect(new bson.Timestamp(1, 100))).to.equal('Timestamp(1, 100)');
+    expect(inspect(new bson.Timestamp(new bson.Long(100, 1)))).to.equal('Timestamp({ t: 1, i: 100 })');
   });
 
   it('formats Symbol correctly', function() {

--- a/packages/service-provider-core/src/printable-bson.ts
+++ b/packages/service-provider-core/src/printable-bson.ts
@@ -23,7 +23,7 @@ export const bsonStringifiers: Record<string, (this: any, depth: any, options: a
   },
 
   Timestamp: function(): string {
-    return `Timestamp(${this.getLowBits().toString()}, ${this.getHighBits().toString()})`;
+    return `Timestamp({ t: ${this.getHighBits()}, i: ${this.getLowBits()} })`;
   },
 
   BSONSymbol: function(): string {

--- a/packages/shell-api/src/shard.spec.ts
+++ b/packages/shell-api/src/shard.spec.ts
@@ -1293,7 +1293,7 @@ describe('Shard', () => {
         // Make sure that each individual chunk in the output is on a single line
         expect(inspectedCollectionInfo).to.include('chunks: [\n' +
           '    { min: { key: MinKey() }, max: { key: MaxKey() }, ' +
-          `'on shard': '${collectionInfo.chunks[0]['on shard']}', 'last modified': Timestamp(0, 1) }\n` +
+          `'on shard': '${collectionInfo.chunks[0]['on shard']}', 'last modified': Timestamp({ t: 1, i: 0 }) }\n` +
           '  ],\n');
       });
     });

--- a/packages/shell-api/src/shell-bson.spec.ts
+++ b/packages/shell-api/src/shell-bson.spec.ts
@@ -196,8 +196,14 @@ describe('Shell BSON', () => {
     });
     it('constructs with default args 1', () => {
       const s = shellBson.Timestamp(1);
-      expect(s.low).to.equal(1);
-      expect(s.high).to.equal(0);
+      expect(s.low).to.equal(0);
+      expect(s.high).to.equal(1);
+    });
+    it('constructs with { t, i } signature', () => {
+      const s = shellBson.Timestamp({ t: 10, i: 20 });
+      expect(s.low).to.equal(20);
+      expect(s.high).to.equal(10);
+      expect(s.toExtendedJSON()).to.deep.equal({ $timestamp: { t: 10, i: 20 } });
     });
   });
   describe('Code', () => {


### PR DESCRIPTION
- Accept a `Timestamp({ t: <number>, i: <number> })` signature
- Reverse the order of arguments when two arguments are passed,
  i.e. `Timestamp(t, i)` instead of `Timestamp(i, t)`, to match
  the legacy shell
- Print Timestamps using the `Timestamp({ t, i })` format

This should land together with the corresponding BSON package PR,
https://github.com/mongodb/js-bson/pull/449.