### PR TITLE
fix: print a deprecation warning when trying to use Collection.count() (MONGOSH-957)

### DIFF
--- a/packages/shell-api/src/collection.ts
+++ b/packages/shell-api/src/collection.ts
@@ -246,6 +246,11 @@ export default class Collection extends ShellApiWithMongoClass {
   @serverVersions([ServerVersions.earliest, '4.0.0'])
   @apiVersions([])
   async count(query = {}, options: CountOptions = {}): Promise<number> {
+    printDeprecationWarning(
+      'Collection.count() is deprecated. Use countDocuments or estimatedDocumentCount.',
+      this._mongo._internalState.context.print
+    );
+
     this._emitCollectionApiCall(
       'count',
       { query, options }


### PR DESCRIPTION
This solves point 1 in the issue. I don't know what to do about 2 and if that's even a good idea. This is what the node driver does if you ask for the count. I had a look at mongo's [count method](https://github.com/mongodb/mongo/blob/3675df9065981e30e289c2aa487b23c22c9702ed/src/mongo/shell/collection.js#L1291-L1318) but I'm not sure how we'd get the same behaviour.