### PR TITLE
docs (async-rewriter2): Typo on readme

### DIFF
--- a/packages/async-rewriter2/README.md
+++ b/packages/async-rewriter2/README.md
@@ -84,7 +84,7 @@ is transformed into
 try {
   foo3();
 } catch (_err) {
-  if (!err || !_err[Symbol.for('@@mongosh.uncatchable')]) {
+  if (!_err || !_err[Symbol.for('@@mongosh.uncatchable')]) {
     bar3();
   } else {
     throw _err;


### PR DESCRIPTION
Hi,

I think there is a typo on `async-rewriter2` Readme, on *Making certain exceptions uncatchable* step.

On the transformed code there is a check if `err` exist but on the catch just a line above it is declared as `_err`. If I got it wrong please ignore the PR.

Thank you in advance.