### PR TITLE
chore(node-runtime-worker-thread): Clean-up worker runtime prod dependencies so they are not installed with the library

### DIFF
--- a/packages/node-runtime-worker-thread/package-lock.json
+++ b/packages/node-runtime-worker-thread/package-lock.json
@@ -481,7 +481,8 @@
 		"base64-js": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
-			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+			"integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA==",
+			"dev": true
 		},
 		"big.js": {
 			"version": "5.2.2",
@@ -636,6 +637,7 @@
 			"version": "4.5.2",
 			"resolved": "https://registry.npmjs.org/bson/-/bson-4.5.2.tgz",
 			"integrity": "sha512-8CEMJpwc7qlQtrn2rney38jQSEeMar847lz0LyitwRmVknAW8iHXrzW4fTjHfyWm0E3sukyD/zppdH+QU1QefA==",
+			"dev": true,
 			"requires": {
 				"buffer": "^5.6.0"
 			},
@@ -644,6 +646,7 @@
 					"version": "5.7.1",
 					"resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
 					"integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+					"dev": true,
 					"requires": {
 						"base64-js": "^1.3.1",
 						"ieee754": "^1.1.13"
@@ -1916,7 +1919,8 @@
 		"ieee754": {
 			"version": "1.2.1",
 			"resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+			"integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+			"dev": true
 		},
 		"iferr": {
 			"version": "0.1.5",
@@ -2621,7 +2625,8 @@
 		"nanoid": {
 			"version": "2.1.11",
 			"resolved": "https://registry.npmjs.org/nanoid/-/nanoid-2.1.11.tgz",
-			"integrity": "sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA=="
+			"integrity": "sha512-s/snB+WGm6uwi0WjsZdaVcuf3KJXlfGl2LcxgwkEwJF0D/BWzVWAZW/XY4bFaiR7s0Jk3FPvlnepg1H1b1UwlA==",
+			"dev": true
 		},
 		"nanomatch": {
 			"version": "1.2.13",
@@ -2982,6 +2987,7 @@
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/postmsg-rpc/-/postmsg-rpc-2.4.0.tgz",
 			"integrity": "sha512-adGH2zGSxhCUOfUfAXdRn4tgZVWauaSP2X8on+g7uBA45sxkzORL1oia95eXZtcZk5Sp4JTZmDFOTe+D24avBQ==",
+			"dev": true,
 			"requires": {
 				"shortid": "^2.2.8"
 			}
@@ -3360,6 +3366,7 @@
 			"version": "2.2.16",
 			"resolved": "https://registry.npmjs.org/shortid/-/shortid-2.2.16.tgz",
 			"integrity": "sha512-Ugt+GIZqvGXCIItnsL+lvFJOiN7RYqlGy7QE41O3YC1xbNSeDGIRO7xg2JJXIAj1cAGnOeC1r7/T9pgrtQbv4g==",
+			"dev": true,
 			"requires": {
 				"nanoid": "^2.1.0"
 			}

--- a/packages/node-runtime-worker-thread/package.json
+++ b/packages/node-runtime-worker-thread/package.json
@@ -28,20 +28,20 @@
     "prepublish": "npm run webpack-build"
   },
   "devDependencies": {
-    "mocha": "^7.1.2",
-    "terser-webpack-plugin": "^4.2.3",
-    "ts-loader": "^8.0.14",
-    "webpack": "^4.44.2",
-    "webpack-cli": "^4.3.1"
-  },
-  "dependencies": {
     "@mongosh/browser-runtime-core": "0.0.0-dev.0",
     "@mongosh/browser-runtime-electron": "0.0.0-dev.0",
     "@mongosh/service-provider-core": "0.0.0-dev.0",
     "@mongosh/service-provider-server": "0.0.0-dev.0",
     "@mongosh/types": "0.0.0-dev.0",
     "bson": "^4.5.2",
-    "interruptor": "^1.0.1",
-    "postmsg-rpc": "^2.4.0"
+    "mocha": "^7.1.2",
+    "postmsg-rpc": "^2.4.0",
+    "terser-webpack-plugin": "^4.2.3",
+    "ts-loader": "^8.0.14",
+    "webpack": "^4.44.2",
+    "webpack-cli": "^4.3.1"
+  },
+  "dependencies": {
+    "interruptor": "^1.0.1"
   }
 }


### PR DESCRIPTION
Only `interruptor` is a real dependency of this package that's required for the package to work when installed externally. This PR removes all the other ones so that when Compass installs this as a dependency, we don't waste time installing the other ones