### PR TITLE
feat: add db.sql helper for ADL $sql MONGOSH-900

### DIFF
--- a/config/eslintrc.base.js
+++ b/config/eslintrc.base.js
@@ -30,7 +30,7 @@ const tsRules = {
 module.exports = {
   plugins: ['mocha'],
   overrides: [{
-    files: ['**/*.js'],
+    files: ['**/*.js', '**/*.jsx'],
     extends: [
       'eslint-config-mongodb-js/react'
     ],
@@ -39,7 +39,7 @@ module.exports = {
     }
   },
   {
-    files: ['**/*.ts'],
+    files: ['**/*.ts', '**/*.tsx'],
     parser: '@typescript-eslint/parser',
     extends: [
       'eslint-config-mongodb-js/react',

--- a/config/eslintrc.base.js
+++ b/config/eslintrc.base.js
@@ -1,49 +1,53 @@
-const typescriptEslintEslintPlugin = require('@typescript-eslint/eslint-plugin');
+const jsRules = {
+  'object-curly-spacing': [2, 'always'],
+  'no-empty-function': 0,
+  'valid-jsdoc': 0,
+  'react/sort-comp': 0, // does not seem work as expected with typescript
+  'mocha/no-skipped-tests': 1,
+  'mocha/no-exclusive-tests': 2,
+  'semi': [2, 'always'],
+  'no-console': [1, { allow: ['warn', 'error', 'info'] }],
+  'no-shadow': 0,
+  'no-use-before-define': 0,
+  'no-cond-assign': [2, 'except-parens']
+}
 
-// ovrerrides do not work with extends
-const ruleOverridesForJs = Object.keys(typescriptEslintEslintPlugin.rules).reduce(
-  (overrides, rule) => ({ ...overrides, [`@typescript-eslint/${rule}`]: 0 }), {}
-);
+const tsRules = {
+  '@typescript-eslint/no-empty-function': 0,
+  '@typescript-eslint/no-use-before-define': 0,
+  '@typescript-eslint/no-explicit-any': 0,
+  '@typescript-eslint/no-var-requires': 0, // seems necessary to import less files
+  '@typescript-eslint/no-unused-vars': 2,
+  '@typescript-eslint/no-floating-promises': 2,
+  '@typescript-eslint/await-thenable': 2,
+  '@typescript-eslint/require-await': 2,
+  '@typescript-eslint/explicit-module-boundary-types': 0,
+  '@typescript-eslint/ban-types': 0,
+  'semi': 0,
+  '@typescript-eslint/semi': [2, 'always']
+};
 
 module.exports = {
   plugins: ['mocha'],
-  parser: '@typescript-eslint/parser',
-  parserOptions: {
-    project: './tsconfig.lint.json'
-  },
-  extends: [
-    'eslint-config-mongodb-js/react',
-    'plugin:@typescript-eslint/recommended'
-  ],
-  rules: {
-    'object-curly-spacing': [2, 'always'],
-    'no-empty-function': 0,
-    'valid-jsdoc': 0,
-    'react/sort-comp': 0, // does not seem work as expected with typescript
-    '@typescript-eslint/no-empty-function': 0,
-    '@typescript-eslint/no-use-before-define': 0,
-    '@typescript-eslint/no-explicit-any': 0,
-    '@typescript-eslint/no-var-requires': 0, // seems necessary to import less files
-    '@typescript-eslint/no-unused-vars': 2,
-    '@typescript-eslint/no-floating-promises': 2,
-    '@typescript-eslint/await-thenable': 2,
-    '@typescript-eslint/require-await': 2,
-    '@typescript-eslint/explicit-module-boundary-types': 0,
-    '@typescript-eslint/ban-types': 0,
-    'mocha/no-skipped-tests': 1,
-    'mocha/no-exclusive-tests': 2,
-    'semi': 0,
-    '@typescript-eslint/semi': [2, 'always'],
-    'no-console': [1, { allow: ['warn', 'error', 'info'] }],
-    'no-shadow': 0,
-    'no-use-before-define': 0,
-    'no-cond-assign': [2, 'except-parens']
-  },
   overrides: [{
     files: ['**/*.js'],
+    extends: [
+      'eslint-config-mongodb-js/react'
+    ],
     rules: {
-      ...ruleOverridesForJs,
-      semi: [2, 'always']
+      ...jsRules
+    }
+  },
+  {
+    files: ['**/*.ts'],
+    parser: '@typescript-eslint/parser',
+    extends: [
+      'eslint-config-mongodb-js/react',
+      'plugin:@typescript-eslint/recommended'
+    ],
+    rules: {
+      ...jsRules,
+      ...tsRules
     }
   }]
 };

--- a/packages/async-rewriter2/.eslintrc.js
+++ b/packages/async-rewriter2/.eslintrc.js
@@ -1,1 +1,8 @@
-module.exports = require('../../config/eslintrc.base');
+module.exports = {
+  ...require('../../config/eslintrc.base'),
+  root: true,
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+    project: './tsconfig.lint.json'
+  }
+};

--- a/packages/autocomplete/.eslintrc.js
+++ b/packages/autocomplete/.eslintrc.js
@@ -1,1 +1,8 @@
-module.exports = require('../../config/eslintrc.base');
+module.exports = {
+  ...require('../../config/eslintrc.base'),
+  root: true,
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+    project: './tsconfig.lint.json'
+  }
+};

--- a/packages/browser-repl/.eslintrc.js
+++ b/packages/browser-repl/.eslintrc.js
@@ -1,1 +1,8 @@
-module.exports = require('../../config/eslintrc.base');
+module.exports = {
+  ...require('../../config/eslintrc.base'),
+  root: true,
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+    project: './tsconfig.lint.json'
+  }
+};

--- a/packages/browser-runtime-core/.eslintrc.js
+++ b/packages/browser-runtime-core/.eslintrc.js
@@ -1,1 +1,8 @@
-module.exports = require('../../config/eslintrc.base');
+module.exports = {
+  ...require('../../config/eslintrc.base'),
+  root: true,
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+    project: './tsconfig.lint.json'
+  }
+};

--- a/packages/browser-runtime-electron/.eslintrc.js
+++ b/packages/browser-runtime-electron/.eslintrc.js
@@ -1,1 +1,8 @@
-module.exports = require('../../config/eslintrc.base');
+module.exports = {
+  ...require('../../config/eslintrc.base'),
+  root: true,
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+    project: './tsconfig.lint.json'
+  }
+};

--- a/packages/build/.eslintrc.js
+++ b/packages/build/.eslintrc.js
@@ -1,1 +1,8 @@
-module.exports = require('../../config/eslintrc.base');
+module.exports = {
+  ...require('../../config/eslintrc.base'),
+  root: true,
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+    project: './tsconfig.lint.json'
+  }
+};

--- a/packages/cli-repl/.eslintrc.js
+++ b/packages/cli-repl/.eslintrc.js
@@ -1,1 +1,8 @@
-module.exports = require('../../config/eslintrc.base');
+module.exports = {
+  ...require('../../config/eslintrc.base'),
+  root: true,
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+    project: './tsconfig.lint.json'
+  }
+};

--- a/packages/errors/.eslintrc.js
+++ b/packages/errors/.eslintrc.js
@@ -1,1 +1,8 @@
-module.exports = require('../../config/eslintrc.base');
+module.exports = {
+  ...require('../../config/eslintrc.base'),
+  root: true,
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+    project: './tsconfig.lint.json'
+  }
+};

--- a/packages/history/.eslintrc.js
+++ b/packages/history/.eslintrc.js
@@ -1,1 +1,8 @@
-module.exports = require('../../config/eslintrc.base');
+module.exports = {
+  ...require('../../config/eslintrc.base'),
+  root: true,
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+    project: './tsconfig.lint.json'
+  }
+};

--- a/packages/i18n/.eslintrc.js
+++ b/packages/i18n/.eslintrc.js
@@ -1,1 +1,8 @@
-module.exports = require('../../config/eslintrc.base');
+module.exports = {
+  ...require('../../config/eslintrc.base'),
+  root: true,
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+    project: './tsconfig.lint.json'
+  }
+};

--- a/packages/node-runtime-worker-thread/.eslintrc.js
+++ b/packages/node-runtime-worker-thread/.eslintrc.js
@@ -1,1 +1,8 @@
-module.exports = require('../../config/eslintrc.base');
+module.exports = {
+  ...require('../../config/eslintrc.base'),
+  root: true,
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+    project: './tsconfig.lint.json'
+  }
+};

--- a/packages/service-provider-core/.eslintrc.js
+++ b/packages/service-provider-core/.eslintrc.js
@@ -1,1 +1,8 @@
-module.exports = require('../../config/eslintrc.base');
+module.exports = {
+  ...require('../../config/eslintrc.base'),
+  root: true,
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+    project: './tsconfig.lint.json'
+  }
+};

--- a/packages/service-provider-server/.eslintrc.js
+++ b/packages/service-provider-server/.eslintrc.js
@@ -1,1 +1,8 @@
-module.exports = require('../../config/eslintrc.base');
+module.exports = {
+  ...require('../../config/eslintrc.base'),
+  root: true,
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+    project: './tsconfig.lint.json'
+  }
+};

--- a/packages/shell-api/.eslintrc.js
+++ b/packages/shell-api/.eslintrc.js
@@ -1,1 +1,8 @@
-module.exports = require('../../config/eslintrc.base');
+module.exports = {
+  ...require('../../config/eslintrc.base'),
+  root: true,
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+    project: './tsconfig.lint.json'
+  }
+};

--- a/packages/shell-api/src/database.spec.ts
+++ b/packages/shell-api/src/database.spec.ts
@@ -2471,6 +2471,31 @@ describe('Database', () => {
         expect.fail('Failed to throw');
       });
     });
+    describe('sql', () => {
+      it('runs a $sql aggregation', async() => {
+        const serviceProviderCursor = stubInterface<ServiceProviderAggCursor>();
+        serviceProvider.aggregateDb.returns(serviceProviderCursor as any);
+        await database.sql('SELECT * FROM somecollection;', { options: true });
+        expect(serviceProvider.aggregateDb).to.have.been.calledWith(
+          database._name,
+          [{
+            $sql: {
+              dialect: 'mongosql',
+              format: 'jdbc',
+              formatVersion: 1,
+              statement: 'SELECT * FROM somecollection;'
+            }
+          }],
+          { options: true }
+        );
+      });
+
+      it('throws if aggregateDb fails', async() => {
+        serviceProvider.aggregateDb.throws(new Error('err'));
+        const error: any = await database.sql('SELECT * FROM somecollection;').catch(err => err);
+        expect(error.message).to.be.equal('err');
+      });
+    });
   });
   describe('with session', () => {
     let serviceProvider: StubbedInstance<ServiceProvider>;

--- a/packages/shell-api/src/database.ts
+++ b/packages/shell-api/src/database.ts
@@ -1427,7 +1427,7 @@ export default class Database extends ShellApiWithMongoClass {
     await this._mongo.setSecondaryOk();
   }
 
-  @serverVersions(['3.1.0', ServerVersions.latest])
+  @serverVersions(['4.4.0', ServerVersions.latest])
   @topologies([Topologies.ReplSet, Topologies.Sharded])
   @apiVersions([1])
   @returnsPromise
@@ -1444,5 +1444,19 @@ export default class Database extends ShellApiWithMongoClass {
     await cursor.tryNext(); // See comment in coll.watch().
     this._mongo._instanceState.currentCursor = cursor;
     return cursor;
+  }
+
+  @returnsPromise
+  @returnType('AggregationCursor')
+  async sql(sqlString: string, options?: Document): Promise<AggregationCursor> {
+    this._emitDatabaseApiCall('sql', { sqlString: sqlString, options });
+    return await this.aggregate([{
+      $sql: {
+        statement: sqlString,
+        format: 'jdbc',
+        dialect: 'mongosql',
+        formatVersion: 1
+      }
+    }], options);
   }
 }

--- a/packages/shell-evaluator/.eslintrc.js
+++ b/packages/shell-evaluator/.eslintrc.js
@@ -1,1 +1,8 @@
-module.exports = require('../../config/eslintrc.base');
+module.exports = {
+  ...require('../../config/eslintrc.base'),
+  root: true,
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+    project: './tsconfig.lint.json'
+  }
+};

--- a/packages/snippet-manager/.eslintrc.js
+++ b/packages/snippet-manager/.eslintrc.js
@@ -1,1 +1,8 @@
-module.exports = require('../../config/eslintrc.base');
+module.exports = {
+  ...require('../../config/eslintrc.base'),
+  root: true,
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+    project: './tsconfig.lint.json'
+  }
+};

--- a/packages/types/.eslintrc.js
+++ b/packages/types/.eslintrc.js
@@ -1,1 +1,8 @@
-module.exports = require('../../config/eslintrc.base');
+module.exports = {
+  ...require('../../config/eslintrc.base'),
+  root: true,
+  parserOptions: {
+    tsconfigRootDir: __dirname,
+    project: './tsconfig.lint.json'
+  }
+};


### PR DESCRIPTION
Add a `db.sql` helper that runs `$sql` aggregations in ADL. 

NOTE: Also fixes the integration of eslint with VSCode.