### PR TITLE
fix(cli-repl): do not print ShellResult for interruption MONGOSH-971

### DIFF
--- a/packages/cli-repl/src/mongosh-repl.ts
+++ b/packages/cli-repl/src/mongosh-repl.ts
@@ -435,12 +435,7 @@ class MongoshNodeRepl implements EvaluationListener {
         this.bus.emit('mongosh:eval-interrupted');
         // The shell is interrupted by CTRL-C - so we ignore any errors
         // that happened during evaluation.
-        const result: ShellResult = {
-          type: null,
-          rawValue: undefined,
-          printable: undefined
-        };
-        return result;
+        return undefined;
       }
 
       if (!isErrorLike(err)) {


### PR DESCRIPTION
This was missed in bf84ae252762a6d31708 when the signature of the
`eval()` return type changed.