### PR TITLE
chore(deps): bump mongodb-download-url to 1.1.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18437,9 +18437,9 @@
       }
     },
     "mongodb-download-url": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/mongodb-download-url/-/mongodb-download-url-1.1.1.tgz",
-      "integrity": "sha512-LTZcnD1By5G80DFgLEnCZhrl0TFINfcVT/iGgrjCNj7EYZjEvhtlE9Ik19Q5PebrULWqWA8cVwYtDOVBsLcPgw==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/mongodb-download-url/-/mongodb-download-url-1.1.2.tgz",
+      "integrity": "sha512-El64L/3WgZdobgDrG91N2mXAnvEWO2xUARTv9T3vZ3ivrg+Qh7CqU91Aw6VNjCLfmEIHe9i+5tYDtWAlD/u+OA==",
       "dev": true,
       "requires": {
         "debug": "^4.1.1",

--- a/package.json
+++ b/package.json
@@ -123,7 +123,7 @@
     "lerna": "^4.0.0",
     "mocha": "^7.1.2",
     "mongodb": "^4.1.1",
-    "mongodb-download-url": "^1.1.1",
+    "mongodb-download-url": "^1.1.2",
     "mongodb-js-precommit": "^2.0.0",
     "nock": "^13.0.11",
     "node-codesign": "^0.3.2",


### PR DESCRIPTION
Mostly just bumping this to be extra sure that the fix in https://github.com/mongodb-js/download-url/pull/245 didn’t break anything :)