### PR TITLE
fix(cli-repl): persist custom appname MONGOSH-1015

### DIFF
--- a/packages/cli-repl/src/arg-mapper.spec.ts
+++ b/packages/cli-repl/src/arg-mapper.spec.ts
@@ -3,8 +3,10 @@ import chai, { expect } from 'chai';
 import path from 'path';
 import sinonChai from 'sinon-chai';
 import sinon from 'ts-sinon';
-import mapCliToDriver, { applyTlsCertificateSelector } from './arg-mapper';
+import mapCliToDriver, { getTlsCertificateSelector } from './arg-mapper';
 chai.use(sinonChai);
+
+const packageJSON = require('../package.json');
 
 describe('arg-mapper.mapCliToDriver', () => {
   context('when cli args have authenticationDatabase', () => {
@@ -15,8 +17,7 @@ describe('arg-mapper.mapCliToDriver', () => {
         authSource: 'authDb',
         driverInfo: {
           name: 'mongosh',
-          platform: 'darwin',
-          version: '0.0.0-dev.0'
+          version: packageJSON.version
         }
       });
     });
@@ -30,8 +31,7 @@ describe('arg-mapper.mapCliToDriver', () => {
         authMechanism: 'SCRAM-SHA-1',
         driverInfo: {
           name: 'mongosh',
-          platform: 'darwin',
-          version: '0.0.0-dev.0'
+          version: packageJSON.version
         }
       });
     });
@@ -45,8 +45,7 @@ describe('arg-mapper.mapCliToDriver', () => {
         loggerLevel: 'error',
         driverInfo: {
           name: 'mongosh',
-          platform: 'darwin',
-          version: '0.0.0-dev.0'
+          version: packageJSON.version
         }
       });
     });
@@ -60,8 +59,7 @@ describe('arg-mapper.mapCliToDriver', () => {
         loggerLevel: 'debug',
         driverInfo: {
           name: 'mongosh',
-          platform: 'darwin',
-          version: '0.0.0-dev.0'
+          version: packageJSON.version
         }
       });
     });
@@ -77,8 +75,7 @@ describe('arg-mapper.mapCliToDriver', () => {
         },
         driverInfo: {
           name: 'mongosh',
-          platform: 'darwin',
-          version: '0.0.0-dev.0'
+          version: packageJSON.version
         }
       });
     });
@@ -94,8 +91,7 @@ describe('arg-mapper.mapCliToDriver', () => {
         },
         driverInfo: {
           name: 'mongosh',
-          platform: 'darwin',
-          version: '0.0.0-dev.0'
+          version: packageJSON.version
         }
       });
     });
@@ -112,8 +108,7 @@ describe('arg-mapper.mapCliToDriver', () => {
         },
         driverInfo: {
           name: 'mongosh',
-          platform: 'darwin',
-          version: '0.0.0-dev.0'
+          version: packageJSON.version
         }
       });
     });
@@ -127,8 +122,7 @@ describe('arg-mapper.mapCliToDriver', () => {
         retryWrites: true,
         driverInfo: {
           name: 'mongosh',
-          platform: 'darwin',
-          version: '0.0.0-dev.0'
+          version: packageJSON.version
         }
       });
     });
@@ -142,8 +136,7 @@ describe('arg-mapper.mapCliToDriver', () => {
         tls: true,
         driverInfo: {
           name: 'mongosh',
-          platform: 'darwin',
-          version: '0.0.0-dev.0'
+          version: packageJSON.version
         }
       });
     });
@@ -157,8 +150,7 @@ describe('arg-mapper.mapCliToDriver', () => {
         tlsAllowInvalidCertificates: true,
         driverInfo: {
           name: 'mongosh',
-          platform: 'darwin',
-          version: '0.0.0-dev.0'
+          version: packageJSON.version
         }
       });
     });
@@ -172,8 +164,7 @@ describe('arg-mapper.mapCliToDriver', () => {
         tlsAllowInvalidHostnames: true,
         driverInfo: {
           name: 'mongosh',
-          platform: 'darwin',
-          version: '0.0.0-dev.0'
+          version: packageJSON.version
         }
       });
     });
@@ -187,8 +178,7 @@ describe('arg-mapper.mapCliToDriver', () => {
         tlsCAFile: 'ca',
         driverInfo: {
           name: 'mongosh',
-          platform: 'darwin',
-          version: '0.0.0-dev.0'
+          version: packageJSON.version
         }
       });
     });
@@ -202,8 +192,7 @@ describe('arg-mapper.mapCliToDriver', () => {
         sslCRL: 'key',
         driverInfo: {
           name: 'mongosh',
-          platform: 'darwin',
-          version: '0.0.0-dev.0'
+          version: packageJSON.version
         }
       });
     });
@@ -217,8 +206,7 @@ describe('arg-mapper.mapCliToDriver', () => {
         tlsCertificateKeyFile: 'key',
         driverInfo: {
           name: 'mongosh',
-          platform: 'darwin',
-          version: '0.0.0-dev.0'
+          version: packageJSON.version
         }
       });
     });
@@ -232,8 +220,7 @@ describe('arg-mapper.mapCliToDriver', () => {
         tlsCertificateKeyFilePassword: 'pw',
         driverInfo: {
           name: 'mongosh',
-          platform: 'darwin',
-          version: '0.0.0-dev.0'
+          version: packageJSON.version
         }
       });
     });
@@ -253,8 +240,7 @@ describe('arg-mapper.mapCliToDriver', () => {
         },
         driverInfo: {
           name: 'mongosh',
-          platform: 'darwin',
-          version: '0.0.0-dev.0'
+          version: packageJSON.version
         }
       });
     });
@@ -274,8 +260,7 @@ describe('arg-mapper.mapCliToDriver', () => {
         },
         driverInfo: {
           name: 'mongosh',
-          platform: 'darwin',
-          version: '0.0.0-dev.0'
+          version: packageJSON.version
         }
       });
     });
@@ -291,8 +276,7 @@ describe('arg-mapper.mapCliToDriver', () => {
         },
         driverInfo: {
           name: 'mongosh',
-          platform: 'darwin',
-          version: '0.0.0-dev.0'
+          version: packageJSON.version
         }
       });
     });
@@ -308,8 +292,7 @@ describe('arg-mapper.mapCliToDriver', () => {
         },
         driverInfo: {
           name: 'mongosh',
-          platform: 'darwin',
-          version: '0.0.0-dev.0'
+          version: packageJSON.version
         }
       });
     });
@@ -325,8 +308,7 @@ describe('arg-mapper.mapCliToDriver', () => {
         },
         driverInfo: {
           name: 'mongosh',
-          platform: 'darwin',
-          version: '0.0.0-dev.0'
+          version: packageJSON.version
         }
       });
     });
@@ -340,8 +322,7 @@ describe('arg-mapper.mapCliToDriver', () => {
         expect(mapCliToDriver(cliOptions)).to.deep.equal({
           driverInfo: {
             name: 'mongosh',
-            platform: 'darwin',
-            version: '0.0.0-dev.0'
+            version: packageJSON.version
           }
         });
       });
@@ -357,8 +338,7 @@ describe('arg-mapper.mapCliToDriver', () => {
           },
           driverInfo: {
             name: 'mongosh',
-            platform: 'darwin',
-            version: '0.0.0-dev.0'
+            version: packageJSON.version
           }
         });
       });
@@ -389,8 +369,7 @@ describe('arg-mapper.mapCliToDriver', () => {
         },
         driverInfo: {
           name: 'mongosh',
-          platform: 'darwin',
-          version: '0.0.0-dev.0'
+          version: packageJSON.version
         }
       });
     });
@@ -416,8 +395,7 @@ describe('arg-mapper.mapCliToDriver', () => {
         },
         driverInfo: {
           name: 'mongosh',
-          platform: 'darwin',
-          version: '0.0.0-dev.0'
+          version: packageJSON.version
         }
       });
     });
@@ -439,8 +417,7 @@ describe('arg-mapper.mapCliToDriver', () => {
         },
         driverInfo: {
           name: 'mongosh',
-          platform: 'darwin',
-          version: '0.0.0-dev.0'
+          version: packageJSON.version
         }
       });
     });
@@ -462,16 +439,13 @@ describe('arg-mapper.applyTlsCertificateSelector', () => {
     });
 
     it('leaves node options unchanged when no selector is given', () => {
-      const options = {};
-      applyTlsCertificateSelector(undefined, options);
-      expect(options).to.deep.equal({});
+      const applyTlsCertificateSelector = getTlsCertificateSelector(undefined);
+      expect(applyTlsCertificateSelector).to.not.exist;
     });
 
     it('throws when the selector has an odd format', () => {
-      const options = {};
-      expect(() => applyTlsCertificateSelector('foo=bar', options))
+      expect(() => getTlsCertificateSelector('foo=bar'))
         .to.throw(/tlsCertificateSelector needs to include subject or thumbprint/);
-      expect(options).to.deep.equal({});
     });
 
     it('returns passphrase and pfx as given by the (fake) OS', () => {
@@ -480,9 +454,8 @@ describe('arg-mapper.applyTlsCertificateSelector', () => {
       exportCertificateAndPrivateKey.returns({
         passphrase, pfx
       });
-      const options = {};
-      applyTlsCertificateSelector('subject=Foo Bar', options);
-      expect(options).to.deep.equal({
+      const applyTlsCertificateSelector = getTlsCertificateSelector('subject=Foo Bar');
+      expect(applyTlsCertificateSelector).to.deep.equal({
         passphrase, pfx
       });
     });
@@ -493,8 +466,7 @@ describe('arg-mapper.applyTlsCertificateSelector', () => {
       if (process.platform === 'win32' || process.platform === 'darwin') {
         return this.skip();
       }
-      const options = {};
-      expect(() => applyTlsCertificateSelector('subject=Foo Bar', options))
+      expect(() => getTlsCertificateSelector('subject=Foo Bar'))
         .to.throw(/tlsCertificateSelector is not supported on this platform/);
     });
 
@@ -502,8 +474,7 @@ describe('arg-mapper.applyTlsCertificateSelector', () => {
       if (process.platform !== 'win32') {
         return this.skip();
       }
-      const options = {};
-      expect(() => applyTlsCertificateSelector('subject=Foo Bar', options))
+      expect(() => getTlsCertificateSelector('subject=Foo Bar'))
         .to.throw(/Could not resolve certificate specification/);
     });
 
@@ -511,8 +482,7 @@ describe('arg-mapper.applyTlsCertificateSelector', () => {
       if (process.platform !== 'darwin') {
         return this.skip();
       }
-      const options = {};
-      expect(() => applyTlsCertificateSelector('subject=Foo Bar', options))
+      expect(() => getTlsCertificateSelector('subject=Foo Bar'))
         .to.throw(/Could not find a matching certificate/);
     });
   });

--- a/packages/cli-repl/src/arg-mapper.spec.ts
+++ b/packages/cli-repl/src/arg-mapper.spec.ts
@@ -12,7 +12,12 @@ describe('arg-mapper.mapCliToDriver', () => {
 
     it('maps to authSource', () => {
       expect(mapCliToDriver(cliOptions)).to.deep.equal({
-        authSource: 'authDb'
+        authSource: 'authDb',
+        driverInfo: {
+          name: 'mongosh',
+          platform: 'darwin',
+          version: '0.0.0-dev.0'
+        }
       });
     });
   });
@@ -22,7 +27,12 @@ describe('arg-mapper.mapCliToDriver', () => {
 
     it('maps to authMechanism', () => {
       expect(mapCliToDriver(cliOptions)).to.deep.equal({
-        authMechanism: 'SCRAM-SHA-1'
+        authMechanism: 'SCRAM-SHA-1',
+        driverInfo: {
+          name: 'mongosh',
+          platform: 'darwin',
+          version: '0.0.0-dev.0'
+        }
       });
     });
   });
@@ -32,7 +42,12 @@ describe('arg-mapper.mapCliToDriver', () => {
 
     it('maps to loggerLevel', () => {
       expect(mapCliToDriver(cliOptions)).to.deep.equal({
-        loggerLevel: 'error'
+        loggerLevel: 'error',
+        driverInfo: {
+          name: 'mongosh',
+          platform: 'darwin',
+          version: '0.0.0-dev.0'
+        }
       });
     });
   });
@@ -42,7 +57,12 @@ describe('arg-mapper.mapCliToDriver', () => {
 
     it('maps to loggerLevel', () => {
       expect(mapCliToDriver(cliOptions)).to.deep.equal({
-        loggerLevel: 'debug'
+        loggerLevel: 'debug',
+        driverInfo: {
+          name: 'mongosh',
+          platform: 'darwin',
+          version: '0.0.0-dev.0'
+        }
       });
     });
   });
@@ -54,6 +74,11 @@ describe('arg-mapper.mapCliToDriver', () => {
       expect(mapCliToDriver(cliOptions)).to.deep.equal({
         auth: {
           username: 'richard'
+        },
+        driverInfo: {
+          name: 'mongosh',
+          platform: 'darwin',
+          version: '0.0.0-dev.0'
         }
       });
     });
@@ -66,6 +91,11 @@ describe('arg-mapper.mapCliToDriver', () => {
       expect(mapCliToDriver(cliOptions)).to.deep.equal({
         auth: {
           password: 'aphextwin'
+        },
+        driverInfo: {
+          name: 'mongosh',
+          platform: 'darwin',
+          version: '0.0.0-dev.0'
         }
       });
     });
@@ -79,6 +109,11 @@ describe('arg-mapper.mapCliToDriver', () => {
         auth: {
           username: 'richard',
           password: 'aphextwin'
+        },
+        driverInfo: {
+          name: 'mongosh',
+          platform: 'darwin',
+          version: '0.0.0-dev.0'
         }
       });
     });
@@ -89,7 +124,12 @@ describe('arg-mapper.mapCliToDriver', () => {
 
     it('maps the same argument', () => {
       expect(mapCliToDriver(cliOptions)).to.deep.equal({
-        retryWrites: true
+        retryWrites: true,
+        driverInfo: {
+          name: 'mongosh',
+          platform: 'darwin',
+          version: '0.0.0-dev.0'
+        }
       });
     });
   });
@@ -99,7 +139,12 @@ describe('arg-mapper.mapCliToDriver', () => {
 
     it('maps the same argument', () => {
       expect(mapCliToDriver(cliOptions)).to.deep.equal({
-        tls: true
+        tls: true,
+        driverInfo: {
+          name: 'mongosh',
+          platform: 'darwin',
+          version: '0.0.0-dev.0'
+        }
       });
     });
   });
@@ -109,7 +154,12 @@ describe('arg-mapper.mapCliToDriver', () => {
 
     it('maps the same argument', () => {
       expect(mapCliToDriver(cliOptions)).to.deep.equal({
-        tlsAllowInvalidCertificates: true
+        tlsAllowInvalidCertificates: true,
+        driverInfo: {
+          name: 'mongosh',
+          platform: 'darwin',
+          version: '0.0.0-dev.0'
+        }
       });
     });
   });
@@ -119,7 +169,12 @@ describe('arg-mapper.mapCliToDriver', () => {
 
     it('maps the same argument', () => {
       expect(mapCliToDriver(cliOptions)).to.deep.equal({
-        tlsAllowInvalidHostnames: true
+        tlsAllowInvalidHostnames: true,
+        driverInfo: {
+          name: 'mongosh',
+          platform: 'darwin',
+          version: '0.0.0-dev.0'
+        }
       });
     });
   });
@@ -129,7 +184,12 @@ describe('arg-mapper.mapCliToDriver', () => {
 
     it('maps the same argument', () => {
       expect(mapCliToDriver(cliOptions)).to.deep.equal({
-        tlsCAFile: 'ca'
+        tlsCAFile: 'ca',
+        driverInfo: {
+          name: 'mongosh',
+          platform: 'darwin',
+          version: '0.0.0-dev.0'
+        }
       });
     });
   });
@@ -139,7 +199,12 @@ describe('arg-mapper.mapCliToDriver', () => {
 
     it('maps to sslCRL', () => {
       expect(mapCliToDriver(cliOptions)).to.deep.equal({
-        sslCRL: 'key'
+        sslCRL: 'key',
+        driverInfo: {
+          name: 'mongosh',
+          platform: 'darwin',
+          version: '0.0.0-dev.0'
+        }
       });
     });
   });
@@ -149,7 +214,12 @@ describe('arg-mapper.mapCliToDriver', () => {
 
     it('maps the same argument', () => {
       expect(mapCliToDriver(cliOptions)).to.deep.equal({
-        tlsCertificateKeyFile: 'key'
+        tlsCertificateKeyFile: 'key',
+        driverInfo: {
+          name: 'mongosh',
+          platform: 'darwin',
+          version: '0.0.0-dev.0'
+        }
       });
     });
   });
@@ -159,7 +229,12 @@ describe('arg-mapper.mapCliToDriver', () => {
 
     it('maps the same argument', () => {
       expect(mapCliToDriver(cliOptions)).to.deep.equal({
-        tlsCertificateKeyFilePassword: 'pw'
+        tlsCertificateKeyFilePassword: 'pw',
+        driverInfo: {
+          name: 'mongosh',
+          platform: 'darwin',
+          version: '0.0.0-dev.0'
+        }
       });
     });
   });
@@ -175,6 +250,11 @@ describe('arg-mapper.mapCliToDriver', () => {
               accessKeyId: 'awskey'
             }
           }
+        },
+        driverInfo: {
+          name: 'mongosh',
+          platform: 'darwin',
+          version: '0.0.0-dev.0'
         }
       });
     });
@@ -191,6 +271,11 @@ describe('arg-mapper.mapCliToDriver', () => {
               secretAccessKey: 'secretkey'
             }
           }
+        },
+        driverInfo: {
+          name: 'mongosh',
+          platform: 'darwin',
+          version: '0.0.0-dev.0'
         }
       });
     });
@@ -203,6 +288,11 @@ describe('arg-mapper.mapCliToDriver', () => {
       expect(mapCliToDriver(cliOptions)).to.deep.equal({
         authMechanismProperties: {
           AWS_SESSION_TOKEN: 'token'
+        },
+        driverInfo: {
+          name: 'mongosh',
+          platform: 'darwin',
+          version: '0.0.0-dev.0'
         }
       });
     });
@@ -215,6 +305,11 @@ describe('arg-mapper.mapCliToDriver', () => {
       expect(mapCliToDriver(cliOptions)).to.deep.equal({
         authMechanismProperties: {
           SERVICE_NAME: 'alternate'
+        },
+        driverInfo: {
+          name: 'mongosh',
+          platform: 'darwin',
+          version: '0.0.0-dev.0'
         }
       });
     });
@@ -227,6 +322,11 @@ describe('arg-mapper.mapCliToDriver', () => {
       expect(mapCliToDriver(cliOptions)).to.deep.equal({
         authMechanismProperties: {
           SERVICE_REALM: 'REALM.COM'
+        },
+        driverInfo: {
+          name: 'mongosh',
+          platform: 'darwin',
+          version: '0.0.0-dev.0'
         }
       });
     });
@@ -237,7 +337,13 @@ describe('arg-mapper.mapCliToDriver', () => {
       const cliOptions: CliOptions = { sspiHostnameCanonicalization: 'none' };
 
       it('is not mapped to authMechanismProperties', () => {
-        expect(mapCliToDriver(cliOptions)).to.deep.equal({});
+        expect(mapCliToDriver(cliOptions)).to.deep.equal({
+          driverInfo: {
+            name: 'mongosh',
+            platform: 'darwin',
+            version: '0.0.0-dev.0'
+          }
+        });
       });
     });
 
@@ -248,6 +354,11 @@ describe('arg-mapper.mapCliToDriver', () => {
         expect(mapCliToDriver(cliOptions)).to.deep.equal({
           authMechanismProperties: {
             gssapiCanonicalizeHostName: 'true'
+          },
+          driverInfo: {
+            name: 'mongosh',
+            platform: 'darwin',
+            version: '0.0.0-dev.0'
           }
         });
       });
@@ -275,6 +386,11 @@ describe('arg-mapper.mapCliToDriver', () => {
       expect(mapCliToDriver(cliOptions)).to.deep.equal({
         autoEncryption: {
           keyVaultNamespace: 'db.datakeys'
+        },
+        driverInfo: {
+          name: 'mongosh',
+          platform: 'darwin',
+          version: '0.0.0-dev.0'
         }
       });
     });
@@ -297,6 +413,11 @@ describe('arg-mapper.mapCliToDriver', () => {
               secretAccessKey: 'secretkey'
             }
           }
+        },
+        driverInfo: {
+          name: 'mongosh',
+          platform: 'darwin',
+          version: '0.0.0-dev.0'
         }
       });
     });
@@ -315,6 +436,11 @@ describe('arg-mapper.mapCliToDriver', () => {
           strict: true,
           deprecationErrors: true,
           version: '1'
+        },
+        driverInfo: {
+          name: 'mongosh',
+          platform: 'darwin',
+          version: '0.0.0-dev.0'
         }
       });
     });

--- a/packages/cli-repl/src/arg-mapper.ts
+++ b/packages/cli-repl/src/arg-mapper.ts
@@ -70,16 +70,12 @@ function mapCliToDriver(options: CliOptions): MongoClientOptions {
     }
   }
 
-  const tlsCertificateSelector = getTlsCertificateSelector(options.tlsCertificateSelector);
-  if (tlsCertificateSelector) {
-    nodeOptions.passphrase = tlsCertificateSelector.passphrase;
-    nodeOptions.pfx = tlsCertificateSelector.pfx;
-  }
-
   const { version } = require('../package.json');
-  nodeOptions.driverInfo = { name: 'mongosh', version };
-
-  return nodeOptions;
+  return {
+    ...nodeOptions,
+    ...getTlsCertificateSelector(options.tlsCertificateSelector),
+    driverInfo: { name: 'mongosh', version }
+  };
 }
 
 type TlsCertificateExporter = (search: { subject: string } | { thumbprint: Buffer }) => { passphrase: string, pfx: Buffer };

--- a/packages/cli-repl/src/arg-mapper.ts
+++ b/packages/cli-repl/src/arg-mapper.ts
@@ -70,6 +70,7 @@ function mapCliToDriver(options: CliOptions): MongoClientOptions {
     }
   }
   applyTlsCertificateSelector(options.tlsCertificateSelector, nodeOptions);
+  applyDriverInfo(nodeOptions);
   return nodeOptions;
 }
 
@@ -101,6 +102,25 @@ export function applyTlsCertificateSelector(
   } catch (err) {
     throw new MongoshInvalidInputError(`Could not resolve certificate specification '${selector}': ${err.message}`);
   }
+}
+
+/**
+   * Applies driverInfo to track usage of mongosh,
+   * because appName can be overwritten by a user in their connection string.
+   *
+   * @param {MongoClientOptions} nodeOptions - The MongoClient options.
+   *
+   * @returns {DriverInfo} The driverInfo metadata.
+   */
+export function applyDriverInfo(
+  nodeOptions: MongoClientOptions
+): void {
+  const { version } = require('../package.json');
+  nodeOptions.driverInfo = {
+    name: 'mongosh',
+    version,
+    platform: process.platform
+  };
 }
 
 function getCertificateExporter(): TlsCertificateExporter | undefined {

--- a/packages/cli-repl/src/cli-repl.ts
+++ b/packages/cli-repl/src/cli-repl.ts
@@ -163,6 +163,10 @@ class CliRepl {
           cs.password = await this.requirePassword();
           driverUri = cs.href;
         }
+        if (this.isAppNameMissingURI(cs)) {
+          cs.searchParams.set('appName', `mongosh ${version}`);
+          driverUri = cs.href;
+        }
       }
       this.ensurePasswordFieldIsPresentInAuth(driverOptions);
     }
@@ -452,6 +456,17 @@ class CliRepl {
       !cs.password &&
       cs.searchParams.get('authMechanism') !== 'GSSAPI' // no need for a password for Kerberos
     );
+  }
+
+  /**
+   * Is the appName missing from the connection string?
+   *
+   * @param {ConnectionString} cs - The existing connection string.
+   *
+   * @returns {boolean} If the appName is missing.
+   */
+  isAppNameMissingURI(cs: ConnectionString): boolean {
+    return !cs.searchParams.get('appName');
   }
 
   /**

--- a/packages/cli-repl/src/cli-repl.ts
+++ b/packages/cli-repl/src/cli-repl.ts
@@ -155,26 +155,19 @@ class CliRepl {
     await this.verifyNodeVersion();
 
     if (!this.cliOptions.nodb) {
-      let cs;
-      if (driverUri !== '') {
-        cs = new ConnectionString(driverUri);
-
-        if (!cs.searchParams.get('appName')) {
-          cs.searchParams.set('appName', `mongosh ${version}`);
-          driverUri = cs.href;
-        }
+      const cs = new ConnectionString(driverUri);
+      if (!cs.searchParams.get('appName')) {
+        cs.searchParams.set('appName', `mongosh ${version}`);
       }
 
       if (this.isPasswordMissingOptions(driverOptions)) {
         (driverOptions.auth as any).password = await this.requirePassword();
-      } else if (cs) {
-        if (this.isPasswordMissingURI(cs)) {
-          cs.password = await this.requirePassword();
-          driverUri = cs.href;
-        }
+      } else if (this.isPasswordMissingURI(cs)) {
+        cs.password = await this.requirePassword();
       }
-
       this.ensurePasswordFieldIsPresentInAuth(driverOptions);
+
+      driverUri = cs.href;
     }
 
     try {

--- a/packages/cli-repl/src/run.ts
+++ b/packages/cli-repl/src/run.ts
@@ -86,7 +86,6 @@ import stream from 'stream';
       process.title = title;
       setTerminalWindowTitle(title);
 
-      const appName = `mongosh ${version}`;
       const shellHomePaths = getStoragePaths();
       repl = new CliRepl({
         shellCliOptions: {
@@ -98,7 +97,7 @@ import stream from 'stream';
         onExit: process.exit,
         shellHomePaths: shellHomePaths
       });
-      await repl.start(driverUri, { appName, ...driverOptions });
+      await repl.start(driverUri, driverOptions);
     }
   } catch (e) {
     console.error(`${e.name}: ${e.message}`);

--- a/packages/cli-repl/test/e2e.spec.ts
+++ b/packages/cli-repl/test/e2e.spec.ts
@@ -203,6 +203,38 @@ describe('e2e', function() {
     }
   });
 
+  describe('set appName', () => {
+    context('with default appName', () => {
+      let shell;
+      beforeEach(async() => {
+        shell = TestShell.start({ args: [`mongodb://${await testServer.hostport()}/`] });
+        await shell.waitForPrompt();
+        shell.assertNoErrors();
+      });
+      it('appName set correctly', async() => {
+        const currentOp = await shell.executeLine('db.currentOp()');
+        expect(currentOp).to.include("appName: 'mongosh 0.0.0-dev.0'");
+        expect(currentOp).to.include("name: 'nodejs|mongosh'");
+        shell.assertNoErrors();
+      });
+    });
+
+    context('with custom appName', () => {
+      let shell;
+      beforeEach(async() => {
+        shell = TestShell.start({ args: [`mongodb://${await testServer.hostport()}/?appName=Felicia`] });
+        await shell.waitForPrompt();
+        shell.assertNoErrors();
+      });
+      it('appName set correctly', async() => {
+        const currentOp = await shell.executeLine('db.currentOp()');
+        expect(currentOp).to.include("appName: 'Felicia'");
+        expect(currentOp).to.include("name: 'nodejs|mongosh'");
+        shell.assertNoErrors();
+      });
+    });
+  });
+
   describe('with connection string', () => {
     let db;
     let client;

--- a/packages/cli-repl/test/e2e.spec.ts
+++ b/packages/cli-repl/test/e2e.spec.ts
@@ -211,7 +211,10 @@ describe('e2e', function() {
         await shell.waitForPrompt();
         shell.assertNoErrors();
       });
-      it('appName set correctly', async() => {
+      it('appName set correctly', async function() {
+        if (process.env.MONGOSH_TEST_FORCE_API_STRICT) {
+          return this.skip(); // $currentOp is unversioned
+        }
         const currentOp = await shell.executeLine('db.currentOp()');
         expect(currentOp).to.include("appName: 'mongosh 0.0.0-dev.0'");
         expect(currentOp).to.include("name: 'nodejs|mongosh'");
@@ -226,7 +229,10 @@ describe('e2e', function() {
         await shell.waitForPrompt();
         shell.assertNoErrors();
       });
-      it('appName set correctly', async() => {
+      it('appName set correctly', async function() {
+        if (process.env.MONGOSH_TEST_FORCE_API_STRICT) {
+          return this.skip(); // $currentOp is unversioned
+        }
         const currentOp = await shell.executeLine('db.currentOp()');
         expect(currentOp).to.include("appName: 'Felicia'");
         expect(currentOp).to.include("name: 'nodejs|mongosh'");


### PR DESCRIPTION
Allow users to overwrite appName in a connection string. Keep the application name via driverInfo metadata.