### PR TITLE
chore(cli-repl): also bump analytics node test rs.initiate timeout

### DIFF
--- a/packages/cli-repl/test/e2e-analytics.spec.ts
+++ b/packages/cli-repl/test/e2e-analytics.spec.ts
@@ -18,6 +18,7 @@ describe('e2e Analytics Node', () => {
     if (process.env.MONGOSH_TEST_FORCE_API_STRICT) {
       return this.skip();
     }
+    this.timeout(60_000);
     const rsConfig = {
       _id: replSetName,
       members: [


### PR DESCRIPTION
This is just like 3e4fd873efd3dca38a5746a41835313bb5ffb746, I just
missed that there is a second test that also runs `rs.initiate()`
and sometimes times out in CI.