### PR TITLE
fix: do babel transformations for script, not module MONGOSH-986

### DIFF
--- a/packages/async-rewriter2/src/async-writer-babel.spec.ts
+++ b/packages/async-rewriter2/src/async-writer-babel.spec.ts
@@ -120,6 +120,15 @@ describe('AsyncWriter', () => {
     it('runs code in sloppy mode by default', () => {
       expect(runTranspiledCode('delete Object.prototype')).to.equal(false);
     });
+
+    it('parses code in sloppy mode by default', () => {
+      expect(runTranspiledCode('"<\\101>"')).to.equal('<A>');
+      expect(runTranspiledCode('"x" + "<\\101>"')).to.equal('x<A>');
+    });
+
+    it('parses code in strict mode if strict mode is explicitly enabled', () => {
+      expect(() => runTranspiledCode('"use strict"; "<\\101>"')).to.throw(SyntaxError);
+    });
   });
 
   context('scoping', () => {

--- a/packages/async-rewriter2/src/async-writer-babel.ts
+++ b/packages/async-rewriter2/src/async-writer-babel.ts
@@ -32,7 +32,8 @@ export default class AsyncWriter {
       code: true,
       configFile: false,
       babelrc: false,
-      compact: code.length > 10_000
+      compact: code.length > 10_000,
+      sourceType: 'script'
     })?.code as string;
   }
 

--- a/packages/async-rewriter2/src/stages/wrap-as-iife.ts
+++ b/packages/async-rewriter2/src/stages/wrap-as-iife.ts
@@ -135,7 +135,7 @@ export default ({ types: t }: { types: typeof BabelTypes }): babel.PluginObj<Wra
               path.node.body.length === 0) {
             path.replaceWith(t.program([
               t.expressionStatement(
-                t.stringLiteral(path.node.directives[0].value.value))
+                { ...path.node.directives[0].value, type: 'StringLiteral' })
             ]));
           }
         },

--- a/packages/cli-repl/src/js-multiline-to-singleline.ts
+++ b/packages/cli-repl/src/js-multiline-to-singleline.ts
@@ -57,7 +57,8 @@ export function makeMultilineJSIntoSingleLine(src: string): string {
       compact: false,
       code: true,
       comments: true,
-      plugins: [lineCommentToBlockComment]
+      plugins: [lineCommentToBlockComment],
+      sourceType: 'script'
     })?.code ?? src;
   } catch {
     // The src might still be invalid, e.g. because a recoverable error was not fixed

--- a/packages/cli-repl/test/e2e.spec.ts
+++ b/packages/cli-repl/test/e2e.spec.ts
@@ -136,6 +136,14 @@ describe('e2e', function() {
       const err = await shell.executeLine('parcelRequire');
       expect(err).to.match(/ReferenceError: parcelRequire is not defined/);
     });
+    it('parses code in sloppy mode by default (single line)', async() => {
+      const result = await shell.executeLine('"<\\101>"');
+      expect(result).to.match(/<A>/);
+    });
+    it('parses code in sloppy mode by default (multiline)', async() => {
+      const result = await shell.executeLine('"a"+\n"<\\101>"');
+      expect(result).to.match(/a<A>/);
+    });
   });
   describe('set db', () => {
     for (const { mode, dbname, dbnameUri } of [


### PR DESCRIPTION
Tell babel that we are targeting script mode, not ES module mode.
(Note that the babel docs indicate that `script` should be the
default – it seems that that is not entirely accurate.)

This fixes the linked bug because unlike ES modules, script mode
does not automatically also enable strict mode.

This also fixes a minor bug in the wrap-as-iife babel plugin,
where if the input was a single string literal, escaped characters
would have remained escaped (e.g., entering `'\x41'` in mongosh
would have returned `\x41`, not 'A'), by keeping the existing
information about the raw source instead of generating an
entirely new string literal in that case.