### PR TITLE
feat(editor): handle editor specifies as name with multiple parts MONGOSH-996

### DIFF
--- a/packages/editor/src/editor.ts
+++ b/packages/editor/src/editor.ts
@@ -66,7 +66,7 @@ export class Editor {
 
   // In case of using VSCode as an external editor,
   // detect whether the MongoDB extension is installed and open a .mongodb file.
-  // If not open a .js file instead.
+  // If not open a .js file.
   async _getExtension(cmd: string): Promise<string> {
     if (!this._isVscodeApp(cmd)) {
       return 'js';

--- a/packages/editor/src/editor.ts
+++ b/packages/editor/src/editor.ts
@@ -170,7 +170,11 @@ export class Editor {
       code
     });
 
-    const proc = spawn(editor, [tmpDoc], { stdio: 'inherit' });
+    const proc = spawn(editor, [path.basename(tmpDoc)], {
+      stdio: 'inherit',
+      cwd: path.dirname(tmpDoc),
+      shell: true
+    });
     // Pause the parent readable stream to stop emitting data events
     // and get a child the total control over the input.
     this._input.pause();


### PR DESCRIPTION
A user can specify something in the editor that contains multiple parts (eg EDITOR='nano -cA' or EDITOR='code --wait'). We could spawn the editor using a shell flag to support the following cases:

EDITOR=code
EDITOR=C:\Program Files\Editor\editor.exe
EDITOR="code --wait"

Since we cannot easily distinguish between the semantics of the spaces between cases 2 and 3, we will need the OS shell to do that for us.