### PR TITLE
feat(JMongosh): don't convert object from Java to JS and back if results are returned directly to user

### DIFF
--- a/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/result/Cursor.kt
+++ b/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/result/Cursor.kt
@@ -1,10 +1,18 @@
 package com.mongodb.mongosh.result
 
 import com.mongodb.mongosh.MongoShellConverter
+import com.mongodb.mongosh.get
+import com.mongodb.mongosh.set
 import org.graalvm.polyglot.Value
 
 open class Cursor<out T> internal constructor(protected var cursor: Value?, private var converter: MongoShellConverter?) : Iterator<T> {
     private var currentIterationResult: List<T>? = null
+
+    init {
+        if (cursor?.get("_transform")?.isNull == true) {
+            cursor?.get("_cursor")?.set("resultsUsedInScript", false)
+        }
+    }
 
     fun _asPrintable(): String = ArrayResult(currentIterationResult ?: it())._asPrintable()
 

--- a/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/service/Cursor.kt
+++ b/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/service/Cursor.kt
@@ -15,6 +15,10 @@ internal class Cursor(private var helper: BaseMongoIterableHelper<*>, private va
     @HostAccess.Export
     var closed = false
 
+    @JvmField
+    @HostAccess.Export
+    var resultsUsedInScript = true
+
     private fun getOrCreateIterator(): MongoCursor<out Any?> {
         var it = iterator
         if (it == null) {
@@ -172,13 +176,13 @@ internal class Cursor(private var helper: BaseMongoIterableHelper<*>, private va
     @HostAccess.Export
     override fun next(): Any? {
         val value = getOrCreateIterator().next()
-        return converter.toJs(value)
+        return if (resultsUsedInScript) converter.toJs(value) else value
     }
 
     @HostAccess.Export
     override fun tryNext(): Any? {
         val value = getOrCreateIterator().tryNext()
-        return converter.toJs(value)
+        return if (resultsUsedInScript) converter.toJs(value) else value
     }
 
     @HostAccess.Export

--- a/packages/java-shell/src/test/resources/collection/insertOne.expected.txt
+++ b/packages/java-shell/src/test/resources/collection/insertOne.expected.txt
@@ -1,3 +1,3 @@
 { "acknowledged": true, "insertedId": "UNKNOWN" }
 true
-[ { "_id": <ObjectID>, "a": 1, "objectId": <ObjectID>, "maxKey": {"$maxKey": 1}, "minKey": {"$minKey": 1}, "binData": {"$binary": {"base64": "MTIzNA==", "subType": "10"}}, "date": {"$date": {"$numberLong": "1355875200000"}}, "isoDate": {"$date": {"$numberLong": "1355875200000"}}, "numberInt": 24, "timestamp": {"$timestamp": {"t": 100, "i": 0}}, "undefined": null, "null": null, "uuid": <UUID> } ]
+[ { "_id": <ObjectID>, "a": 1, "objectId": <ObjectID>, "maxKey": {"$maxKey": 1}, "minKey": {"$minKey": 1}, "binData": {"$binary": {"base64": "MTIzNA==", "subType": "10"}}, "date": {"$date": {"$numberLong": "1355875200000"}}, "isoDate": {"$date": {"$numberLong": "1355875200000"}}, "numberInt": 24, "timestamp": Timestamp{value=429496729600, seconds=100, inc=0}, "undefined": null, "null": null, "uuid": <UUID> } ]


### PR DESCRIPTION
A simple fix but it needs to access private fields `Cursor._cursor` and `Cursor._transform`

It sets `resultsUsedInScript` flag to `false` right before cursor is returned to user.
When `resultsUsedInScript` is `false`, internal Java cursor doesn't convert Java objects to JS