### PR TITLE
chore(shell-api): replace ‘catched’ with ‘caught’

### DIFF
--- a/packages/shell-api/src/bulk.spec.ts
+++ b/packages/shell-api/src/bulk.spec.ts
@@ -167,9 +167,9 @@ describe('Bulk API', () => {
             it('throws if innerBulk.execute rejects', async() => {
               const expectedError = new Error();
               innerStub.execute.rejects(expectedError);
-              const catchedError = await bulk.execute()
+              const caughtError = await bulk.execute()
                 .catch(e => e);
-              expect(catchedError).to.equal(expectedError);
+              expect(caughtError).to.equal(expectedError);
             });
           });
           describe('getOperations', () => {

--- a/packages/shell-api/src/collection.spec.ts
+++ b/packages/shell-api/src/collection.spec.ts
@@ -981,9 +981,9 @@ describe('Collection', () => {
         });
 
         it('rejects with error', async() => {
-          let catched;
-          await collection.dropIndexes('index_1').catch(err => { catched = err; });
-          expect(catched.message).to.equal(error.message);
+          let caught;
+          await collection.dropIndexes('index_1').catch(err => { caught = err; });
+          expect(caught.message).to.equal(error.message);
         });
       });
     });
@@ -1001,25 +1001,25 @@ describe('Collection', () => {
         });
 
         it('throws if index is "*"', async() => {
-          let catched;
-          await collection.dropIndex('*').catch(err => { catched = err; });
+          let caught;
+          await collection.dropIndex('*').catch(err => { caught = err; });
 
-          expect(catched).to.be.instanceOf(MongoshInvalidInputError);
-          expect(catched.message).to.contain(
+          expect(caught).to.be.instanceOf(MongoshInvalidInputError);
+          expect(caught.message).to.contain(
             'To drop indexes in the collection using \'*\', use db.collection.dropIndexes().'
           );
-          expect(catched.code).to.equal(CommonErrors.InvalidArgument);
+          expect(caught.code).to.equal(CommonErrors.InvalidArgument);
         });
 
         it('throws if index is an array', async() => {
-          let catched;
-          await collection.dropIndex(['index-1']).catch(err => { catched = err; });
+          let caught;
+          await collection.dropIndex(['index-1']).catch(err => { caught = err; });
 
-          expect(catched).to.be.instanceOf(MongoshInvalidInputError);
-          expect(catched.message).to.contain(
+          expect(caught).to.be.instanceOf(MongoshInvalidInputError);
+          expect(caught.message).to.contain(
             'The index to drop must be either the index name or the index specification document.'
           );
-          expect(catched.code).to.equal(CommonErrors.InvalidArgument);
+          expect(caught.code).to.equal(CommonErrors.InvalidArgument);
         });
       });
     });
@@ -1037,15 +1037,15 @@ describe('Collection', () => {
       });
 
       it('throws an error if called with verbose', async() => {
-        let catched;
+        let caught;
         await collection.totalIndexSize(true)
-          .catch(err => { catched = err; });
+          .catch(err => { caught = err; });
 
-        expect(catched).to.be.instanceOf(MongoshInvalidInputError);
-        expect(catched.message).to.contain(
+        expect(caught).to.be.instanceOf(MongoshInvalidInputError);
+        expect(caught.message).to.contain(
           '"totalIndexSize" takes no argument. Use db.collection.stats to get detailed information.'
         );
-        expect(catched.code).to.equal(CommonErrors.InvalidArgument);
+        expect(caught.code).to.equal(CommonErrors.InvalidArgument);
       });
     });
 
@@ -1155,9 +1155,9 @@ describe('Collection', () => {
       it('throws if serviceProvider.runCommandWithCheck rejects', async() => {
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.rejects(expectedError);
-        const catchedError = await collection.stats()
+        const caughtError = await collection.stats()
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
 
       it('throws is serviceProvider.runCommandWithCheck returns undefined', async() => {
@@ -1514,9 +1514,9 @@ describe('Collection', () => {
       it('throws if serviceProvider.aggregate rejects', async() => {
         const expectedError = new Error();
         serviceProvider.aggregate.throws(expectedError);
-        const catchedError = await collection.latencyStats()
+        const caughtError = await collection.latencyStats()
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
     });
 
@@ -1542,9 +1542,9 @@ describe('Collection', () => {
       it('throws if serviceProvider.initializeBulkOp rejects', async() => {
         const expectedError = new Error();
         serviceProvider.initializeBulkOp.throws(expectedError);
-        const catchedError = await collection.initializeUnorderedBulkOp()
+        const caughtError = await collection.initializeUnorderedBulkOp()
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
     });
     describe('initializeOrderedBulkOp', () => {
@@ -1569,9 +1569,9 @@ describe('Collection', () => {
       it('throws if serviceProvider rejects', async() => {
         const expectedError = new Error();
         serviceProvider.initializeBulkOp.throws(expectedError);
-        const catchedError = await collection.initializeOrderedBulkOp()
+        const caughtError = await collection.initializeOrderedBulkOp()
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
     });
     describe('getPlanCache', () => {
@@ -1625,9 +1625,9 @@ describe('Collection', () => {
       it('throws if serviceProvider.runCommand rejects', async() => {
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.rejects(expectedError);
-        const catchedError = await collection.validate()
+        const caughtError = await collection.validate()
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
     });
     describe('mapReduce', () => {
@@ -1676,9 +1676,9 @@ describe('Collection', () => {
       it('throws if serviceProvider.mapReduce rejects', async() => {
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.rejects(expectedError);
-        const catchedError = await collection.mapReduce(mapFn, reduceFn, { out: { inline: 1 } })
+        const caughtError = await collection.mapReduce(mapFn, reduceFn, { out: { inline: 1 } })
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
 
       it('throws if optiosn is an object and options.out is not defined', async() => {
@@ -1710,9 +1710,9 @@ describe('Collection', () => {
       it('throws if serviceProvider.runCommand rejects', async() => {
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.rejects(expectedError);
-        const catchedError = await collection.getShardVersion()
+        const caughtError = await collection.getShardVersion()
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
     });
     describe('getShardDistribution', () => {

--- a/packages/shell-api/src/database.spec.ts
+++ b/packages/shell-api/src/database.spec.ts
@@ -223,9 +223,9 @@ describe('Database', () => {
       it('throws if serviceProvider.runCommand rejects', async() => {
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.rejects(expectedError);
-        const catchedError = await database.runCommand({ someCommand: 'someCollection' })
+        const caughtError = await database.runCommand({ someCommand: 'someCollection' })
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
     });
 
@@ -261,9 +261,9 @@ describe('Database', () => {
       it('throws if serviceProvider.runCommand rejects', async() => {
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.rejects(expectedError);
-        const catchedError = await database.adminCommand({ someCommand: 'someCollection' })
+        const caughtError = await database.adminCommand({ someCommand: 'someCollection' })
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
     });
 
@@ -475,9 +475,9 @@ describe('Database', () => {
       it('throws if serviceProvider.dropDatabase rejects', async() => {
         const expectedError = new Error();
         serviceProvider.dropDatabase.rejects(expectedError);
-        const catchedError = await database.dropDatabase()
+        const caughtError = await database.dropDatabase()
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
     });
     describe('createUser', () => {
@@ -560,45 +560,45 @@ describe('Database', () => {
       it('throws if serviceProvider.runCommandWithCheck rejects', async() => {
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.rejects(expectedError);
-        const catchedError = await database.createUser({
+        const caughtError = await database.createUser({
           user: 'anna',
           pwd: 'pwd',
           customData: { anything: true },
           roles: []
         }, { w: 1 })
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
 
       it('throws if roles is not provided', async() => {
-        const catchedError = await database.createUser({
+        const caughtError = await database.createUser({
           user: 'anna',
           pwd: 'pwd'
         }).catch(e => e);
-        expect(catchedError).to.be.instanceOf(MongoshInvalidInputError);
-        expect(catchedError.message).to.contain('Missing required property: "roles"');
-        expect(catchedError.code).to.equal(CommonErrors.InvalidArgument);
+        expect(caughtError).to.be.instanceOf(MongoshInvalidInputError);
+        expect(caughtError.message).to.contain('Missing required property: "roles"');
+        expect(caughtError.code).to.equal(CommonErrors.InvalidArgument);
       });
 
       it('throws if password is missing on database other than $external', async() => {
-        const catchedError = await database.createUser({
+        const caughtError = await database.createUser({
           user: 'anna'
         }).catch(e => e);
-        expect(catchedError).to.be.instanceOf(MongoshInvalidInputError);
-        expect(catchedError.message).to.contain('Missing required property: "roles"');
-        expect(catchedError.code).to.equal(CommonErrors.InvalidArgument);
+        expect(caughtError).to.be.instanceOf(MongoshInvalidInputError);
+        expect(caughtError.message).to.contain('Missing required property: "roles"');
+        expect(caughtError.code).to.equal(CommonErrors.InvalidArgument);
       });
 
       it('throws if createUser option is provided', async() => {
-        const catchedError = await database.createUser({
+        const caughtError = await database.createUser({
           user: 'anna',
           pwd: 'pwd',
           createUser: 1,
           roles: []
         }).catch(e => e);
-        expect(catchedError).to.be.instanceOf(MongoshInvalidInputError);
-        expect(catchedError.message).to.contain('Cannot set createUser field in helper method');
-        expect(catchedError.code).to.equal(CommonErrors.InvalidArgument);
+        expect(caughtError).to.be.instanceOf(MongoshInvalidInputError);
+        expect(caughtError.message).to.contain('Cannot set createUser field in helper method');
+        expect(caughtError.code).to.equal(CommonErrors.InvalidArgument);
       });
 
       context('on $external database', () => {
@@ -718,27 +718,27 @@ describe('Database', () => {
       it('throws if serviceProvider.runCommandWithCheck rejects', async() => {
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.rejects(expectedError);
-        const catchedError = await database.updateUser('anna', {
+        const caughtError = await database.updateUser('anna', {
           user: 'anna',
           pwd: 'pwd',
           customData: { anything: true },
           roles: []
         }, { w: 1 })
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
 
       it('throws if an invalid passwordDigestor is provided', async() => {
-        const catchedError = await database.updateUser('anna', {
+        const caughtError = await database.updateUser('anna', {
           user: 'anna',
           pwd: 'pwd',
           customData: { anything: true },
           roles: [],
           passwordDigestor: 'whatever'
         }, { w: 1 }).catch(e => e);
-        expect(catchedError).to.be.instanceOf(MongoshInvalidInputError);
-        expect(catchedError.message).to.contain('passwordDigestor must be \'client\' or \'server\'');
-        expect(catchedError.code).to.equal(CommonErrors.InvalidArgument);
+        expect(caughtError).to.be.instanceOf(MongoshInvalidInputError);
+        expect(caughtError.message).to.contain('passwordDigestor must be \'client\' or \'server\'');
+        expect(caughtError.code).to.equal(CommonErrors.InvalidArgument);
       });
     });
     describe('changeUserPassword', () => {
@@ -764,9 +764,9 @@ describe('Database', () => {
       it('throws if serviceProvider.runCommandWithCheck rejects', async() => {
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.rejects(expectedError);
-        const catchedError = await database.changeUserPassword('anna', 'pwd')
+        const caughtError = await database.changeUserPassword('anna', 'pwd')
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
     });
     describe('logout', () => {
@@ -789,9 +789,9 @@ describe('Database', () => {
       it('throws if serviceProvider.runCommandWithCheck rejects', async() => {
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.rejects(expectedError);
-        const catchedError = await database.logout()
+        const caughtError = await database.logout()
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
     });
     describe('dropUser', () => {
@@ -814,9 +814,9 @@ describe('Database', () => {
       it('throws if serviceProvider.runCommandWithCheck rejects', async() => {
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.rejects(expectedError);
-        const catchedError = await database.dropUser('anna')
+        const caughtError = await database.dropUser('anna')
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
     });
     describe('dropAllUsers', () => {
@@ -839,9 +839,9 @@ describe('Database', () => {
       it('throws if serviceProvider.runCommandWithCheck rejects', async() => {
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.rejects(expectedError);
-        const catchedError = await database.dropAllUsers()
+        const caughtError = await database.dropAllUsers()
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
     });
     describe('auth', () => {
@@ -883,27 +883,27 @@ describe('Database', () => {
       it('throws if serviceProvider.runCommandWithCheck rejects', async() => {
         const expectedError = new Error();
         serviceProvider.authenticate.rejects(expectedError);
-        const catchedError = await database.auth('anna', 'pwd')
+        const caughtError = await database.auth('anna', 'pwd')
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
 
       [[{}], [{ user: 'anna', pass: 'pwd' }], ['name', 'pwd', 'hmm']].forEach(args => {
         it('throws for invalid arguments', async() => {
-          const catchedError = await database.auth(...args as any).catch(e => e);
-          expect(catchedError).to.be.instanceOf(MongoshInvalidInputError);
-          expect(catchedError.code).to.equal(CommonErrors.InvalidArgument);
+          const caughtError = await database.auth(...args as any).catch(e => e);
+          expect(caughtError).to.be.instanceOf(MongoshInvalidInputError);
+          expect(caughtError.code).to.equal(CommonErrors.InvalidArgument);
         });
       });
 
       it('throws if digestPassword is specified', async() => {
-        const catchedError = await database.auth({
+        const caughtError = await database.auth({
           user: 'anna',
           pwd: 'pwd',
           digestPassword: 'nope'
         } as any).catch(e => e);
-        expect(catchedError).to.be.instanceOf(MongoshUnimplementedError);
-        expect(catchedError.code).to.equal(CommonErrors.NotImplemented);
+        expect(caughtError).to.be.instanceOf(MongoshUnimplementedError);
+        expect(caughtError.code).to.equal(CommonErrors.NotImplemented);
       });
 
       it('asks for password if only username is passed', async() => {
@@ -943,9 +943,9 @@ describe('Database', () => {
       it('throws if serviceProvider.runCommandWithCheck rejects', async() => {
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.rejects(expectedError);
-        const catchedError = await database.grantRolesToUser('anna', [ 'role1' ])
+        const caughtError = await database.grantRolesToUser('anna', [ 'role1' ])
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
     });
     describe('revokeRolesFromUser', () => {
@@ -968,9 +968,9 @@ describe('Database', () => {
       it('throws if serviceProvider.runCommandWithCheck rejects', async() => {
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.rejects(expectedError);
-        const catchedError = await database.revokeRolesFromUser('anna', [ 'role1' ])
+        const caughtError = await database.revokeRolesFromUser('anna', [ 'role1' ])
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
     });
     describe('getUser', () => {
@@ -1020,9 +1020,9 @@ describe('Database', () => {
       it('throws if serviceProvider.runCommandWithCheck rejects', async() => {
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.rejects(expectedError);
-        const catchedError = await database.getUser('anna')
+        const caughtError = await database.getUser('anna')
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
     });
     describe('getUsers', () => {
@@ -1060,9 +1060,9 @@ describe('Database', () => {
       it('throws if serviceProvider.runCommandWithCheck rejects', async() => {
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.rejects(expectedError);
-        const catchedError = await database.getUsers()
+        const caughtError = await database.getUsers()
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
     });
     describe('createCollection', () => {
@@ -1103,9 +1103,9 @@ describe('Database', () => {
       it('throws if serviceProvider.createCollection rejects', async() => {
         const expectedError = new Error();
         serviceProvider.createCollection.rejects(expectedError);
-        const catchedError = await database.createCollection('newcoll')
+        const caughtError = await database.createCollection('newcoll')
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
     });
     describe('createView', () => {
@@ -1145,9 +1145,9 @@ describe('Database', () => {
       it('throws if serviceProvider.createCollection rejects', async() => {
         const expectedError = new Error();
         serviceProvider.createCollection.rejects(expectedError);
-        const catchedError = await database.createView('newcoll', 'sourcecoll', [])
+        const caughtError = await database.createView('newcoll', 'sourcecoll', [])
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
     });
     describe('createRole', () => {
@@ -1203,24 +1203,24 @@ describe('Database', () => {
       it('throws if serviceProvider.runCommandWithCheck rejects', async() => {
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.rejects(expectedError);
-        const catchedError = await database.createRole({
+        const caughtError = await database.createRole({
           role: 'anna',
           roles: [],
           privileges: []
         }, { w: 1 })
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
 
       it('throws if createRole is specified', async() => {
-        const catchedError = await database.createRole({
+        const caughtError = await database.createRole({
           createRole: 1,
           role: 'anna',
           roles: [],
           privileges: []
         }, { w: 1 }).catch(e => e);
-        expect(catchedError).to.be.instanceOf(MongoshInvalidInputError);
-        expect(catchedError.code).to.equal(CommonErrors.InvalidArgument);
+        expect(caughtError).to.be.instanceOf(MongoshInvalidInputError);
+        expect(caughtError.code).to.equal(CommonErrors.InvalidArgument);
       });
     });
     describe('updateRole', () => {
@@ -1271,13 +1271,13 @@ describe('Database', () => {
       it('throws if serviceProvider.runCommandWithCheck rejects', async() => {
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.rejects(expectedError);
-        const catchedError = await database.updateRole('anna', {
+        const caughtError = await database.updateRole('anna', {
           role: 'anna',
           privileges: [],
           roles: []
         }, { w: 1 })
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
     });
     describe('dropRole', () => {
@@ -1300,9 +1300,9 @@ describe('Database', () => {
       it('throws if serviceProvider.runCommandWithCheck rejects', async() => {
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.rejects(expectedError);
-        const catchedError = await database.dropRole('anna')
+        const caughtError = await database.dropRole('anna')
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
     });
     describe('dropAllRoles', () => {
@@ -1325,9 +1325,9 @@ describe('Database', () => {
       it('throws if serviceProvider.runCommandWithCheck rejects', async() => {
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.rejects(expectedError);
-        const catchedError = await database.dropAllRoles()
+        const caughtError = await database.dropAllRoles()
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
     });
     describe('grantRolesToRole', () => {
@@ -1350,9 +1350,9 @@ describe('Database', () => {
       it('throws if serviceProvider.runCommandWithCheck rejects', async() => {
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.rejects(expectedError);
-        const catchedError = await database.grantRolesToRole('anna', [ 'role1' ])
+        const caughtError = await database.grantRolesToRole('anna', [ 'role1' ])
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
     });
     describe('revokeRolesFromRole', () => {
@@ -1375,9 +1375,9 @@ describe('Database', () => {
       it('throws if serviceProvider.runCommandWithCheck rejects', async() => {
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.rejects(expectedError);
-        const catchedError = await database.revokeRolesFromRole('anna', [ 'role1' ])
+        const caughtError = await database.revokeRolesFromRole('anna', [ 'role1' ])
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
     });
 
@@ -1401,9 +1401,9 @@ describe('Database', () => {
       it('throws if serviceProvider.runCommandWithCheck rejects', async() => {
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.rejects(expectedError);
-        const catchedError = await database.grantPrivilegesToRole('anna', [ 'privilege1' ])
+        const caughtError = await database.grantPrivilegesToRole('anna', [ 'privilege1' ])
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
     });
     describe('revokePrivilegesFromRole', () => {
@@ -1426,9 +1426,9 @@ describe('Database', () => {
       it('throws if serviceProvider.runCommandWithCheck rejects', async() => {
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.rejects(expectedError);
-        const catchedError = await database.revokePrivilegesFromRole('anna', [ 'privilege1' ])
+        const caughtError = await database.revokePrivilegesFromRole('anna', [ 'privilege1' ])
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
     });
     describe('getRole', () => {
@@ -1476,9 +1476,9 @@ describe('Database', () => {
       it('throws if serviceProvider.runCommandWithCheck rejects', async() => {
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.rejects(expectedError);
-        const catchedError = await database.getRole('anna')
+        const caughtError = await database.getRole('anna')
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
     });
     describe('getRoles', () => {
@@ -1516,9 +1516,9 @@ describe('Database', () => {
       it('throws if serviceProvider.runCommandWithCheck rejects', async() => {
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.rejects(expectedError);
-        const catchedError = await database.getRoles()
+        const caughtError = await database.getRoles()
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
     });
 
@@ -1559,9 +1559,9 @@ describe('Database', () => {
       it('throws if serviceProvider.runCommandWithCheck rejects', async() => {
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.rejects(expectedError);
-        const catchedError = await database.currentOp()
+        const caughtError = await database.currentOp()
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
     });
 
@@ -1587,9 +1587,9 @@ describe('Database', () => {
       it('throws if serviceProvider.runCommandWithCheck rejects', async() => {
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.rejects(expectedError);
-        const catchedError = await database.killOp(123)
+        const caughtError = await database.killOp(123)
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
     });
 
@@ -1628,9 +1628,9 @@ describe('Database', () => {
       it('throws if serviceProvider.runCommandWithCheck rejects', async() => {
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.rejects(expectedError);
-        const catchedError = await database.shutdownServer()
+        const caughtError = await database.shutdownServer()
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
     });
 
@@ -1656,9 +1656,9 @@ describe('Database', () => {
       it('throws if serviceProvider.runCommandWithCheck rejects', async() => {
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.rejects(expectedError);
-        const catchedError = await database.fsyncLock()
+        const caughtError = await database.fsyncLock()
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
     });
 
@@ -1684,9 +1684,9 @@ describe('Database', () => {
       it('throws if serviceProvider.runCommandWithCheck rejects', async() => {
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.rejects(expectedError);
-        const catchedError = await database.fsyncUnlock()
+        const caughtError = await database.fsyncUnlock()
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
     });
 
@@ -1713,16 +1713,16 @@ describe('Database', () => {
       it('throws if serviceProvider.runCommandWithCheck rejects', async() => {
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.rejects(expectedError);
-        const catchedError = await database.version()
+        const caughtError = await database.version()
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
 
       it('throws if runCommand returns undefined', async() => {
         serviceProvider.runCommandWithCheck.resolves(undefined);
-        const catchedError = await database.version().catch(e => e);
-        expect(catchedError).to.be.instanceOf(MongoshRuntimeError);
-        expect(catchedError.code).to.equal(CommonErrors.CommandFailed);
+        const caughtError = await database.version().catch(e => e);
+        expect(caughtError).to.be.instanceOf(MongoshRuntimeError);
+        expect(caughtError.code).to.equal(CommonErrors.CommandFailed);
       });
     });
 
@@ -1749,16 +1749,16 @@ describe('Database', () => {
       it('throws if serviceProvider.runCommandWithCheck rejects', async() => {
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.rejects(expectedError);
-        const catchedError = await database.serverBits()
+        const caughtError = await database.serverBits()
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
 
       it('throws if runCommand returns undefined', async() => {
         serviceProvider.runCommandWithCheck.resolves(undefined);
-        const catchedError = await database.serverBits().catch(e => e);
-        expect(catchedError).to.be.instanceOf(MongoshRuntimeError);
-        expect(catchedError.code).to.equal(CommonErrors.CommandFailed);
+        const caughtError = await database.serverBits().catch(e => e);
+        expect(caughtError).to.be.instanceOf(MongoshRuntimeError);
+        expect(caughtError.code).to.equal(CommonErrors.CommandFailed);
       });
     });
 
@@ -1784,9 +1784,9 @@ describe('Database', () => {
       it('throws if serviceProvider.runCommandWithCheck rejects', async() => {
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.rejects(expectedError);
-        const catchedError = await database.isMaster()
+        const caughtError = await database.isMaster()
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
     });
 
@@ -1812,9 +1812,9 @@ describe('Database', () => {
       it('throws if serviceProvider.runCommandWithCheck rejects', async() => {
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.rejects(expectedError);
-        const catchedError = await database.serverBuildInfo()
+        const caughtError = await database.serverBuildInfo()
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
     });
 
@@ -1853,9 +1853,9 @@ describe('Database', () => {
       it('throws if serviceProvider.runCommandWithCheck rejects', async() => {
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.rejects(expectedError);
-        const catchedError = await database.stats(1)
+        const caughtError = await database.stats(1)
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
     });
 
@@ -1891,9 +1891,9 @@ describe('Database', () => {
       it('throws if serviceProvider.runCommandWithCheck rejects', async() => {
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.rejects(expectedError);
-        const catchedError = await database.serverStatus()
+        const caughtError = await database.serverStatus()
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
     });
 
@@ -1919,9 +1919,9 @@ describe('Database', () => {
       it('throws if serviceProvider.runCommandWithCheck rejects', async() => {
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.rejects(expectedError);
-        const catchedError = await database.hostInfo()
+        const caughtError = await database.hostInfo()
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
     });
 
@@ -1947,9 +1947,9 @@ describe('Database', () => {
       it('throws if serviceProvider.runCommandWithCheck rejects', async() => {
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.rejects(expectedError);
-        const catchedError = await database.serverCmdLineOpts()
+        const caughtError = await database.serverCmdLineOpts()
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
     });
 
@@ -1990,9 +1990,9 @@ describe('Database', () => {
       it('throws if serviceProvider.runCommandWithCheck rejects', async() => {
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.rejects(expectedError);
-        const catchedError = await database.getFreeMonitoringStatus()
+        const caughtError = await database.getFreeMonitoringStatus()
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
     });
 
@@ -2020,19 +2020,19 @@ describe('Database', () => {
       it('throws if serviceProvider.runCommandWithCheck rejects', async() => {
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.rejects(expectedError);
-        const catchedError = await database.disableFreeMonitoring()
+        const caughtError = await database.disableFreeMonitoring()
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
     });
 
     describe('enableFreeMonitoring', () => {
       it('throws if serviceProvider isMaster is false', async() => {
         serviceProvider.runCommandWithCheck.resolves({ isWritablePrimary: false });
-        const catchedError = await database.enableFreeMonitoring()
+        const caughtError = await database.enableFreeMonitoring()
           .catch(e => e);
-        expect(catchedError).to.be.instanceOf(MongoshInvalidInputError);
-        expect(catchedError.code).to.equal(CommonErrors.InvalidOperation);
+        expect(caughtError).to.be.instanceOf(MongoshInvalidInputError);
+        expect(caughtError.code).to.equal(CommonErrors.InvalidOperation);
       });
 
       it('calls serviceProvider.runCommand on the database', async() => {
@@ -2099,9 +2099,9 @@ describe('Database', () => {
       it('throws if serviceProvider.runCommand rejects without auth error', async() => {
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.rejects(expectedError);
-        const catchedError = await database.enableFreeMonitoring()
+        const caughtError = await database.enableFreeMonitoring()
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
     });
 
@@ -2128,9 +2128,9 @@ describe('Database', () => {
       it('throws if serviceProvider.runCommandWithCheck rejects', async() => {
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.rejects(expectedError);
-        const catchedError = await database.getProfilingStatus()
+        const caughtError = await database.getProfilingStatus()
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
     });
 
@@ -2184,15 +2184,15 @@ describe('Database', () => {
       it('throws if serviceProvider.runCommandWithCheck rejects', async() => {
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.rejects(expectedError);
-        const catchedError = await database.setProfilingLevel(1)
+        const caughtError = await database.setProfilingLevel(1)
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
 
       it('throws if profiling level is invalid', async() => {
-        const catchedError = await database.setProfilingLevel(4).catch(e => e);
-        expect(catchedError).to.be.instanceOf(MongoshInvalidInputError);
-        expect(catchedError.code).to.equal(CommonErrors.InvalidArgument);
+        const caughtError = await database.setProfilingLevel(4).catch(e => e);
+        expect(caughtError).to.be.instanceOf(MongoshInvalidInputError);
+        expect(caughtError.code).to.equal(CommonErrors.InvalidArgument);
       });
     });
 
@@ -2232,15 +2232,15 @@ describe('Database', () => {
       it('throws if serviceProvider.runCommandWithCheck rejects', async() => {
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.rejects(expectedError);
-        const catchedError = await database.setLogLevel(2)
+        const caughtError = await database.setLogLevel(2)
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
 
       it('throws if component is given but not a string', async() => {
-        const catchedError = await database.setLogLevel(1, {}).catch(e => e);
-        expect(catchedError).to.be.instanceOf(MongoshInvalidInputError);
-        expect(catchedError.code).to.equal(CommonErrors.InvalidArgument);
+        const caughtError = await database.setLogLevel(1, {}).catch(e => e);
+        expect(caughtError).to.be.instanceOf(MongoshInvalidInputError);
+        expect(caughtError.code).to.equal(CommonErrors.InvalidArgument);
       });
     });
 
@@ -2267,17 +2267,17 @@ describe('Database', () => {
 
       it('throws if serviceProvider.runCommandWithCheck returns undefined', async() => {
         serviceProvider.runCommandWithCheck.resolves(undefined);
-        const catchedError = await database.getLogComponents().catch(e => e);
-        expect(catchedError).to.be.instanceOf(MongoshRuntimeError);
-        expect(catchedError.code).to.equal(CommonErrors.CommandFailed);
+        const caughtError = await database.getLogComponents().catch(e => e);
+        expect(caughtError).to.be.instanceOf(MongoshRuntimeError);
+        expect(caughtError.code).to.equal(CommonErrors.CommandFailed);
       });
 
       it('throws if serviceProvider.runCommandWithCheck rejects', async() => {
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.rejects(expectedError);
-        const catchedError = await database.getLogComponents()
+        const caughtError = await database.getLogComponents()
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
     });
 
@@ -2319,17 +2319,17 @@ describe('Database', () => {
 
       it('throws if serviceProvider.runCommandWithCheck returns undefined', async() => {
         serviceProvider.runCommandWithCheck.resolves(undefined);
-        const catchedError = await database.commandHelp('listDatabases').catch(e => e);
-        expect(catchedError).to.be.instanceOf(MongoshRuntimeError);
-        expect(catchedError.code).to.equal(CommonErrors.CommandFailed);
+        const caughtError = await database.commandHelp('listDatabases').catch(e => e);
+        expect(caughtError).to.be.instanceOf(MongoshRuntimeError);
+        expect(caughtError.code).to.equal(CommonErrors.CommandFailed);
       });
 
       it('throws if serviceProvider.runCommandWithCheck rejects', async() => {
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.rejects(expectedError);
-        const catchedError = await database.commandHelp('listDatabases')
+        const caughtError = await database.commandHelp('listDatabases')
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
     });
 
@@ -2358,17 +2358,17 @@ describe('Database', () => {
 
       it('throws if serviceProvider.runCommandWithCheck returns undefined', async() => {
         serviceProvider.runCommandWithCheck.resolves(undefined);
-        const catchedError = await database.listCommands().catch(e => e);
-        expect(catchedError).to.be.instanceOf(MongoshRuntimeError);
-        expect(catchedError.code).to.equal(CommonErrors.CommandFailed);
+        const caughtError = await database.listCommands().catch(e => e);
+        expect(caughtError).to.be.instanceOf(MongoshRuntimeError);
+        expect(caughtError.code).to.equal(CommonErrors.CommandFailed);
       });
 
       it('throws if serviceProvider.runCommandWithCheck rejects', async() => {
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.rejects(expectedError);
-        const catchedError = await database.listCommands()
+        const caughtError = await database.listCommands()
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
     });
     describe('getLastError', () => {

--- a/packages/shell-api/src/mongo.spec.ts
+++ b/packages/shell-api/src/mongo.spec.ts
@@ -109,9 +109,9 @@ describe('Mongo', () => {
           it('throws if serviceProvider.listCommands rejects', async() => {
             const expectedError = new Error();
             serviceProvider.listDatabases.rejects(expectedError);
-            const catchedError = await mongo.show(t)
+            const caughtError = await mongo.show(t)
               .catch(e => e);
-            expect(catchedError).to.equal(expectedError);
+            expect(caughtError).to.equal(expectedError);
           });
         });
       });
@@ -144,9 +144,9 @@ describe('Mongo', () => {
           it('throws if database.getCollectionNames rejects', async() => {
             const expectedError = new Error();
             database._getCollectionNamesWithTypes.rejects(expectedError);
-            const catchedError = await mongo.show(t)
+            const caughtError = await mongo.show(t)
               .catch(e => e);
-            expect(catchedError).to.equal(expectedError);
+            expect(caughtError).to.equal(expectedError);
           });
         });
       });
@@ -171,9 +171,9 @@ describe('Mongo', () => {
         it('throws if database.getUsers rejects', async() => {
           const expectedError = new Error();
           database.getUsers.rejects(expectedError);
-          const catchedError = await mongo.show('users')
+          const caughtError = await mongo.show('users')
             .catch(e => e);
-          expect(catchedError).to.equal(expectedError);
+          expect(caughtError).to.equal(expectedError);
         });
       });
       describe('roles', () => {
@@ -197,9 +197,9 @@ describe('Mongo', () => {
         it('throws if database.getRoles rejects', async() => {
           const expectedError = new Error();
           database.getRoles.rejects(expectedError);
-          const catchedError = await mongo.show('roles')
+          const caughtError = await mongo.show('roles')
             .catch(e => e);
-          expect(catchedError).to.equal(expectedError);
+          expect(caughtError).to.equal(expectedError);
         });
       });
       describe('log', () => {
@@ -231,9 +231,9 @@ describe('Mongo', () => {
         it('throws if database.adminCommand rejects', async() => {
           const expectedError = new Error();
           database.adminCommand.rejects(expectedError);
-          const catchedError = await mongo.show('log')
+          const caughtError = await mongo.show('log')
             .catch(e => e);
-          expect(catchedError).to.equal(expectedError);
+          expect(caughtError).to.equal(expectedError);
         });
       });
       describe('logs', () => {
@@ -257,9 +257,9 @@ describe('Mongo', () => {
         it('throws if database.adminCommand rejects', async() => {
           const expectedError = new Error();
           database.adminCommand.rejects(expectedError);
-          const catchedError = await mongo.show('logs')
+          const caughtError = await mongo.show('logs')
             .catch(e => e);
-          expect(catchedError).to.equal(expectedError);
+          expect(caughtError).to.equal(expectedError);
         });
       });
       describe('profile', () => {
@@ -300,18 +300,18 @@ describe('Mongo', () => {
           syscoll.countDocuments.resolves(1);
           const expectedError = new Error();
           syscoll.find.throws(expectedError);
-          const catchedError = await mongo.show('profile')
+          const caughtError = await mongo.show('profile')
             .catch(e => e);
-          expect(catchedError).to.equal(expectedError);
+          expect(caughtError).to.equal(expectedError);
         });
         it('throws if collection.countDocuments rejects', async() => {
           const syscoll = stubInterface<Collection>();
           database.getCollection.returns(syscoll);
           const expectedError = new Error();
           syscoll.countDocuments.rejects(expectedError);
-          const catchedError = await mongo.show('profile')
+          const caughtError = await mongo.show('profile')
             .catch(e => e);
-          expect(catchedError).to.equal(expectedError);
+          expect(caughtError).to.equal(expectedError);
         });
       });
       describe('invalid command', () => {
@@ -370,8 +370,8 @@ describe('Mongo', () => {
         serviceProvider.getReadConcern.throws(expectedError);
         try {
           mongo.getReadConcern();
-        } catch (catchedError) {
-          return expect(catchedError).to.be.instanceOf(MongoshInternalError);
+        } catch (caughtError) {
+          return expect(caughtError).to.be.instanceOf(MongoshInternalError);
         }
         expect.fail();
       });
@@ -397,8 +397,8 @@ describe('Mongo', () => {
         serviceProvider.getWriteConcern.throws(expectedError);
         try {
           mongo.getWriteConcern();
-        } catch (catchedError) {
-          return expect(catchedError).to.be.instanceOf(MongoshInternalError);
+        } catch (caughtError) {
+          return expect(caughtError).to.be.instanceOf(MongoshInternalError);
         }
         expect.fail();
       });
@@ -422,8 +422,8 @@ describe('Mongo', () => {
         serviceProvider.resetConnectionOptions.throws(expectedError);
         try {
           await mongo.setReadPref('primary');
-        } catch (catchedError) {
-          return expect(catchedError).to.equal(expectedError);
+        } catch (caughtError) {
+          return expect(caughtError).to.equal(expectedError);
         }
         expect.fail();
       });
@@ -444,8 +444,8 @@ describe('Mongo', () => {
         serviceProvider.resetConnectionOptions.throws(expectedError);
         try {
           await mongo.setReadConcern('majority');
-        } catch (catchedError) {
-          return expect(catchedError).to.equal(expectedError);
+        } catch (caughtError) {
+          return expect(caughtError).to.equal(expectedError);
         }
         expect.fail();
       });
@@ -470,8 +470,8 @@ describe('Mongo', () => {
         serviceProvider.resetConnectionOptions.throws(expectedError);
         try {
           await mongo.setWriteConcern('majority');
-        } catch (catchedError) {
-          return expect(catchedError).to.equal(expectedError);
+        } catch (caughtError) {
+          return expect(caughtError).to.equal(expectedError);
         }
         expect.fail();
       });
@@ -494,8 +494,8 @@ describe('Mongo', () => {
         serviceProvider.startSession.throws(expectedError);
         try {
           mongo.startSession();
-        } catch (catchedError) {
-          return expect(catchedError).to.equal(expectedError);
+        } catch (caughtError) {
+          return expect(caughtError).to.equal(expectedError);
         }
         expect.fail();
       });

--- a/packages/shell-api/src/plan-cache.spec.ts
+++ b/packages/shell-api/src/plan-cache.spec.ts
@@ -69,9 +69,9 @@ describe('PlanCache', () => {
       it('throws if collection.runCommand rejects', async() => {
         const expectedError = new Error();
         collection.runCommand.rejects(expectedError);
-        const catchedError = await planCache.clear()
+        const caughtError = await planCache.clear()
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
     });
     describe('clearPlansByQuery', () => {
@@ -100,9 +100,9 @@ describe('PlanCache', () => {
       it('throws if collection.runCommand rejects', async() => {
         const expectedError = new Error();
         collection.runCommand.rejects(expectedError);
-        const catchedError = await planCache.clearPlansByQuery({})
+        const caughtError = await planCache.clearPlansByQuery({})
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
     });
     describe('list', () => {
@@ -132,9 +132,9 @@ describe('PlanCache', () => {
       it('throws if collection.aggregate rejects', async() => {
         const expectedError = new Error();
         collection.aggregate.rejects(expectedError);
-        const catchedError = await planCache.list()
+        const caughtError = await planCache.list()
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
     });
   });

--- a/packages/shell-api/src/replica-set.spec.ts
+++ b/packages/shell-api/src/replica-set.spec.ts
@@ -327,9 +327,9 @@ describe('ReplicaSet', () => {
       it('throws if serviceProvider.runCommandWithCheck rejects', async() => {
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.rejects(expectedError);
-        const catchedError = await rs.status()
+        const caughtError = await rs.status()
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
     });
     describe('isMaster', () => {
@@ -354,9 +354,9 @@ describe('ReplicaSet', () => {
       it('throws if serviceProvider.runCommandWithCheck rejects', async() => {
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.rejects(expectedError);
-        const catchedError = await rs.isMaster()
+        const caughtError = await rs.isMaster()
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
     });
     describe('hello', () => {
@@ -381,9 +381,9 @@ describe('ReplicaSet', () => {
       it('throws if serviceProvider.runCommandWithCheck rejects', async() => {
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.rejects(expectedError);
-        const catchedError = await rs.hello()
+        const caughtError = await rs.hello()
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
     });
     describe('add', () => {
@@ -527,9 +527,9 @@ describe('ReplicaSet', () => {
       it('throws if serviceProvider.runCommandWithCheck rejects', async() => {
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.rejects(expectedError);
-        const catchedError = await rs.add('hostname')
+        const caughtError = await rs.add('hostname')
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
     });
     describe('remove', () => {
@@ -565,17 +565,17 @@ describe('ReplicaSet', () => {
       it('throws if serviceProvider.runCommandWithCheck rejects', async() => {
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.rejects(expectedError);
-        const catchedError = await rs.remove('localhost:1')
+        const caughtError = await rs.remove('localhost:1')
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
       it('throws if hostname not in members', async() => {
         const configDoc = { version: 1, members: [{ _id: 0, host: 'localhost:0' }, { _id: 1, host: 'lcoalhost:1' }] };
         serviceProvider.runCommandWithCheck.resolves({ ok: 1, config: configDoc });
-        const catchedError = await rs.remove('localhost:2')
+        const caughtError = await rs.remove('localhost:2')
           .catch(e => e);
-        expect(catchedError).to.be.instanceOf(MongoshInvalidInputError);
-        expect(catchedError.code).to.equal(CommonErrors.InvalidArgument);
+        expect(caughtError).to.be.instanceOf(MongoshInvalidInputError);
+        expect(caughtError.code).to.equal(CommonErrors.InvalidArgument);
       });
     });
     describe('freeze', () => {
@@ -600,9 +600,9 @@ describe('ReplicaSet', () => {
       it('throws if serviceProvider.runCommandWithCheck rejects', async() => {
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.rejects(expectedError);
-        const catchedError = await rs.freeze(100)
+        const caughtError = await rs.freeze(100)
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
     });
     describe('syncFrom', () => {
@@ -627,9 +627,9 @@ describe('ReplicaSet', () => {
       it('throws if serviceProvider.runCommandWithCheck rejects', async() => {
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.rejects(expectedError);
-        const catchedError = await rs.syncFrom('localhost:27017')
+        const caughtError = await rs.syncFrom('localhost:27017')
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
     });
     describe('stepDown', () => {
@@ -676,9 +676,9 @@ describe('ReplicaSet', () => {
       it('throws if serviceProvider.runCommandWithCheck rejects', async() => {
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.rejects(expectedError);
-        const catchedError = await rs.stepDown(10)
+        const caughtError = await rs.stepDown(10)
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
     });
     describe('reconfigForPSASet', () => {

--- a/packages/shell-api/src/shard.spec.ts
+++ b/packages/shell-api/src/shard.spec.ts
@@ -112,9 +112,9 @@ describe('Shard', () => {
       it('throws if serviceProvider.runCommandWithCheck rejects', async() => {
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.rejects(expectedError);
-        const catchedError = await shard.enableSharding('dbname')
+        const caughtError = await shard.enableSharding('dbname')
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
     });
     describe('shardCollection', () => {
@@ -152,9 +152,9 @@ describe('Shard', () => {
       it('throws if serviceProvider.runCommandWithCheck rejects', async() => {
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.rejects(expectedError);
-        const catchedError = await shard.shardCollection('db.coll', { key: 1 })
+        const caughtError = await shard.shardCollection('db.coll', { key: 1 })
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
     });
     describe('reshardCollection', () => {
@@ -192,9 +192,9 @@ describe('Shard', () => {
       it('throws if serviceProvider.runCommandWithCheck rejects', async() => {
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.rejects(expectedError);
-        const catchedError = await shard.reshardCollection('db.coll', { key: 1 })
+        const caughtError = await shard.reshardCollection('db.coll', { key: 1 })
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
     });
     describe('commitReshardCollection', () => {
@@ -218,9 +218,9 @@ describe('Shard', () => {
       it('throws if serviceProvider.runCommandWithCheck rejects', async() => {
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.rejects(expectedError);
-        const catchedError = await shard.commitReshardCollection('db.coll')
+        const caughtError = await shard.commitReshardCollection('db.coll')
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
     });
     describe('abortReshardCollection', () => {
@@ -244,9 +244,9 @@ describe('Shard', () => {
       it('throws if serviceProvider.runCommandWithCheck rejects', async() => {
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.rejects(expectedError);
-        const catchedError = await shard.abortReshardCollection('db.coll')
+        const caughtError = await shard.abortReshardCollection('db.coll')
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
     });
     describe('addShard', () => {
@@ -274,18 +274,18 @@ describe('Shard', () => {
         serviceProvider.runCommandWithCheck.onCall(0).resolves({ ok: 1, msg: 'isdbgrid' });
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.onCall(1).rejects(expectedError);
-        const catchedError = await shard.addShard('uri')
+        const caughtError = await shard.addShard('uri')
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
 
       it('throws if not mongos', async() => {
         const expectedResult = { ok: 1 };
         serviceProvider.runCommandWithCheck.onCall(0).resolves({ ok: 1, msg: 'not dbgrid' });
         serviceProvider.runCommandWithCheck.onCall(1).resolves(expectedResult);
-        const catchedError = await shard.addShard('uri')
+        const caughtError = await shard.addShard('uri')
           .catch(e => e);
-        expect(catchedError.message).to.include('Not connected to a mongos');
+        expect(caughtError.message).to.include('Not connected to a mongos');
       });
     });
     describe('addShardToZone', () => {
@@ -314,18 +314,18 @@ describe('Shard', () => {
         serviceProvider.runCommandWithCheck.onCall(0).resolves({ ok: 1, msg: 'isdbgrid' });
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.onCall(1).rejects(expectedError);
-        const catchedError = await shard.addShardToZone('shard', 'zone')
+        const caughtError = await shard.addShardToZone('shard', 'zone')
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
 
       it('throws if not mongos', async() => {
         const expectedResult = { ok: 1 };
         serviceProvider.runCommandWithCheck.onCall(0).resolves({ ok: 1, msg: 'not dbgrid' });
         serviceProvider.runCommandWithCheck.onCall(1).resolves(expectedResult);
-        const catchedError = await shard.addShardToZone('shard', 'zone')
+        const caughtError = await shard.addShardToZone('shard', 'zone')
           .catch(e => e);
-        expect(catchedError.message).to.include('Not connected to a mongos');
+        expect(caughtError.message).to.include('Not connected to a mongos');
       });
     });
     describe('addShardTag', () => {
@@ -354,18 +354,18 @@ describe('Shard', () => {
         serviceProvider.runCommandWithCheck.onCall(0).resolves({ ok: 1, msg: 'isdbgrid' });
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.onCall(1).rejects(expectedError);
-        const catchedError = await shard.addShardTag('shard', 'zone')
+        const caughtError = await shard.addShardTag('shard', 'zone')
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
 
       it('throws if not mongos', async() => {
         const expectedResult = { ok: 1 };
         serviceProvider.runCommandWithCheck.onCall(0).resolves({ ok: 1, msg: 'not dbgrid' });
         serviceProvider.runCommandWithCheck.onCall(1).resolves(expectedResult);
-        const catchedError = await shard.addShardTag('shard', 'zone')
+        const caughtError = await shard.addShardTag('shard', 'zone')
           .catch(e => e);
-        expect(catchedError.message).to.include('Not connected to a mongos');
+        expect(caughtError.message).to.include('Not connected to a mongos');
       });
 
       it('adds version suggestion if command not found', async() => {
@@ -373,9 +373,9 @@ describe('Shard', () => {
         const expectedError = new Error();
         (expectedError as any).codeName = 'CommandNotFound';
         serviceProvider.runCommandWithCheck.rejects(expectedError);
-        const catchedError = await shard.addShardTag('shard', 'zone')
+        const caughtError = await shard.addShardTag('shard', 'zone')
           .catch(e => e);
-        expect(catchedError.message).to.include('> 3.4');
+        expect(caughtError.message).to.include('> 3.4');
       });
     });
     describe('updateZoneKeyRange', () => {
@@ -406,18 +406,18 @@ describe('Shard', () => {
         serviceProvider.runCommandWithCheck.onCall(0).resolves({ ok: 1, msg: 'isdbgrid' });
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.onCall(1).rejects(expectedError);
-        const catchedError = await shard.updateZoneKeyRange('ns', {}, {}, 'zone')
+        const caughtError = await shard.updateZoneKeyRange('ns', {}, {}, 'zone')
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
 
       it('throws if not mongos', async() => {
         const expectedResult = { ok: 1 };
         serviceProvider.runCommandWithCheck.onCall(0).resolves({ ok: 1, msg: 'not dbgrid' });
         serviceProvider.runCommandWithCheck.onCall(1).resolves(expectedResult);
-        const catchedError = await shard.updateZoneKeyRange('ns', {}, {}, 'zone')
+        const caughtError = await shard.updateZoneKeyRange('ns', {}, {}, 'zone')
           .catch(e => e);
-        expect(catchedError.message).to.include('Not connected to a mongos');
+        expect(caughtError.message).to.include('Not connected to a mongos');
       });
     });
     describe('addTagRange', () => {
@@ -448,18 +448,18 @@ describe('Shard', () => {
         serviceProvider.runCommandWithCheck.onCall(0).resolves({ ok: 1, msg: 'isdbgrid' });
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.onCall(1).rejects(expectedError);
-        const catchedError = await shard.addTagRange('ns', {}, {}, 'zone')
+        const caughtError = await shard.addTagRange('ns', {}, {}, 'zone')
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
 
       it('throws if not mongos', async() => {
         const expectedResult = { ok: 1 };
         serviceProvider.runCommandWithCheck.onCall(0).resolves({ ok: 1, msg: 'not dbgrid' });
         serviceProvider.runCommandWithCheck.onCall(1).resolves(expectedResult);
-        const catchedError = await shard.addTagRange('ns', {}, {}, 'zone')
+        const caughtError = await shard.addTagRange('ns', {}, {}, 'zone')
           .catch(e => e);
-        expect(catchedError.message).to.include('Not connected to a mongos');
+        expect(caughtError.message).to.include('Not connected to a mongos');
       });
 
       it('adds version suggestion if command not found', async() => {
@@ -467,9 +467,9 @@ describe('Shard', () => {
         const expectedError = new Error();
         (expectedError as any).codeName = 'CommandNotFound';
         serviceProvider.runCommandWithCheck.onCall(1).rejects(expectedError);
-        const catchedError = await shard.addTagRange('ns', {}, {}, 'zone')
+        const caughtError = await shard.addTagRange('ns', {}, {}, 'zone')
           .catch(e => e);
-        expect(catchedError.message).to.include('> 3.4');
+        expect(caughtError.message).to.include('> 3.4');
       });
     });
     describe('removeRangeFromZone', () => {
@@ -505,17 +505,17 @@ describe('Shard', () => {
         serviceProvider.runCommandWithCheck.onCall(0).resolves({ ok: 1, msg: 'isdbgrid' });
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.onCall(1).rejects(expectedError);
-        const catchedError = await shard.removeRangeFromZone('ns', { min: 1 }, { max: 1 })
+        const caughtError = await shard.removeRangeFromZone('ns', { min: 1 }, { max: 1 })
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
       it('throws if not mongos', async() => {
         const expectedResult = { ok: 1, msg: 'isdbgrid' };
         serviceProvider.runCommandWithCheck.onCall(0).resolves({ ok: 1, msg: 'not dbgrid' });
         serviceProvider.runCommandWithCheck.onCall(1).resolves(expectedResult);
-        const catchedError = await shard.removeRangeFromZone('ns', {}, {})
+        const caughtError = await shard.removeRangeFromZone('ns', {}, {})
           .catch(e => e);
-        expect(catchedError.message).to.include('Not connected to a mongos');
+        expect(caughtError.message).to.include('Not connected to a mongos');
       });
     });
     describe('removeTagRange', () => {
@@ -551,26 +551,26 @@ describe('Shard', () => {
         serviceProvider.runCommandWithCheck.onCall(0).resolves({ ok: 1, msg: 'isdbgrid' });
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.onCall(1).rejects(expectedError);
-        const catchedError = await shard.removeTagRange('ns', { min: 1 }, { max: 1 })
+        const caughtError = await shard.removeTagRange('ns', { min: 1 }, { max: 1 })
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
       it('throws if not mongos', async() => {
         const expectedResult = { ok: 1 };
         serviceProvider.runCommandWithCheck.onCall(0).resolves({ ok: 1, msg: 'not dbgrid' });
         serviceProvider.runCommandWithCheck.onCall(1).resolves(expectedResult);
-        const catchedError = await shard.removeTagRange('ns', {}, {})
+        const caughtError = await shard.removeTagRange('ns', {}, {})
           .catch(e => e);
-        expect(catchedError.message).to.include('Not connected to a mongos');
+        expect(caughtError.message).to.include('Not connected to a mongos');
       });
       it('adds version suggestion if command not found', async() => {
         serviceProvider.runCommandWithCheck.onCall(0).resolves({ ok: 1, msg: 'isdbgrid' });
         const expectedError = new Error();
         (expectedError as any).codeName = 'CommandNotFound';
         serviceProvider.runCommandWithCheck.onCall(1).rejects(expectedError);
-        const catchedError = await shard.removeTagRange('ns', {}, {})
+        const caughtError = await shard.removeTagRange('ns', {}, {})
           .catch(e => e);
-        expect(catchedError.message).to.include('> 3.4');
+        expect(caughtError.message).to.include('> 3.4');
       });
     });
     describe('removeShardFromZone', () => {
@@ -599,17 +599,17 @@ describe('Shard', () => {
         serviceProvider.runCommandWithCheck.onCall(0).resolves({ ok: 1, msg: 'isdbgrid' });
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.onCall(1).rejects(expectedError);
-        const catchedError = await shard.removeShardFromZone('shard', 'zone')
+        const caughtError = await shard.removeShardFromZone('shard', 'zone')
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
       it('throws if not mongos', async() => {
         const expectedResult = { ok: 1 };
         serviceProvider.runCommandWithCheck.onCall(0).resolves({ ok: 1, msg: 'not dbgrid' });
         serviceProvider.runCommandWithCheck.onCall(1).resolves(expectedResult);
-        const catchedError = await shard.removeShardFromZone('shard', 'zone')
+        const caughtError = await shard.removeShardFromZone('shard', 'zone')
           .catch(e => e);
-        expect(catchedError.message).to.include('Not connected to a mongos');
+        expect(caughtError.message).to.include('Not connected to a mongos');
       });
     });
     describe('removeShardTag', () => {
@@ -638,26 +638,26 @@ describe('Shard', () => {
         serviceProvider.runCommandWithCheck.onCall(0).resolves({ ok: 1, msg: 'isdbgrid' });
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.onCall(1).rejects(expectedError);
-        const catchedError = await shard.removeShardTag('shard', 'zone')
+        const caughtError = await shard.removeShardTag('shard', 'zone')
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
       it('throws if not mongos', async() => {
         const expectedResult = { ok: 1 };
         serviceProvider.runCommandWithCheck.onCall(0).resolves({ ok: 1, msg: 'not dbgrid' });
         serviceProvider.runCommandWithCheck.onCall(1).resolves(expectedResult);
-        const catchedError = await shard.removeShardTag('shard', 'zone')
+        const caughtError = await shard.removeShardTag('shard', 'zone')
           .catch(e => e);
-        expect(catchedError.message).to.include('Not connected to a mongos');
+        expect(caughtError.message).to.include('Not connected to a mongos');
       });
       it('adds version suggestion if command not found', async() => {
         serviceProvider.runCommandWithCheck.onCall(0).resolves({ ok: 1, msg: 'isdbgrid' });
         const expectedError = new Error();
         (expectedError as any).codeName = 'CommandNotFound';
         serviceProvider.runCommandWithCheck.onCall(1).rejects(expectedError);
-        const catchedError = await shard.removeShardTag('shard', 'tag')
+        const caughtError = await shard.removeShardTag('shard', 'tag')
           .catch(e => e);
-        expect(catchedError.message).to.include('> 3.4');
+        expect(caughtError.message).to.include('> 3.4');
       });
     });
     describe('enableAutoSplit', () => {
@@ -704,18 +704,18 @@ describe('Shard', () => {
         serviceProvider.runCommandWithCheck.resolves({ ok: 1, msg: 'isdbgrid' });
         const expectedError = new Error();
         serviceProvider.updateOne.rejects(expectedError);
-        const catchedError = await shard.enableAutoSplit()
+        const caughtError = await shard.enableAutoSplit()
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
 
       it('throws if not mongos', async() => {
         const expectedResult = { acknowledged: 1 } as any;
         serviceProvider.runCommandWithCheck.resolves({ ok: 1, msg: 'not dbgrid' });
         serviceProvider.updateOne.resolves(expectedResult);
-        const catchedError = await shard.enableAutoSplit()
+        const caughtError = await shard.enableAutoSplit()
           .catch(e => e);
-        expect(catchedError.message).to.include('Not connected to a mongos');
+        expect(caughtError.message).to.include('Not connected to a mongos');
       });
     });
     describe('disableAutoSplit', () => {
@@ -763,18 +763,18 @@ describe('Shard', () => {
         serviceProvider.runCommandWithCheck.resolves({ ok: 1, msg: 'isdbgrid' });
         const expectedError = new Error();
         serviceProvider.updateOne.rejects(expectedError);
-        const catchedError = await shard.disableAutoSplit()
+        const caughtError = await shard.disableAutoSplit()
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
 
       it('throws if not mongos', async() => {
         const expectedResult = { ok: 1 } as any;
         serviceProvider.runCommandWithCheck.resolves({ ok: 1, msg: 'not dbgrid' });
         serviceProvider.updateOne.resolves(expectedResult);
-        const catchedError = await shard.disableAutoSplit()
+        const caughtError = await shard.disableAutoSplit()
           .catch(e => e);
-        expect(catchedError.message).to.include('Not connected to a mongos');
+        expect(caughtError.message).to.include('Not connected to a mongos');
       });
     });
     describe('splitAt', () => {
@@ -803,9 +803,9 @@ describe('Shard', () => {
       it('throws if serviceProvider.runCommandWithCheck rejects', async() => {
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.rejects(expectedError);
-        const catchedError = await shard.splitAt('ns', { query: 1 })
+        const caughtError = await shard.splitAt('ns', { query: 1 })
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
     });
     describe('splitFind', () => {
@@ -834,9 +834,9 @@ describe('Shard', () => {
       it('throws if serviceProvider.runCommandWithCheck rejects', async() => {
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.rejects(expectedError);
-        const catchedError = await shard.splitFind('ns', { query: 1 })
+        const caughtError = await shard.splitFind('ns', { query: 1 })
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
     });
     describe('moveChunk', () => {
@@ -862,9 +862,9 @@ describe('Shard', () => {
       it('throws if serviceProvider.runCommandWithCheck rejects', async() => {
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.rejects(expectedError);
-        const catchedError = await shard.moveChunk('ns', { query: 1 }, 'destination')
+        const caughtError = await shard.moveChunk('ns', { query: 1 }, 'destination')
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
     });
     describe('balancerCollectionStatus', () => {
@@ -889,9 +889,9 @@ describe('Shard', () => {
       it('throws if serviceProvider.runCommandWithCheck rejects', async() => {
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.rejects(expectedError);
-        const catchedError = await shard.balancerCollectionStatus('ns')
+        const caughtError = await shard.balancerCollectionStatus('ns')
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
     });
     describe('disableBalancing', () => {
@@ -938,18 +938,18 @@ describe('Shard', () => {
         serviceProvider.runCommandWithCheck.resolves({ ok: 1, msg: 'isdbgrid' });
         const expectedError = new Error();
         serviceProvider.updateOne.rejects(expectedError);
-        const catchedError = await shard.disableBalancing('ns')
+        const caughtError = await shard.disableBalancing('ns')
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
 
       it('throws if not mongos', async() => {
         const expectedResult = { ok: 1 } as any;
         serviceProvider.runCommandWithCheck.resolves({ ok: 1, msg: 'not dbgrid' });
         serviceProvider.updateOne.resolves(expectedResult);
-        const catchedError = await shard.disableBalancing('ns')
+        const caughtError = await shard.disableBalancing('ns')
           .catch(e => e);
-        expect(catchedError.message).to.include('Not connected to a mongos');
+        expect(caughtError.message).to.include('Not connected to a mongos');
       });
     });
     describe('enableBalancing', () => {
@@ -996,18 +996,18 @@ describe('Shard', () => {
         serviceProvider.runCommandWithCheck.resolves({ ok: 1, msg: 'isdbgrid' });
         const expectedError = new Error();
         serviceProvider.updateOne.rejects(expectedError);
-        const catchedError = await shard.enableBalancing('ns')
+        const caughtError = await shard.enableBalancing('ns')
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
 
       it('throws if not mongos', async() => {
         const expectedResult = { ok: 1 } as any;
         serviceProvider.runCommandWithCheck.resolves({ ok: 1, msg: 'not dbgrid' });
         serviceProvider.updateOne.resolves(expectedResult);
-        const catchedError = await shard.enableBalancing('ns')
+        const caughtError = await shard.enableBalancing('ns')
           .catch(e => e);
-        expect(catchedError.message).to.include('Not connected to a mongos');
+        expect(caughtError.message).to.include('Not connected to a mongos');
       });
     });
     describe('getBalancerState', () => {
@@ -1031,18 +1031,18 @@ describe('Shard', () => {
         serviceProvider.runCommandWithCheck.resolves({ ok: 1, msg: 'isdbgrid' });
         const expectedError = new Error();
         serviceProvider.find.throws(expectedError);
-        const catchedError = await shard.getBalancerState()
+        const caughtError = await shard.getBalancerState()
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
 
       it('throws if not mongos', async() => {
         const expectedResult = { ok: 1 };
         serviceProvider.runCommandWithCheck.resolves({ ok: 1, msg: 'not dbgrid' });
         serviceProvider.find.resolves(expectedResult);
-        const catchedError = await shard.getBalancerState()
+        const caughtError = await shard.getBalancerState()
           .catch(e => e);
-        expect(catchedError.message).to.include('Not connected to a mongos');
+        expect(caughtError.message).to.include('Not connected to a mongos');
       });
     });
     describe('isBalancerRunning', () => {
@@ -1070,17 +1070,17 @@ describe('Shard', () => {
         serviceProvider.runCommandWithCheck.onCall(0).resolves({ ok: 1, msg: 'isdbgrid' });
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.onCall(1).rejects(expectedError);
-        const catchedError = await shard.isBalancerRunning()
+        const caughtError = await shard.isBalancerRunning()
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
       it('throws if not mongos', async() => {
         const expectedResult = { ok: 1 };
         serviceProvider.runCommandWithCheck.onCall(0).resolves({ ok: 1, msg: 'not dbgrid' });
         serviceProvider.runCommandWithCheck.onCall(1).resolves(expectedResult);
-        const catchedError = await shard.isBalancerRunning()
+        const caughtError = await shard.isBalancerRunning()
           .catch(e => e);
-        expect(catchedError.message).to.include('Not connected to a mongos');
+        expect(caughtError.message).to.include('Not connected to a mongos');
       });
     });
     describe('startBalancer', () => {
@@ -1115,9 +1115,9 @@ describe('Shard', () => {
       it('throws if serviceProvider.runCommandWithCheck rejects', async() => {
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.rejects(expectedError);
-        const catchedError = await shard.startBalancer(10000)
+        const caughtError = await shard.startBalancer(10000)
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
     });
     describe('stopBalancer', () => {
@@ -1152,9 +1152,9 @@ describe('Shard', () => {
       it('throws if serviceProvider.runCommandWithCheck rejects', async() => {
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.rejects(expectedError);
-        const catchedError = await shard.stopBalancer(10000)
+        const caughtError = await shard.stopBalancer(10000)
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
     });
     describe('setBalancerState', () => {
@@ -1188,9 +1188,9 @@ describe('Shard', () => {
       it('throws if serviceProvider.runCommandWithCheck rejects', async() => {
         const expectedError = new Error();
         serviceProvider.runCommandWithCheck.rejects(expectedError);
-        const catchedError = await shard.setBalancerState(true)
+        const caughtError = await shard.setBalancerState(true)
           .catch(e => e);
-        expect(catchedError).to.equal(expectedError);
+        expect(caughtError).to.equal(expectedError);
       });
     });
   });


### PR DESCRIPTION
I know it’s silly, but it catches me by surprise every time. :)