### PR TITLE
chore(cli-repl): increase rs.initiate test timeout

### DIFF
--- a/packages/cli-repl/test/e2e-direct.spec.ts
+++ b/packages/cli-repl/test/e2e-direct.spec.ts
@@ -39,7 +39,8 @@ describe('e2e direct connection', () => {
     context('after rs.initiate()', () => {
       let dbname: string;
 
-      before(async() => {
+      before(async function() {
+        this.timeout(60_000);
         const replSetConfig = {
           _id: replSetId,
           version: 1,


### PR DESCRIPTION
This has been one of the most frequent failures in recent CI runs.
Hopefully this is something that can be mitigated by increasing
the timeout for the replset being fully initiated.