### PR TITLE
chore(async-rewriter): several smaller performance improvements MONGOSH-1040

### DIFF
--- a/packages/async-rewriter2/benchmark/index.ts
+++ b/packages/async-rewriter2/benchmark/index.ts
@@ -1,0 +1,10 @@
+import AsyncWriter from '../src/index';
+
+const RUNS = 10;
+
+const start = process.hrtime.bigint();
+for (let i = 0; i < RUNS; i++)
+  new AsyncWriter().runtimeSupportCode();
+const stop = process.hrtime.bigint();
+
+console.log('Time for processing runtime support code', Number(stop - start) / 1_000_000 / RUNS, 'ms');

--- a/packages/async-rewriter2/package-lock.json
+++ b/packages/async-rewriter2/package-lock.json
@@ -276,9 +276,9 @@
 			}
 		},
 		"@types/babel__core": {
-			"version": "7.1.15",
-			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.15.tgz",
-			"integrity": "sha512-bxlMKPDbY8x5h6HBwVzEOk2C8fb6SLfYQ5Jw3uBYuYF1lfWk/kbLd81la82vrIkBb0l+JdmrZaDikPrNxpS/Ew==",
+			"version": "7.1.18",
+			"resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.1.18.tgz",
+			"integrity": "sha512-S7unDjm/C7z2A2R9NzfKCK1I+BAALDtxEmsJBwlB3EzNfb929ykjL++1CK9LO++EIp2fQrC8O+BwjKvz6UeDyQ==",
 			"requires": {
 				"@babel/parser": "^7.1.0",
 				"@babel/types": "^7.0.0",
@@ -288,9 +288,9 @@
 			}
 		},
 		"@types/babel__generator": {
-			"version": "7.6.3",
-			"resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.3.tgz",
-			"integrity": "sha512-/GWCmzJWqV7diQW54smJZzWbSFf4QYtF71WCKhcx6Ru/tFyQIY2eiiITcCAeuPbNSvT9YCGkVMqqvSk2Z0mXiA==",
+			"version": "7.6.4",
+			"resolved": "https://registry.npmjs.org/@types/babel__generator/-/babel__generator-7.6.4.tgz",
+			"integrity": "sha512-tFkciB9j2K755yrTALxD44McOrk+gfpIpvC3sxHjRawj6PfnQxrse4Clq5y/Rq+G3mrBurMax/lG8Qn2t9mSsg==",
 			"requires": {
 				"@babel/types": "^7.0.0"
 			}

--- a/packages/async-rewriter2/package-lock.json
+++ b/packages/async-rewriter2/package-lock.json
@@ -5,184 +5,172 @@
 	"requires": true,
 	"dependencies": {
 		"@babel/code-frame": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.14.5.tgz",
-			"integrity": "sha512-9pzDqyc6OLDaqe+zbACgFkb6fKMNG6CObKpnYXChRsvYGyEdc7CA2BaqeOM+vOtCS5ndmJicPJhKAwYRI6UfFw==",
+			"version": "7.16.7",
+			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.16.7.tgz",
+			"integrity": "sha512-iAXqUn8IIeBTNd72xsFlgaXHkMBMt6y4HJp1tIaK465CWLT/fG1aqB7ykr95gHHmlBdGbFeWWfyB4NJJ0nmeIg==",
 			"requires": {
-				"@babel/highlight": "^7.14.5"
+				"@babel/highlight": "^7.16.7"
 			}
 		},
 		"@babel/compat-data": {
-			"version": "7.14.7",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.14.7.tgz",
-			"integrity": "sha512-nS6dZaISCXJ3+518CWiBfEr//gHyMO02uDxBkXTKZDN5POruCnOZ1N4YBRZDCabwF8nZMWBpRxIicmXtBs+fvw=="
+			"version": "7.16.8",
+			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.16.8.tgz",
+			"integrity": "sha512-m7OkX0IdKLKPpBlJtF561YJal5y/jyI5fNfWbPxh2D/nbzzGI4qRyrD8xO2jB24u7l+5I2a43scCG2IrfjC50Q=="
 		},
 		"@babel/core": {
-			"version": "7.14.8",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.14.8.tgz",
-			"integrity": "sha512-/AtaeEhT6ErpDhInbXmjHcUQXH0L0TEgscfcxk1qbOvLuKCa5aZT0SOOtDKFY96/CLROwbLSKyFor6idgNaU4Q==",
+			"version": "7.16.12",
+			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.16.12.tgz",
+			"integrity": "sha512-dK5PtG1uiN2ikk++5OzSYsitZKny4wOCD0nrO4TqnW4BVBTQ2NGS3NgilvT/TEyxTST7LNyWV/T4tXDoD3fOgg==",
 			"requires": {
-				"@babel/code-frame": "^7.14.5",
-				"@babel/generator": "^7.14.8",
-				"@babel/helper-compilation-targets": "^7.14.5",
-				"@babel/helper-module-transforms": "^7.14.8",
-				"@babel/helpers": "^7.14.8",
-				"@babel/parser": "^7.14.8",
-				"@babel/template": "^7.14.5",
-				"@babel/traverse": "^7.14.8",
-				"@babel/types": "^7.14.8",
+				"@babel/code-frame": "^7.16.7",
+				"@babel/generator": "^7.16.8",
+				"@babel/helper-compilation-targets": "^7.16.7",
+				"@babel/helper-module-transforms": "^7.16.7",
+				"@babel/helpers": "^7.16.7",
+				"@babel/parser": "^7.16.12",
+				"@babel/template": "^7.16.7",
+				"@babel/traverse": "^7.16.10",
+				"@babel/types": "^7.16.8",
 				"convert-source-map": "^1.7.0",
 				"debug": "^4.1.0",
 				"gensync": "^1.0.0-beta.2",
 				"json5": "^2.1.2",
 				"semver": "^6.3.0",
 				"source-map": "^0.5.0"
+			},
+			"dependencies": {
+				"@babel/parser": {
+					"version": "7.16.12",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.12.tgz",
+					"integrity": "sha512-VfaV15po8RiZssrkPweyvbGVSe4x2y+aciFCgn0n0/SJMR22cwofRV1mtnJQYcSB1wUTaA/X1LnA3es66MCO5A=="
+				}
 			}
 		},
 		"@babel/generator": {
-			"version": "7.14.8",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.8.tgz",
-			"integrity": "sha512-cYDUpvIzhBVnMzRoY1fkSEhK/HmwEVwlyULYgn/tMQYd6Obag3ylCjONle3gdErfXBW61SVTlR9QR7uWlgeIkg==",
+			"version": "7.16.8",
+			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.16.8.tgz",
+			"integrity": "sha512-1ojZwE9+lOXzcWdWmO6TbUzDfqLD39CmEhN8+2cX9XkDo5yW1OpgfejfliysR2AWLpMamTiOiAp/mtroaymhpw==",
 			"requires": {
-				"@babel/types": "^7.14.8",
+				"@babel/types": "^7.16.8",
 				"jsesc": "^2.5.1",
 				"source-map": "^0.5.0"
 			}
 		},
 		"@babel/helper-compilation-targets": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.14.5.tgz",
-			"integrity": "sha512-v+QtZqXEiOnpO6EYvlImB6zCD2Lel06RzOPzmkz/D/XgQiUu3C/Jb1LOqSt/AIA34TYi/Q+KlT8vTQrgdxkbLw==",
+			"version": "7.16.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.16.7.tgz",
+			"integrity": "sha512-mGojBwIWcwGD6rfqgRXVlVYmPAv7eOpIemUG3dGnDdCY4Pae70ROij3XmfrH6Fa1h1aiDylpglbZyktfzyo/hA==",
 			"requires": {
-				"@babel/compat-data": "^7.14.5",
-				"@babel/helper-validator-option": "^7.14.5",
-				"browserslist": "^4.16.6",
+				"@babel/compat-data": "^7.16.4",
+				"@babel/helper-validator-option": "^7.16.7",
+				"browserslist": "^4.17.5",
 				"semver": "^6.3.0"
 			}
 		},
-		"@babel/helper-function-name": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.14.5.tgz",
-			"integrity": "sha512-Gjna0AsXWfFvrAuX+VKcN/aNNWonizBj39yGwUzVDVTlMYJMK2Wp6xdpy72mfArFq5uK+NOuexfzZlzI1z9+AQ==",
+		"@babel/helper-environment-visitor": {
+			"version": "7.16.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.16.7.tgz",
+			"integrity": "sha512-SLLb0AAn6PkUeAfKJCCOl9e1R53pQlGAfc4y4XuMRZfqeMYLE0dM1LMhqbGAlGQY0lfw5/ohoYWAe9V1yibRag==",
 			"requires": {
-				"@babel/helper-get-function-arity": "^7.14.5",
-				"@babel/template": "^7.14.5",
-				"@babel/types": "^7.14.5"
+				"@babel/types": "^7.16.7"
+			}
+		},
+		"@babel/helper-function-name": {
+			"version": "7.16.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.16.7.tgz",
+			"integrity": "sha512-QfDfEnIUyyBSR3HtrtGECuZ6DAyCkYFp7GHl75vFtTnn6pjKeK0T1DB5lLkFvBea8MdaiUABx3osbgLyInoejA==",
+			"requires": {
+				"@babel/helper-get-function-arity": "^7.16.7",
+				"@babel/template": "^7.16.7",
+				"@babel/types": "^7.16.7"
 			}
 		},
 		"@babel/helper-get-function-arity": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.14.5.tgz",
-			"integrity": "sha512-I1Db4Shst5lewOM4V+ZKJzQ0JGGaZ6VY1jYvMghRjqs6DWgxLCIyFt30GlnKkfUeFLpJt2vzbMVEXVSXlIFYUg==",
+			"version": "7.16.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-get-function-arity/-/helper-get-function-arity-7.16.7.tgz",
+			"integrity": "sha512-flc+RLSOBXzNzVhcLu6ujeHUrD6tANAOU5ojrRx/as+tbzf8+stUCj7+IfRRoAbEZqj/ahXEMsjhOhgeZsrnTw==",
 			"requires": {
-				"@babel/types": "^7.14.5"
+				"@babel/types": "^7.16.7"
 			}
 		},
 		"@babel/helper-hoist-variables": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.14.5.tgz",
-			"integrity": "sha512-R1PXiz31Uc0Vxy4OEOm07x0oSjKAdPPCh3tPivn/Eo8cvz6gveAeuyUUPB21Hoiif0uoPQSSdhIPS3352nvdyQ==",
+			"version": "7.16.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.16.7.tgz",
+			"integrity": "sha512-m04d/0Op34H5v7pbZw6pSKP7weA6lsMvfiIAMeIvkY/R4xQtBSMFEigu9QTZ2qB/9l22vsxtM8a+Q8CzD255fg==",
 			"requires": {
-				"@babel/types": "^7.14.5"
-			}
-		},
-		"@babel/helper-member-expression-to-functions": {
-			"version": "7.14.7",
-			"resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.14.7.tgz",
-			"integrity": "sha512-TMUt4xKxJn6ccjcOW7c4hlwyJArizskAhoSTOCkA0uZ+KghIaci0Qg9R043kUMWI9mtQfgny+NQ5QATnZ+paaA==",
-			"requires": {
-				"@babel/types": "^7.14.5"
+				"@babel/types": "^7.16.7"
 			}
 		},
 		"@babel/helper-module-imports": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.14.5.tgz",
-			"integrity": "sha512-SwrNHu5QWS84XlHwGYPDtCxcA0hrSlL2yhWYLgeOc0w7ccOl2qv4s/nARI0aYZW+bSwAL5CukeXA47B/1NKcnQ==",
+			"version": "7.16.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.7.tgz",
+			"integrity": "sha512-LVtS6TqjJHFc+nYeITRo6VLXve70xmq7wPhWTqDJusJEgGmkAACWwMiTNrvfoQo6hEhFwAIixNkvB0jPXDL8Wg==",
 			"requires": {
-				"@babel/types": "^7.14.5"
+				"@babel/types": "^7.16.7"
 			}
 		},
 		"@babel/helper-module-transforms": {
-			"version": "7.14.8",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.14.8.tgz",
-			"integrity": "sha512-RyE+NFOjXn5A9YU1dkpeBaduagTlZ0+fccnIcAGbv1KGUlReBj7utF7oEth8IdIBQPcux0DDgW5MFBH2xu9KcA==",
+			"version": "7.16.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.16.7.tgz",
+			"integrity": "sha512-gaqtLDxJEFCeQbYp9aLAefjhkKdjKcdh6DB7jniIGU3Pz52WAmP268zK0VgPz9hUNkMSYeH976K2/Y6yPadpng==",
 			"requires": {
-				"@babel/helper-module-imports": "^7.14.5",
-				"@babel/helper-replace-supers": "^7.14.5",
-				"@babel/helper-simple-access": "^7.14.8",
-				"@babel/helper-split-export-declaration": "^7.14.5",
-				"@babel/helper-validator-identifier": "^7.14.8",
-				"@babel/template": "^7.14.5",
-				"@babel/traverse": "^7.14.8",
-				"@babel/types": "^7.14.8"
-			}
-		},
-		"@babel/helper-optimise-call-expression": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-optimise-call-expression/-/helper-optimise-call-expression-7.14.5.tgz",
-			"integrity": "sha512-IqiLIrODUOdnPU9/F8ib1Fx2ohlgDhxnIDU7OEVi+kAbEZcyiF7BLU8W6PfvPi9LzztjS7kcbzbmL7oG8kD6VA==",
-			"requires": {
-				"@babel/types": "^7.14.5"
+				"@babel/helper-environment-visitor": "^7.16.7",
+				"@babel/helper-module-imports": "^7.16.7",
+				"@babel/helper-simple-access": "^7.16.7",
+				"@babel/helper-split-export-declaration": "^7.16.7",
+				"@babel/helper-validator-identifier": "^7.16.7",
+				"@babel/template": "^7.16.7",
+				"@babel/traverse": "^7.16.7",
+				"@babel/types": "^7.16.7"
 			}
 		},
 		"@babel/helper-plugin-utils": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
-			"integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ=="
-		},
-		"@babel/helper-replace-supers": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.14.5.tgz",
-			"integrity": "sha512-3i1Qe9/8x/hCHINujn+iuHy+mMRLoc77b2nI9TB0zjH1hvn9qGlXjWlggdwUcju36PkPCy/lpM7LLUdcTyH4Ow==",
-			"requires": {
-				"@babel/helper-member-expression-to-functions": "^7.14.5",
-				"@babel/helper-optimise-call-expression": "^7.14.5",
-				"@babel/traverse": "^7.14.5",
-				"@babel/types": "^7.14.5"
-			}
+			"version": "7.16.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
+			"integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA=="
 		},
 		"@babel/helper-simple-access": {
-			"version": "7.14.8",
-			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.14.8.tgz",
-			"integrity": "sha512-TrFN4RHh9gnWEU+s7JloIho2T76GPwRHhdzOWLqTrMnlas8T9O7ec+oEDNsRXndOmru9ymH9DFrEOxpzPoSbdg==",
+			"version": "7.16.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.16.7.tgz",
+			"integrity": "sha512-ZIzHVyoeLMvXMN/vok/a4LWRy8G2v205mNP0XOuf9XRLyX5/u9CnVulUtDgUTama3lT+bf/UqucuZjqiGuTS1g==",
 			"requires": {
-				"@babel/types": "^7.14.8"
+				"@babel/types": "^7.16.7"
 			}
 		},
 		"@babel/helper-split-export-declaration": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.14.5.tgz",
-			"integrity": "sha512-hprxVPu6e5Kdp2puZUmvOGjaLv9TCe58E/Fl6hRq4YiVQxIcNvuq6uTM2r1mT/oPskuS9CgR+I94sqAYv0NGKA==",
+			"version": "7.16.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.16.7.tgz",
+			"integrity": "sha512-xbWoy/PFoxSWazIToT9Sif+jJTlrMcndIsaOKvTA6u7QEo7ilkRZpjew18/W3c7nm8fXdUDXh02VXTbZ0pGDNw==",
 			"requires": {
-				"@babel/types": "^7.14.5"
+				"@babel/types": "^7.16.7"
 			}
 		},
 		"@babel/helper-validator-identifier": {
-			"version": "7.14.8",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.8.tgz",
-			"integrity": "sha512-ZGy6/XQjllhYQrNw/3zfWRwZCTVSiBLZ9DHVZxn9n2gip/7ab8mv2TWlKPIBk26RwedCBoWdjLmn+t9na2Gcow=="
+			"version": "7.16.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
+			"integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw=="
 		},
 		"@babel/helper-validator-option": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.14.5.tgz",
-			"integrity": "sha512-OX8D5eeX4XwcroVW45NMvoYaIuFI+GQpA2a8Gi+X/U/cDUIRsV37qQfF905F0htTRCREQIB4KqPeaveRJUl3Ow=="
+			"version": "7.16.7",
+			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.16.7.tgz",
+			"integrity": "sha512-TRtenOuRUVo9oIQGPC5G9DgK4743cdxvtOw0weQNpZXaS16SCBi5MNjZF8vba3ETURjZpTbVn7Vvcf2eAwFozQ=="
 		},
 		"@babel/helpers": {
-			"version": "7.14.8",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.14.8.tgz",
-			"integrity": "sha512-ZRDmI56pnV+p1dH6d+UN6GINGz7Krps3+270qqI9UJ4wxYThfAIcI5i7j5vXC4FJ3Wap+S9qcebxeYiqn87DZw==",
+			"version": "7.16.7",
+			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.16.7.tgz",
+			"integrity": "sha512-9ZDoqtfY7AuEOt3cxchfii6C7GDyyMBffktR5B2jvWv8u2+efwvpnVKXMWzNehqy68tKgAfSwfdw/lWpthS2bw==",
 			"requires": {
-				"@babel/template": "^7.14.5",
-				"@babel/traverse": "^7.14.8",
-				"@babel/types": "^7.14.8"
+				"@babel/template": "^7.16.7",
+				"@babel/traverse": "^7.16.7",
+				"@babel/types": "^7.16.7"
 			}
 		},
 		"@babel/highlight": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.14.5.tgz",
-			"integrity": "sha512-qf9u2WFWVV0MppaL877j2dBtQIDgmidgjGk5VIMw3OadXvYaXn66U1BFlH2t4+t3i+8PhedppRv+i40ABzd+gg==",
+			"version": "7.16.10",
+			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.16.10.tgz",
+			"integrity": "sha512-5FnTQLSLswEj6IkgVw5KusNUUFY9ZGqe/TRFnP/BKYHYgfh7tc+C7mwiy95/yNP7Dh9x580Vv8r7u7ZfTBFxdw==",
 			"requires": {
-				"@babel/helper-validator-identifier": "^7.14.5",
+				"@babel/helper-validator-identifier": "^7.16.7",
 				"chalk": "^2.0.0",
 				"js-tokens": "^4.0.0"
 			}
@@ -193,86 +181,77 @@
 			"integrity": "sha512-syoCQFOoo/fzkWDeM0dLEZi5xqurb5vuyzwIMNZRNun+N/9A4cUZeQaE7dTrB8jGaKuJRBtEOajtnmw0I5hvvA=="
 		},
 		"@babel/plugin-transform-destructuring": {
-			"version": "7.14.7",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.14.7.tgz",
-			"integrity": "sha512-0mDE99nK+kVh3xlc5vKwB6wnP9ecuSj+zQCa/n0voENtP/zymdT4HH6QEb65wjjcbqr1Jb/7z9Qp7TF5FtwYGw==",
+			"version": "7.16.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-destructuring/-/plugin-transform-destructuring-7.16.7.tgz",
+			"integrity": "sha512-VqAwhTHBnu5xBVDCvrvqJbtLUa++qZaWC0Fgr2mqokBlulZARGyIvZDoqbPlPaKImQ9dKAcCzbv+ul//uqu70A==",
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.14.5"
+				"@babel/helper-plugin-utils": "^7.16.7"
 			}
 		},
 		"@babel/plugin-transform-parameters": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.14.5.tgz",
-			"integrity": "sha512-Tl7LWdr6HUxTmzQtzuU14SqbgrSKmaR77M0OKyq4njZLQTPfOvzblNKyNkGwOfEFCEx7KeYHQHDI0P3F02IVkA==",
+			"version": "7.16.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-parameters/-/plugin-transform-parameters-7.16.7.tgz",
+			"integrity": "sha512-AT3MufQ7zZEhU2hwOA11axBnExW0Lszu4RL/tAlUJBuNoRak+wehQW8h6KcXOcgjY42fHtDxswuMhMjFEuv/aw==",
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.14.5"
+				"@babel/helper-plugin-utils": "^7.16.7"
 			}
 		},
 		"@babel/plugin-transform-shorthand-properties": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.14.5.tgz",
-			"integrity": "sha512-xLucks6T1VmGsTB+GWK5Pl9Jl5+nRXD1uoFdA5TSO6xtiNjtXTjKkmPdFXVLGlK5A2/or/wQMKfmQ2Y0XJfn5g==",
+			"version": "7.16.7",
+			"resolved": "https://registry.npmjs.org/@babel/plugin-transform-shorthand-properties/-/plugin-transform-shorthand-properties-7.16.7.tgz",
+			"integrity": "sha512-hah2+FEnoRoATdIb05IOXf+4GzXYTq75TVhIn1PewihbpyrNWUt2JbudKQOETWw6QpLe+AIUpJ5MVLYTQbeeUg==",
 			"requires": {
-				"@babel/helper-plugin-utils": "^7.14.5"
+				"@babel/helper-plugin-utils": "^7.16.7"
 			}
 		},
 		"@babel/template": {
-			"version": "7.14.5",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
-			"integrity": "sha512-6Z3Po85sfxRGachLULUhOmvAaOo7xCvqGQtxINai2mEGPFm6pQ4z5QInFnUrRpfoSV60BnjyF5F3c+15fxFV1g==",
+			"version": "7.16.7",
+			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.16.7.tgz",
+			"integrity": "sha512-I8j/x8kHUrbYRTUxXrrMbfCa7jxkE7tZre39x3kjr9hvI82cK1FfqLygotcWN5kdPGWcLdWMHpSBavse5tWw3w==",
 			"requires": {
-				"@babel/code-frame": "^7.14.5",
-				"@babel/parser": "^7.14.5",
-				"@babel/types": "^7.14.5"
+				"@babel/code-frame": "^7.16.7",
+				"@babel/parser": "^7.16.7",
+				"@babel/types": "^7.16.7"
+			},
+			"dependencies": {
+				"@babel/parser": {
+					"version": "7.16.12",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.12.tgz",
+					"integrity": "sha512-VfaV15po8RiZssrkPweyvbGVSe4x2y+aciFCgn0n0/SJMR22cwofRV1mtnJQYcSB1wUTaA/X1LnA3es66MCO5A=="
+				}
 			}
 		},
 		"@babel/traverse": {
-			"version": "7.14.9",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.14.9.tgz",
-			"integrity": "sha512-bldh6dtB49L8q9bUyB7bC20UKgU+EFDwKJylwl234Kv+ySZeMD31Xeht6URyueQ6LrRRpF2tmkfcZooZR9/e8g==",
+			"version": "7.16.10",
+			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.16.10.tgz",
+			"integrity": "sha512-yzuaYXoRJBGMlBhsMJoUW7G1UmSb/eXr/JHYM/MsOJgavJibLwASijW7oXBdw3NQ6T0bW7Ty5P/VarOs9cHmqw==",
 			"requires": {
-				"@babel/code-frame": "^7.14.5",
-				"@babel/generator": "^7.14.9",
-				"@babel/helper-function-name": "^7.14.5",
-				"@babel/helper-hoist-variables": "^7.14.5",
-				"@babel/helper-split-export-declaration": "^7.14.5",
-				"@babel/parser": "^7.14.9",
-				"@babel/types": "^7.14.9",
+				"@babel/code-frame": "^7.16.7",
+				"@babel/generator": "^7.16.8",
+				"@babel/helper-environment-visitor": "^7.16.7",
+				"@babel/helper-function-name": "^7.16.7",
+				"@babel/helper-hoist-variables": "^7.16.7",
+				"@babel/helper-split-export-declaration": "^7.16.7",
+				"@babel/parser": "^7.16.10",
+				"@babel/types": "^7.16.8",
 				"debug": "^4.1.0",
 				"globals": "^11.1.0"
 			},
 			"dependencies": {
-				"@babel/generator": {
-					"version": "7.14.9",
-					"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.14.9.tgz",
-					"integrity": "sha512-4yoHbhDYzFa0GLfCzLp5GxH7vPPMAHdZjyE7M/OajM9037zhx0rf+iNsJwp4PT0MSFpwjG7BsHEbPkBQpZ6cYA==",
-					"requires": {
-						"@babel/types": "^7.14.9",
-						"jsesc": "^2.5.1",
-						"source-map": "^0.5.0"
-					}
-				},
 				"@babel/parser": {
-					"version": "7.14.9",
-					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.9.tgz",
-					"integrity": "sha512-RdUTOseXJ8POjjOeEBEvNMIZU/nm4yu2rufRkcibzkkg7DmQvXU8v3M4Xk9G7uuI86CDGkKcuDWgioqZm+mScQ=="
+					"version": "7.16.12",
+					"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.16.12.tgz",
+					"integrity": "sha512-VfaV15po8RiZssrkPweyvbGVSe4x2y+aciFCgn0n0/SJMR22cwofRV1mtnJQYcSB1wUTaA/X1LnA3es66MCO5A=="
 				}
 			}
 		},
 		"@babel/types": {
-			"version": "7.14.9",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.14.9.tgz",
-			"integrity": "sha512-u0bLTnv3DFHeaQLYzb7oRJ1JHr1sv/SYDM7JSqHFFLwXG1wTZRughxFI5NCP8qBEo1rVVsn7Yg2Lvw49nne/Ow==",
+			"version": "7.16.8",
+			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.16.8.tgz",
+			"integrity": "sha512-smN2DQc5s4M7fntyjGtyIPbRJv6wW4rU/94fmYJ7PKQuZkC0qGMHXJbg6sNGt12JmVr4k5YaptI/XtiLJBnmIg==",
 			"requires": {
-				"@babel/helper-validator-identifier": "^7.14.9",
+				"@babel/helper-validator-identifier": "^7.16.7",
 				"to-fast-properties": "^2.0.0"
-			},
-			"dependencies": {
-				"@babel/helper-validator-identifier": {
-					"version": "7.14.9",
-					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
-					"integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g=="
-				}
 			}
 		},
 		"@types/babel__core": {
@@ -321,21 +300,21 @@
 			}
 		},
 		"browserslist": {
-			"version": "4.16.6",
-			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.16.6.tgz",
-			"integrity": "sha512-Wspk/PqO+4W9qp5iUTJsa1B/QrYn1keNCcEP5OvP7WBwT4KaDly0uONYmC6Xa3Z5IqnUgS0KcgLYu1l74x0ZXQ==",
+			"version": "4.19.1",
+			"resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.19.1.tgz",
+			"integrity": "sha512-u2tbbG5PdKRTUoctO3NBD8FQ5HdPh1ZXPHzp1rwaa5jTc+RV9/+RlWiAIKmjRPQF+xbGM9Kklj5bZQFa2s/38A==",
 			"requires": {
-				"caniuse-lite": "^1.0.30001219",
-				"colorette": "^1.2.2",
-				"electron-to-chromium": "^1.3.723",
+				"caniuse-lite": "^1.0.30001286",
+				"electron-to-chromium": "^1.4.17",
 				"escalade": "^3.1.1",
-				"node-releases": "^1.1.71"
+				"node-releases": "^2.0.1",
+				"picocolors": "^1.0.0"
 			}
 		},
 		"caniuse-lite": {
-			"version": "1.0.30001248",
-			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001248.tgz",
-			"integrity": "sha512-NwlQbJkxUFJ8nMErnGtT0QTM2TJ33xgz4KXJSMIrjXIbDVdaYueGyjOrLKRtJC+rTiWfi6j5cnZN1NBiSBJGNw=="
+			"version": "1.0.30001303",
+			"resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001303.tgz",
+			"integrity": "sha512-/Mqc1oESndUNszJP0kx0UaQU9kEv9nNtJ7Kn8AdA0mNnH8eR1cj0kG+NbNuC1Wq/b21eA8prhKRA3bbkjONegQ=="
 		},
 		"chalk": {
 			"version": "2.4.2",
@@ -360,11 +339,6 @@
 			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
 			"integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU="
 		},
-		"colorette": {
-			"version": "1.2.2",
-			"resolved": "https://registry.npmjs.org/colorette/-/colorette-1.2.2.tgz",
-			"integrity": "sha512-MKGMzyfeuutC/ZJ1cba9NqcNpfeqMUcYmyF1ZFY6/Cn7CNSAKx6a+s48sqLqyAiZuaP2TcqMhoo+dlwFnVxT9w=="
-		},
 		"convert-source-map": {
 			"version": "1.8.0",
 			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
@@ -374,17 +348,17 @@
 			}
 		},
 		"debug": {
-			"version": "4.3.2",
-			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.2.tgz",
-			"integrity": "sha512-mOp8wKcvj7XxC78zLgw/ZA+6TSgkoE2C/ienthhRD298T7UNwAg9diBpLRxC0mOezLl4B0xV7M0cCO6P/O0Xhw==",
+			"version": "4.3.3",
+			"resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+			"integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
 			"requires": {
 				"ms": "2.1.2"
 			}
 		},
 		"electron-to-chromium": {
-			"version": "1.3.789",
-			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.3.789.tgz",
-			"integrity": "sha512-lK4xn6C6ZF1kgLaC/EhOtC1MSKENExj3rMwGVnBTfHW81Z/Hb1Rge5YaWawN/YOXy3xCaESuE4KWSD50kOZ9rQ=="
+			"version": "1.4.54",
+			"resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.54.tgz",
+			"integrity": "sha512-jRAoneRdSxnpRHO0ANpnEUtQHXxlgfVjrLOnQSisw1ryjXJXvS0pJaR/v2B7S++/tRjgEDp4Sjn5nmgb6uTySw=="
 		},
 		"escalade": {
 			"version": "3.1.1",
@@ -440,9 +414,14 @@
 			"integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
 		},
 		"node-releases": {
-			"version": "1.1.73",
-			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-1.1.73.tgz",
-			"integrity": "sha512-uW7fodD6pyW2FZNZnp/Z3hvWKeEW1Y8R1+1CnErE8cXFXzl5blBOoVB41CvMer6P6Q0S5FXDwcHgFd1Wj0U9zg=="
+			"version": "2.0.1",
+			"resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.1.tgz",
+			"integrity": "sha512-CqyzN6z7Q6aMeF/ktcMVTzhAHCEpf8SOarwpzpf8pNBY2k5/oM34UHldUwp8VKI7uxct2HxSRdJjBaZeESzcxA=="
+		},
+		"picocolors": {
+			"version": "1.0.0",
+			"resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.0.tgz",
+			"integrity": "sha512-1fygroTLlHu66zi26VoTDv8yRgm0Fccecssto+MhsZ0D/DGW2sm8E8AjW7NU5VVTRt5GxbeZ5qBuJr+HyLYkjQ=="
 		},
 		"safe-buffer": {
 			"version": "5.1.2",

--- a/packages/async-rewriter2/package.json
+++ b/packages/async-rewriter2/package.json
@@ -5,6 +5,7 @@
   "main": "./lib/index.js",
   "scripts": {
     "pretest": "npm run compile-ts",
+    "benchmark": "node -r ts-node/register benchmark/index.ts",
     "test": "mocha --experimental-vm-modules -r \"../../scripts/import-expansions.js\" --timeout 60000 -r ts-node/register \"./{src,lib}/**/*.spec.ts\"",
     "test-ci": "node ../../scripts/run-if-package-requested.js npm test",
     "lint": "eslint --report-unused-disable-directives \"./{src,test}/**/*.{js,ts,tsx}\"",
@@ -35,6 +36,6 @@
     "@babel/plugin-transform-parameters": "^7.14.5",
     "@babel/plugin-transform-shorthand-properties": "^7.14.5",
     "@babel/types": "^7.14.9",
-    "@types/babel__core": "^7.1.15"
+    "@types/babel__core": "^7.1.18"
   }
 }

--- a/packages/async-rewriter2/package.json
+++ b/packages/async-rewriter2/package.json
@@ -31,11 +31,11 @@
     "unitTestsOnly": true
   },
   "dependencies": {
-    "@babel/core": "^7.14.8",
-    "@babel/plugin-transform-destructuring": "^7.14.7",
-    "@babel/plugin-transform-parameters": "^7.14.5",
-    "@babel/plugin-transform-shorthand-properties": "^7.14.5",
-    "@babel/types": "^7.14.9",
+    "@babel/core": "^7.16.12",
+    "@babel/plugin-transform-destructuring": "^7.16.7",
+    "@babel/plugin-transform-parameters": "^7.16.7",
+    "@babel/plugin-transform-shorthand-properties": "^7.16.7",
+    "@babel/types": "^7.16.8",
     "@types/babel__core": "^7.1.18"
   }
 }

--- a/packages/async-rewriter2/src/async-writer-babel.spec.ts
+++ b/packages/async-rewriter2/src/async-writer-babel.spec.ts
@@ -824,11 +824,11 @@ describe('AsyncWriter', () => {
 
       it('lets us not worry about special characters', () => {
         expect(runTranspiledCode('Function.prototype.toString.call(() => {\n  method();\n})'))
-          .to.equal('() => {\n    method();\n  }');
+          .to.equal('() => {\n  method();\n}');
         expect(runTranspiledCode('Function.prototype.toString.call(() => { const 八 = 8; })'))
-          .to.equal('() => {\n    const 八 = 8;\n  }');
+          .to.equal('() => { const 八 = 8; }');
         expect(runTranspiledCode('Function.prototype.toString.call(() => { const str = \'"extra quotes"\'; })'))
-          .to.equal('() => {\n    const str = \'"extra quotes"\';\n  }');
+          .to.equal('() => { const str = \'"extra quotes"\'; }');
       });
     });
   });

--- a/packages/async-rewriter2/src/async-writer-babel.spec.ts
+++ b/packages/async-rewriter2/src/async-writer-babel.spec.ts
@@ -441,6 +441,45 @@ describe('AsyncWriter', () => {
         .to.deep.equal({ y: 'y' });
     });
 
+    it('supports awaiting destructured objects', async() => {
+      implicitlyAsyncFn.resolves({ foo: 'bar' });
+      const ret = runTranspiledCode(`
+      const { foo } = implicitlyAsyncFn();
+      foo`);
+      expect(ret.constructor.name).to.equal('Promise');
+      expect(ret[Symbol.for('@@mongosh.syntheticPromise')]).to.equal(true);
+      expect(await ret).to.equal('bar');
+    });
+
+    it('supports awaiting destructured arrays', async() => {
+      implicitlyAsyncFn.resolves([ 'bar' ]);
+      const ret = runTranspiledCode(`
+      const [ foo ] = implicitlyAsyncFn();
+      foo`);
+      expect(ret.constructor.name).to.equal('Promise');
+      expect(ret[Symbol.for('@@mongosh.syntheticPromise')]).to.equal(true);
+      expect(await ret).to.equal('bar');
+    });
+
+    it('supports awaiting nested destructured objects', async() => {
+      implicitlyAsyncFn.resolves({ nested: [{ foo: 'bar' }] });
+      const ret = runTranspiledCode(`
+      const { nested: [{ foo }] } = implicitlyAsyncFn();
+      foo`);
+      expect(ret.constructor.name).to.equal('Promise');
+      expect(ret[Symbol.for('@@mongosh.syntheticPromise')]).to.equal(true);
+      expect(await ret).to.equal('bar');
+    });
+
+    it('supports awaiting destructured function parameters', async() => {
+      implicitlyAsyncFn.resolves({ nested: [{ foo: 'bar' }] });
+      const ret = runTranspiledCode(`
+      (({ nested: [{ foo }] } = {}) => foo)(implicitlyAsyncFn())`);
+      expect(ret.constructor.name).to.equal('Promise');
+      expect(ret[Symbol.for('@@mongosh.syntheticPromise')]).to.equal(true);
+      expect(await ret).to.equal('bar');
+    });
+
     context('invalid implicit awaits', () => {
       beforeEach(() => {
         runUntranspiledCode(asyncWriter.runtimeSupportCode());

--- a/packages/async-rewriter2/src/async-writer-babel.spec.ts
+++ b/packages/async-rewriter2/src/async-writer-babel.spec.ts
@@ -788,6 +788,8 @@ describe('AsyncWriter', () => {
           .to.equal('() => {\n    method();\n  }');
         expect(runTranspiledCode('Function.prototype.toString.call(() => { const 八 = 8; })'))
           .to.equal('() => {\n    const 八 = 8;\n  }');
+        expect(runTranspiledCode('Function.prototype.toString.call(() => { const str = \'"extra quotes"\'; })'))
+          .to.equal('() => {\n    const str = \'"extra quotes"\';\n  }');
       });
     });
   });

--- a/packages/async-rewriter2/src/runtime-support.nocov.js
+++ b/packages/async-rewriter2/src/runtime-support.nocov.js
@@ -495,11 +495,10 @@ module.exports = '(' + function() {
   const origFptS = Function.prototype.toString;
   Function.prototype.toString = function() {
     const source = origFptS.call(this, arguments);
-    const match = source.match(/^[^"]*"<async_rewriter>(?<encoded>[a-z0-9]+)<\/>";/);
+    const match = source.match(/^[^"]*"<async_rewriter>(?<encoded>[^<]*)<\/>";/);
     if (match) {
-      // Decode using hex + UTF-16
-      return String.fromCharCode(
-        ...match.groups.encoded.match(/.{4}/g).map(hex => parseInt(hex, 16)));
+      // Decode using percent encoding
+      return decodeURIComponent(match.groups.encoded);
     }
     return source;
   };

--- a/packages/async-rewriter2/src/stages/transform-maybe-await.ts
+++ b/packages/async-rewriter2/src/stages/transform-maybe-await.ts
@@ -166,10 +166,9 @@ export default ({ types: t }: { types: typeof BabelTypes }): babel.PluginObj<{ f
         const originalSource = path.parent.start !== undefined ?
           this.file.code.slice(path.parent.start ?? undefined, path.parent.end ?? undefined) :
           'function () { [unknown code] }';
-        // Encode using UTF-16 + hex encoding so we don't have to worry about
+        // Encode using percent encoding so we don't have to worry about
         // special characters.
-        const encodedOriginalSource =
-          [...originalSource].map(char => char.charCodeAt(0).toString(16).padStart(4, '0')).join('');
+        const encodedOriginalSource = encodeURIComponent(originalSource);
         const originalSourceNode = t.expressionStatement(
           t.stringLiteral(`<async_rewriter>${encodedOriginalSource}</>`));
 


### PR DESCRIPTION
##### chore(async-rewriter): add benchmark script


##### chore(async-rewriter): use percent encoding instead of UTF-16

This gives a ~5 % performance boost.

##### test(async-rewriter): add tests for destructured reads

So I don’t run into the temptation to remove the destructuring plugin
(without ensuring that everything still works properly).

##### chore(async-rewriter): bump babel versions to latest

This does not appear to have a significant performace impact,
but should be done sooner or later anyway.

##### chore(async-rewriter): keep ast between babel passes

This improves performance by ~20 %.
