### PR TITLE
chore(shell-api): make coll.find() an async function

### DIFF
--- a/packages/shell-api/src/collection.ts
+++ b/packages/shell-api/src/collection.ts
@@ -405,9 +405,11 @@ export default class Collection extends ShellApiWithMongoClass {
    *
    * @returns {Cursor} The promise of the cursor.
    */
+  // eslint-disable-next-line @typescript-eslint/require-await
   @returnType('Cursor')
   @apiVersions([1])
-  find(query?: Document, projection?: Document, options: FindOptions = {}): Cursor {
+  @returnsPromise
+  async find(query?: Document, projection?: Document, options: FindOptions = {}): Promise<Cursor> {
     if (projection) {
       options.projection = projection;
     }

--- a/packages/shell-api/src/database.ts
+++ b/packages/shell-api/src/database.ts
@@ -1351,8 +1351,8 @@ export default class Database extends ShellApiWithMongoClass {
     result.usedMB = olStats.size / (1024 * 1024);
     result.usedMB = Math.ceil(result.usedMB * 100) / 100;
 
-    const first = await ol.find().sort({ $natural: 1 }).limit(1).tryNext();
-    const last = await ol.find().sort({ $natural: -1 }).limit(1).tryNext();
+    const first = await (await ol.find()).sort({ $natural: 1 }).limit(1).tryNext();
+    const last = await (await ol.find()).sort({ $natural: -1 }).limit(1).tryNext();
     if (first === null || last === null) {
       throw new MongoshRuntimeError(
         'objects not found in local.oplog.$main -- is this a new and empty db instance?',

--- a/packages/shell-api/src/explainable.spec.ts
+++ b/packages/shell-api/src/explainable.spec.ts
@@ -26,7 +26,7 @@ describe('Explainable', () => {
     it('attributes', () => {
       expect(signatures.Explainable.attributes.find).to.deep.equal({
         type: 'function',
-        returnsPromise: false,
+        returnsPromise: true,
         deprecated: false,
         returnType: 'ExplainableCursor',
         platforms: ALL_PLATFORMS,
@@ -103,15 +103,15 @@ describe('Explainable', () => {
     describe('find', () => {
       let cursorStub;
       let explainResult;
-      beforeEach(() => {
+      beforeEach(async() => {
         explainResult = { ok: 1 };
 
         const cursorSpy = {
           explain: sinon.spy(() => explainResult)
         } as unknown;
-        collection.find = sinon.spy(() => (cursorSpy as Cursor));
+        collection.find = sinon.spy(() => Promise.resolve(cursorSpy as Cursor));
 
-        cursorStub = explainable.find(
+        cursorStub = await explainable.find(
           { query: 1 },
           { projection: 1 }
         );

--- a/packages/shell-api/src/explainable.ts
+++ b/packages/shell-api/src/explainable.ts
@@ -85,10 +85,11 @@ export default class Explainable extends ShellApiWithMongoClass {
 
   @returnType('ExplainableCursor')
   @apiVersions([1])
-  find(query?: Document, projection?: Document): ExplainableCursor {
+  @returnsPromise
+  async find(query?: Document, projection?: Document): Promise<ExplainableCursor> {
     this._emitExplainableApiCall('find', { query, projection });
 
-    const cursor = this._collection.find(query, projection);
+    const cursor = await this._collection.find(query, projection);
     return new ExplainableCursor(this._mongo, cursor, this._verbosity);
   }
 

--- a/packages/shell-api/src/field-level-encryption.spec.ts
+++ b/packages/shell-api/src/field-level-encryption.spec.ts
@@ -287,29 +287,29 @@ describe('Field Level Encryption', () => {
       });
     });
     describe('getKey', () => {
-      it('calls find on key coll', () => {
+      it('calls find on key coll', async() => {
         const c = { cursor: 1 } as any;
         sp.find.returns(c);
-        const result = keyVault.getKey(KEY_ID);
+        const result = await keyVault.getKey(KEY_ID);
         expect(sp.find).to.have.been.calledOnceWithExactly(DB, COLL, { _id: KEY_ID }, {});
         expect(result._cursor).to.deep.equal(c);
       });
     });
     describe('getKeyByAltName', () => {
-      it('calls find on key coll', () => {
+      it('calls find on key coll', async() => {
         const c = { cursor: 1 } as any;
         const keyaltname = 'abc';
         sp.find.returns(c);
-        const result = keyVault.getKeyByAltName(keyaltname);
+        const result = await keyVault.getKeyByAltName(keyaltname);
         expect(sp.find).to.have.been.calledOnceWithExactly(DB, COLL, { keyAltNames: keyaltname }, {});
         expect(result._cursor).to.deep.equal(c);
       });
     });
     describe('getKeys', () => {
-      it('calls find on key coll', () => {
+      it('calls find on key coll', async() => {
         const c = { cursor: 1 } as any;
         sp.find.returns(c);
-        const result = keyVault.getKeys();
+        const result = await keyVault.getKeys();
         expect(sp.find).to.have.been.calledOnceWithExactly(DB, COLL, {}, {});
         expect(result._cursor).to.deep.equal(c);
       });

--- a/packages/shell-api/src/field-level-encryption.ts
+++ b/packages/shell-api/src/field-level-encryption.ts
@@ -179,21 +179,24 @@ export class KeyVault extends ShellApiWithMongoClass {
 
   @returnType('Cursor')
   @apiVersions([1])
-  getKey(keyId: BinaryType): Cursor {
+  @returnsPromise
+  async getKey(keyId: BinaryType): Promise<Cursor> {
     assertArgsDefinedType([keyId], [true], 'KeyVault.getKey');
     return this._keyColl.find({ '_id': keyId });
   }
 
   @returnType('Cursor')
   @apiVersions([1])
-  getKeyByAltName(keyAltName: string): Cursor {
+  @returnsPromise
+  async getKeyByAltName(keyAltName: string): Promise<Cursor> {
     assertArgsDefinedType([keyAltName], ['string'], 'KeyVault.getKeyByAltName');
     return this._keyColl.find({ 'keyAltNames': keyAltName });
   }
 
   @returnType('Cursor')
   @apiVersions([1])
-  getKeys(): Cursor {
+  @returnsPromise
+  async getKeys(): Promise<Cursor> {
     return this._keyColl.find({});
   }
 

--- a/packages/shell-api/src/mongo.spec.ts
+++ b/packages/shell-api/src/mongo.spec.ts
@@ -283,7 +283,7 @@ describe('Mongo', () => {
           cursor.toArray.resolves(expectedResult);
           database.getCollection.returns(syscoll);
           syscoll.countDocuments.resolves(1);
-          syscoll.find.returns(cursor);
+          syscoll.find.resolves(cursor);
           const result = await mongo.show('profile');
           expect(database.getCollection).to.have.been.calledWith('system.profile');
           expect(syscoll.countDocuments).to.have.been.calledWith({});

--- a/packages/shell-api/src/mongo.spec.ts
+++ b/packages/shell-api/src/mongo.spec.ts
@@ -714,7 +714,7 @@ describe('Mongo', () => {
   describe('integration', () => {
     const testServer = startTestServer('shared');
     let serviceProvider;
-    let internalState;
+    let internalState: ShellInternalState;
     let uri: string;
 
     beforeEach(async() => {
@@ -737,7 +737,7 @@ describe('Mongo', () => {
             const mongo = await internalState.shellApi.Mongo(uri, null, {
               api: { version: '1' }
             });
-            await mongo.getDB('test').getCollection('coll').find().toArray();
+            await (await mongo.getDB('test').getCollection('coll').find()).toArray();
             expect.fail('missed exception');
           } catch (err) {
             expect(err.name).to.match(/MongoServer(Selection)?Error/);
@@ -755,7 +755,7 @@ describe('Mongo', () => {
           });
           expect(mongo._apiOptions).to.deep.equal({ version: '1' });
           // Does not throw, unlike the 4.4 test case above:
-          await mongo.getDB('test').getCollection('coll').find().toArray();
+          await (await mongo.getDB('test').getCollection('coll').find()).toArray();
         });
       });
     });

--- a/packages/shell-api/src/mongo.ts
+++ b/packages/shell-api/src/mongo.ts
@@ -297,7 +297,7 @@ export default class Mongo extends ShellApiClass {
         const sysprof = this._internalState.currentDb.getCollection('system.profile');
         const profiles = { count: await sysprof.countDocuments({}) } as Document;
         if (profiles.count !== 0) {
-          profiles.result = await sysprof.find({ millis: { $gt: 0 } })
+          profiles.result = await (await sysprof.find({ millis: { $gt: 0 } }))
             .sort({ $natural: -1 })
             .limit(5)
             .toArray();

--- a/packages/shell-api/src/result.ts
+++ b/packages/shell-api/src/result.ts
@@ -3,10 +3,10 @@ import { shellApiType, asPrintable } from './enums';
 import { Document, ObjectIdType } from '@mongosh/service-provider-core';
 
 @shellApiClassDefault
-export class CommandResult extends ShellApiValueClass {
-  value: unknown;
+export class CommandResult<T = unknown> extends ShellApiValueClass {
+  value: T;
   type: string;
-  constructor(type: string, value: unknown) {
+  constructor(type: string, value: T) {
     super();
     this.type = type;
     this.value = value;
@@ -16,11 +16,11 @@ export class CommandResult extends ShellApiValueClass {
   /**
    * Internal method to determine what is printed for this class.
    */
-  [asPrintable](): unknown {
+  [asPrintable](): T {
     return this.value;
   }
 
-  toJSON(): unknown {
+  toJSON(): T {
     return this.value;
   }
 }

--- a/packages/shell-api/src/shard.ts
+++ b/packages/shell-api/src/shard.ts
@@ -136,7 +136,7 @@ export default class Shard extends ShellApiWithMongoClass {
 
   @returnsPromise
   @apiVersions([1])
-  async status(verbose = false): Promise<CommandResult> {
+  async status(verbose = false): Promise<CommandResult<Document>> {
     const result = await getPrintableShardStatus(this._database, verbose);
     return new CommandResult('StatsResult', result);
   }


### PR DESCRIPTION
This is in preparation for MONGOSH-537, where it will make things a bit
easier if we have the liberty to make async calls inside all methods
that perform interactions with the database (i.e. fetching
`_baseOptions` can be an async operation).

Also tighten up some types in the tests along with this.