### PR TITLE
fix(cli-repl): disable short-option-groups args parser option MONGOSH…

### DIFF
--- a/packages/cli-repl/src/arg-parser.spec.ts
+++ b/packages/cli-repl/src/arg-parser.spec.ts
@@ -417,7 +417,7 @@ describe('arg-parser', () => {
         });
 
         context('when providing -tlsCertificateKeyFile (single dash)', () => {
-          const argv = [ ...baseArgv, uri, '--tlsCertificateKeyFile', 'test' ];
+          const argv = [ ...baseArgv, uri, '-tlsCertificateKeyFile', 'test' ];
 
           it('returns the URI in the object', () => {
             expect(parseCliArgs(argv).connectionSpecifier).to.equal(uri);

--- a/packages/cli-repl/src/arg-parser.spec.ts
+++ b/packages/cli-repl/src/arg-parser.spec.ts
@@ -392,7 +392,31 @@ describe('arg-parser', () => {
           });
         });
 
+        context('when providing -tls (single dash)', () => {
+          const argv = [ ...baseArgv, uri, '-tls' ];
+
+          it('returns the URI in the object', () => {
+            expect(parseCliArgs(argv).connectionSpecifier).to.equal(uri);
+          });
+
+          it('sets the tls in the object', () => {
+            expect(parseCliArgs(argv).tls).to.equal(true);
+          });
+        });
+
         context('when providing --tlsCertificateKeyFile', () => {
+          const argv = [ ...baseArgv, uri, '--tlsCertificateKeyFile', 'test' ];
+
+          it('returns the URI in the object', () => {
+            expect(parseCliArgs(argv).connectionSpecifier).to.equal(uri);
+          });
+
+          it('sets the tlsCertificateKeyFile in the object', () => {
+            expect(parseCliArgs(argv).tlsCertificateKeyFile).to.equal('test');
+          });
+        });
+
+        context('when providing -tlsCertificateKeyFile (single dash)', () => {
           const argv = [ ...baseArgv, uri, '--tlsCertificateKeyFile', 'test' ];
 
           it('returns the URI in the object', () => {

--- a/packages/cli-repl/src/arg-parser.ts
+++ b/packages/cli-repl/src/arg-parser.ts
@@ -87,7 +87,8 @@ const OPTIONS = {
     'unknown-options-as-args': true,
     'parse-positional-numbers': false,
     'parse-numbers': false,
-    'greedy-arrays': false
+    'greedy-arrays': false,
+    'short-option-groups': false
   }
 };
 


### PR DESCRIPTION
…-974

This enables things like `-tls` to work like they did in the legacy shell.