### PR TITLE
feat: bump ace autocompleter to 0.8.0

### DIFF
--- a/packages/autocomplete/package-lock.json
+++ b/packages/autocomplete/package-lock.json
@@ -549,6 +549,14 @@
 				"chalk": "^2.4.2"
 			}
 		},
+		"lru-cache": {
+			"version": "6.0.0",
+			"resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
+			"integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
+			"requires": {
+				"yallist": "^4.0.0"
+			}
+		},
 		"minimatch": {
 			"version": "3.0.4",
 			"resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
@@ -606,11 +614,21 @@
 			}
 		},
 		"mongodb-ace-autocompleter": {
-			"version": "0.5.0",
-			"resolved": "https://registry.npmjs.org/mongodb-ace-autocompleter/-/mongodb-ace-autocompleter-0.5.0.tgz",
-			"integrity": "sha512-5U+dgqFgBBmzIPqMXFp2JzViw9CxIkl+Ex0l8Wyu0L2A2ryP7z7JUh3vplOp/i+zDFVoZGqv3ljE6tmDOej4OQ==",
+			"version": "0.8.0",
+			"resolved": "https://registry.npmjs.org/mongodb-ace-autocompleter/-/mongodb-ace-autocompleter-0.8.0.tgz",
+			"integrity": "sha512-I86NDpg6YDbZ2thoouClzlv8e0obZJI7urvFWE0B4cB2LdNVAYMAD5WnGnNOl8ySpNHrWDK/ESCRAPW4LeDAZQ==",
 			"requires": {
-				"semver": "^7.1.1"
+				"semver": "^7.3.5"
+			},
+			"dependencies": {
+				"semver": {
+					"version": "7.3.5",
+					"resolved": "https://registry.npmjs.org/semver/-/semver-7.3.5.tgz",
+					"integrity": "sha512-PoeGJYh8HK4BTO/a9Tf6ZG3veo/A7ZVsYrSA6J8ny9nb3B1VrpkuN+z9OE5wfE5p6H4LchYZsegiQgbJD94ZFQ==",
+					"requires": {
+						"lru-cache": "^6.0.0"
+					}
+				}
 			}
 		},
 		"ms": {
@@ -963,6 +981,11 @@
 			"resolved": "https://registry.npmjs.org/y18n/-/y18n-4.0.3.tgz",
 			"integrity": "sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==",
 			"dev": true
+		},
+		"yallist": {
+			"version": "4.0.0",
+			"resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
+			"integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
 		},
 		"yargs": {
 			"version": "13.3.2",

--- a/packages/autocomplete/package.json
+++ b/packages/autocomplete/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@mongosh/shell-api": "0.0.0-dev.0",
-    "mongodb-ace-autocompleter": "^0.5.0",
+    "mongodb-ace-autocompleter": "^0.8.0",
     "semver": "^7.3.2"
   }
 }

--- a/packages/autocomplete/src/index.ts
+++ b/packages/autocomplete/src/index.ts
@@ -29,8 +29,8 @@ export interface AutocompleteParameters {
 }
 
 export const BASE_COMPLETIONS = EXPRESSION_OPERATORS.concat(
-  CONVERSION_OPERATORS.concat(BSON_TYPES.concat(STAGE_OPERATORS)
-  ));
+  CONVERSION_OPERATORS.concat(BSON_TYPES.concat(STAGE_OPERATORS))
+);
 
 export const MATCH_COMPLETIONS = QUERY_OPERATORS.concat(BSON_TYPES);
 


### PR DESCRIPTION
Bump ace-autocompleter to `0.8.0` to support new aggregation stages and keywords added in mongodb 5.1:

- $searchMeta and $documents: [MONGOSH-1019](https://jira.mongodb.org/browse/MONGOSH-1019)
- $tsSecond and $tsIncrement: [MONGOSH-1020](https://jira.mongodb.org/browse/MONGOSH-1020)
- $getField: [MONGOSH-1003](https://jira.mongodb.org/browse/MONGOSH-1003)
- $densify: [MONGOSH-1022](https://jira.mongodb.org/browse/MONGOSH-1022)