### PR TITLE
chore(deps): bump mongodb-connection-string-url to 2.0.0

### DIFF
--- a/packages/service-provider-core/package-lock.json
+++ b/packages/service-provider-core/package-lock.json
@@ -298,12 +298,31 @@
       }
     },
     "mongodb-connection-string-url": {
-      "version": "1.1.2",
-      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-1.1.2.tgz",
-      "integrity": "sha512-mp5lv4guWuykOpkwNNqQ0tKKytuJUjL/aC/bu/DqoJVWL5NSh4j/u+gJ+EiOdweLujHyq6JZZqcTVipHhL5xRg==",
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.0.0.tgz",
+      "integrity": "sha512-M0I1vyLoq5+HQTuPSJWbt+hIXsMCfE8sS1fS5mvP9R2DOMoi2ZD32yWqgBIITyu0dFu4qtS50erxKjvUeBiyog==",
       "requires": {
-        "@types/whatwg-url": "^8.0.0",
-        "whatwg-url": "^8.4.0"
+        "@types/whatwg-url": "^8.2.1",
+        "whatwg-url": "^9.1.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "2.1.0",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-2.1.0.tgz",
+          "integrity": "sha512-15Ih7phfcdP5YxqiB+iDtLoaTz4Nd35+IiAv0kQ5FNKHzXgdWqPoTIqEDDJmXceQt4JZk6lVPT8lnDlPpGDppw==",
+          "requires": {
+            "punycode": "^2.1.1"
+          }
+        },
+        "whatwg-url": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-9.1.0.tgz",
+          "integrity": "sha512-CQ0UcrPHyomtlOCot1TL77WyMIm/bCwrJ2D6AOKGwEczU9EpyoqAokfqrf/MioU9kHcMsmJZcg1egXix2KYEsA==",
+          "requires": {
+            "tr46": "^2.1.0",
+            "webidl-conversions": "^6.1.0"
+          }
+        }
       }
     },
     "nan": {

--- a/packages/service-provider-core/package.json
+++ b/packages/service-provider-core/package.json
@@ -35,7 +35,7 @@
     "bson": "^4.4.1",
     "mongodb": "^4.1.0",
     "mongodb-build-info": "^1.2.0",
-    "mongodb-connection-string-url": "^1.1.2"
+    "mongodb-connection-string-url": "^2.0.0"
   },
   "optionalDependencies": {
     "mongodb-client-encryption": "^1.2.6"

--- a/packages/service-provider-server/package-lock.json
+++ b/packages/service-provider-server/package-lock.json
@@ -328,12 +328,23 @@
 			}
 		},
 		"mongodb-connection-string-url": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-1.1.2.tgz",
-			"integrity": "sha512-mp5lv4guWuykOpkwNNqQ0tKKytuJUjL/aC/bu/DqoJVWL5NSh4j/u+gJ+EiOdweLujHyq6JZZqcTVipHhL5xRg==",
+			"version": "2.0.0",
+			"resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.0.0.tgz",
+			"integrity": "sha512-M0I1vyLoq5+HQTuPSJWbt+hIXsMCfE8sS1fS5mvP9R2DOMoi2ZD32yWqgBIITyu0dFu4qtS50erxKjvUeBiyog==",
 			"requires": {
-				"@types/whatwg-url": "^8.0.0",
-				"whatwg-url": "^8.4.0"
+				"@types/whatwg-url": "^8.2.1",
+				"whatwg-url": "^9.1.0"
+			},
+			"dependencies": {
+				"whatwg-url": {
+					"version": "9.1.0",
+					"resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-9.1.0.tgz",
+					"integrity": "sha512-CQ0UcrPHyomtlOCot1TL77WyMIm/bCwrJ2D6AOKGwEczU9EpyoqAokfqrf/MioU9kHcMsmJZcg1egXix2KYEsA==",
+					"requires": {
+						"tr46": "^2.1.0",
+						"webidl-conversions": "^6.1.0"
+					}
+				}
 			}
 		},
 		"nan": {

--- a/packages/service-provider-server/package.json
+++ b/packages/service-provider-server/package.json
@@ -44,7 +44,7 @@
     "@types/sinon-chai": "^3.2.3",
     "mongodb": "^4.1.0",
     "saslprep": "mongodb-js/saslprep#v1.0.4",
-    "mongodb-connection-string-url": "^1.1.2"
+    "mongodb-connection-string-url": "^2.0.0"
   },
   "optionalDependencies": {
     "mongodb-client-encryption": "^1.2.6",


### PR DESCRIPTION
This is only a major bump because the release dropped out-of-the-box
Node.js 10.x support, which we don’t care about here.