### PR TITLE
fix(async-rewriter): properly process dynamic import() MONGOSH-1062

### DIFF
--- a/packages/async-rewriter2/package.json
+++ b/packages/async-rewriter2/package.json
@@ -5,7 +5,7 @@
   "main": "./lib/index.js",
   "scripts": {
     "pretest": "npm run compile-ts",
-    "test": "mocha -r \"../../scripts/import-expansions.js\" --timeout 60000 -r ts-node/register \"./{src,lib}/**/*.spec.ts\"",
+    "test": "mocha --experimental-vm-modules -r \"../../scripts/import-expansions.js\" --timeout 60000 -r ts-node/register \"./{src,lib}/**/*.spec.ts\"",
     "test-ci": "node ../../scripts/run-if-package-requested.js npm test",
     "lint": "eslint --report-unused-disable-directives \"./{src,test}/**/*.{js,ts,tsx}\"",
     "check": "npm run lint && depcheck --skip-missing=true",

--- a/packages/async-rewriter2/src/stages/transform-maybe-await.ts
+++ b/packages/async-rewriter2/src/stages/transform-maybe-await.ts
@@ -415,12 +415,14 @@ export default ({ types: t }: { types: typeof BabelTypes }): babel.PluginObj<{ f
           // If we ever do, replacing all function calls with
           // Function.prototype.call.call(fn, target, ...originalArgs) might be
           // a feasible solution.
-          // Additionally, skip calls to 'eval', since literal calls to it
-          // have semantics that are different from calls to an expressio that
-          // evaluates to 'eval'.
+          // Additionally, skip calls to 'eval' and 'import', since literal
+          // calls to those have semantics that are different from calls to
+          // an expression that evaluates to 'eval'/'import'.
           if (path.parentPath.isCallExpression() &&
               path.key === 'callee' &&
-              (path.isMemberExpression() || (path.isIdentifier() && path.node.name === 'eval'))) {
+              (path.isMemberExpression() ||
+               path.isImport() ||
+               (path.isIdentifier() && path.node.name === 'eval'))) {
             return;
           }
 


### PR DESCRIPTION
As noted in the ticket, this only fixes the problem partially,
because using `import()` from a function that is then called
from another line in the REPL can crash the process
(depending on garbage collection) due to a Node.js ESM bug.