### PR TITLE
chore(deps): bump multiple types packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6301,9 +6301,9 @@
       "dev": true
     },
     "@types/express-serve-static-core": {
-      "version": "4.17.13",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.13.tgz",
-      "integrity": "sha512-RgDi5a4nuzam073lRGKTUIaL3eF2+H7LJvJ8eUnCI0wA6SNjXc44DCmWNiTLs/AZ7QlsFWZiw/gTG3nSQGL0fA==",
+      "version": "4.17.24",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.24.tgz",
+      "integrity": "sha512-3UJuW+Qxhzwjq3xhwXm2onQcFHn76frIYVbTu+kn24LFxI+dEhdfISDFovPB8VpEgW8oQCTpRuCe+0zJxB7NEA==",
       "dev": true,
       "requires": {
         "@types/node": "*",
@@ -6436,15 +6436,15 @@
       "dev": true
     },
     "@types/qs": {
-      "version": "6.9.5",
-      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.5.tgz",
-      "integrity": "sha512-/JHkVHtx/REVG0VVToGRGH2+23hsYLHdyG+GrvoUGlGAd0ErauXDyvHtRI/7H7mzLm+tBCKA7pfcpkQ1lf58iQ==",
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@types/qs/-/qs-6.9.7.tgz",
+      "integrity": "sha512-FGa1F62FT09qcrueBA6qYTrJPVDzah9a+493+o2PCXsesWHIn27G98TsSMs3WPNbZIEj4+VJf6saSFpvD+3Zsw==",
       "dev": true
     },
     "@types/range-parser": {
-      "version": "1.2.3",
-      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.3.tgz",
-      "integrity": "sha512-ewFXqrQHlFsgc09MK5jP5iR7vumV/BYayNC6PgJO2LPe8vrnNFyjQjSppfEngITi0qvfKtzFvgKymGheFM9UOA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@types/range-parser/-/range-parser-1.2.4.tgz",
+      "integrity": "sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==",
       "dev": true
     },
     "@types/responselike": {


### PR DESCRIPTION
Bump a small number of `@types/` npm packages.

This should address CI failures:

    [2021/08/03 10:07:50.109] > tsc -p tsconfig.json
    [2021/08/03 10:07:55.031] ../../node_modules/@types/express-serve-static-core/index.d.ts(504,18): error TS2430: Interface 'Response<ResBody, StatusCode>' incorrectly extends interface 'ServerResponse'.
    [2021/08/03 10:07:55.031]   Types of property 'req' are incompatible.
    [2021/08/03 10:07:55.031]     Type 'Request<ParamsDictionary, any, any, ParsedQs> | undefined' is not assignable to type 'IncomingMessage'.
    [2021/08/03 10:07:55.031]       Type 'undefined' is not assignable to type 'IncomingMessage'.

I’m not sure why those failures don’t show up in our waterfall builds,
or what exactly introduced them, but they appear in both PR and
Node.js driver integration builds at least:

- https://evergreen.mongodb.com/task/mongosh_linux_compile_ts_patch_fb1691775754ab5b9018acdb4831b423ee3d77e6_61041cb00305b97fe6c5119d_21_07_30_15_37_21
- https://evergreen.mongodb.com/task/mongo_node_driver_mongosh_integration_tests_run_mongosh_integration_tests_b42a1b417e8a4e222000336b0fe9e94053d30d98_21_07_30_17_03_33