### PR TITLE
fix(shell-api): implement own map/forEach for cursors MONGOSH-936

### DIFF
--- a/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/service/BaseMongoIterableHelper.kt
+++ b/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/service/BaseMongoIterableHelper.kt
@@ -15,12 +15,6 @@ internal abstract class BaseMongoIterableHelper<T : MongoIterable<*>>(val iterab
     abstract val converters: Map<String, (T, Any?) -> Either<T>>
     abstract val defaultConverter: (T, String, Any?) -> Either<T>
 
-    fun map(function: Value): BaseMongoIterableHelper<*> {
-        return helper(iterable.map { v ->
-            converter.toJava(function.execute(converter.toJs(v))).value
-        }, converter)
-    }
-
     fun itcount(): Int {
         return iterable.count()
     }

--- a/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/service/Cursor.kt
+++ b/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/service/Cursor.kt
@@ -104,16 +104,6 @@ internal class Cursor(private var helper: BaseMongoIterableHelper<*>, private va
     }
 
     @HostAccess.Export
-    override fun forEach(func: Value) {
-        if (!func.canExecute()) {
-            throw IllegalArgumentException("Expected one argument of type function. Got: $func")
-        }
-        getOrCreateIterator().forEach { v ->
-            func.execute(converter.toJs(v))
-        }
-    }
-
-    @HostAccess.Export
     override fun hasNext(): Boolean = getOrCreateIterator().hasNext()
 
     @HostAccess.Export
@@ -145,16 +135,6 @@ internal class Cursor(private var helper: BaseMongoIterableHelper<*>, private va
     override fun limit(v: Int): Cursor {
         checkQueryNotExecuted()
         helper.limit(v)
-        return this
-    }
-
-    @HostAccess.Export
-    override fun map(func: Value): Cursor {
-        checkQueryNotExecuted()
-        if (!func.canExecute()) {
-            throw IllegalArgumentException("Expected one argument of type function. Got: $func")
-        }
-        helper = helper.map(func)
         return this
     }
 

--- a/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/service/ServiceProviderCursor.kt
+++ b/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/service/ServiceProviderCursor.kt
@@ -13,13 +13,11 @@ interface ServiceProviderCursor {
   fun collation(v: Value): ServiceProviderCursor
   fun comment(v: String): ServiceProviderCursor
   fun count(): Long
-  fun forEach(func: Value)
   fun hasNext(): Boolean
   fun hint(v: Value): ServiceProviderCursor
   fun isExhausted(): Boolean
   fun itcount(): Int
   fun limit(v: Int): ServiceProviderCursor
-  fun map(func: Value): ServiceProviderCursor
   fun max(v: Value): ServiceProviderCursor
   fun maxTimeMS(v: Long): ServiceProviderCursor
   fun maxAwaitTimeMS(value: Int): ServiceProviderCursor

--- a/packages/shell-api/src/aggregation-cursor.spec.ts
+++ b/packages/shell-api/src/aggregation-cursor.spec.ts
@@ -65,12 +65,6 @@ describe('AggregationCursor', () => {
     it('pretty returns the same cursor', () => {
       expect(cursor.pretty()).to.equal(cursor);
     });
-
-    it('calls wrappee.map with arguments', () => {
-      const arg = {};
-      cursor.map(arg);
-      expect(wrappee.map).to.have.callCount(1);
-    });
   });
 
   describe('Cursor Internals', () => {

--- a/packages/shell-api/src/collection.spec.ts
+++ b/packages/shell-api/src/collection.spec.ts
@@ -180,15 +180,16 @@ describe('Collection', () => {
       });
 
       it('returns an AggregationCursor that wraps the service provider one', async() => {
-        const toArrayResult = [];
-        serviceProviderCursor.toArray.resolves(toArrayResult);
+        const toArrayResult = [{ foo: 'bar' }];
+        serviceProviderCursor.tryNext.onFirstCall().resolves({ foo: 'bar' });
+        serviceProviderCursor.tryNext.onSecondCall().resolves(null);
         serviceProvider.aggregate.returns(serviceProviderCursor);
 
         const cursor = await collection.aggregate([{
           $piplelineStage: {}
         }]);
 
-        expect(await (cursor as AggregationCursor).toArray()).to.equal(toArrayResult);
+        expect(await (cursor as AggregationCursor).toArray()).to.deep.equal(toArrayResult);
       });
 
       it('throws if serviceProvider.aggregate rejects', async() => {

--- a/packages/shell-api/src/cursor.spec.ts
+++ b/packages/shell-api/src/cursor.spec.ts
@@ -70,12 +70,6 @@ describe('Cursor', () => {
       expect(cursor.pretty()).to.equal(cursor);
     });
 
-    it('calls wrappee.map with arguments', () => {
-      const arg = {};
-      cursor.map(arg);
-      expect(wrappee.map).to.have.callCount(1);
-    });
-
     it('has the correct metadata', () => {
       expect(cursor.collation.serverVersions).to.deep.equal(['3.4.0', ServerVersions.latest]);
     });

--- a/packages/shell-api/src/database.spec.ts
+++ b/packages/shell-api/src/database.spec.ts
@@ -297,12 +297,13 @@ describe('Database', () => {
       });
 
       it('returns an AggregationCursor that wraps the service provider one', async() => {
-        const toArrayResult = [];
-        serviceProviderCursor.toArray.resolves(toArrayResult);
+        const toArrayResult = [{ foo: 'bar' }];
+        serviceProviderCursor.tryNext.onFirstCall().resolves({ foo: 'bar' });
+        serviceProviderCursor.tryNext.onSecondCall().resolves(null);
         serviceProvider.aggregateDb.returns(serviceProviderCursor);
 
         const cursor = await database.aggregate([{ $piplelineStage: {} }]);
-        expect(await cursor.toArray()).to.equal(toArrayResult);
+        expect(await cursor.toArray()).to.deep.equal(toArrayResult);
       });
 
       it('throws if serviceProvider.aggregateDb rejects', async() => {

--- a/packages/shell-api/src/explainable-cursor.spec.ts
+++ b/packages/shell-api/src/explainable-cursor.spec.ts
@@ -55,12 +55,6 @@ describe('ExplainableCursor', () => {
       expect(eCursor.map()).to.equal(eCursor);
     });
 
-    it('calls wrappee.map with arguments', () => {
-      const arg = () => {};
-      eCursor.map(arg);
-      expect(wrappee.map).to.have.callCount(1);
-    });
-
     it('has the correct metadata', () => {
       expect(eCursor.collation.serverVersions).to.deep.equal(['3.4.0', ServerVersions.latest]);
     });

--- a/packages/shell-api/src/integration.spec.ts
+++ b/packages/shell-api/src/integration.spec.ts
@@ -2240,7 +2240,7 @@ describe('Shell API (integration)', function() {
       let calls = 0;
       cursor.map(() => { calls++; throw error; });
       for (let i = 0; i < 2; i++) {
-        // Try reading twice to make sure .map() is not called again for the second attempt.
+        // Try reading twice to make sure .map() is called again for the second attempt.
         try {
           await cursor.tryNext();
           expect.fail('missed exception');
@@ -2248,7 +2248,7 @@ describe('Shell API (integration)', function() {
           expect(err).to.equal(error);
         }
       }
-      expect(calls).to.equal(1);
+      expect(calls).to.equal(2);
     });
   });
 


### PR DESCRIPTION
Because the driver expects `.map()` and `.forEach()` callbacks to work
synchronously, but mongosh users can use pseudo-synchronous async
functions, the driver cannot properly handle the functions we pass
to it.
In order to fix this, if we don’t jump through a lot of extra hoops,
it’s easiest to just implement `.map()` and `.forEach()` ourselves.