### PR TITLE
fix: remove sunsetted bintray repo

### DIFF
--- a/packages/java-shell/settings.gradle
+++ b/packages/java-shell/settings.gradle
@@ -1,6 +1,5 @@
 pluginManagement {
     repositories {
-        maven { url 'https://dl.bintray.com/kotlin/kotlin-eap' }
         mavenCentral()
         maven { url 'https://plugins.gradle.org/m2/' }
     }


### PR DESCRIPTION
Bintray was sunsetted several months ago and seems they finally pulled the plug completely. Kotlin resources are now in Maven Central.