### PR TITLE
fix(async-rewriter): do not load browserlist config MONGOSH-1085

### DIFF
--- a/packages/async-rewriter2/src/async-writer-babel.ts
+++ b/packages/async-rewriter2/src/async-writer-babel.ts
@@ -32,9 +32,10 @@ export default class AsyncWriter {
       code: true,
       configFile: false,
       babelrc: false,
+      browserslistConfigFile: false,
       compact: code.length > 10_000,
       sourceType: 'script'
-    })?.code as string;
+    } as any /* https://github.com/DefinitelyTyped/DefinitelyTyped/pull/57732 */)?.code as string;
   }
 
   /**


### PR DESCRIPTION
We should tell babel not to try to load the browerlist config from
disk, especially since we are not interested in it anyway.

A proper regression test seems hard to write, since it would
essentially consist of making sure that mongosh does not access
files from its current working directory when it starts up.