### PR TITLE
chore(ci): use Rocky Linux 8 instead of CentOS 8 for docker tests

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -8010,7 +8010,7 @@ tasks:
       - func: test_artifact_docker
         vars:
           dockerfile: amazonlinux2-rpm
-  - name: pkg_test_docker_centos8_rpm
+  - name: pkg_test_docker_rocky8_rpm
     tags: ["smoke-test"]
     depends_on:
       - name: package_and_upload_artifact_rhel8_x64
@@ -8023,7 +8023,7 @@ tasks:
       - func: write_preload_script
       - func: test_artifact_docker
         vars:
-          dockerfile: centos8-rpm
+          dockerfile: rocky8-rpm
   - name: pkg_test_docker_fedora34_rpm
     tags: ["smoke-test"]
     depends_on:
@@ -8737,7 +8737,7 @@ buildvariants:
     run_on: ubuntu1804-small
     tasks:
       - name: pkg_test_docker_centos7_rpm
-      - name: pkg_test_docker_centos8_rpm
+      - name: pkg_test_docker_rocky8_rpm
       - name: pkg_test_docker_fedora34_rpm
       - name: pkg_test_docker_suse12_rpm
       - name: pkg_test_docker_suse15_rpm

--- a/.evergreen/evergreen.yml.in
+++ b/.evergreen/evergreen.yml.in
@@ -77,7 +77,7 @@ const EXECUTABLE_PKG_INFO = [
       { name: 'linux-x64', packageOn: 'linux', smokeTestKind: 'none' },
       { name: 'debian-x64', packageOn: 'linux', smokeTestKind: 'docker', smokeTestDockerfiles: ['ubuntu18.04-deb', 'ubuntu20.04-deb', 'debian9-deb', 'debian10-deb'] },
       { name: 'rhel7-x64', packageOn: 'linux', smokeTestKind: 'docker', smokeTestDockerfiles: ['centos7-rpm', 'amazonlinux2-rpm'] },
-      { name: 'rhel8-x64', packageOn: 'linux', smokeTestKind: 'docker', smokeTestDockerfiles: ['centos8-rpm', 'fedora34-rpm'] },
+      { name: 'rhel8-x64', packageOn: 'linux', smokeTestKind: 'docker', smokeTestDockerfiles: ['rocky8-rpm', 'fedora34-rpm'] },
       { name: 'suse-x64', packageOn: 'linux', smokeTestKind: 'docker', smokeTestDockerfiles: ['suse12-rpm', 'suse15-rpm'] },
       { name: 'amzn1-x64', packageOn: 'linux', smokeTestKind: 'docker', smokeTestDockerfiles: ['amazonlinux1-rpm'] }
     ]
@@ -1050,7 +1050,7 @@ buildvariants:
     run_on: ubuntu1804-small
     tasks:
       - name: pkg_test_docker_centos7_rpm
-      - name: pkg_test_docker_centos8_rpm
+      - name: pkg_test_docker_rocky8_rpm
       - name: pkg_test_docker_fedora34_rpm
       - name: pkg_test_docker_suse12_rpm
       - name: pkg_test_docker_suse15_rpm

--- a/scripts/docker/README.md
+++ b/scripts/docker/README.md
@@ -5,9 +5,9 @@ This folder contains scripts and Dockerfiles to test the main branch build of mo
 ## Usage
 
 ```
-bash scripts/docker/build.sh centos8-rpm
+bash scripts/docker/build.sh ubuntu20.04-deb
 ```
 
 ```
-bash scripts/docker/run.sh centos8-rpm arg1 arg2 ...
+bash scripts/docker/run.sh ubuntu20.04-deb arg1 arg2 ...
 ```

--- a/scripts/docker/build.sh
+++ b/scripts/docker/build.sh
@@ -11,8 +11,9 @@ if [ x"$ARTIFACT_URL" = x"" ]; then
     suse*)      FILENAME="mongodb-mongosh-${VERSION}.suse12.x86_64.rpm";;
     amazon1*)   FILENAME="mongodb-mongosh-${VERSION}.amzn1.x86_64.rpm";;
     centos7*)   FILENAME="mongodb-mongosh-${VERSION}.el8.x86_64.rpm";;
+    rocky8*)    FILENAME="mongodb-mongosh-${VERSION}.el8.x86_64.rpm";;
     fedora*)    FILENAME="mongodb-mongosh-${VERSION}.el8.x86_64.rpm";;
-    *)          FILENAME="mongodb-mongosh-${VERSION}.el7.x86_64.rpm";; # amzn2, centos8
+    *)          FILENAME="mongodb-mongosh-${VERSION}.el7.x86_64.rpm";; # amzn2
   esac
   ARTIFACT_URL="https://s3.amazonaws.com/mciuploads/mongosh/${SHA}/${FILENAME}"
 fi

--- a/scripts/docker/rocky8-rpm.Dockerfile
+++ b/scripts/docker/rocky8-rpm.Dockerfile
@@ -1,4 +1,4 @@
-FROM centos:8
+FROM rockylinux:8
 
 ARG artifact_url=""
 ADD ${artifact_url} /tmp


### PR DESCRIPTION
The CentOS 8 docker tests are currently failing in CI:

    Failed to download metadata for repo 'appstream': Cannot prepare internal mirrorlist: No URLs in mirrorlist

Using Rocky Linux as the successor to CentOS instead is probably
the easiest sensible choice here.