### PR TITLE
chore(shell-api): adjust expected version for $setField to be in vers…

### DIFF
--- a/packages/shell-api/src/integration.spec.ts
+++ b/packages/shell-api/src/integration.spec.ts
@@ -989,7 +989,7 @@ describe('Shell API (integration)', function() {
       skipIfServerVersion(testServer, '<= 4.4');
       if (process.env.MONGOSH_TEST_FORCE_API_STRICT) {
         // https://jira.mongodb.org/browse/SERVER-58076
-        skipIfServerVersion(testServer, '<= 5.1');
+        skipIfServerVersion(testServer, '<= 5.2');
       }
       it('can insert, modify and retrieve fields with $-prefixed .-containing names', async() => {
         await collection.insertOne({ '$x.y': 1, _id: '_id' });


### PR DESCRIPTION
…ioned API

Our tests have started picking up the 5.2.0-alpha versions and
`$setField` is not part of the versioned API in them.