### PR TITLE
fix(cli-repl): handle MONGOSH_RUN_NODE_SCRIPT for compiled binary properly

### DIFF
--- a/packages/cli-repl/src/run.ts
+++ b/packages/cli-repl/src/run.ts
@@ -9,10 +9,9 @@ import stream from 'stream';
 // eslint-disable-next-line complexity, @typescript-eslint/no-floating-promises
 (async() => {
   if (process.env.MONGOSH_RUN_NODE_SCRIPT) {
-    if (process.execPath !== process.argv[1]) {
-      // node /path/to/this/file script ... -> node script ...
-      process.argv.splice(1, 1);
-    }
+    // For uncompiled mongosh: node /path/to/this/file script ... -> node script ...
+    // FOr compiled mongosh: mongosh mongosh script ... -> mongosh script ...
+    process.argv.splice(1, 1);
     (runMain as any)(process.argv[1]);
     return;
   }

--- a/packages/cli-repl/test/e2e.spec.ts
+++ b/packages/cli-repl/test/e2e.spec.ts
@@ -1123,5 +1123,17 @@ describe('e2e', function() {
       shell.assertNoErrors();
     });
   });
+
+  describe('run Node.js scripts as-is', () => {
+    it('runs Node.js scripts as they are when using MONGOSH_RUN_NODE_SCRIPT', async() => {
+      const filename = path.resolve(__dirname, 'fixtures', 'simple-console-log.js');
+      const shell = TestShell.start({
+        args: [filename],
+        env: { ...process.env, MONGOSH_RUN_NODE_SCRIPT: '1' }
+      });
+      expect(await shell.waitForExit()).to.equal(0);
+      shell.assertContainsOutput('610');
+    });
+  });
 });
 

--- a/packages/cli-repl/test/fixtures/simple-console-log.js
+++ b/packages/cli-repl/test/fixtures/simple-console-log.js
@@ -1,0 +1,2 @@
+// eslint-disable-next-line no-console
+console.log(233 + 377);


### PR DESCRIPTION
MONGOSH-981

In compiled mode, `process.argv[0]` and `process.argv[1]` are the same
(both point to the compiled binary), but that still means that
`process.argv[1]` should be removed in order to run the entry point
normally.