### PR TITLE
fix(cli-repl): re-add aws4 as dependency to cli-repl to enable AWS auth

### DIFF
--- a/packages/service-provider-server/package-lock.json
+++ b/packages/service-provider-server/package-lock.json
@@ -64,6 +64,11 @@
 				"readable-stream": "^2.0.6"
 			}
 		},
+		"aws4": {
+			"version": "1.11.0",
+			"resolved": "https://registry.npmjs.org/aws4/-/aws4-1.11.0.tgz",
+			"integrity": "sha512-xh1Rl34h6Fi1DC2WWKfxUTVqRsNnr6LsKz2+hfwDxQJWmrx8+c7ylaqBMcHfl1U1r2dsifOvKX3LQuLNZ+XSvA=="
+		},
 		"base64-js": {
 			"version": "1.5.1",
 			"resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",

--- a/packages/service-provider-server/package.json
+++ b/packages/service-provider-server/package.json
@@ -17,7 +17,7 @@
     "test-ci": "node ../../scripts/run-if-package-requested.js npm test",
     "prepublish": "npm run compile-ts",
     "lint": "eslint --report-unused-disable-directives \"./{src,test}/**/*.{js,ts,tsx}\"",
-    "check": "npm run lint && depcheck --skip-missing=true"
+    "check": "npm run lint && depcheck --skip-missing=true --ignores aws4"
   },
   "license": "Apache-2.0",
   "publishConfig": {
@@ -42,9 +42,10 @@
     "@mongosh/service-provider-core": "0.0.0-dev.0",
     "@mongosh/types": "0.0.0-dev.0",
     "@types/sinon-chai": "^3.2.3",
+    "aws4": "^1.11.0",
     "mongodb": "^4.1.3",
-    "saslprep": "mongodb-js/saslprep#v1.0.4",
-    "mongodb-connection-string-url": "^2.0.0"
+    "mongodb-connection-string-url": "^2.0.0",
+    "saslprep": "mongodb-js/saslprep#v1.0.4"
   },
   "optionalDependencies": {
     "mongodb-client-encryption": "^2.0.0-beta.0",


### PR DESCRIPTION
When I used mongosh with aws roles I got the below error in the screenshot attached.

I saw that this package was added it this earlier pr
https://github.com/mongodb-js/mongosh/pull/718/files
and removed in this one
https://github.com/mongodb-js/mongosh/pull/959/files

<img width="885" alt="Screen Shot 2021-11-05 at 10 53 26 AM" src="https://user-images.githubusercontent.com/9276441/140499113-401599f9-75e7-4028-acfd-75f474635943.png">
