### PR TITLE
chore: no need for webpack-resolver, set useWorker: false COMPASS-4528

### DIFF
--- a/packages/browser-repl/src/components/editor.tsx
+++ b/packages/browser-repl/src/components/editor.tsx
@@ -1,8 +1,10 @@
 import React, { Component } from 'react';
 import AceEditor from 'react-ace';
 import type { IAceEditor } from 'react-ace/lib/types';
-import 'ace-builds';
-import 'ace-builds/webpack-resolver';
+import ace from 'ace-builds';
+// @ts-ignore
+import jsWorkerUrl from "file-loader!ace-builds/src-noconflict/worker-javascript";
+ace.config.setModuleUrl("ace/mode/javascript_worker", jsWorkerUrl);
 import tools from 'ace-builds/src-noconflict/ext-language_tools';
 import 'ace-builds/src-noconflict/mode-javascript';
 import { Autocompleter } from '@mongosh/browser-runtime-core';

--- a/packages/browser-repl/src/components/editor.tsx
+++ b/packages/browser-repl/src/components/editor.tsx
@@ -1,13 +1,9 @@
 import React, { Component } from 'react';
-import AceEditor from 'react-ace';
-import type { IAceEditor } from 'react-ace/lib/types';
-import ace from 'ace-builds';
-// eslint-disable-next-line @typescript-eslint/ban-ts-comment
-// @ts-ignore
-import jsWorkerUrl from 'file-loader!ace-builds/src-noconflict/worker-javascript';
-ace.config.setModuleUrl('ace/mode/javascript_worker', jsWorkerUrl);
+import 'ace-builds';
 import tools from 'ace-builds/src-noconflict/ext-language_tools';
 import 'ace-builds/src-noconflict/mode-javascript';
+import type { IAceEditor } from 'react-ace/lib/types';
+import AceEditor from 'react-ace';
 import { Autocompleter } from '@mongosh/browser-runtime-core';
 import { AceAutocompleterAdapter } from './ace-autocompleter-adapter';
 import './ace-theme';
@@ -96,7 +92,8 @@ export class Editor extends Component<EditorProps> {
         enableLiveAutocompletion: !!this.props.autocompleter,
         enableSnippets: false,
         showLineNumbers: false,
-        tabSize: 2
+        tabSize: 2,
+        useWorker: false
       }}
       name={`mongosh-ace-${Date.now()}`}
       mode="javascript"

--- a/packages/browser-repl/src/components/editor.tsx
+++ b/packages/browser-repl/src/components/editor.tsx
@@ -2,9 +2,10 @@ import React, { Component } from 'react';
 import AceEditor from 'react-ace';
 import type { IAceEditor } from 'react-ace/lib/types';
 import ace from 'ace-builds';
+// eslint-disable-next-line @typescript-eslint/ban-ts-comment
 // @ts-ignore
-import jsWorkerUrl from "file-loader!ace-builds/src-noconflict/worker-javascript";
-ace.config.setModuleUrl("ace/mode/javascript_worker", jsWorkerUrl);
+import jsWorkerUrl from 'file-loader!ace-builds/src-noconflict/worker-javascript';
+ace.config.setModuleUrl('ace/mode/javascript_worker', jsWorkerUrl);
 import tools from 'ace-builds/src-noconflict/ext-language_tools';
 import 'ace-builds/src-noconflict/mode-javascript';
 import { Autocompleter } from '@mongosh/browser-runtime-core';


### PR DESCRIPTION
some reference https://github.com/securingsincity/react-ace/issues/725

See https://jira.mongodb.org/browse/COMPASS-5328 for some future follow-up work