### PR TITLE
chore(cli-repl): move arg parser warning printing to run.ts

### DIFF
--- a/packages/cli-repl/src/arg-parser.ts
+++ b/packages/cli-repl/src/arg-parser.ts
@@ -146,13 +146,14 @@ function isConnectionSpecifier(arg?: string): boolean {
  *
  * @returns The arguments as cli options.
  */
-export function parseCliArgs(args: string[]): (CliOptions & { smokeTests: boolean, buildInfo: boolean }) {
+export function parseCliArgs(args: string[]): (CliOptions & { smokeTests: boolean, buildInfo: boolean, _argParseWarnings: string[] }) {
   const programArgs = args.slice(2);
   i18n.setLocale(getLocale(programArgs, process.env));
 
   const parsed = parser(programArgs, OPTIONS) as unknown as CliOptions & {
     smokeTests: boolean;
     buildInfo: boolean;
+    _argParseWarnings: string[];
     _?: string[];
     file?: string[];
   };
@@ -175,8 +176,7 @@ export function parseCliArgs(args: string[]): (CliOptions & { smokeTests: boolea
   // and should only be accessed that way now.
   delete parsed._;
 
-  const messages = verifyCliArguments(parsed);
-  messages.forEach(m => console.warn(m));
+  parsed._argParseWarnings = verifyCliArguments(parsed);
 
   return parsed;
 }

--- a/packages/cli-repl/src/run.ts
+++ b/packages/cli-repl/src/run.ts
@@ -21,6 +21,10 @@ import stream from 'stream';
   let isSingleConsoleProcess = false;
   try {
     const options = parseCliArgs(process.argv);
+    for (const warning of options._argParseWarnings) {
+      console.warn(warning);
+    }
+
     const { version } = require('../package.json');
 
     if (options.help) {


### PR DESCRIPTION
This is just a small bit of cleanup. The arg parser should not
be printing warnings on its own, without knowing where those end up;
specifying the output stream is the top level program’s responsibility.

This also makes running the arg parser test suite a bit nicer, because
now the test output is not mixed with these warnings.