### PR TITLE
fix(async-rewriter): ensure finally blocks always run MONGOSH-1076

### DIFF
--- a/packages/async-rewriter2/README.md
+++ b/packages/async-rewriter2/README.md
@@ -107,14 +107,21 @@ try {
 into
 
 ```js
-let _isCatchable;
+let _isCatchable = true;
 
 try {
   foo1();
 } catch (err) {
   _isCatchable = !err || !err[Symbol.for('@@mongosh.uncatchable')];
 
-  if (_isCatchable) bar1(err); else throw err;
+  if (_isCatchable) {
+    try {
+      bar1(err);
+    } catch (innerErr) {
+      _isCatchable = !innerErr || !innerErr[Symbol.for('@@mongosh.uncatchable')];
+      throw innerErr;
+    }
+  } else throw err;
 } finally {
   if (_isCatchable) baz();
 }


### PR DESCRIPTION
Ensure that `finally` blocks are run even if the `try` block did
not result in an exception.

(The README change probably gives the best idea of what exactly is being changed in the generated code here)