### PR TITLE
fix(shell-api): add toBSON overrides to MinKey/MaxKey ctors MONGOSH-1024

### DIFF
--- a/packages/cli-repl/test/e2e-bson.spec.ts
+++ b/packages/cli-repl/test/e2e-bson.spec.ts
@@ -323,7 +323,7 @@ describe('BSON e2e', function() {
       await shell.executeLine(`db.test.insertOne({
         maxfn: MaxKey, maxval: MaxKey(), minfn: MinKey, minval: MinKey()
       })`);
-      const output = await shell.executeLine(`db.test.findOne()`);
+      const output = await shell.executeLine('db.test.findOne()');
       expect(output).to.include('maxfn: MaxKey()');
       expect(output).to.include('maxval: MaxKey()');
       expect(output).to.include('minfn: MinKey()');

--- a/packages/cli-repl/test/e2e-bson.spec.ts
+++ b/packages/cli-repl/test/e2e-bson.spec.ts
@@ -317,6 +317,19 @@ describe('BSON e2e', function() {
       shell.assertNoErrors();
     });
   });
+  describe('MaxKey/MinKey special handling', () => {
+    it('inserts and retrieves MaxKey/MinKey regardless of whether they have been called as functions', async() => {
+      await shell.executeLine(`use ${dbName}`);
+      await shell.executeLine(`db.test.insertOne({
+        maxfn: MaxKey, maxval: MaxKey(), minfn: MinKey, minval: MinKey()
+      })`);
+      const output = await shell.executeLine(`db.test.findOne()`);
+      expect(output).to.include('maxfn: MaxKey()');
+      expect(output).to.include('maxval: MaxKey()');
+      expect(output).to.include('minfn: MinKey()');
+      expect(output).to.include('minval: MinKey()');
+    });
+  });
   describe('help methods', () => {
     it('ObjectId has help when returned from the server', async() => {
       const value = new bson.ObjectId();

--- a/packages/shell-api/src/shell-bson.ts
+++ b/packages/shell-api/src/shell-bson.ts
@@ -94,12 +94,13 @@ export default function constructShellBson(bson: typeof BSON, printWarning: (msg
       assertArgsDefinedType([object], ['object'], 'bsonsize');
       return bson.calculateObjectSize(object);
     },
+    // See https://jira.mongodb.org/browse/MONGOSH-1024 for context on the toBSON additions
     MaxKey: Object.assign(function MaxKey(): typeof bson.MaxKey.prototype {
       return new bson.MaxKey();
-    }, { ...bson.MaxKey, prototype: bson.MaxKey.prototype }),
+    }, { ...bson.MaxKey, toBSON: () => new bson.MaxKey(), prototype: bson.MaxKey.prototype }),
     MinKey: Object.assign(function MinKey(): typeof bson.MinKey.prototype {
       return new bson.MinKey();
-    }, { ...bson.MinKey, prototype: bson.MinKey.prototype }),
+    }, { ...bson.MinKey, toBSON: () => new bson.MinKey(), prototype: bson.MinKey.prototype }),
     ObjectId: Object.assign(function ObjectId(id?: string | number | typeof bson.ObjectId.prototype | Buffer): typeof bson.ObjectId.prototype {
       assertArgsDefinedType([id], [[undefined, 'string', 'number', 'object']], 'ObjectId');
       return new bson.ObjectId(id);


### PR DESCRIPTION
Add `.toBSON` overrides so that sending `MinKey` or `MaxKey`
over the wire results in the same document that `MinKey()` or
`MaxKey()` would have generated, for compatibility with the
legacy shell.