### PR TITLE
fix(ci): fix Windows packaging URL upload

### DIFF
--- a/.evergreen/package-and-upload-artifact.sh
+++ b/.evergreen/package-and-upload-artifact.sh
@@ -74,7 +74,7 @@ else
 
   if [ "$OS" == "Windows_NT" ]; then
     # Fix absolute path before handing over to node
-    export ARTIFACT_URL_FILE="\$(cygpath -w "\$ARTIFACT_URL_FILE")"
+    export ARTIFACT_URL_FILE="$(cygpath -w "$ARTIFACT_URL_FILE")"
   fi
   npm run evergreen-release upload
 fi


### PR DESCRIPTION
In c9151ce70b79, I removed a layer of indirection in
`package-and-upload-artifact.sh`, which previously wrote most
of its content into another bash script and then executed it.

However, this also mean that I should have adjusted the escaping
to be one layer less deep, which I forgot and which causes
CI to be red on Windows right now.