### PR TITLE
feat(shell-api): add deprecated setSecondaryOk helpers MONGOSH-910

### DIFF
--- a/packages/shell-api/src/database.spec.ts
+++ b/packages/shell-api/src/database.spec.ts
@@ -2510,6 +2510,7 @@ describe('Database', () => {
       'cloneCollection',
       'copyDatabase',
       'getReplicationInfo',
+      'setSecondaryOk'
     ];
     const args = [ {}, {}, {} ];
     beforeEach(() => {

--- a/packages/shell-api/src/database.ts
+++ b/packages/shell-api/src/database.ts
@@ -1421,6 +1421,12 @@ export default class Database extends ShellApiWithMongoClass {
     throw new MongoshDeprecatedError('Method deprecated, use db.printSecondaryReplicationInfo instead');
   }
 
+  @deprecated
+  @returnsPromise
+  async setSecondaryOk(): Promise<void> {
+    await this._mongo.setSecondaryOk();
+  }
+
   @serverVersions(['3.1.0', ServerVersions.latest])
   @topologies([Topologies.ReplSet, Topologies.Sharded])
   @apiVersions([1])

--- a/packages/shell-api/src/deprecation-warning.ts
+++ b/packages/shell-api/src/deprecation-warning.ts
@@ -1,3 +1,8 @@
+// TODO: Integrate this into ShellInstanceState.
+// The set of shown warnings should not be global, but rather per-Shell,
+// and we should not be using methods like console.warn inside the
+// shell-api package either (because we should generally stick to
+// what's in the language itself, not the specific runtime environments).
 const warningShown: Set<string> = new Set();
 
 /**

--- a/packages/shell-api/src/replica-set.ts
+++ b/packages/shell-api/src/replica-set.ts
@@ -371,6 +371,12 @@ export default class ReplicaSet extends ShellApiWithMongoClass {
     );
   }
 
+  @deprecated
+  @returnsPromise
+  async secondaryOk(): Promise<void> {
+    await this._mongo.setSecondaryOk();
+  }
+
   /**
    * Internal method to determine what is printed for this class.
    */


### PR DESCRIPTION
Add these helpers for legacy compatibility and point users to
the replacement methods in the deprecation message.