### PR TITLE
feat: expand config support MONGOSH-{1063,1055,959}

### DIFF
--- a/packages/cli-repl/package-lock.json
+++ b/packages/cli-repl/package-lock.json
@@ -40,6 +40,12 @@
 				"@types/chai": "*"
 			}
 		},
+		"@types/js-yaml": {
+			"version": "4.0.5",
+			"resolved": "https://registry.npmjs.org/@types/js-yaml/-/js-yaml-4.0.5.tgz",
+			"integrity": "sha512-FhpRzf927MNQdRZP0J5DLIdTXhjLYzeUTmLAu69mnVksLH9CJY3IuSeEgbKUki7GQZm0WqDkGzyxju2EZGD2wA==",
+			"dev": true
+		},
 		"@types/lodash": {
 			"version": "4.14.163",
 			"resolved": "https://registry.npmjs.org/@types/lodash/-/lodash-4.14.163.tgz",

--- a/packages/cli-repl/package.json
+++ b/packages/cli-repl/package.json
@@ -72,6 +72,7 @@
     "@types/analytics-node": "^3.1.3",
     "@types/ansi-escape-sequences": "^4.0.0",
     "@types/chai-as-promised": "^7.1.3",
+    "@types/js-yaml": "^4.0.5",
     "@types/lodash.set": "^4.3.6",
     "@types/node": "^14.14.5",
     "@types/text-table": "^0.2.1",

--- a/packages/cli-repl/src/arg-parser.ts
+++ b/packages/cli-repl/src/arg-parser.ts
@@ -162,7 +162,7 @@ export function parseCliArgs(args: string[]): (CliOptions & { smokeTests: boolea
   for (const arg of positionalArguments) {
     if (arg.startsWith('-')) {
       throw new Error(
-        `  ${clr(i18n.__(UNKNOWN), ['red', 'bold'])} ${clr(String(arg), 'bold')}
+        `  ${clr(i18n.__(UNKNOWN), 'mongosh:error')} ${clr(String(arg), 'bold')}
         ${USAGE}`
       );
     }

--- a/packages/cli-repl/src/cli-repl.spec.ts
+++ b/packages/cli-repl/src/cli-repl.spec.ts
@@ -102,9 +102,8 @@ describe('CliRepl', () => {
         const updateUser = waitBus(cliRepl.bus, 'mongosh:update-user');
         const evalComplete = waitBus(cliRepl.bus, 'mongosh:eval-complete');
         input.write('disableTelemetry()\n');
-        const [ userId, enableTelemetry ] = await updateUser;
+        const [ userId ] = await updateUser;
         expect(typeof userId).to.equal('string');
-        expect(enableTelemetry).to.equal(false);
 
         await evalComplete; // eval-complete includes the fs.writeFile() call.
         const content = await fs.readFile(path.join(tmpdir.path, 'config'), { encoding: 'utf8' });

--- a/packages/cli-repl/src/cli-repl.spec.ts
+++ b/packages/cli-repl/src/cli-repl.spec.ts
@@ -235,6 +235,23 @@ describe('CliRepl', () => {
         expect(output).to.match(/^[a-z0-9]{24}\n> $/);
       });
 
+      it('can restore previous config settings', async() => {
+        output = '';
+        input.write('config.set("editor", "vim")\n');
+        await waitEval(cliRepl.bus);
+        expect(output).to.include('Setting "editor" has been changed');
+
+        output = '';
+        input.write('config.reset("editor")\n');
+        await waitEval(cliRepl.bus);
+        expect(output).to.include('Setting "editor" has been reset to its default value');
+
+        output = '';
+        input.write('config.get("editor")\n');
+        await waitEval(cliRepl.bus);
+        expect(output).to.include('null');
+      });
+
       context('loading JS files from disk', () => {
         it('allows loading a file from the disk', async() => {
           const filenameA = path.resolve(__dirname, '..', 'test', 'fixtures', 'load', 'a.js');

--- a/packages/cli-repl/src/cli-repl.ts
+++ b/packages/cli-repl/src/cli-repl.ts
@@ -19,7 +19,7 @@ import { ConfigManager, ShellHomeDirectory, ShellHomePaths } from './config-dire
 import { CliReplErrors } from './error-codes';
 import { MongoLogManager, MongoLogWriter, mongoLogId } from 'mongodb-log-writer';
 import { MongocryptdManager } from './mongocryptd-manager';
-import MongoshNodeRepl, { MongoshNodeReplOptions } from './mongosh-repl';
+import MongoshNodeRepl, { MongoshNodeReplOptions, MongoshIOProvider } from './mongosh-repl';
 import { setupLoggerAndTelemetry, ToggleableAnalytics } from '@mongosh/logging';
 import { MongoshBus, CliUserConfig, CliUserConfigValidator } from '@mongosh/types';
 import { promises as fs } from 'fs';
@@ -73,7 +73,7 @@ type CliUserConfigOnDisk = Partial<CliUserConfig> & Pick<CliUserConfig, 'enableT
  *
  * Unlike MongoshNodeRepl, this class implements I/O interactions.
  */
-class CliRepl {
+class CliRepl implements MongoshIOProvider {
   mongoshRepl: MongoshNodeRepl;
   bus: MongoshBus;
   cliOptions: CliOptions;

--- a/packages/cli-repl/src/cli-repl.ts
+++ b/packages/cli-repl/src/cli-repl.ts
@@ -326,11 +326,11 @@ class CliRepl {
       // when running `mongosh --eval --shell "eval script"`, which can happen
       // if you're like me and sometimes insert options in the wrong place
       const msg = 'Warning: --eval requires an argument, but no argument was given\n';
-      this.output.write(this.clr(msg, ['bold', 'yellow']));
+      this.output.write(this.clr(msg, 'mongosh:warning'));
     }
     for (const file of files) {
       if (!this.cliOptions.quiet) {
-        this.output.write(`Loading file: ${this.clr(file, ['bold', 'blue'])}\n`);
+        this.output.write(`Loading file: ${this.clr(file, 'mongosh:filename')}\n`);
       }
       await this.mongoshRepl.loadExternalFile(file);
     }
@@ -357,7 +357,7 @@ class CliRepl {
         this.bus.emit('mongosh:mongoshrc-load');
         await this.mongoshRepl.loadExternalFile(mongoshrcPath);
       } catch (err) {
-        this.output.write(this.clr('Error while running ~/.mongoshrc.js:\n', ['bold', 'yellow']));
+        this.output.write(this.clr('Error while running ~/.mongoshrc.js:\n', 'mongosh:warning'));
         this.output.write(this.mongoshRepl.writer(err) + '\n');
       }
       return;
@@ -377,7 +377,7 @@ class CliRepl {
       const msg =
         'Warning: Found ~/.mongorc.js, but not ~/.mongoshrc.js. ~/.mongorc.js will not be loaded.\n' +
         '  You may want to copy or rename ~/.mongorc.js to ~/.mongoshrc.js.\n';
-      this.output.write(this.clr(msg, ['bold', 'yellow']));
+      this.output.write(this.clr(msg, 'mongosh:warning'));
       return;
     }
 
@@ -389,7 +389,7 @@ class CliRepl {
     if (hasMisspelledFilename) {
       const msg =
         'Warning: Found ~/.mongoshrc, but not ~/.mongoshrc.js. Did you forget to add .js?\n';
-      this.output.write(this.clr(msg, ['bold', 'yellow']));
+      this.output.write(this.clr(msg, 'mongosh:warning'));
     }
   }
 
@@ -418,7 +418,7 @@ class CliRepl {
         const validationResult = await CliUserConfigValidator.validate(key, value);
         if (validationResult) {
           const msg = `Warning: Ignoring config option "${key}" from ${filename}: ${validationResult}\n`;
-          this.output.write(this.clr(msg, ['bold', 'yellow']));
+          this.output.write(this.clr(msg, 'mongosh:warning'));
           delete config[key];
         }
       }
@@ -426,7 +426,7 @@ class CliRepl {
     } catch (err) {
       this.bus.emit('mongosh:error', err, 'config');
       const msg = `Warning: Could not parse global configuration file at ${filename}: ${err.message}\n`;
-      this.output.write(this.clr(msg, ['bold', 'yellow']));
+      this.output.write(this.clr(msg, 'mongosh:warning'));
       return {};
     }
   }
@@ -444,7 +444,7 @@ class CliRepl {
     }
     this.warnedAboutInaccessibleFiles = true;
     const msg = `Warning: Could not access file${path ? 'at ' + path : ''}: ${err.message}\n`;
-    this.output.write(this.clr(msg, ['bold', 'yellow']));
+    this.output.write(this.clr(msg, 'mongosh:warning'));
   }
 
   /**
@@ -455,7 +455,7 @@ class CliRepl {
    */
   async connect(driverUri: string, driverOptions: MongoClientOptions): Promise<CliServiceProvider> {
     if (!this.cliOptions.nodb && !this.cliOptions.quiet) {
-      this.output.write(i18n.__(CONNECTING) + '\t\t' + this.clr(redactURICredentials(driverUri), ['bold', 'green']) + '\n');
+      this.output.write(i18n.__(CONNECTING) + '\t\t' + this.clr(redactURICredentials(driverUri), 'mongosh:uri') + '\n');
     }
     return await CliServiceProvider.connect(driverUri, driverOptions, this.cliOptions, this.bus);
   }

--- a/packages/cli-repl/src/clr.ts
+++ b/packages/cli-repl/src/clr.ts
@@ -1,10 +1,31 @@
 import ansi from 'ansi-escape-sequences';
 
-export type StyleDefinition = Parameters<typeof ansi.format>[1];
+type MongoshStyle = 'warning' | 'error' | 'section-header' | 'uri' | 'filename' | 'additional-error-info';
+export type StyleDefinition = Parameters<typeof ansi.format>[1] | `mongosh:${MongoshStyle}`;
 
 /** Optionally colorize a string, given a set of style definition(s). */
 export default function colorize(text: string, style: StyleDefinition, options: { colors: boolean }): string {
   if (options.colors) {
+    switch (style) {
+      case 'mongosh:section-header':
+      case 'mongosh:warning':
+        style = ['bold', 'yellow'];
+        break;
+      case 'mongosh:error':
+        style = ['bold', 'red'];
+        break;
+      case 'mongosh:filename':
+        style = ['bold', 'blue'];
+        break;
+      case 'mongosh:uri':
+        style = ['bold', 'green'];
+        break;
+      case 'mongosh:additional-error-info':
+        style = ['yellow'];
+        break;
+      default:
+        break;
+    }
     return ansi.format(text, style);
   }
   return text;

--- a/packages/cli-repl/src/config-directory.ts
+++ b/packages/cli-repl/src/config-directory.ts
@@ -162,3 +162,30 @@ export function getStoragePaths(): ShellHomePaths {
     shellRcPath: os.homedir()
   };
 }
+
+/**
+ * Compute the list of global configuration files that mongosh uses,
+ * depending on the platform.
+ */
+export function getGlobalConfigPaths(): string[] {
+  const paths: string[] = [];
+
+  if (process.env.MONGOSH_GLOBAL_CONFIG_FILE_FOR_TESTING) {
+    paths.push(process.env.MONGOSH_GLOBAL_CONFIG_FILE_FOR_TESTING);
+  }
+
+  switch (process.platform) {
+    case 'win32':
+      if (process.execPath === process.argv[1]) {
+        paths.push(path.resolve(process.execPath, '..', 'mongosh.cfg'));
+      }
+      return paths;
+    case 'darwin':
+      paths.push('/usr/local/etc/mongosh.conf');
+      paths.push('/opt/homebrew/etc/mongosh.conf');
+      // fallthrough
+    default:
+      paths.push('/etc/mongosh.conf');
+      return paths;
+  }
+}

--- a/packages/cli-repl/src/constants.ts
+++ b/packages/cli-repl/src/constants.ts
@@ -16,7 +16,7 @@ export const USAGE = `
 
   ${clr(i18n.__('cli-repl.args.usage'), 'bold')}
 
-  ${clr(i18n.__('cli-repl.args.options'), ['bold', 'yellow'])}
+  ${clr(i18n.__('cli-repl.args.options'), 'mongosh:section-header')}
 
     -h, --help                                 ${i18n.__('cli-repl.args.help')}
     -f, --file [arg]                           ${i18n.__('cli-repl.args.file')}
@@ -31,7 +31,7 @@ export const USAGE = `
         --eval [arg]                           ${i18n.__('cli-repl.args.eval')}
         --retryWrites                          ${i18n.__('cli-repl.args.retryWrites')}
 
-  ${clr(i18n.__('cli-repl.args.authenticationOptions'), ['bold', 'yellow'])}
+  ${clr(i18n.__('cli-repl.args.authenticationOptions'), 'mongosh:section-header')}
 
     -u, --username [arg]                       ${i18n.__('cli-repl.args.username')}
     -p, --password [arg]                       ${i18n.__('cli-repl.args.password')}
@@ -42,7 +42,7 @@ export const USAGE = `
         --sspiHostnameCanonicalization [arg]   ${i18n.__('cli-repl.args.sspiHostnameCanonicalization')}
         --sspiRealmOverride [arg]              ${i18n.__('cli-repl.args.sspiRealmOverride')}
 
-  ${clr(i18n.__('cli-repl.args.tlsOptions'), ['bold', 'yellow'])}
+  ${clr(i18n.__('cli-repl.args.tlsOptions'), 'mongosh:section-header')}
 
         --tls                                  ${i18n.__('cli-repl.args.tls')}
         --tlsCertificateKeyFile [arg]          ${i18n.__('cli-repl.args.tlsCertificateKeyFile')}
@@ -54,13 +54,13 @@ export const USAGE = `
         --tlsCRLFile [arg]                     ${i18n.__('cli-repl.args.tlsCRLFile')}
         --tlsDisabledProtocols [arg]           ${i18n.__('cli-repl.args.tlsDisabledProtocols')}
 
-  ${clr(i18n.__('cli-repl.args.apiVersionOptions'), ['bold', 'yellow'])}
+  ${clr(i18n.__('cli-repl.args.apiVersionOptions'), 'mongosh:section-header')}
 
         --apiVersion [arg]                     ${i18n.__('cli-repl.args.apiVersion')}
         --apiStrict                            ${i18n.__('cli-repl.args.apiStrict')}
         --apiDeprecationErrors                 ${i18n.__('cli-repl.args.apiDeprecationErrors')}
 
-  ${clr(i18n.__('cli-repl.args.fleOptions'), ['bold', 'yellow'])}
+  ${clr(i18n.__('cli-repl.args.fleOptions'), 'mongosh:section-header')}
 
         --awsAccessKeyId [arg]                 ${i18n.__('cli-repl.args.awsAccessKeyId')}
         --awsSecretAccessKey [arg]             ${i18n.__('cli-repl.args.awsSecretAccessKey')}
@@ -68,21 +68,21 @@ export const USAGE = `
         --keyVaultNamespace [arg]              ${i18n.__('cli-repl.args.keyVaultNamespace')}
         --kmsURL [arg]                         ${i18n.__('cli-repl.args.kmsURL')}
 
-  ${clr(i18n.__('cli-repl.args.dbAddressOptions'), ['bold', 'yellow'])}
+  ${clr(i18n.__('cli-repl.args.dbAddressOptions'), 'mongosh:section-header')}
 
         foo                                    ${i18n.__('cli-repl.args.dbAddress/foo')}
         192.168.0.5/foo                        ${i18n.__('cli-repl.args.dbAddress/192/foo')}
         192.168.0.5:9999/foo                   ${i18n.__('cli-repl.args.dbAddress/192/host/foo')}
         mongodb://192.168.0.5:9999/foo         ${i18n.__('cli-repl.args.dbAddress/connectionURI')}
 
-  ${clr(i18n.__('cli-repl.args.fileNames'), ['bold', 'yellow'])}
+  ${clr(i18n.__('cli-repl.args.fileNames'), 'mongosh:section-header')}
 
         ${i18n.__('cli-repl.args.filenameDescription')}
 
-  ${clr(i18n.__('cli-repl.args.examples'), ['bold', 'yellow'])}
+  ${clr(i18n.__('cli-repl.args.examples'), 'mongosh:section-header')}
 
         ${i18n.__('cli-repl.args.connectionExampleWithDatabase')}
-        ${clr('$ mongosh mongodb://192.168.0.5:9999/ships', 'green')}
+        ${clr('$ mongosh mongodb://192.168.0.5:9999/ships', 'mongosh:uri')}
 
-  ${clr(i18n.__('cli-repl.args.moreInformation'), 'bold')} ${clr('https://docs.mongodb.com/mongodb-shell', 'green')}.
+  ${clr(i18n.__('cli-repl.args.moreInformation'), 'bold')} ${clr('https://docs.mongodb.com/mongodb-shell', 'mongosh:uri')}.
 `.replace(/\n$/, '').replace(/^\n/, '');

--- a/packages/cli-repl/src/format-output.ts
+++ b/packages/cli-repl/src/format-output.ts
@@ -152,7 +152,7 @@ function formatDatabases(output: any[], options: FormatOptions): string {
 
 function formatStats(output: Record<string, any>, options: FormatOptions): string {
   return Object.keys(output).map((c) => {
-    return `${clr(c, ['bold', 'yellow'], options)}\n` +
+    return `${clr(c, 'mongosh:section-header', options)}\n` +
       `${inspect(output[c], options)}`;
   }).join('\n---\n');
 }
@@ -166,7 +166,7 @@ function formatListCommands(output: Record<string, any>, options: FormatOptions)
           return `${str} ${clr(k, ['bold', 'white'], options)}`;
         }
         return str;
-      }, `${clr(cmd, ['bold', 'yellow'], options)}: `);
+      }, `${clr(cmd, 'mongosh:section-header', options)}: `);
       result += val.help ? `\n${clr(val.help, 'green', options)}` : '';
       return result;
     }
@@ -176,7 +176,7 @@ function formatListCommands(output: Record<string, any>, options: FormatOptions)
 
 export function formatError(error: Error, options: FormatOptions): string {
   let result = '';
-  if (error.name) result += `\r${clr(error.name, ['bold', 'red'], options)}: `;
+  if (error.name) result += `\r${clr(error.name, 'mongosh:error', options)}: `;
   if (error.message) result += error.message;
   if (isShouldReportAsBugError(error)) {
     result += '\nThis is an error inside mongosh. Please file a bug report for the MONGOSH project here: https://jira.mongodb.org/projects/MONGOSH/issues.';
@@ -199,11 +199,11 @@ export function formatError(error: Error, options: FormatOptions): string {
     result += error.stack.slice(error.stack.indexOf('\n'));
   }
   if ((error as any).errInfo) {
-    result += `\n${clr(i18n.__('cli-repl.cli-repl.additionalErrorInfo'), ['yellow'], options)}: `;
+    result += `\n${clr(i18n.__('cli-repl.cli-repl.additionalErrorInfo'), 'mongosh:additional-error-info', options)}: `;
     result += inspect((error as any).errInfo, options);
   }
   if ((error as any).result) {
-    result += `\n${clr(i18n.__('cli-repl.cli-repl.additionalErrorResult'), ['yellow'], options)}: `;
+    result += `\n${clr(i18n.__('cli-repl.cli-repl.additionalErrorResult'), 'mongosh:additional-error-info', options)}: `;
     result += inspect((error as any).result, options);
   }
 
@@ -266,7 +266,7 @@ function formatHelp(value: HelpProperties, options: FormatOptions): string {
   let helpMenu = '';
 
   if (value.help) {
-    helpMenu += `\n  ${clr(`${value.help}:`, ['yellow', 'bold'], options)}\n\n`;
+    helpMenu += `\n  ${clr(`${value.help}:`, 'mongosh:section-header', options)}\n\n`;
   }
 
   (value.attr || []).forEach((method) => {
@@ -294,7 +294,7 @@ function formatHelp(value: HelpProperties, options: FormatOptions): string {
 
   if (value.docs) {
     helpMenu += `\n  ${clr(i18n.__('cli-repl.args.moreInformation'), 'bold', options)} ` +
-      `${clr(value.docs, ['green', 'bold'], options)}`;
+      `${clr(value.docs, 'mongosh:uri', options)}`;
   }
 
   return helpMenu;

--- a/packages/cli-repl/src/mongosh-repl.ts
+++ b/packages/cli-repl/src/mongosh-repl.ts
@@ -412,7 +412,7 @@ class MongoshNodeRepl implements EvaluationListener {
     if (!this.shellCliOptions.nodb) {
       text += `Using MongoDB:\t\t${mongodVersion}\n`;
     }
-    text += `${this.clr('Using Mongosh', ['bold', 'yellow'])}:\t\t${version}\n`;
+    text += `${this.clr('Using Mongosh', 'mongosh:section-header')}:\t\t${version}\n`;
     text += `${MONGOSH_WIKI}\n`;
     if (!await this.getConfig('disableGreetingMessage')) {
       text += `${TELEMETRY_GREETING_MESSAGE}\n`;
@@ -446,8 +446,8 @@ class MongoshNodeRepl implements EvaluationListener {
     }
 
     let text = '';
-    text += `${this.clr('------', ['bold', 'yellow'])}\n`;
-    text += `   ${this.clr('The server generated these startup warnings when booting:', ['bold', 'yellow'])}\n`;
+    text += `${this.clr('------', 'mongosh:section-header')}\n`;
+    text += `   ${this.clr('The server generated these startup warnings when booting:', 'mongosh:warning')}\n`;
     result.log.forEach(logLine => {
       try {
         const entry: LogEntry = parseAnyLogEntry(logLine);
@@ -456,7 +456,7 @@ class MongoshNodeRepl implements EvaluationListener {
         text += `   Unexpected log line format: ${logLine}\n`;
       }
     });
-    text += `${this.clr('------', ['bold', 'yellow'])}\n`;
+    text += `${this.clr('------', 'mongosh:section-header')}\n`;
     text += '\n';
     this.output.write(text);
   }
@@ -478,7 +478,7 @@ class MongoshNodeRepl implements EvaluationListener {
       err = error;
     }
 
-    const text = this.clr('The server failed to respond to a ping and may be unavailable:', ['bold', 'yellow']);
+    const text = this.clr('The server failed to respond to a ping and may be unavailable:', 'mongosh:warning');
     this.output.write(text + '\n' + this.formatError(err) + '\n');
   }
 
@@ -612,7 +612,7 @@ class MongoshNodeRepl implements EvaluationListener {
       this.output.write(this.clr(
         `\nWARNING: Operations running on the server cannot be killed automatically for MongoDB ${mongodVersion}.` +
         '\n         Please make sure to kill them manually. Killing operations is supported starting with MongoDB 4.1.',
-        ['bold', 'yellow']
+        'mongosh:warning'
       ));
     }
 

--- a/packages/cli-repl/src/mongosh-repl.ts
+++ b/packages/cli-repl/src/mongosh-repl.ts
@@ -192,6 +192,7 @@ class MongoshNodeRepl implements EvaluationListener {
     this.inspectCompact = await this.getConfig('inspectCompact');
     this.inspectDepth = await this.getConfig('inspectDepth');
     this.showStackTraces = await this.getConfig('showStackTraces');
+    this.redactHistory = await this.getConfig('redactHistory');
 
     const repl = asyncRepl.start({
       start: prettyRepl.start,

--- a/packages/cli-repl/src/mongosh-repl.ts
+++ b/packages/cli-repl/src/mongosh-repl.ts
@@ -33,7 +33,7 @@ export type MongoshCliOptions = ShellCliOptions & {
  * An interface that contains everything necessary for {@link MongoshNodeRepl}
  * instances to actually perform I/O operations.
  */
-export type MongoshIOProvider = Omit<ConfigProvider<CliUserConfig>, 'validateConfig'> & {
+export type MongoshIOProvider = Omit<ConfigProvider<CliUserConfig>, 'validateConfig' | 'resetConfig'> & {
   getHistoryFilePath(): string;
   exit(code?: number): Promise<never>;
   readFileUTF8(filename: string): Promise<{ contents: string, absolutePath: string }>;
@@ -831,6 +831,13 @@ class MongoshNodeRepl implements EvaluationListener {
       }
     }
     return result;
+  }
+
+  /**
+   * Implements resetConfig from the {@link ConfigProvider} interface.
+   */
+  async resetConfig<K extends keyof CliUserConfig>(key: K): Promise<'success' | 'ignored'> {
+    return await this.setConfig(key, (new CliUserConfig())[key]);
   }
 
   /**

--- a/packages/cli-repl/src/run.ts
+++ b/packages/cli-repl/src/run.ts
@@ -1,4 +1,5 @@
-import { CliRepl, parseCliArgs, mapCliToDriver, getStoragePaths, getMongocryptdPaths, runSmokeTests, USAGE, buildInfo } from './index';
+import { CliRepl, parseCliArgs, mapCliToDriver, getMongocryptdPaths, runSmokeTests, USAGE, buildInfo } from './index';
+import { getStoragePaths, getGlobalConfigPaths } from './config-directory';
 import { generateUri } from '@mongosh/service-provider-server';
 import { redactURICredentials } from '@mongosh/history';
 import { runMain } from 'module';
@@ -87,6 +88,7 @@ import stream from 'stream';
       setTerminalWindowTitle(title);
 
       const shellHomePaths = getStoragePaths();
+      const globalConfigPaths = getGlobalConfigPaths();
       repl = new CliRepl({
         shellCliOptions: {
           ...options,
@@ -95,7 +97,8 @@ import stream from 'stream';
         input: process.stdin,
         output: process.stdout,
         onExit: process.exit,
-        shellHomePaths: shellHomePaths
+        shellHomePaths: shellHomePaths,
+        globalConfigPaths: globalConfigPaths
       });
       await repl.start(driverUri, driverOptions);
     }

--- a/packages/cli-repl/test/e2e.spec.ts
+++ b/packages/cli-repl/test/e2e.spec.ts
@@ -895,6 +895,22 @@ describe('e2e', function() {
           const config2 = await readConfig();
           expect(config1.userId).to.equal(config2.userId);
         });
+
+        it('loads a global config file if present', async() => {
+          const globalConfig = path.join(homedir, 'globalconfig.conf');
+          await fs.writeFile(globalConfig, 'mongosh:\n  redactHistory: remove-redact');
+          shell = TestShell.start({
+            args: [ '--nodb' ],
+            env: {
+              ...env,
+              MONGOSH_GLOBAL_CONFIG_FILE_FOR_TESTING: globalConfig
+            },
+            forceTerminal: true
+          });
+          await shell.waitForPrompt();
+          expect(await shell.executeLine('config.get("redactHistory")')).to.include('remove-redact');
+          shell.assertNoErrors();
+        });
       });
 
       describe('telemetry toggling', () => {

--- a/packages/i18n/src/locales/en_US.ts
+++ b/packages/i18n/src/locales/en_US.ts
@@ -177,6 +177,9 @@ const translations: Catalog = {
             },
             set: {
               description: 'Change a configuration value with config.set(key, value)'
+            },
+            reset: {
+              description: 'Reset a configuration value to its default value with config.reset(key)'
             }
           }
         },

--- a/packages/logging/src/analytics-helpers.spec.ts
+++ b/packages/logging/src/analytics-helpers.spec.ts
@@ -1,0 +1,44 @@
+import { expect } from 'chai';
+import { ToggleableAnalytics, MongoshAnalytics } from './analytics-helpers';
+
+describe('ToggleableAnalytics', () => {
+  let events: any[];
+  let target: MongoshAnalytics;
+
+  beforeEach(() => {
+    events = [];
+    target = {
+      identify(info: any) { events.push(['identify', info]); },
+      track(info: any) { events.push(['track', info]); }
+    };
+  });
+
+  it('starts out in paused state and can be toggled on and off', () => {
+    const toggleable = new ToggleableAnalytics(target);
+    expect(events).to.have.lengthOf(0);
+
+    toggleable.identify({ userId: 'me', traits: { platform: '1234' } });
+    toggleable.track({ userId: 'me', event: 'something', properties: { mongosh_version: '1.2.3' } });
+    expect(events).to.have.lengthOf(0);
+
+    toggleable.enable();
+    expect(events).to.have.lengthOf(2);
+
+    toggleable.track({ userId: 'me', event: 'something2', properties: { mongosh_version: '1.2.3' } });
+    expect(events).to.have.lengthOf(3);
+
+    toggleable.pause();
+    toggleable.track({ userId: 'me', event: 'something3', properties: { mongosh_version: '1.2.3' } });
+    expect(events).to.have.lengthOf(3);
+
+    toggleable.disable();
+    expect(events).to.have.lengthOf(3);
+    toggleable.enable();
+
+    expect(events).to.deep.equal([
+      [ 'identify', { userId: 'me', traits: { platform: '1234' } } ],
+      [ 'track', { userId: 'me', event: 'something', properties: { mongosh_version: '1.2.3' } } ],
+      [ 'track', { userId: 'me', event: 'something2', properties: { mongosh_version: '1.2.3' } } ]
+    ]);
+  });
+});

--- a/packages/logging/src/analytics-helpers.ts
+++ b/packages/logging/src/analytics-helpers.ts
@@ -1,0 +1,88 @@
+/**
+ * General interface for an Analytics provider that mongosh can use.
+ */
+export interface MongoshAnalytics {
+  identify(message: {
+    userId: string,
+    traits: { platform: string }
+  }): void;
+
+  track(message: {
+    userId: string,
+    event: string,
+    properties: {
+      // eslint-disable-next-line camelcase
+      mongosh_version: string,
+      [key: string]: any;
+    }
+  }): void;
+}
+
+/**
+ * A no-op implementation of MongoshAnalytics that can be used when
+ * actually connecting to the telemetry provider is not possible
+ * (e.g. because we are running without an API key).
+ */
+export class NoopAnalytics implements MongoshAnalytics {
+  identify(_info: any): void {} // eslint-disable-line @typescript-eslint/no-unused-vars
+  track(_info: any): void {} // eslint-disable-line @typescript-eslint/no-unused-vars
+}
+
+/**
+ * An implementation of MongoshAnalytics that forwards to another implementation
+ * and can be enabled/paused/disabled.
+ */
+export class ToggleableAnalytics implements MongoshAnalytics {
+  _queue: Array<['identify', Parameters<MongoshAnalytics['identify']>] | ['track', Parameters<MongoshAnalytics['track']>]> = [];
+  _state: 'enabled' | 'disabled' | 'paused' = 'paused';
+  _target: MongoshAnalytics;
+
+  constructor(target: MongoshAnalytics = new NoopAnalytics()) {
+    this._target = target;
+  }
+
+  identify(...args: Parameters<MongoshAnalytics['identify']>): void {
+    switch (this._state) {
+      case 'enabled':
+        this._target.identify(...args);
+        break;
+      case 'paused':
+        this._queue.push(['identify', args]);
+        break;
+      default:
+        break;
+    }
+  }
+
+  track(...args: Parameters<MongoshAnalytics['track']>): void {
+    switch (this._state) {
+      case 'enabled':
+        this._target.track(...args);
+        break;
+      case 'paused':
+        this._queue.push(['track', args]);
+        break;
+      default:
+        break;
+    }
+  }
+
+  enable() {
+    this._state = 'enabled';
+    const queue = this._queue;
+    this._queue = [];
+    for (const entry of queue) {
+      if (entry[0] === 'identify') this.identify(...entry[1]);
+      if (entry[0] === 'track') this.track(...entry[1]);
+    }
+  }
+
+  disable() {
+    this._state = 'disabled';
+    this._queue = [];
+  }
+
+  pause() {
+    this._state = 'paused';
+  }
+}

--- a/packages/logging/src/index.ts
+++ b/packages/logging/src/index.ts
@@ -1,1 +1,2 @@
-export { MongoshAnalytics, setupLoggerAndTelemetry } from './setup-logger-and-telemetry';
+export { setupLoggerAndTelemetry } from './setup-logger-and-telemetry';
+export { MongoshAnalytics, ToggleableAnalytics, NoopAnalytics } from './analytics-helpers';

--- a/packages/logging/src/setup-logger-and-telemetry.spec.ts
+++ b/packages/logging/src/setup-logger-and-telemetry.spec.ts
@@ -71,6 +71,7 @@ describe('setupLoggerAndTelemetry', () => {
     bus.emit('mongosh:mongoshrc-load');
     bus.emit('mongosh:mongoshrc-mongorc-warn');
     bus.emit('mongosh:eval-cli-script');
+    bus.emit('mongosh:globalconfig-load', { filename: '/etc/mongosh.conf', found: true });
 
     bus.emit('mongosh:mongocryptd-tryspawn', { spawnPath: ['mongocryptd'], path: 'path' });
     bus.emit('mongosh:mongocryptd-error', { cause: 'something', error: new Error('mongocryptd error!'), stderr: 'stderr', pid: 12345 });
@@ -169,6 +170,8 @@ describe('setupLoggerAndTelemetry', () => {
     expect(logOutput[i++].msg).to.equal('Loading .mongoshrc.js');
     expect(logOutput[i++].msg).to.equal('Warning about .mongorc.js/.mongoshrc.js mismatch');
     expect(logOutput[i++].msg).to.equal('Evaluating script passed on the command line');
+    expect(logOutput[i].msg).to.equal('Loading global configuration file');
+    expect(logOutput[i++].attr.filename).to.equal('/etc/mongosh.conf');
     expect(logOutput[i].msg).to.equal('Trying to spawn mongocryptd');
     expect(logOutput[i++].attr).to.deep.equal({ spawnPath: ['mongocryptd'], path: 'path' });
     expect(logOutput[i].msg).to.equal('Error running mongocryptd');

--- a/packages/logging/src/setup-logger-and-telemetry.ts
+++ b/packages/logging/src/setup-logger-and-telemetry.ts
@@ -12,6 +12,7 @@ import type {
   ScriptLoadFileEvent,
   StartLoadingCliScriptsEvent,
   StartMongoshReplEvent,
+  GlobalConfigFileLoadEvent,
   MongocryptdTrySpawnEvent,
   MongocryptdLogEvent,
   MongocryptdErrorEvent,
@@ -177,6 +178,10 @@ export function setupLoggerAndTelemetry(
         }
       });
     }
+  });
+
+  bus.on('mongosh:globalconfig-load', function(args: GlobalConfigFileLoadEvent) {
+    log.info('MONGOSH', mongoLogId(1_000_000_048), 'config', 'Loading global configuration file', args);
   });
 
   bus.on('mongosh:evaluate-input', function(args: EvaluateInputEvent) {
@@ -426,7 +431,7 @@ export function setupLoggerAndTelemetry(
   });
 
   bus.on('mongosh-editor:run-edit-command', function(ev: EditorRunEditCommandEvent) {
-    log.error('MONGOSH-EDITOR', mongoLogId(1_000_000_045), 'editor', 'Open external editor', redactInfo(ev));
+    log.error('MONGOSH-EDITOR', mongoLogId(1_000_000_047), 'editor', 'Open external editor', redactInfo(ev));
   });
 
   bus.on('mongosh-editor:read-vscode-extensions-done', function(ev: EditorReadVscodeExtensionsDoneEvent) {

--- a/packages/node-runtime-worker-thread/src/child-process-evaluation-listener.ts
+++ b/packages/node-runtime-worker-thread/src/child-process-evaluation-listener.ts
@@ -20,6 +20,9 @@ export class ChildProcessEvaluationListener {
         setConfig(key, value) {
           return workerRuntime.evaluationListener?.setConfig?.(key, value) ?? Promise.resolve('ignored');
         },
+        resetConfig(key) {
+          return workerRuntime.evaluationListener?.resetConfig?.(key) ?? Promise.resolve('ignored');
+        },
         validateConfig(key, value) {
           return workerRuntime.evaluationListener?.validateConfig?.(key, value) ?? Promise.resolve(null);
         },

--- a/packages/node-runtime-worker-thread/src/child-process-proxy.ts
+++ b/packages/node-runtime-worker-thread/src/child-process-proxy.ts
@@ -95,7 +95,10 @@ exposeAll(worker, process);
 
 const evaluationListener = Object.assign(
   createCaller(
-    ['onPrint', 'onPrompt', 'getConfig', 'setConfig', 'validateConfig', 'listConfigOptions', 'onClearCommand', 'onExit'],
+    [
+      'onPrint', 'onPrompt', 'getConfig', 'setConfig', 'resetConfig',
+      'validateConfig', 'listConfigOptions', 'onClearCommand', 'onExit'
+    ],
     process
   ),
   {

--- a/packages/node-runtime-worker-thread/src/worker-runtime.spec.ts
+++ b/packages/node-runtime-worker-thread/src/worker-runtime.spec.ts
@@ -495,6 +495,7 @@ describe('worker', () => {
         },
         getConfig() {},
         setConfig() {},
+        resetConfig() {},
         validateConfig() {},
         listConfigOptions() { return ['displayBatchSize']; },
         onRunInterruptible() {}
@@ -504,6 +505,7 @@ describe('worker', () => {
       spySandbox.spy(evalListener, 'onPrompt');
       spySandbox.spy(evalListener, 'getConfig');
       spySandbox.spy(evalListener, 'setConfig');
+      spySandbox.spy(evalListener, 'resetConfig');
       spySandbox.spy(evalListener, 'validateConfig');
       spySandbox.spy(evalListener, 'listConfigOptions');
       spySandbox.spy(evalListener, 'onRunInterruptible');
@@ -579,6 +581,20 @@ describe('worker', () => {
         await evaluate('config.set("displayBatchSize", 200)');
         expect(evalListener.validateConfig).to.have.been.calledWith('displayBatchSize', 200);
         expect(evalListener.setConfig).to.have.been.calledWith('displayBatchSize', 200);
+      });
+    });
+
+    describe('resetConfig', () => {
+      it('should be called when shell evaluates `config.reset()`', async() => {
+        const { init, evaluate } = caller;
+        const evalListener = createSpiedEvaluationListener();
+
+        exposed = exposeAll(evalListener, worker);
+
+        await init('mongodb://nodb/', {}, { nodb: true });
+
+        await evaluate('config.reset("displayBatchSize")');
+        expect(evalListener.resetConfig).to.have.been.calledWith('displayBatchSize');
       });
     });
 

--- a/packages/node-runtime-worker-thread/src/worker-runtime.ts
+++ b/packages/node-runtime-worker-thread/src/worker-runtime.ts
@@ -48,6 +48,7 @@ const evaluationListener = createCaller<WorkerRuntimeEvaluationListener>(
     'onPrompt',
     'getConfig',
     'setConfig',
+    'resetConfig',
     'validateConfig',
     'listConfigOptions',
     'onClearCommand',

--- a/packages/shell-api/src/integration.spec.ts
+++ b/packages/shell-api/src/integration.spec.ts
@@ -2191,6 +2191,7 @@ describe('Shell API (integration)', function() {
       instanceState.setEvaluationListener({
         getConfig(key: string) { return cfg[key]; },
         setConfig(key: string, value: any) { cfg[key] = value; return 'success'; },
+        resetConfig(key: string) { cfg[key] = (new ShellUserConfig())[key]; return 'success'; },
         listConfigOptions() { return Object.keys(cfg); }
       });
       expect((await (await collection.find())._it()).documents).to.have.lengthOf(20);

--- a/packages/shell-api/src/shell-api.spec.ts
+++ b/packages/shell-api/src/shell-api.spec.ts
@@ -698,6 +698,11 @@ describe('ShellApi', () => {
             return 'success';
           });
           // eslint-disable-next-line @typescript-eslint/require-await
+          evaluationListener.resetConfig.callsFake(async(key) => {
+            store[key] = '';
+            return 'success';
+          });
+          // eslint-disable-next-line @typescript-eslint/require-await
           evaluationListener.getConfig.callsFake(async key => store[key]);
           // eslint-disable-next-line @typescript-eslint/require-await
           evaluationListener.validateConfig.callsFake(async(key, value) => validators[key]?.(value));
@@ -710,6 +715,8 @@ describe('ShellApi', () => {
           expect(await config.get('somekey')).to.deep.equal(value);
           expect((await toShellResult(config)).printable).to.deep.equal(
             new Map([['somekey', value]]));
+          expect(await config.reset('somekey')).to.deep.equal('Setting "somekey" has been reset to its default value');
+          expect(await config.get('somekey')).to.deep.equal('');
         });
 
         it('will fall back to defaults', async() => {

--- a/packages/shell-api/src/shell-api.ts
+++ b/packages/shell-api/src/shell-api.ts
@@ -69,6 +69,18 @@ class ShellConfig extends ShellApiClass {
     return await evaluationListener.getConfig?.(key) ?? this.defaults[key];
   }
 
+  @returnsPromise
+  async reset<K extends keyof ShellUserConfig>(key: K): Promise<string> {
+    assertArgsDefinedType([key], ['string'], 'config.reset');
+    const { evaluationListener } = this._instanceState;
+    const result = await evaluationListener.resetConfig?.(key);
+    if (result !== 'success') {
+      return `Option "${key}" cannot be changed in this environment`;
+    }
+
+    return `Setting "${key}" has been reset to its default value`;
+  }
+
   async _allKeys(): Promise<(keyof ShellUserConfig)[]> {
     const { evaluationListener } = this._instanceState;
     return (await evaluationListener.listConfigOptions?.() ?? Object.keys(this.defaults)) as (keyof ShellUserConfig)[];

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -460,6 +460,7 @@ export class CliUserConfigValidator extends SnippetShellUserConfigValidator {
 export interface ConfigProvider<T> {
   getConfig<K extends keyof T>(key: K): Promise<T[K]>;
   setConfig<K extends keyof T>(key: K, value: T[K]): Promise<'success' | 'ignored'>;
+  resetConfig<K extends keyof T>(key: K): Promise<'success' | 'ignored'>;
   validateConfig<K extends keyof T>(key: K, value: T[K]): Promise<string | null>;
   listConfigOptions(): string[] | Promise<string[]>;
 }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -176,11 +176,11 @@ export interface MongoshBusEventsMap extends ConnectEventMap {
   /**
    * Signals that the shell is started by a new user.
    */
-  'mongosh:new-user': (id: string, enableTelemetry: boolean) => void;
+  'mongosh:new-user': (id: string) => void;
   /**
    * Signals a change of the user telemetry settings.
    */
-  'mongosh:update-user': (id: string, enableTelemetry: boolean) => void;
+  'mongosh:update-user': (id: string) => void;
   /**
    * Signals an error that should be logged or potentially tracked by analytics.
    */

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -72,6 +72,11 @@ export interface StartLoadingCliScriptsEvent {
   usesShellOption: boolean;
 }
 
+export interface GlobalConfigFileLoadEvent {
+  filename: string;
+  found: boolean;
+}
+
 export interface MongocryptdTrySpawnEvent {
   spawnPath: string[];
   path: string;
@@ -238,6 +243,10 @@ export interface MongoshBusEventsMap extends ConnectEventMap {
    * Signals the start of loading a mongosh configuration file.
    */
   'mongosh:mongoshrc-load': () => void;
+  /**
+   * Signals the start of loading a global mongosh configuration file.
+   */
+  'mongosh:globalconfig-load': (ev: GlobalConfigFileLoadEvent) => void;
   /**
    * Signals the detection of a legacy `mongo` configuration file or a misnamed mongosh configuration file.
    */

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -414,6 +414,7 @@ export class SnippetShellUserConfigValidator extends ShellUserConfigValidator {
 export class CliUserConfig extends SnippetShellUserConfig {
   userId = '';
   disableGreetingMessage = false;
+  forceDisableTelemetry = false;
   inspectCompact: number | boolean = 3;
   inspectDepth = 6;
   historyLength = 1000;
@@ -439,6 +440,7 @@ export class CliUserConfigValidator extends SnippetShellUserConfigValidator {
           return `${key} must be a positive integer`;
         }
         return null;
+      case 'forceDisableTelemetry':
       case 'showStackTraces':
         if (typeof value !== 'boolean') {
           return `${key} must be a boolean`;


### PR DESCRIPTION
Please review on a commit-by-commit basis :)

##### feat(cli-repl): add support for global config file MONGOSH-1063

This adds support for a global YAML config file.

mongosh loads one global config file, attempting:
- `.\mongosh.cfg` on Windows, relative to the mongosh.exe binary
- `/usr/local/etc/mongosh.conf`, `/opt/homebrew/etc/mongosh.conf`
  and `/etc/mongosh.conf` on Darwin
- `/etc/mongosh.conf` on all other platforms

On Windows, this file is only loaded if mongosh is distributed
as a single-executable binary, since otherwise there is no reasonable
starting point for searching the global config file.

The global config file uses YAML, with options namespaced under
the `mongosh` key, instead of only supporting plain EJSON, since that
matches the mongod global configuration file.

##### fix(cli-repl): load value of redactHistory on MongoshNodeRepl startup


##### chore(logging): move telemetry disable/enable tracking to cli-repl

Instead of manually keeping track of whether telemetry is
enabled/disabled inside the logging package, always generate
telemetry events there and let the consumer determine whether
the events should be sent out or not.

The logging package provides a utility class that lets
consumers do this easily, and adds support for queueing up events.

This has a few advantages:
- It allows consumers to pause telemetry until they have determined
  whether telemetry should be enabled. This determination should not
  need to be made at the same time as instantiating logging (which
  is as early as posssible, generally speaking).
- It simplifies the logging code to remove repetitive `if (telemetry)`
  statements by localizing this decision to a single piece of code.
- It gets rid of the unnecessary `makeAnalytics()` redirection
  in the `setupLoggerAndTelemetry` arguments.

The last part needs to come with a change in Compass as well
(mongodb-js/compass@45518410d0e900629ac85e4558b48f38fab3f094).

##### feat(cli-repl): add global forceDisableTelemetry option MONGOSH-1055

- Add a global `forceDisableTelemetry` config variable. This
  can not be set in the user config.
- Test that when the CLI starts in telemetry-disabled mode,
  no telemetry data is emitted.
- Ensure that the relative timing of command-line scripts
  and telemetry data is correct (in particular, that command-line
  scripts can disable telemetr without starting to send any).

##### feat(shell-api): add config.reset() method MONGOSH-959

This allows resetting configuration values to their default
states without having to know which value that is.
