### PR TITLE
chore: increase coverage for newly added packages

### DIFF
--- a/packages/editor/src/editor.ts
+++ b/packages/editor/src/editor.ts
@@ -83,8 +83,8 @@ export class Editor {
       return hasMongodbExtension ? 'mongodb' : 'js';
     } catch (error) {
       this.messageBus.emit('mongosh-editor:read-vscode-extensions-failed', {
-        action: 'mongosh-editor:read-vscode-extensions-failed',
-        error: (error as Error).message
+        vscodeDir: this._vscodeDir,
+        error: error as Error
       });
 
       return 'js';
@@ -187,7 +187,7 @@ export class Editor {
         return;
       }
 
-      throw new Error(`Command '${code}' failed with an exit code ${exitCode}`);
+      throw new Error(`Command '${editor} ${path.basename(tmpDoc)}' failed with an exit code ${exitCode}`);
     } finally {
       // Resume the parent readable stream to recive data events.
       this._input.resume();

--- a/packages/js-multiline-to-singleline/src/index.spec.ts
+++ b/packages/js-multiline-to-singleline/src/index.spec.ts
@@ -16,4 +16,8 @@ describe('makeMultilineJSIntoSingleLine', () => {
     expect(toSingleLine('a // comment\n b')).to.equal('a; /* comment*/ b');
     expect(toSingleLine('a /* comment*/\n b')).to.equal('a; /* comment*/ b');
   });
+
+  it('keeps invalid code as-is', () => {
+    expect(toSingleLine('---\n---')).to.equal('--- ---');
+  });
 });

--- a/packages/logging/src/setup-logger-and-telemetry.ts
+++ b/packages/logging/src/setup-logger-and-telemetry.ts
@@ -273,7 +273,10 @@ export function setupLoggerAndTelemetry(
   });
 
   bus.on('mongosh:mongocryptd-error', function(ev: MongocryptdErrorEvent) {
-    log.warn('MONGOCRYPTD', mongoLogId(1_000_000_017), 'mongocryptd', 'Error running mongocryptd', ev);
+    log.warn('MONGOCRYPTD', mongoLogId(1_000_000_017), 'mongocryptd', 'Error running mongocryptd', {
+      ...ev,
+      error: ev.error?.message
+    });
   });
 
   bus.on('mongosh:mongocryptd-log', function(ev: MongocryptdLogEvent) {
@@ -423,14 +426,17 @@ export function setupLoggerAndTelemetry(
   });
 
   bus.on('mongosh-editor:run-edit-command', function(ev: EditorRunEditCommandEvent) {
-    log.error('MONGOSH-EDITOR', mongoLogId(1_000_000_042), 'editor', 'Open external editor', ev);
+    log.error('MONGOSH-EDITOR', mongoLogId(1_000_000_042), 'editor', 'Open external editor', redactInfo(ev));
   });
 
   bus.on('mongosh-editor:read-vscode-extensions-done', function(ev: EditorReadVscodeExtensionsDoneEvent) {
-    log.error('MONGOSH-EDITOR', mongoLogId(1_000_000_043), 'editor', 'Reading vscode extensions from disc succeeded', ev);
+    log.error('MONGOSH-EDITOR', mongoLogId(1_000_000_043), 'editor', 'Reading vscode extensions from file system succeeded', ev);
   });
 
   bus.on('mongosh-editor:read-vscode-extensions-failed', function(ev: EditorReadVscodeExtensionsFailedEvent) {
-    log.error('MONGOSH-EDITOR', mongoLogId(1_000_000_044), 'editor', 'Reading vscode extensions from disc failed', ev);
+    log.error('MONGOSH-EDITOR', mongoLogId(1_000_000_044), 'editor', 'Reading vscode extensions from file system failed', {
+      ...ev,
+      error: ev.error.message
+    });
   });
 }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -174,19 +174,14 @@ export interface EditorRunEditCommandEvent {
   code: string;
 }
 
-export interface EditorRunEditCommandFailedEvent {
-  action: string;
-  error: string;
-}
-
 export interface EditorReadVscodeExtensionsDoneEvent {
   vscodeDir: string;
   hasMongodbExtension: boolean;
 }
 
 export interface EditorReadVscodeExtensionsFailedEvent {
-  action: string;
-  error: string;
+  vscodeDir: string;
+  error: Error;
 }
 
 export interface MongoshBusEventsMap {


### PR DESCRIPTION
Bring `js-multiline-to-singleline` and `logging` to full line
coverage, and fix a few minor issues in the process. These
packages were recently added and not yet counted for coverage/run
in CI, see https://github.com/mongodb-js/mongosh/pull/1121.