### PR TITLE
fix(shell-api): adjust argument types for some commands MONGOSH-967

### DIFF
--- a/packages/shell-api/src/collection.ts
+++ b/packages/shell-api/src/collection.ts
@@ -12,7 +12,7 @@ import {
   deprecated,
   ShellApiWithMongoClass
 } from './decorators';
-import { ADMIN_DB, asPrintable, namespaceInfo, ServerVersions, Topologies } from './enums';
+import { asPrintable, namespaceInfo, ServerVersions, Topologies } from './enums';
 import {
   adaptAggregateOptions,
   assertKeysDefined,
@@ -974,12 +974,11 @@ export default class Collection extends ShellApiWithMongoClass {
   @apiVersions([])
   async convertToCapped(size: number): Promise<Document> {
     this._emitCollectionApiCall('convertToCapped', { size });
-    return await this._mongo._serviceProvider.runCommandWithCheck(
-      this._database._name, {
+    return await this._database._runCommand(
+      {
         convertToCapped: this._name,
         size
-      },
-      await this._database._baseOptions()
+      }
     );
   }
 
@@ -1151,13 +1150,11 @@ export default class Collection extends ShellApiWithMongoClass {
   async dropIndexes(indexes: string|string[]|Document|Document[] = '*'): Promise<Document> {
     this._emitCollectionApiCall('dropIndexes', { indexes });
     try {
-      return await this._mongo._serviceProvider.runCommandWithCheck(
-        this._database._name,
+      return await this._database._runCommand(
         {
           dropIndexes: this._name,
           index: indexes,
-        },
-        await this._database._baseOptions());
+        });
     } catch (error) {
       // If indexes is an array and we're failing because of that, we fall back to
       // trying to drop all the indexes individually because that's what's supported
@@ -1246,9 +1243,9 @@ export default class Collection extends ShellApiWithMongoClass {
   @apiVersions([])
   async reIndex(): Promise<Document> {
     this._emitCollectionApiCall('reIndex');
-    return await this._mongo._serviceProvider.runCommandWithCheck(this._database._name, {
+    return await this._database._runCommand({
       reIndex: this._name
-    }, await this._database._baseOptions());
+    });
   }
 
   /**
@@ -1400,11 +1397,7 @@ export default class Collection extends ShellApiWithMongoClass {
       [commandName]: this._name,
       ...options
     } : commandName;
-    return await this._mongo._serviceProvider.runCommandWithCheck(
-      this._database._name,
-      cmd,
-      await this._database._baseOptions()
-    );
+    return await this._database._runCommand(cmd);
   }
 
   @returnType('Explainable')
@@ -1443,12 +1436,10 @@ export default class Collection extends ShellApiWithMongoClass {
     options.indexDetails = options.indexDetails || false;
 
     this._emitCollectionApiCall('stats', { options });
-    const result = await this._mongo._serviceProvider.runCommandWithCheck(
-      this._database._name,
+    const result = await this._database._runCommand(
       {
         collStats: this._name, scale: options.scale
-      },
-      await this._database._baseOptions()
+      }
     );
     if (!result) {
       throw new MongoshRuntimeError(
@@ -1572,11 +1563,7 @@ export default class Collection extends ShellApiWithMongoClass {
       };
     }
 
-    return await this._mongo._serviceProvider.runCommandWithCheck(
-      this._database._name,
-      cmd,
-      await this._database._baseOptions()
-    );
+    return await this._database._runCommand(cmd);
   }
 
   @returnsPromise
@@ -1586,13 +1573,11 @@ export default class Collection extends ShellApiWithMongoClass {
     if (typeof options === 'boolean') {
       options = { full: options };
     }
-    return await this._mongo._serviceProvider.runCommandWithCheck(
-      this._database._name,
+    return await this._database._runCommand(
       {
         validate: this._name,
         ...options
-      },
-      await this._database._baseOptions()
+      }
     );
   }
 
@@ -1601,12 +1586,10 @@ export default class Collection extends ShellApiWithMongoClass {
   @apiVersions([])
   async getShardVersion(): Promise<Document> {
     this._emitCollectionApiCall('getShardVersion', {});
-    return await this._mongo._serviceProvider.runCommandWithCheck(
-      ADMIN_DB,
+    return await this._database._runAdminCommand(
       {
         getShardVersion: `${this._database._name}.${this._name}`
-      },
-      await this._database._baseOptions()
+      }
     );
   }
 

--- a/packages/shell-api/src/database.spec.ts
+++ b/packages/shell-api/src/database.spec.ts
@@ -228,6 +228,28 @@ describe('Database', () => {
           .catch(e => e);
         expect(caughtError).to.equal(expectedError);
       });
+
+      it('automatically adjusts replSetResizeOplog parameter types', async() => {
+        await database.runCommand({ replSetResizeOplog: 1, size: 990, minRetentionHours: 3 });
+
+        expect(serviceProvider.runCommandWithCheck).to.have.been.calledWith(
+          database._name,
+          {
+            replSetResizeOplog: 1, minRetentionHours: new bson.Double(3), size: new bson.Double(990)
+          }
+        );
+      });
+
+      it('automatically adjusts profile parameter types', async() => {
+        await database.runCommand({ profile: 1, sampleRate: 0 });
+
+        expect(serviceProvider.runCommandWithCheck).to.have.been.calledWith(
+          database._name,
+          {
+            profile: 1, sampleRate: new bson.Double(0)
+          }
+        );
+      });
     });
 
     describe('adminCommand', () => {

--- a/packages/shell-api/src/database.ts
+++ b/packages/shell-api/src/database.ts
@@ -22,7 +22,8 @@ import {
   tsToSeconds,
   isValidCollectionName,
   getConfigDB,
-  shouldRunAggregationImmediately
+  shouldRunAggregationImmediately,
+  adjustRunCommand
 } from './helpers';
 
 import type {
@@ -138,7 +139,7 @@ export default class Database extends ShellApiWithMongoClass {
   public async _runCommand(cmd: Document, options: CommandOperationOptions = {}): Promise<Document> {
     return this._mongo._serviceProvider.runCommandWithCheck(
       this._name,
-      cmd,
+      adjustRunCommand(cmd, this._instanceState.shellBson),
       { ...this._mongo._getExplicitlyRequestedReadPref(), ...await this._baseOptions(), ...options }
     );
   }

--- a/packages/shell-api/src/helpers.ts
+++ b/packages/shell-api/src/helpers.ts
@@ -630,13 +630,10 @@ export async function setHideIndex(coll: Collection, index: string | Document, h
   } : {
     keyPattern: index, hidden
   };
-  return await coll._mongo._serviceProvider.runCommandWithCheck(
-    coll._database._name, {
-      collMod: coll._name,
-      index: cmd
-    },
-    await coll._database._baseOptions()
-  );
+  return await coll._database._runCommand({
+    collMod: coll._name,
+    index: cmd
+  });
 }
 
 export function assertCLI(platform: ReplPlatform, features: string): void {

--- a/packages/shell-api/src/shell-instance-state.ts
+++ b/packages/shell-api/src/shell-instance-state.ts
@@ -27,7 +27,7 @@ import {
 import { InterruptFlag } from './interruptor';
 import { TransformMongoErrorPlugin } from './mongo-errors';
 import NoDatabase from './no-db';
-import constructShellBson from './shell-bson';
+import constructShellBson, { ShellBson } from './shell-bson';
 
 /**
  * The subset of CLI options that is relevant for the shell API's behavior itself.
@@ -128,7 +128,7 @@ export default class ShellInstanceState {
   public context: any;
   public mongos: Mongo[];
   public shellApi: ShellApi;
-  public shellBson: any;
+  public shellBson: ShellBson;
   public cliOptions: ShellCliOptions;
   public evaluationListener: EvaluationListener;
   public displayBatchSizeFromDBQuery: number | undefined = undefined;
@@ -149,9 +149,7 @@ export default class ShellInstanceState {
     this.messageBus = messageBus;
     this.shellApi = new ShellApi(this);
     this.shellBson = constructShellBson(initialServiceProvider.bsonLibrary, (msg: string) => {
-      if (this.context.print) {
-        this.context.print(`Warning: ${msg}`);
-      }
+      void this.shellApi.print(`Warning: ${msg}`);
     });
     this.mongos = [];
     this.connectionInfo = { buildInfo: {} };


### PR DESCRIPTION
##### chore(shell-api): route all runCommand calls through db._runCommand

This makes it so that all database `runCommand` calls go through
the same code path, making it easier to apply modifications that
we think should apply to all such calls.

##### chore(shell-api): add typings for shell-bson module

Instead of using `any` for the shell bson wrapper types, add
proper TypeScript definitions.

##### fix(shell-api): adjust argument types for some commands MONGOSH-967

Automatically adjust arguments for some server commands that
expect BSON Double values as input where mongosh would currently
send an Int32 by default (unlike the legacy shell).
