### PR TITLE
chore(cli-repl): fix flaky e2e auth test

### DIFF
--- a/packages/cli-repl/test/e2e-auth.spec.ts
+++ b/packages/cli-repl/test/e2e-auth.spec.ts
@@ -811,7 +811,7 @@ describe('Auth e2e', function() {
       ] });
       await shell.waitForPrompt();
       shell.assertNoErrors();
-      shell.writeInputLine('db');
+      await shell.executeLine('db');
       await shell.executeLine(`use ${dbName}`);
       expect(await shell.executeLine(
         'db.runCommand({connectionStatus: 1})'


### PR DESCRIPTION
This should address failures like

    1) Auth e2e
         with options in URI on on the command line
           can auth when there is -u and -p:
       AssertionError: expected 'switched to db test-1628083918784\nEnterprise test-1628083918784> ' to include 'user: \'anna2\''
        at Context.<anonymous> (Z:\data\mci\b788e4fc17091587379cabd712aac21b\src\packages\cli-repl\test\e2e-auth.spec.ts:818:13)