### PR TITLE
feat(shell-api): allow db.stats(options) MONGOSH-1108

### DIFF
--- a/packages/i18n/src/locales/en_US.ts
+++ b/packages/i18n/src/locales/en_US.ts
@@ -1184,7 +1184,7 @@ const translations: Catalog = {
             stats: {
               link: 'https://docs.mongodb.com/manual/reference/method/db.stats',
               description: 'returns the db stats. uses the dbStats command',
-              example: 'db.stats(<scale>)',
+              example: 'db.stats(<scale>) or db.stats({ scale: <scale> })',
             },
             hostInfo: {
               link: 'https://docs.mongodb.com/manual/reference/method/db.hostInfo',

--- a/packages/shell-api/src/database.spec.ts
+++ b/packages/shell-api/src/database.spec.ts
@@ -1843,7 +1843,7 @@ describe('Database', () => {
     });
 
     describe('stats', () => {
-      it('calls serviceProvider.runCommandWithCheck on the database with options', async() => {
+      it('calls serviceProvider.runCommandWithCheck on the database with scale argument', async() => {
         await database.stats(1);
 
         expect(serviceProvider.runCommandWithCheck).to.have.been.calledWith(
@@ -1851,6 +1851,32 @@ describe('Database', () => {
           {
             dbStats: 1,
             scale: 1
+          }
+        );
+      });
+
+      it('calls serviceProvider.runCommandWithCheck on the database with options object', async() => {
+        await database.stats({ scale: 1, freeStorage: 1 });
+
+        expect(serviceProvider.runCommandWithCheck).to.have.been.calledWith(
+          database._name,
+          {
+            dbStats: 1,
+            scale: 1,
+            freeStorage: 1
+          }
+        );
+      });
+
+      it('calls serviceProvider.runCommandWithCheck on the database with options object without explicit scale', async() => {
+        await database.stats({ freeStorage: 1 });
+
+        expect(serviceProvider.runCommandWithCheck).to.have.been.calledWith(
+          database._name,
+          {
+            dbStats: 1,
+            scale: 1,
+            freeStorage: 1
           }
         );
       });

--- a/packages/shell-api/src/database.ts
+++ b/packages/shell-api/src/database.ts
@@ -941,12 +941,17 @@ export default class Database extends ShellApiWithMongoClass {
 
   @returnsPromise
   @apiVersions([])
-  async stats(scale = 1): Promise<Document> {
-    this._emitDatabaseApiCall('stats', { scale: scale });
+  async stats(scaleOrOptions: number | Document = 1): Promise<Document> {
+    assertArgsDefinedType([scaleOrOptions], [['number', 'object']], 'Database.stats');
+    if (typeof scaleOrOptions === 'number') {
+      scaleOrOptions = { scale: scaleOrOptions };
+    }
+    this._emitDatabaseApiCall('stats', { scale: scaleOrOptions.scale });
     return await this._runCommand(
       {
         dbStats: 1,
-        scale: scale
+        scale: 1,
+        ...scaleOrOptions
       }
     );
   }


### PR DESCRIPTION
Starting with 5.0.6, the server allows additional `db.stats()`
options. We extend the shell to also accept an options object.