### PR TITLE
fix(shell-api): .watch() signature and behavior fixes MONGOSH-976

### DIFF
--- a/packages/shell-api/src/mongo.ts
+++ b/packages/shell-api/src/mongo.ts
@@ -507,14 +507,20 @@ export default class Mongo extends ShellApiClass {
   @topologies([Topologies.ReplSet, Topologies.Sharded])
   @apiVersions([1])
   @returnsPromise
-  async watch(pipeline: Document[] = [], options: ChangeStreamOptions = {}): Promise<ChangeStreamCursor> {
+  async watch(pipeline: Document[] | ChangeStreamOptions = [], options: ChangeStreamOptions = {}): Promise<ChangeStreamCursor> {
+    if (!Array.isArray(pipeline)) {
+      options = pipeline;
+      pipeline = [];
+    }
     this._emitMongoApiCall('watch', { pipeline, options });
     const cursor = new ChangeStreamCursor(
       this._serviceProvider.watch(pipeline, options),
       redactURICredentials(this._uri),
       this
     );
-    await cursor.tryNext(); // See comment in coll.watch().
+    if (!options.resumeAfter && !options.startAfter && !options.startAtOperationTime) {
+      await cursor.tryNext(); // See comment in coll.watch().
+    }
     this._instanceState.currentCursor = cursor;
     return cursor;
   }


### PR DESCRIPTION
Modify the `.watch()` signature so that it “officially” allows
omitting the first argument.

As a drive-by fix, stop applying `.tryNext()` for cases in which
the change stream cursor starts from a specific point in time.
(Unfortunately, `.hasNext()` is not an option here, unlike
discussed with the Node.js driver team, because it is blocking
like `.next()` and unlike `.tryNext()`.)