### PR TITLE
fix(shell-api): relax db.auth() input validation MONGOSH-1051

### DIFF
--- a/packages/cli-repl/test/e2e-tls.spec.ts
+++ b/packages/cli-repl/test/e2e-tls.spec.ts
@@ -214,8 +214,13 @@ describe('e2e TLS', () => {
         });
         const prompt = await shell.waitForPromptOrExit();
         expect(prompt.state).to.equal('prompt');
-        await shell.executeLine('db.runCommand({ connectionStatus: 1 })');
-        shell.assertContainsOutput(`user: '${certUser}'`);
+        expect(await shell.executeLine('db.runCommand({ connectionStatus: 1 })'))
+          .to.include(`user: '${certUser}'`);
+
+        expect(await shell.executeLine('db.getSiblingDB("$external").auth({mechanism: "MONGODB-X509"})'))
+          .to.include('ok: 1');
+        expect(await shell.executeLine('db.runCommand({ connectionStatus: 1 })'))
+          .to.include(`user: '${certUser}'`);
       });
 
       it('works with valid cert (connection string)', async() => {
@@ -228,8 +233,13 @@ describe('e2e TLS', () => {
         });
         const prompt = await shell.waitForPromptOrExit();
         expect(prompt.state).to.equal('prompt');
-        await shell.executeLine('db.runCommand({ connectionStatus: 1 })');
-        shell.assertContainsOutput(`user: '${certUser}'`);
+        expect(await shell.executeLine('db.runCommand({ connectionStatus: 1 })'))
+          .to.include(`user: '${certUser}'`);
+
+        expect(await shell.executeLine('db.getSiblingDB("$external").auth({mechanism: "MONGODB-X509"})'))
+          .to.include('ok: 1');
+        expect(await shell.executeLine('db.runCommand({ connectionStatus: 1 })'))
+          .to.include(`user: '${certUser}'`);
       });
 
       it('fails with invalid cert (args)', async() => {

--- a/packages/shell-api/src/database.ts
+++ b/packages/shell-api/src/database.ts
@@ -521,9 +521,9 @@ export default class Database extends ShellApiWithMongoClass {
         CommonErrors.InvalidArgument
       );
     }
-    if (!authDoc.user || !authDoc.pwd) {
+    if ((!authDoc.user || !authDoc.pwd) && !authDoc.mechanism) {
       throw new MongoshInvalidInputError(
-        'auth expects user document with \'user\' and \'pwd\' fields',
+        'auth expects user document with at least \'user\' and \'pwd\' or \'mechanism\' fields',
         CommonErrors.InvalidArgument
       );
     }


### PR DESCRIPTION
Authenticating without username/password can be valid for
some authentication mechanisms, so skip that if a mechanism
was passed in explicitly.