### PR TITLE
chore(build): bump Node.js and regen evergreen cfg MONGOSH-1007

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -796,6 +796,34 @@ functions:
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin-n12_editor.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-n12_editor.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin-n12_editor.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin-n14_editor.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-n14_editor.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin-n14_editor.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
         local_file: src/nyc-output-darwin-n12_errors.tgz
         remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-n12_errors.tgz
         bucket: mciuploads
@@ -876,6 +904,62 @@ functions:
         script: |
           set -e
           tar xvzf nyc-output-darwin-n14_i18n.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin-n12_js_multiline_to_singleline.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-n12_js_multiline_to_singleline.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin-n12_js_multiline_to_singleline.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin-n14_js_multiline_to_singleline.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-n14_js_multiline_to_singleline.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin-n14_js_multiline_to_singleline.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin-n12_logging.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-n12_logging.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin-n12_logging.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin-n14_logging.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-n14_logging.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin-n14_logging.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
@@ -2392,6 +2476,34 @@ functions:
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux-n12_editor.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-n12_editor.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux-n12_editor.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux-n14_editor.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-n14_editor.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux-n14_editor.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
         local_file: src/nyc-output-linux-n12_errors.tgz
         remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-n12_errors.tgz
         bucket: mciuploads
@@ -2724,6 +2836,62 @@ functions:
         script: |
           set -e
           tar xvzf nyc-output-linux-mlatest_n14_java_shell.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux-n12_js_multiline_to_singleline.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-n12_js_multiline_to_singleline.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux-n12_js_multiline_to_singleline.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux-n14_js_multiline_to_singleline.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-n14_js_multiline_to_singleline.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux-n14_js_multiline_to_singleline.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux-n12_logging.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-n12_logging.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux-n12_logging.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux-n14_logging.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-n14_logging.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux-n14_logging.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
@@ -4240,6 +4408,34 @@ functions:
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32-n12_editor.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-n12_editor.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32-n12_editor.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32-n14_editor.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-n14_editor.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32-n14_editor.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
         local_file: src/nyc-output-win32-n12_errors.tgz
         remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-n12_errors.tgz
         bucket: mciuploads
@@ -4320,6 +4516,62 @@ functions:
         script: |
           set -e
           tar xvzf nyc-output-win32-n14_i18n.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32-n12_js_multiline_to_singleline.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-n12_js_multiline_to_singleline.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32-n12_js_multiline_to_singleline.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32-n14_js_multiline_to_singleline.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-n14_js_multiline_to_singleline.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32-n14_js_multiline_to_singleline.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32-n12_logging.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-n12_logging.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32-n12_logging.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32-n14_logging.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-n14_logging.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32-n14_logging.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
@@ -5543,7 +5795,7 @@ tasks:
       - func: checkout
       - func: compile_ts
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
 
   - name: check
     depends_on:
@@ -5553,10 +5805,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: check
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
 
   - name: check_coverage
     depends_on:
@@ -5566,10 +5818,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: check_coverage
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
 
   ###
   # UNIT TESTS
@@ -5584,11 +5836,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: ""
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "n12_async_rewriter2"
           mongosh_run_only_in_package: "async-rewriter2"
@@ -5601,11 +5853,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: ""
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "n14_async_rewriter2"
           mongosh_run_only_in_package: "async-rewriter2"
@@ -5618,11 +5870,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: ""
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "n12_autocomplete"
           mongosh_run_only_in_package: "autocomplete"
@@ -5635,11 +5887,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: ""
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "n14_autocomplete"
           mongosh_run_only_in_package: "autocomplete"
@@ -5652,11 +5904,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: ""
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "n12_browser_repl"
           mongosh_run_only_in_package: "browser-repl"
@@ -5669,11 +5921,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: ""
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "n14_browser_repl"
           mongosh_run_only_in_package: "browser-repl"
@@ -5686,11 +5938,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: ""
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "n12_browser_runtime_core"
           mongosh_run_only_in_package: "browser-runtime-core"
@@ -5703,11 +5955,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: ""
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "n14_browser_runtime_core"
           mongosh_run_only_in_package: "browser-runtime-core"
@@ -5720,11 +5972,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: ""
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "n12_browser_runtime_electron"
           mongosh_run_only_in_package: "browser-runtime-electron"
@@ -5737,11 +5989,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: ""
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "n14_browser_runtime_electron"
           mongosh_run_only_in_package: "browser-runtime-electron"
@@ -5754,11 +6006,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: ""
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "n12_build"
           mongosh_run_only_in_package: "build"
@@ -5771,11 +6023,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: ""
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "n14_build"
           mongosh_run_only_in_package: "build"
@@ -5788,11 +6040,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: "4.0.x-community"
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "m40xc_n12_cli_repl"
           mongosh_run_only_in_package: "cli-repl"
@@ -5805,11 +6057,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: "4.0.x"
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "m40xe_n12_cli_repl"
           mongosh_run_only_in_package: "cli-repl"
@@ -5822,11 +6074,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: "4.2.x-community"
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "m42xc_n12_cli_repl"
           mongosh_run_only_in_package: "cli-repl"
@@ -5839,11 +6091,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: "4.2.x"
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "m42xe_n12_cli_repl"
           mongosh_run_only_in_package: "cli-repl"
@@ -5856,11 +6108,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: "4.4.x-community"
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "m44xc_n12_cli_repl"
           mongosh_run_only_in_package: "cli-repl"
@@ -5873,11 +6125,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: "4.4.x"
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "m44xe_n12_cli_repl"
           mongosh_run_only_in_package: "cli-repl"
@@ -5890,11 +6142,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: "5.0.x-community"
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "m50xc_n12_cli_repl"
           mongosh_run_only_in_package: "cli-repl"
@@ -5907,11 +6159,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: "5.0.x"
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "m50xe_n12_cli_repl"
           mongosh_run_only_in_package: "cli-repl"
@@ -5924,11 +6176,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: "latest-alpha"
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "mlatest_n12_cli_repl"
           mongosh_run_only_in_package: "cli-repl"
@@ -5941,11 +6193,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.0.x-community"
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m40xc_n14_cli_repl"
           mongosh_run_only_in_package: "cli-repl"
@@ -5958,11 +6210,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.0.x"
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m40xe_n14_cli_repl"
           mongosh_run_only_in_package: "cli-repl"
@@ -5975,11 +6227,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.2.x-community"
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m42xc_n14_cli_repl"
           mongosh_run_only_in_package: "cli-repl"
@@ -5992,11 +6244,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.2.x"
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m42xe_n14_cli_repl"
           mongosh_run_only_in_package: "cli-repl"
@@ -6009,11 +6261,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.4.x-community"
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m44xc_n14_cli_repl"
           mongosh_run_only_in_package: "cli-repl"
@@ -6026,11 +6278,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.4.x"
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m44xe_n14_cli_repl"
           mongosh_run_only_in_package: "cli-repl"
@@ -6043,11 +6295,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: "5.0.x-community"
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m50xc_n14_cli_repl"
           mongosh_run_only_in_package: "cli-repl"
@@ -6060,11 +6312,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: "5.0.x"
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m50xe_n14_cli_repl"
           mongosh_run_only_in_package: "cli-repl"
@@ -6077,11 +6329,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: "latest-alpha"
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "mlatest_n14_cli_repl"
           mongosh_run_only_in_package: "cli-repl"
@@ -6094,11 +6346,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: "4.0.x-community"
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "m40xc_n12_connectivity_tests"
           mongosh_run_only_in_package: "connectivity-tests"
@@ -6111,11 +6363,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: "4.0.x"
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "m40xe_n12_connectivity_tests"
           mongosh_run_only_in_package: "connectivity-tests"
@@ -6128,11 +6380,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: "4.2.x-community"
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "m42xc_n12_connectivity_tests"
           mongosh_run_only_in_package: "connectivity-tests"
@@ -6145,11 +6397,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: "4.2.x"
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "m42xe_n12_connectivity_tests"
           mongosh_run_only_in_package: "connectivity-tests"
@@ -6162,11 +6414,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: "4.4.x-community"
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "m44xc_n12_connectivity_tests"
           mongosh_run_only_in_package: "connectivity-tests"
@@ -6179,11 +6431,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: "4.4.x"
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "m44xe_n12_connectivity_tests"
           mongosh_run_only_in_package: "connectivity-tests"
@@ -6196,11 +6448,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: "5.0.x-community"
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "m50xc_n12_connectivity_tests"
           mongosh_run_only_in_package: "connectivity-tests"
@@ -6213,11 +6465,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: "5.0.x"
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "m50xe_n12_connectivity_tests"
           mongosh_run_only_in_package: "connectivity-tests"
@@ -6230,11 +6482,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: "latest-alpha"
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "mlatest_n12_connectivity_tests"
           mongosh_run_only_in_package: "connectivity-tests"
@@ -6247,11 +6499,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.0.x-community"
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m40xc_n14_connectivity_tests"
           mongosh_run_only_in_package: "connectivity-tests"
@@ -6264,11 +6516,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.0.x"
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m40xe_n14_connectivity_tests"
           mongosh_run_only_in_package: "connectivity-tests"
@@ -6281,11 +6533,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.2.x-community"
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m42xc_n14_connectivity_tests"
           mongosh_run_only_in_package: "connectivity-tests"
@@ -6298,11 +6550,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.2.x"
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m42xe_n14_connectivity_tests"
           mongosh_run_only_in_package: "connectivity-tests"
@@ -6315,11 +6567,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.4.x-community"
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m44xc_n14_connectivity_tests"
           mongosh_run_only_in_package: "connectivity-tests"
@@ -6332,11 +6584,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.4.x"
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m44xe_n14_connectivity_tests"
           mongosh_run_only_in_package: "connectivity-tests"
@@ -6349,11 +6601,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: "5.0.x-community"
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m50xc_n14_connectivity_tests"
           mongosh_run_only_in_package: "connectivity-tests"
@@ -6366,11 +6618,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: "5.0.x"
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m50xe_n14_connectivity_tests"
           mongosh_run_only_in_package: "connectivity-tests"
@@ -6383,14 +6635,48 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: "latest-alpha"
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "mlatest_n14_connectivity_tests"
           mongosh_run_only_in_package: "connectivity-tests"
+  - name: test_n12_editor
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "12.22.6"
+      - func: test
+        vars:
+          mongosh_server_test_version: ""
+          node_js_version: "12.22.6"
+          mongosh_skip_node_version_check: "1"
+          mongosh_test_id: "n12_editor"
+          mongosh_run_only_in_package: "editor"
+  - name: test_n14_editor
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "14.18.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: ""
+          node_js_version: "14.18.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "n14_editor"
+          mongosh_run_only_in_package: "editor"
   - name: test_n12_errors
     tags: ["unit-test"]
     depends_on:
@@ -6400,11 +6686,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: ""
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "n12_errors"
           mongosh_run_only_in_package: "errors"
@@ -6417,11 +6703,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: ""
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "n14_errors"
           mongosh_run_only_in_package: "errors"
@@ -6434,11 +6720,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: ""
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "n12_history"
           mongosh_run_only_in_package: "history"
@@ -6451,11 +6737,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: ""
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "n14_history"
           mongosh_run_only_in_package: "history"
@@ -6468,11 +6754,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: ""
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "n12_i18n"
           mongosh_run_only_in_package: "i18n"
@@ -6485,11 +6771,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: ""
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "n14_i18n"
           mongosh_run_only_in_package: "i18n"
@@ -6502,11 +6788,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: "4.0.x-community"
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "m40xc_n12_java_shell"
           mongosh_run_only_in_package: "java-shell"
@@ -6519,11 +6805,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: "4.0.x"
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "m40xe_n12_java_shell"
           mongosh_run_only_in_package: "java-shell"
@@ -6536,11 +6822,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: "4.2.x-community"
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "m42xc_n12_java_shell"
           mongosh_run_only_in_package: "java-shell"
@@ -6553,11 +6839,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: "4.2.x"
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "m42xe_n12_java_shell"
           mongosh_run_only_in_package: "java-shell"
@@ -6570,11 +6856,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: "4.4.x-community"
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "m44xc_n12_java_shell"
           mongosh_run_only_in_package: "java-shell"
@@ -6587,11 +6873,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: "4.4.x"
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "m44xe_n12_java_shell"
           mongosh_run_only_in_package: "java-shell"
@@ -6604,11 +6890,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: "5.0.x-community"
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "m50xc_n12_java_shell"
           mongosh_run_only_in_package: "java-shell"
@@ -6621,11 +6907,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: "5.0.x"
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "m50xe_n12_java_shell"
           mongosh_run_only_in_package: "java-shell"
@@ -6638,11 +6924,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: "latest-alpha"
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "mlatest_n12_java_shell"
           mongosh_run_only_in_package: "java-shell"
@@ -6655,11 +6941,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.0.x-community"
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m40xc_n14_java_shell"
           mongosh_run_only_in_package: "java-shell"
@@ -6672,11 +6958,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.0.x"
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m40xe_n14_java_shell"
           mongosh_run_only_in_package: "java-shell"
@@ -6689,11 +6975,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.2.x-community"
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m42xc_n14_java_shell"
           mongosh_run_only_in_package: "java-shell"
@@ -6706,11 +6992,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.2.x"
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m42xe_n14_java_shell"
           mongosh_run_only_in_package: "java-shell"
@@ -6723,11 +7009,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.4.x-community"
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m44xc_n14_java_shell"
           mongosh_run_only_in_package: "java-shell"
@@ -6740,11 +7026,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.4.x"
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m44xe_n14_java_shell"
           mongosh_run_only_in_package: "java-shell"
@@ -6757,11 +7043,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: "5.0.x-community"
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m50xc_n14_java_shell"
           mongosh_run_only_in_package: "java-shell"
@@ -6774,11 +7060,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: "5.0.x"
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m50xe_n14_java_shell"
           mongosh_run_only_in_package: "java-shell"
@@ -6791,14 +7077,82 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: "latest-alpha"
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "mlatest_n14_java_shell"
           mongosh_run_only_in_package: "java-shell"
+  - name: test_n12_js_multiline_to_singleline
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "12.22.6"
+      - func: test
+        vars:
+          mongosh_server_test_version: ""
+          node_js_version: "12.22.6"
+          mongosh_skip_node_version_check: "1"
+          mongosh_test_id: "n12_js_multiline_to_singleline"
+          mongosh_run_only_in_package: "js-multiline-to-singleline"
+  - name: test_n14_js_multiline_to_singleline
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "14.18.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: ""
+          node_js_version: "14.18.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "n14_js_multiline_to_singleline"
+          mongosh_run_only_in_package: "js-multiline-to-singleline"
+  - name: test_n12_logging
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "12.22.6"
+      - func: test
+        vars:
+          mongosh_server_test_version: ""
+          node_js_version: "12.22.6"
+          mongosh_skip_node_version_check: "1"
+          mongosh_test_id: "n12_logging"
+          mongosh_run_only_in_package: "logging"
+  - name: test_n14_logging
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "14.18.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: ""
+          node_js_version: "14.18.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "n14_logging"
+          mongosh_run_only_in_package: "logging"
   - name: test_m40xc_n12_mongosh
     tags: ["unit-test"]
     depends_on:
@@ -6808,11 +7162,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: "4.0.x-community"
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "m40xc_n12_mongosh"
           mongosh_run_only_in_package: "mongosh"
@@ -6825,11 +7179,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: "4.0.x"
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "m40xe_n12_mongosh"
           mongosh_run_only_in_package: "mongosh"
@@ -6842,11 +7196,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: "4.2.x-community"
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "m42xc_n12_mongosh"
           mongosh_run_only_in_package: "mongosh"
@@ -6859,11 +7213,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: "4.2.x"
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "m42xe_n12_mongosh"
           mongosh_run_only_in_package: "mongosh"
@@ -6876,11 +7230,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: "4.4.x-community"
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "m44xc_n12_mongosh"
           mongosh_run_only_in_package: "mongosh"
@@ -6893,11 +7247,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: "4.4.x"
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "m44xe_n12_mongosh"
           mongosh_run_only_in_package: "mongosh"
@@ -6910,11 +7264,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: "5.0.x-community"
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "m50xc_n12_mongosh"
           mongosh_run_only_in_package: "mongosh"
@@ -6927,11 +7281,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: "5.0.x"
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "m50xe_n12_mongosh"
           mongosh_run_only_in_package: "mongosh"
@@ -6944,11 +7298,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: "latest-alpha"
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "mlatest_n12_mongosh"
           mongosh_run_only_in_package: "mongosh"
@@ -6961,11 +7315,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.0.x-community"
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m40xc_n14_mongosh"
           mongosh_run_only_in_package: "mongosh"
@@ -6978,11 +7332,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.0.x"
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m40xe_n14_mongosh"
           mongosh_run_only_in_package: "mongosh"
@@ -6995,11 +7349,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.2.x-community"
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m42xc_n14_mongosh"
           mongosh_run_only_in_package: "mongosh"
@@ -7012,11 +7366,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.2.x"
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m42xe_n14_mongosh"
           mongosh_run_only_in_package: "mongosh"
@@ -7029,11 +7383,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.4.x-community"
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m44xc_n14_mongosh"
           mongosh_run_only_in_package: "mongosh"
@@ -7046,11 +7400,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.4.x"
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m44xe_n14_mongosh"
           mongosh_run_only_in_package: "mongosh"
@@ -7063,11 +7417,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: "5.0.x-community"
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m50xc_n14_mongosh"
           mongosh_run_only_in_package: "mongosh"
@@ -7080,11 +7434,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: "5.0.x"
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m50xe_n14_mongosh"
           mongosh_run_only_in_package: "mongosh"
@@ -7097,11 +7451,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: "latest-alpha"
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "mlatest_n14_mongosh"
           mongosh_run_only_in_package: "mongosh"
@@ -7114,11 +7468,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: "4.0.x-community"
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "m40xc_n12_node_runtime_worker_thread"
           mongosh_run_only_in_package: "node-runtime-worker-thread"
@@ -7131,11 +7485,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: "4.0.x"
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "m40xe_n12_node_runtime_worker_thread"
           mongosh_run_only_in_package: "node-runtime-worker-thread"
@@ -7148,11 +7502,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: "4.2.x-community"
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "m42xc_n12_node_runtime_worker_thread"
           mongosh_run_only_in_package: "node-runtime-worker-thread"
@@ -7165,11 +7519,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: "4.2.x"
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "m42xe_n12_node_runtime_worker_thread"
           mongosh_run_only_in_package: "node-runtime-worker-thread"
@@ -7182,11 +7536,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: "4.4.x-community"
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "m44xc_n12_node_runtime_worker_thread"
           mongosh_run_only_in_package: "node-runtime-worker-thread"
@@ -7199,11 +7553,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: "4.4.x"
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "m44xe_n12_node_runtime_worker_thread"
           mongosh_run_only_in_package: "node-runtime-worker-thread"
@@ -7216,11 +7570,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: "5.0.x-community"
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "m50xc_n12_node_runtime_worker_thread"
           mongosh_run_only_in_package: "node-runtime-worker-thread"
@@ -7233,11 +7587,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: "5.0.x"
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "m50xe_n12_node_runtime_worker_thread"
           mongosh_run_only_in_package: "node-runtime-worker-thread"
@@ -7250,11 +7604,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: "latest-alpha"
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "mlatest_n12_node_runtime_worker_thread"
           mongosh_run_only_in_package: "node-runtime-worker-thread"
@@ -7267,11 +7621,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.0.x-community"
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m40xc_n14_node_runtime_worker_thread"
           mongosh_run_only_in_package: "node-runtime-worker-thread"
@@ -7284,11 +7638,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.0.x"
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m40xe_n14_node_runtime_worker_thread"
           mongosh_run_only_in_package: "node-runtime-worker-thread"
@@ -7301,11 +7655,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.2.x-community"
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m42xc_n14_node_runtime_worker_thread"
           mongosh_run_only_in_package: "node-runtime-worker-thread"
@@ -7318,11 +7672,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.2.x"
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m42xe_n14_node_runtime_worker_thread"
           mongosh_run_only_in_package: "node-runtime-worker-thread"
@@ -7335,11 +7689,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.4.x-community"
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m44xc_n14_node_runtime_worker_thread"
           mongosh_run_only_in_package: "node-runtime-worker-thread"
@@ -7352,11 +7706,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.4.x"
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m44xe_n14_node_runtime_worker_thread"
           mongosh_run_only_in_package: "node-runtime-worker-thread"
@@ -7369,11 +7723,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: "5.0.x-community"
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m50xc_n14_node_runtime_worker_thread"
           mongosh_run_only_in_package: "node-runtime-worker-thread"
@@ -7386,11 +7740,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: "5.0.x"
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m50xe_n14_node_runtime_worker_thread"
           mongosh_run_only_in_package: "node-runtime-worker-thread"
@@ -7403,11 +7757,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: "latest-alpha"
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "mlatest_n14_node_runtime_worker_thread"
           mongosh_run_only_in_package: "node-runtime-worker-thread"
@@ -7420,11 +7774,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: ""
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "n12_service_provider_core"
           mongosh_run_only_in_package: "service-provider-core"
@@ -7437,11 +7791,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: ""
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "n14_service_provider_core"
           mongosh_run_only_in_package: "service-provider-core"
@@ -7454,11 +7808,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: "4.0.x-community"
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "m40xc_n12_service_provider_server"
           mongosh_run_only_in_package: "service-provider-server"
@@ -7471,11 +7825,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: "4.0.x"
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "m40xe_n12_service_provider_server"
           mongosh_run_only_in_package: "service-provider-server"
@@ -7488,11 +7842,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: "4.2.x-community"
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "m42xc_n12_service_provider_server"
           mongosh_run_only_in_package: "service-provider-server"
@@ -7505,11 +7859,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: "4.2.x"
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "m42xe_n12_service_provider_server"
           mongosh_run_only_in_package: "service-provider-server"
@@ -7522,11 +7876,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: "4.4.x-community"
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "m44xc_n12_service_provider_server"
           mongosh_run_only_in_package: "service-provider-server"
@@ -7539,11 +7893,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: "4.4.x"
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "m44xe_n12_service_provider_server"
           mongosh_run_only_in_package: "service-provider-server"
@@ -7556,11 +7910,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: "5.0.x-community"
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "m50xc_n12_service_provider_server"
           mongosh_run_only_in_package: "service-provider-server"
@@ -7573,11 +7927,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: "5.0.x"
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "m50xe_n12_service_provider_server"
           mongosh_run_only_in_package: "service-provider-server"
@@ -7590,11 +7944,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: "latest-alpha"
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "mlatest_n12_service_provider_server"
           mongosh_run_only_in_package: "service-provider-server"
@@ -7607,11 +7961,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.0.x-community"
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m40xc_n14_service_provider_server"
           mongosh_run_only_in_package: "service-provider-server"
@@ -7624,11 +7978,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.0.x"
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m40xe_n14_service_provider_server"
           mongosh_run_only_in_package: "service-provider-server"
@@ -7641,11 +7995,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.2.x-community"
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m42xc_n14_service_provider_server"
           mongosh_run_only_in_package: "service-provider-server"
@@ -7658,11 +8012,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.2.x"
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m42xe_n14_service_provider_server"
           mongosh_run_only_in_package: "service-provider-server"
@@ -7675,11 +8029,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.4.x-community"
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m44xc_n14_service_provider_server"
           mongosh_run_only_in_package: "service-provider-server"
@@ -7692,11 +8046,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.4.x"
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m44xe_n14_service_provider_server"
           mongosh_run_only_in_package: "service-provider-server"
@@ -7709,11 +8063,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: "5.0.x-community"
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m50xc_n14_service_provider_server"
           mongosh_run_only_in_package: "service-provider-server"
@@ -7726,11 +8080,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: "5.0.x"
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m50xe_n14_service_provider_server"
           mongosh_run_only_in_package: "service-provider-server"
@@ -7743,11 +8097,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: "latest-alpha"
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "mlatest_n14_service_provider_server"
           mongosh_run_only_in_package: "service-provider-server"
@@ -7760,11 +8114,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: "4.0.x-community"
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "m40xc_n12_shell_api"
           mongosh_run_only_in_package: "shell-api"
@@ -7777,11 +8131,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: "4.0.x"
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "m40xe_n12_shell_api"
           mongosh_run_only_in_package: "shell-api"
@@ -7794,11 +8148,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: "4.2.x-community"
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "m42xc_n12_shell_api"
           mongosh_run_only_in_package: "shell-api"
@@ -7811,11 +8165,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: "4.2.x"
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "m42xe_n12_shell_api"
           mongosh_run_only_in_package: "shell-api"
@@ -7828,11 +8182,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: "4.4.x-community"
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "m44xc_n12_shell_api"
           mongosh_run_only_in_package: "shell-api"
@@ -7845,11 +8199,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: "4.4.x"
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "m44xe_n12_shell_api"
           mongosh_run_only_in_package: "shell-api"
@@ -7862,11 +8216,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: "5.0.x-community"
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "m50xc_n12_shell_api"
           mongosh_run_only_in_package: "shell-api"
@@ -7879,11 +8233,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: "5.0.x"
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "m50xe_n12_shell_api"
           mongosh_run_only_in_package: "shell-api"
@@ -7896,11 +8250,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: "latest-alpha"
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "mlatest_n12_shell_api"
           mongosh_run_only_in_package: "shell-api"
@@ -7913,11 +8267,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.0.x-community"
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m40xc_n14_shell_api"
           mongosh_run_only_in_package: "shell-api"
@@ -7930,11 +8284,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.0.x"
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m40xe_n14_shell_api"
           mongosh_run_only_in_package: "shell-api"
@@ -7947,11 +8301,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.2.x-community"
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m42xc_n14_shell_api"
           mongosh_run_only_in_package: "shell-api"
@@ -7964,11 +8318,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.2.x"
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m42xe_n14_shell_api"
           mongosh_run_only_in_package: "shell-api"
@@ -7981,11 +8335,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.4.x-community"
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m44xc_n14_shell_api"
           mongosh_run_only_in_package: "shell-api"
@@ -7998,11 +8352,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.4.x"
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m44xe_n14_shell_api"
           mongosh_run_only_in_package: "shell-api"
@@ -8015,11 +8369,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: "5.0.x-community"
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m50xc_n14_shell_api"
           mongosh_run_only_in_package: "shell-api"
@@ -8032,11 +8386,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: "5.0.x"
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m50xe_n14_shell_api"
           mongosh_run_only_in_package: "shell-api"
@@ -8049,11 +8403,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: "latest-alpha"
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "mlatest_n14_shell_api"
           mongosh_run_only_in_package: "shell-api"
@@ -8066,11 +8420,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: ""
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "n12_shell_evaluator"
           mongosh_run_only_in_package: "shell-evaluator"
@@ -8083,11 +8437,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: ""
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "n14_shell_evaluator"
           mongosh_run_only_in_package: "shell-evaluator"
@@ -8100,11 +8454,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: ""
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "n12_snippet_manager"
           mongosh_run_only_in_package: "snippet-manager"
@@ -8117,11 +8471,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: ""
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "n14_snippet_manager"
           mongosh_run_only_in_package: "snippet-manager"
@@ -8134,11 +8488,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test
         vars:
           mongosh_server_test_version: ""
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
           mongosh_skip_node_version_check: "1"
           mongosh_test_id: "n12_types"
           mongosh_run_only_in_package: "types"
@@ -8151,11 +8505,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test
         vars:
           mongosh_server_test_version: ""
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "n14_types"
           mongosh_run_only_in_package: "types"
@@ -8172,10 +8526,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
       - func: test_vscode
         vars:
-          node_js_version: "12.22.4"
+          node_js_version: "12.22.6"
   - name: test_connectivity
     tags: ["extra-integration-test"]
     depends_on:
@@ -8185,7 +8539,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test_connectivity
   - name: test_apistrict
     tags: ["extra-integration-test"]
@@ -8196,10 +8550,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: test_apistrict
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           mongosh_server_test_version: "latest-alpha"
           mongosh_test_force_api_strict: "1"
   - name: compile_artifact
@@ -8210,10 +8564,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: compile_artifact
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
 
   ###
   # E2E TESTS
@@ -8227,13 +8581,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: darwin-x64
       - func: run_e2e_tests
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
   - name: e2e_tests_linux_x64
     tags: ["e2e-test"]
     depends_on:
@@ -8243,13 +8597,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64
       - func: run_e2e_tests
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
   - name: e2e_tests_linux_arm64
     tags: ["e2e-test"]
     depends_on:
@@ -8259,13 +8613,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64
       - func: run_e2e_tests
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
   - name: e2e_tests_linux_ppc64le
     tags: ["e2e-test"]
     depends_on:
@@ -8275,13 +8629,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-ppc64le
       - func: run_e2e_tests
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
   - name: e2e_tests_linux_s390x
     tags: ["e2e-test"]
     depends_on:
@@ -8291,13 +8645,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-s390x
       - func: run_e2e_tests
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
   - name: e2e_tests_win32
     tags: ["e2e-test"]
     depends_on:
@@ -8307,13 +8661,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: win32
       - func: run_e2e_tests
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
 
   ###
   # PACKAGING
@@ -8326,10 +8680,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: package_and_upload_artifact
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           distribution_build_variant: darwin-x64
           executable_os_id: darwin-x64
   - name: package_and_upload_artifact_darwin_arm64
@@ -8340,10 +8694,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: package_and_upload_artifact
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           distribution_build_variant: darwin-arm64
           executable_os_id: darwin-arm64
   - name: package_and_upload_artifact_linux_x64
@@ -8354,10 +8708,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: package_and_upload_artifact
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           distribution_build_variant: linux-x64
           executable_os_id: linux-x64
   - name: package_and_upload_artifact_debian_x64
@@ -8368,10 +8722,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: package_and_upload_artifact
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           distribution_build_variant: debian-x64
           executable_os_id: linux-x64
   - name: package_and_upload_artifact_rhel7_x64
@@ -8382,10 +8736,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: package_and_upload_artifact
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           distribution_build_variant: rhel7-x64
           executable_os_id: linux-x64
   - name: package_and_upload_artifact_rhel8_x64
@@ -8396,10 +8750,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: package_and_upload_artifact
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           distribution_build_variant: rhel8-x64
           executable_os_id: linux-x64
   - name: package_and_upload_artifact_suse_x64
@@ -8410,10 +8764,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: package_and_upload_artifact
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           distribution_build_variant: suse-x64
           executable_os_id: linux-x64
   - name: package_and_upload_artifact_amzn1_x64
@@ -8424,10 +8778,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: package_and_upload_artifact
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           distribution_build_variant: amzn1-x64
           executable_os_id: linux-x64
   - name: package_and_upload_artifact_linux_arm64
@@ -8438,10 +8792,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: package_and_upload_artifact
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           distribution_build_variant: linux-arm64
           executable_os_id: linux-arm64
   - name: package_and_upload_artifact_debian_arm64
@@ -8452,10 +8806,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: package_and_upload_artifact
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           distribution_build_variant: debian-arm64
           executable_os_id: linux-arm64
   - name: package_and_upload_artifact_rhel8_arm64
@@ -8466,10 +8820,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: package_and_upload_artifact
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           distribution_build_variant: rhel8-arm64
           executable_os_id: linux-arm64
   - name: package_and_upload_artifact_amzn2_arm64
@@ -8480,10 +8834,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: package_and_upload_artifact
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           distribution_build_variant: amzn2-arm64
           executable_os_id: linux-arm64
   - name: package_and_upload_artifact_linux_ppc64le
@@ -8494,10 +8848,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: package_and_upload_artifact
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           distribution_build_variant: linux-ppc64le
           executable_os_id: linux-ppc64le
   - name: package_and_upload_artifact_rhel8_ppc64le
@@ -8508,10 +8862,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: package_and_upload_artifact
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           distribution_build_variant: rhel8-ppc64le
           executable_os_id: linux-ppc64le
   - name: package_and_upload_artifact_linux_s390x
@@ -8522,10 +8876,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: package_and_upload_artifact
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           distribution_build_variant: linux-s390x
           executable_os_id: linux-s390x
   - name: package_and_upload_artifact_rhel7_s390x
@@ -8536,10 +8890,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: package_and_upload_artifact
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           distribution_build_variant: rhel7-s390x
           executable_os_id: linux-s390x
   - name: package_and_upload_artifact_win32_x64
@@ -8550,10 +8904,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: package_and_upload_artifact
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           distribution_build_variant: win32-x64
           executable_os_id: win32
   - name: package_and_upload_artifact_win32msi_x64
@@ -8564,10 +8918,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: package_and_upload_artifact
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
           distribution_build_variant: win32msi-x64
           executable_os_id: win32
 
@@ -8871,10 +9225,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: release_draft
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
   - name: release_publish
     tags: ["publish"]
     git_tag_only: true
@@ -8886,10 +9240,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
       - func: release_publish
         vars:
-          node_js_version: "14.17.4"
+          node_js_version: "14.18.0"
 
 # Need to run builds for every possible build variant.
 buildvariants:
@@ -8954,12 +9308,18 @@ buildvariants:
       - name: test_m50xc_n14_connectivity_tests
       - name: test_m50xe_n14_connectivity_tests
       - name: test_mlatest_n14_connectivity_tests
+      - name: test_n12_editor
+      - name: test_n14_editor
       - name: test_n12_errors
       - name: test_n14_errors
       - name: test_n12_history
       - name: test_n14_history
       - name: test_n12_i18n
       - name: test_n14_i18n
+      - name: test_n12_js_multiline_to_singleline
+      - name: test_n14_js_multiline_to_singleline
+      - name: test_n12_logging
+      - name: test_n14_logging
       - name: test_m40xc_n12_node_runtime_worker_thread
       - name: test_m40xe_n12_node_runtime_worker_thread
       - name: test_m42xc_n12_node_runtime_worker_thread
@@ -9087,6 +9447,8 @@ buildvariants:
       - name: test_m50xc_n14_connectivity_tests
       - name: test_m50xe_n14_connectivity_tests
       - name: test_mlatest_n14_connectivity_tests
+      - name: test_n12_editor
+      - name: test_n14_editor
       - name: test_n12_errors
       - name: test_n14_errors
       - name: test_n12_history
@@ -9111,6 +9473,10 @@ buildvariants:
       - name: test_m50xc_n14_java_shell
       - name: test_m50xe_n14_java_shell
       - name: test_mlatest_n14_java_shell
+      - name: test_n12_js_multiline_to_singleline
+      - name: test_n14_js_multiline_to_singleline
+      - name: test_n12_logging
+      - name: test_n14_logging
       - name: test_m40xc_n12_node_runtime_worker_thread
       - name: test_m40xe_n12_node_runtime_worker_thread
       - name: test_m42xc_n12_node_runtime_worker_thread
@@ -9365,12 +9731,18 @@ buildvariants:
       - name: test_m50xc_n14_connectivity_tests
       - name: test_m50xe_n14_connectivity_tests
       - name: test_mlatest_n14_connectivity_tests
+      - name: test_n12_editor
+      - name: test_n14_editor
       - name: test_n12_errors
       - name: test_n14_errors
       - name: test_n12_history
       - name: test_n14_history
       - name: test_n12_i18n
       - name: test_n14_i18n
+      - name: test_n12_js_multiline_to_singleline
+      - name: test_n14_js_multiline_to_singleline
+      - name: test_n12_logging
+      - name: test_n14_logging
       - name: test_m40xc_n12_node_runtime_worker_thread
       - name: test_m40xe_n12_node_runtime_worker_thread
       - name: test_m42xc_n12_node_runtime_worker_thread

--- a/.evergreen/evergreen.yml.in
+++ b/.evergreen/evergreen.yml.in
@@ -2,8 +2,8 @@
 <%
 const path = require('path');
 
-const NODE_JS_VERSION_14 = '14.17.4';
-const NODE_JS_VERSION_12 = '12.22.4';
+const NODE_JS_VERSION_14 = '14.18.0';
+const NODE_JS_VERSION_12 = '12.22.6';
 
 const MONGODB_VERSIONS = [
   { shortName: '40xc', versionSpec: '4.0.x-community' },

--- a/packages/cli-repl/src/cli-repl.spec.ts
+++ b/packages/cli-repl/src/cli-repl.spec.ts
@@ -170,19 +170,25 @@ describe('CliRepl', () => {
         expect((await log()).filter(entry => entry.attr?.stack?.startsWith('SyntaxError:'))).to.have.lengthOf(0);
         input.write('<cat>\n');
         await waitBus(cliRepl.bus, 'mongosh:error');
-        expect((await log()).filter(entry => entry.attr?.stack?.startsWith('SyntaxError:'))).to.have.lengthOf(1);
+        await eventually(async() => {
+          expect((await log()).filter(entry => entry.attr?.stack?.startsWith('SyntaxError:'))).to.have.lengthOf(1);
+        });
       });
 
       it('writes JS errors to the log file', async() => {
         input.write('throw new Error("plain js error")\n');
         await waitBus(cliRepl.bus, 'mongosh:error');
-        expect((await log()).filter(entry => entry.attr?.stack?.startsWith('Error: plain js error'))).to.have.lengthOf(1);
+        await eventually(async() => {
+          expect((await log()).filter(entry => entry.attr?.stack?.startsWith('Error: plain js error'))).to.have.lengthOf(1);
+        });
       });
 
       it('writes Mongosh errors to the log file', async() => {
         input.write('db.auth()\n');
         await waitBus(cliRepl.bus, 'mongosh:error');
-        expect((await log()).filter(entry => entry.attr?.stack?.startsWith('MongoshInvalidInputError:'))).to.have.lengthOf(1);
+        await eventually(async() => {
+          expect((await log()).filter(entry => entry.attr?.stack?.startsWith('MongoshInvalidInputError:'))).to.have.lengthOf(1);
+        });
       });
 
       it('emits the error event when exit() fails', async() => {
@@ -193,7 +199,9 @@ describe('CliRepl', () => {
         } catch (e) {
           const [emitted] = await onerror;
           expect(emitted).to.be.instanceOf(MongoshInternalError);
-          expect((await log()).filter(entry => entry.attr?.stack?.startsWith('MongoshInternalError:'))).to.have.lengthOf(1);
+          await eventually(async() => {
+            expect((await log()).filter(entry => entry.attr?.stack?.startsWith('MongoshInternalError:'))).to.have.lengthOf(1);
+          });
           return;
         }
         expect.fail('expected error');

--- a/packages/cli-repl/src/cli-repl.spec.ts
+++ b/packages/cli-repl/src/cli-repl.spec.ts
@@ -27,7 +27,8 @@ describe('CliRepl', () => {
   const tmpdir = useTmpdir();
 
   async function log(): Promise<any[]> {
-    return readReplLogfile(path.join(tmpdir.path, `${cliRepl.logWriter.logId}_log`));
+    await cliRepl.logWriter.flush(); // Ensure any pending data is written first
+    return readReplLogfile(cliRepl.logWriter.logFilePath);
   }
 
   async function startWithExpectedImmediateExit(cliRepl: CliRepl, host: string): Promise<void> {

--- a/packages/editor/src/editor.spec.ts
+++ b/packages/editor/src/editor.spec.ts
@@ -171,7 +171,7 @@ describe('Editor', () => {
 
   it('_getEditorContent returns function implementation', async() => {
     const code = 'db.test.find';
-    const content = await editor._getEditorContent(code);
+    const content = (await editor._getEditorContent(code)).replace(/\r\n/g, '\n');
     expect(content).to.be.equal('function wrapper(...args) {\n            return { args, done: true };\n        }');
   });
 


### PR DESCRIPTION
Bump the Node.js versions to the latest ones in the respective
release line and regenerate the evergreen config (which also
includes adding CI jobs for packages that were only recently
added, i.e. editor, logging, js-multiline-to-singleline).