### PR TITLE
fix(autocomplete): fix completion for command + single space MONGOSH-945

### DIFF
--- a/packages/autocomplete/src/index.spec.ts
+++ b/packages/autocomplete/src/index.spec.ts
@@ -551,11 +551,32 @@ describe('completer.completer', () => {
         .to.deep.equal([['show profile'], i, 'exclusive']);
     });
 
-    it('completes use db', async() => {
+    it('completes use db with no space', async() => {
       databases = ['db1', 'db2'];
       const i = 'use';
       expect(await completer(noParams, i))
         .to.deep.equal([['use db1', 'use db2'], i, 'exclusive']);
+    });
+
+    it('completes use db with a space', async() => {
+      databases = ['db1', 'db2'];
+      const i = 'use ';
+      expect(await completer(noParams, i))
+        .to.deep.equal([['use db1', 'use db2'], i, 'exclusive']);
+    });
+
+    it('completes use db with single database and no space', async() => {
+      databases = ['db1'];
+      const i = 'use';
+      expect(await completer(noParams, i))
+        .to.deep.equal([['use db1'], i, 'exclusive']);
+    });
+
+    it('completes use db with single database and space', async() => {
+      databases = ['db1'];
+      const i = 'use ';
+      expect(await completer(noParams, i))
+        .to.deep.equal([['use db1'], i, 'exclusive']);
     });
 
     it('does not try to complete over-long commands', async() => {

--- a/packages/autocomplete/src/index.ts
+++ b/packages/autocomplete/src/index.ts
@@ -73,9 +73,13 @@ async function completer(params: AutocompleteParameters, line: string): Promise<
     // If the shell API provides us with a completer, use it.
     const completer = SHELL_COMPLETIONS[command].shellCommandCompleter;
     if (completer) {
-      if (splitLineWhitespace.length === 1 && splitLineWhitespace[0].trimEnd() === splitLineWhitespace[0]) {
-        // Treat e.g. 'show' like 'show '.
-        splitLineWhitespace[0] += ' ';
+      if (splitLineWhitespace.length === 1) {
+        if (splitLineWhitespace[0].trimEnd() === splitLineWhitespace[0]) {
+          // Treat e.g. 'show' like 'show '.
+          splitLineWhitespace[0] += ' ';
+        }
+
+        // Complete the first argument after the command.
         splitLineWhitespace.push('');
       }
       const hits = await completer(params, splitLineWhitespace.map(item => item.trim())) || [];


### PR DESCRIPTION
Fix completion for e.g. `use ` so that it works like completion
for just `use` (without the space).