### PR TITLE
chore(browser-repl): Bump leafygreen versions, replace Syntax with Code COMPASS-5422

### DIFF
--- a/packages/browser-repl/package-lock.json
+++ b/packages/browser-repl/package-lock.json
@@ -200,6 +200,7 @@
 			"version": "7.8.3",
 			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.8.3.tgz",
 			"integrity": "sha512-R0Bx3jippsbAEtzkpZ/6FIiuzOURPcMjHp+Z6xPe6DtApDJx+w7UYyOLanZqO8+wKR9G10s/FmHXvxaMd9s6Kg==",
+			"dev": true,
 			"requires": {
 				"@babel/types": "^7.8.3"
 			}
@@ -1096,6 +1097,7 @@
 			"version": "7.9.6",
 			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.9.6.tgz",
 			"integrity": "sha512-qxXzvBO//jO9ZnoasKF1uJzHd2+M6Q2ZPIVfnFps8JJvXy0ZBbwbNOmE6SGIY5XOY6d1Bo5lb9d9RJ8nv3WSeA==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-validator-identifier": "^7.9.5",
 				"lodash": "^4.17.13",
@@ -1108,10 +1110,107 @@
 			"integrity": "sha512-Fxt+AfXgjMoin2maPIYzFZnQjAXjAL0PHscM5pRTtatFqB+vZxAM9tLp2Optnuw3QOQC40jTNeGYFOMvyf7v9g==",
 			"dev": true
 		},
+		"@emotion/babel-plugin": {
+			"version": "11.7.2",
+			"resolved": "https://registry.npmjs.org/@emotion/babel-plugin/-/babel-plugin-11.7.2.tgz",
+			"integrity": "sha512-6mGSCWi9UzXut/ZAN6lGFu33wGR3SJisNl3c0tvlmb8XChH1b2SUvxvnOh7hvLpqyRdHHU9AiazV3Cwbk5SXKQ==",
+			"requires": {
+				"@babel/helper-module-imports": "^7.12.13",
+				"@babel/plugin-syntax-jsx": "^7.12.13",
+				"@babel/runtime": "^7.13.10",
+				"@emotion/hash": "^0.8.0",
+				"@emotion/memoize": "^0.7.5",
+				"@emotion/serialize": "^1.0.2",
+				"babel-plugin-macros": "^2.6.1",
+				"convert-source-map": "^1.5.0",
+				"escape-string-regexp": "^4.0.0",
+				"find-root": "^1.1.0",
+				"source-map": "^0.5.7",
+				"stylis": "4.0.13"
+			},
+			"dependencies": {
+				"@babel/helper-module-imports": {
+					"version": "7.16.7",
+					"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.16.7.tgz",
+					"integrity": "sha512-LVtS6TqjJHFc+nYeITRo6VLXve70xmq7wPhWTqDJusJEgGmkAACWwMiTNrvfoQo6hEhFwAIixNkvB0jPXDL8Wg==",
+					"requires": {
+						"@babel/types": "^7.16.7"
+					}
+				},
+				"@babel/helper-plugin-utils": {
+					"version": "7.16.7",
+					"resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.16.7.tgz",
+					"integrity": "sha512-Qg3Nk7ZxpgMrsox6HreY1ZNKdBq7K72tDSliA6dCl5f007jR4ne8iD5UzuNnCJH2xBf2BEEVGr+/OL6Gdp7RxA=="
+				},
+				"@babel/helper-validator-identifier": {
+					"version": "7.16.7",
+					"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.16.7.tgz",
+					"integrity": "sha512-hsEnFemeiW4D08A5gUAZxLBTXpZ39P+a+DGDsHw1yxqyQ/jzFEnxf5uTEGp+3bzAbNOxU1paTgYS4ECU/IgfDw=="
+				},
+				"@babel/plugin-syntax-jsx": {
+					"version": "7.16.7",
+					"resolved": "https://registry.npmjs.org/@babel/plugin-syntax-jsx/-/plugin-syntax-jsx-7.16.7.tgz",
+					"integrity": "sha512-Esxmk7YjA8QysKeT3VhTXvF6y77f/a91SIs4pWb4H2eWGQkCKFgQaG6hdoEVZtGsrAcb2K5BW66XsOErD4WU3Q==",
+					"requires": {
+						"@babel/helper-plugin-utils": "^7.16.7"
+					}
+				},
+				"@babel/runtime": {
+					"version": "7.17.2",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.2.tgz",
+					"integrity": "sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==",
+					"requires": {
+						"regenerator-runtime": "^0.13.4"
+					}
+				},
+				"@babel/types": {
+					"version": "7.17.0",
+					"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.17.0.tgz",
+					"integrity": "sha512-TmKSNO4D5rzhL5bjWFcVHHLETzfQ/AmbKpKPOSjlP0WoHZ6L911fgoOKY4Alp/emzG4cHJdyN49zpgkbXFEHHw==",
+					"requires": {
+						"@babel/helper-validator-identifier": "^7.16.7",
+						"to-fast-properties": "^2.0.0"
+					}
+				},
+				"@emotion/memoize": {
+					"version": "0.7.5",
+					"resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.5.tgz",
+					"integrity": "sha512-igX9a37DR2ZPGYtV6suZ6whr8pTFtyHL3K/oLUotxpSVO2ASaprmAe2Dkq7tBo7CRY7MMDrAa9nuQP9/YG8FxQ=="
+				},
+				"@emotion/serialize": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.0.2.tgz",
+					"integrity": "sha512-95MgNJ9+/ajxU7QIAruiOAdYNjxZX7G2mhgrtDWswA21VviYIRP1R5QilZ/bDY42xiKsaktP4egJb3QdYQZi1A==",
+					"requires": {
+						"@emotion/hash": "^0.8.0",
+						"@emotion/memoize": "^0.7.4",
+						"@emotion/unitless": "^0.7.5",
+						"@emotion/utils": "^1.0.0",
+						"csstype": "^3.0.2"
+					}
+				},
+				"@emotion/utils": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.0.0.tgz",
+					"integrity": "sha512-mQC2b3XLDs6QCW+pDQDiyO/EdGZYOygE8s5N5rrzjSI4M3IejPE/JPndCBwRT9z982aqQNi6beWs1UeayrQxxA=="
+				},
+				"csstype": {
+					"version": "3.0.10",
+					"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.10.tgz",
+					"integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA=="
+				},
+				"escape-string-regexp": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
+					"integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="
+				}
+			}
+		},
 		"@emotion/cache": {
 			"version": "10.0.29",
 			"resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-10.0.29.tgz",
 			"integrity": "sha512-fU2VtSVlHiF27empSbxi1O2JFdNWZO+2NFHfwO0pxgTep6Xa3uGb+3pVKfLww2l/IBGLNEZl5Xf/++A4wAYDYQ==",
+			"dev": true,
 			"requires": {
 				"@emotion/sheet": "0.9.4",
 				"@emotion/stylis": "0.8.5",
@@ -1163,10 +1262,74 @@
 			"resolved": "https://registry.npmjs.org/@emotion/memoize/-/memoize-0.7.4.tgz",
 			"integrity": "sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw=="
 		},
+		"@emotion/react": {
+			"version": "11.7.1",
+			"resolved": "https://registry.npmjs.org/@emotion/react/-/react-11.7.1.tgz",
+			"integrity": "sha512-DV2Xe3yhkF1yT4uAUoJcYL1AmrnO5SVsdfvu+fBuS7IbByDeTVx9+wFmvx9Idzv7/78+9Mgx2Hcmr7Fex3tIyw==",
+			"requires": {
+				"@babel/runtime": "^7.13.10",
+				"@emotion/cache": "^11.7.1",
+				"@emotion/serialize": "^1.0.2",
+				"@emotion/sheet": "^1.1.0",
+				"@emotion/utils": "^1.0.0",
+				"@emotion/weak-memoize": "^0.2.5",
+				"hoist-non-react-statics": "^3.3.1"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.17.2",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.2.tgz",
+					"integrity": "sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==",
+					"requires": {
+						"regenerator-runtime": "^0.13.4"
+					}
+				},
+				"@emotion/cache": {
+					"version": "11.7.1",
+					"resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.7.1.tgz",
+					"integrity": "sha512-r65Zy4Iljb8oyjtLeCuBH8Qjiy107dOYC6SJq7g7GV5UCQWMObY4SJDPGFjiiVpPrOJ2hmJOoBiYTC7hwx9E2A==",
+					"requires": {
+						"@emotion/memoize": "^0.7.4",
+						"@emotion/sheet": "^1.1.0",
+						"@emotion/utils": "^1.0.0",
+						"@emotion/weak-memoize": "^0.2.5",
+						"stylis": "4.0.13"
+					}
+				},
+				"@emotion/serialize": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.0.2.tgz",
+					"integrity": "sha512-95MgNJ9+/ajxU7QIAruiOAdYNjxZX7G2mhgrtDWswA21VviYIRP1R5QilZ/bDY42xiKsaktP4egJb3QdYQZi1A==",
+					"requires": {
+						"@emotion/hash": "^0.8.0",
+						"@emotion/memoize": "^0.7.4",
+						"@emotion/unitless": "^0.7.5",
+						"@emotion/utils": "^1.0.0",
+						"csstype": "^3.0.2"
+					}
+				},
+				"@emotion/sheet": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.1.0.tgz",
+					"integrity": "sha512-u0AX4aSo25sMAygCuQTzS+HsImZFuS8llY8O7b9MDRzbJM0kVJlAz6KNDqcG7pOuQZJmj/8X/rAW+66kMnMW+g=="
+				},
+				"@emotion/utils": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.0.0.tgz",
+					"integrity": "sha512-mQC2b3XLDs6QCW+pDQDiyO/EdGZYOygE8s5N5rrzjSI4M3IejPE/JPndCBwRT9z982aqQNi6beWs1UeayrQxxA=="
+				},
+				"csstype": {
+					"version": "3.0.10",
+					"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.10.tgz",
+					"integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA=="
+				}
+			}
+		},
 		"@emotion/serialize": {
 			"version": "0.11.16",
 			"resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-0.11.16.tgz",
 			"integrity": "sha512-G3J4o8by0VRrO+PFeSc3js2myYNOXVJ3Ya+RGVxnshRYgsvErfAOglKAiy1Eo1vhzxqtUvjCyS5gtewzkmvSSg==",
+			"dev": true,
 			"requires": {
 				"@emotion/hash": "0.8.0",
 				"@emotion/memoize": "0.7.4",
@@ -1175,10 +1338,29 @@
 				"csstype": "^2.5.7"
 			}
 		},
+		"@emotion/server": {
+			"version": "11.4.0",
+			"resolved": "https://registry.npmjs.org/@emotion/server/-/server-11.4.0.tgz",
+			"integrity": "sha512-IHovdWA3V0DokzxLtUNDx4+hQI82zUXqQFcVz/om2t44O0YSc+NHB+qifnyAOoQwt3SXcBTgaSntobwUI9gnfA==",
+			"requires": {
+				"@emotion/utils": "^1.0.0",
+				"html-tokenize": "^2.0.0",
+				"multipipe": "^1.0.2",
+				"through": "^2.3.8"
+			},
+			"dependencies": {
+				"@emotion/utils": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.0.0.tgz",
+					"integrity": "sha512-mQC2b3XLDs6QCW+pDQDiyO/EdGZYOygE8s5N5rrzjSI4M3IejPE/JPndCBwRT9z982aqQNi6beWs1UeayrQxxA=="
+				}
+			}
+		},
 		"@emotion/sheet": {
 			"version": "0.9.4",
 			"resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-0.9.4.tgz",
-			"integrity": "sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA=="
+			"integrity": "sha512-zM9PFmgVSqBw4zL101Q0HrBVTGmpAxFZH/pYx/cjJT5advXguvcgjHFTCaIO3enL/xr89vK2bh0Mfyj9aa0ANA==",
+			"dev": true
 		},
 		"@emotion/styled": {
 			"version": "10.0.27",
@@ -1205,7 +1387,8 @@
 		"@emotion/stylis": {
 			"version": "0.8.5",
 			"resolved": "https://registry.npmjs.org/@emotion/stylis/-/stylis-0.8.5.tgz",
-			"integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ=="
+			"integrity": "sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==",
+			"dev": true
 		},
 		"@emotion/unitless": {
 			"version": "0.7.5",
@@ -1215,7 +1398,8 @@
 		"@emotion/utils": {
 			"version": "0.11.3",
 			"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-0.11.3.tgz",
-			"integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw=="
+			"integrity": "sha512-0o4l6pZC+hI88+bzuaX/6BgOvQVhbt2PfmxauVaYOGgbsAw14wdKyvMCZXnsnsHys94iadcF+RG/wZyx6+ZZBw==",
+			"dev": true
 		},
 		"@emotion/weak-memoize": {
 			"version": "0.2.5",
@@ -1228,56 +1412,1173 @@
 			"integrity": "sha512-QPcGmICAPbGLGb6F/yNf/KzKqvFx8z5qx3D1yFqVAjoFmXK35EgyW+cJ57Te3CNsmzblwtzakLGFqHPqrfb4Tw==",
 			"dev": true
 		},
-		"@jest/types": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/@jest/types/-/types-24.9.0.tgz",
-			"integrity": "sha512-XKK7ze1apu5JWQ5eZjHITP66AX+QsLlbaJRBGYr8pNzwcAE2JVkwnf0yqjHTsDRcjR0mujy/NmZMXw5kl+kGBw==",
+		"@leafygreen-ui/a11y": {
+			"version": "1.2.2",
+			"resolved": "https://registry.npmjs.org/@leafygreen-ui/a11y/-/a11y-1.2.2.tgz",
+			"integrity": "sha512-frgrAUv1xTJHsFMLXttAX5eHMhVXAvU3z5aKDjlUIDBPf28A3tMTAJg/+K5dGoa4qmAyv/ZzLyY6I3GOx7ip1A==",
 			"requires": {
-				"@types/istanbul-lib-coverage": "^2.0.0",
-				"@types/istanbul-reports": "^1.1.1",
-				"@types/yargs": "^13.0.0"
+				"@leafygreen-ui/emotion": "^4.0.0",
+				"@leafygreen-ui/hooks": "^7.0.0",
+				"@leafygreen-ui/lib": "^9.0.0"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.17.2",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.2.tgz",
+					"integrity": "sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==",
+					"requires": {
+						"regenerator-runtime": "^0.13.4"
+					}
+				},
+				"@emotion/cache": {
+					"version": "11.7.1",
+					"resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.7.1.tgz",
+					"integrity": "sha512-r65Zy4Iljb8oyjtLeCuBH8Qjiy107dOYC6SJq7g7GV5UCQWMObY4SJDPGFjiiVpPrOJ2hmJOoBiYTC7hwx9E2A==",
+					"requires": {
+						"@emotion/memoize": "^0.7.4",
+						"@emotion/sheet": "^1.1.0",
+						"@emotion/utils": "^1.0.0",
+						"@emotion/weak-memoize": "^0.2.5",
+						"stylis": "4.0.13"
+					}
+				},
+				"@emotion/css": {
+					"version": "11.7.1",
+					"resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.7.1.tgz",
+					"integrity": "sha512-RUUgPlMZunlc7SE5A6Hg+VWRzb2cU6O9xlV78KCFgcnl25s7Qz/20oQg71iKudpLqk7xj0vhbJlwcJJMT0BOZg==",
+					"requires": {
+						"@emotion/babel-plugin": "^11.7.1",
+						"@emotion/cache": "^11.7.1",
+						"@emotion/serialize": "^1.0.0",
+						"@emotion/sheet": "^1.0.3",
+						"@emotion/utils": "^1.0.0"
+					}
+				},
+				"@emotion/serialize": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.0.2.tgz",
+					"integrity": "sha512-95MgNJ9+/ajxU7QIAruiOAdYNjxZX7G2mhgrtDWswA21VviYIRP1R5QilZ/bDY42xiKsaktP4egJb3QdYQZi1A==",
+					"requires": {
+						"@emotion/hash": "^0.8.0",
+						"@emotion/memoize": "^0.7.4",
+						"@emotion/unitless": "^0.7.5",
+						"@emotion/utils": "^1.0.0",
+						"csstype": "^3.0.2"
+					}
+				},
+				"@emotion/sheet": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.1.0.tgz",
+					"integrity": "sha512-u0AX4aSo25sMAygCuQTzS+HsImZFuS8llY8O7b9MDRzbJM0kVJlAz6KNDqcG7pOuQZJmj/8X/rAW+66kMnMW+g=="
+				},
+				"@emotion/utils": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.0.0.tgz",
+					"integrity": "sha512-mQC2b3XLDs6QCW+pDQDiyO/EdGZYOygE8s5N5rrzjSI4M3IejPE/JPndCBwRT9z982aqQNi6beWs1UeayrQxxA=="
+				},
+				"@leafygreen-ui/emotion": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/@leafygreen-ui/emotion/-/emotion-4.0.0.tgz",
+					"integrity": "sha512-nr2g6OFsy+psaMto3H4HQ1ivM1tCwd9k1bbR5WH4U7YibDagfBekFTwlhohmC/K7hUM/eDVPGw0w4zQyC+BwZg==",
+					"requires": {
+						"@emotion/css": "^11.1.3",
+						"@emotion/react": "^11.4.0",
+						"@emotion/server": "^11.4.0"
+					}
+				},
+				"@leafygreen-ui/lib": {
+					"version": "9.1.0",
+					"resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-9.1.0.tgz",
+					"integrity": "sha512-JH3mnoCZNtUcJfXrvVG4I3PAIm1ehlR1H5WkDqkjengcf/iVMo7+AluzwfTCQb2fqQgohURs+qY4vEhJe+9+2g==",
+					"requires": {
+						"@leafygreen-ui/emotion": "^4.0.0",
+						"facepaint": "^1.2.1",
+						"polished": "^4.1.3",
+						"prop-types": "^15.0.0"
+					}
+				},
+				"csstype": {
+					"version": "3.0.10",
+					"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.10.tgz",
+					"integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA=="
+				},
+				"polished": {
+					"version": "4.1.4",
+					"resolved": "https://registry.npmjs.org/polished/-/polished-4.1.4.tgz",
+					"integrity": "sha512-Nq5Mbza+Auo7N3sQb1QMFaQiDO+4UexWuSGR7Cjb4Sw11SZIJcrrFtiZ+L0jT9MBsUsxDboHVASbCLbE1rnECg==",
+					"requires": {
+						"@babel/runtime": "^7.16.7"
+					}
+				}
 			}
 		},
-		"@leafygreen-ui/emotion": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@leafygreen-ui/emotion/-/emotion-2.0.1.tgz",
-			"integrity": "sha512-eswO+aWs6vbuiEDUpZz3tGjCBtgWr3hU4ndgrjFLNOQpWOsVOaW8zQzVu1XOMLHCjtfZy2/GDME7zQWVvcrVFg==",
+		"@leafygreen-ui/box": {
+			"version": "3.0.6",
+			"resolved": "https://registry.npmjs.org/@leafygreen-ui/box/-/box-3.0.6.tgz",
+			"integrity": "sha512-KuefTm/DRWAhbw6eT7AEu+vg8XXQZPXJHsmnP8E6YDUswBage7jPcWgUSMCnV79ftvShFoVWEJ+wLeex89L2rA==",
 			"requires": {
-				"create-emotion": "^10.0.7",
-				"create-emotion-server": "10.0.27",
-				"emotion": "^10.0.7"
+				"@leafygreen-ui/lib": "^9.0.0",
+				"lodash": "^4.17.21"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.17.2",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.2.tgz",
+					"integrity": "sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==",
+					"requires": {
+						"regenerator-runtime": "^0.13.4"
+					}
+				},
+				"@emotion/cache": {
+					"version": "11.7.1",
+					"resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.7.1.tgz",
+					"integrity": "sha512-r65Zy4Iljb8oyjtLeCuBH8Qjiy107dOYC6SJq7g7GV5UCQWMObY4SJDPGFjiiVpPrOJ2hmJOoBiYTC7hwx9E2A==",
+					"requires": {
+						"@emotion/memoize": "^0.7.4",
+						"@emotion/sheet": "^1.1.0",
+						"@emotion/utils": "^1.0.0",
+						"@emotion/weak-memoize": "^0.2.5",
+						"stylis": "4.0.13"
+					}
+				},
+				"@emotion/css": {
+					"version": "11.7.1",
+					"resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.7.1.tgz",
+					"integrity": "sha512-RUUgPlMZunlc7SE5A6Hg+VWRzb2cU6O9xlV78KCFgcnl25s7Qz/20oQg71iKudpLqk7xj0vhbJlwcJJMT0BOZg==",
+					"requires": {
+						"@emotion/babel-plugin": "^11.7.1",
+						"@emotion/cache": "^11.7.1",
+						"@emotion/serialize": "^1.0.0",
+						"@emotion/sheet": "^1.0.3",
+						"@emotion/utils": "^1.0.0"
+					}
+				},
+				"@emotion/serialize": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.0.2.tgz",
+					"integrity": "sha512-95MgNJ9+/ajxU7QIAruiOAdYNjxZX7G2mhgrtDWswA21VviYIRP1R5QilZ/bDY42xiKsaktP4egJb3QdYQZi1A==",
+					"requires": {
+						"@emotion/hash": "^0.8.0",
+						"@emotion/memoize": "^0.7.4",
+						"@emotion/unitless": "^0.7.5",
+						"@emotion/utils": "^1.0.0",
+						"csstype": "^3.0.2"
+					}
+				},
+				"@emotion/sheet": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.1.0.tgz",
+					"integrity": "sha512-u0AX4aSo25sMAygCuQTzS+HsImZFuS8llY8O7b9MDRzbJM0kVJlAz6KNDqcG7pOuQZJmj/8X/rAW+66kMnMW+g=="
+				},
+				"@emotion/utils": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.0.0.tgz",
+					"integrity": "sha512-mQC2b3XLDs6QCW+pDQDiyO/EdGZYOygE8s5N5rrzjSI4M3IejPE/JPndCBwRT9z982aqQNi6beWs1UeayrQxxA=="
+				},
+				"@leafygreen-ui/emotion": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/@leafygreen-ui/emotion/-/emotion-4.0.0.tgz",
+					"integrity": "sha512-nr2g6OFsy+psaMto3H4HQ1ivM1tCwd9k1bbR5WH4U7YibDagfBekFTwlhohmC/K7hUM/eDVPGw0w4zQyC+BwZg==",
+					"requires": {
+						"@emotion/css": "^11.1.3",
+						"@emotion/react": "^11.4.0",
+						"@emotion/server": "^11.4.0"
+					}
+				},
+				"@leafygreen-ui/lib": {
+					"version": "9.1.0",
+					"resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-9.1.0.tgz",
+					"integrity": "sha512-JH3mnoCZNtUcJfXrvVG4I3PAIm1ehlR1H5WkDqkjengcf/iVMo7+AluzwfTCQb2fqQgohURs+qY4vEhJe+9+2g==",
+					"requires": {
+						"@leafygreen-ui/emotion": "^4.0.0",
+						"facepaint": "^1.2.1",
+						"polished": "^4.1.3",
+						"prop-types": "^15.0.0"
+					}
+				},
+				"csstype": {
+					"version": "3.0.10",
+					"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.10.tgz",
+					"integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA=="
+				},
+				"polished": {
+					"version": "4.1.4",
+					"resolved": "https://registry.npmjs.org/polished/-/polished-4.1.4.tgz",
+					"integrity": "sha512-Nq5Mbza+Auo7N3sQb1QMFaQiDO+4UexWuSGR7Cjb4Sw11SZIJcrrFtiZ+L0jT9MBsUsxDboHVASbCLbE1rnECg==",
+					"requires": {
+						"@babel/runtime": "^7.16.7"
+					}
+				}
+			}
+		},
+		"@leafygreen-ui/button": {
+			"version": "12.0.5",
+			"resolved": "https://registry.npmjs.org/@leafygreen-ui/button/-/button-12.0.5.tgz",
+			"integrity": "sha512-Atr7y7BfewlcbqwZHHWo7yhP14EHxUSxJ7ao5jXJWVX6+x1hBVcfd9m3/nN6LBCLOpGf38jAXhT2iWBV7KtktA==",
+			"requires": {
+				"@leafygreen-ui/box": "^3.0.6",
+				"@leafygreen-ui/emotion": "^4.0.0",
+				"@leafygreen-ui/lib": "^9.0.0",
+				"@leafygreen-ui/palette": "^3.2.2",
+				"@leafygreen-ui/ripple": "^1.1.1",
+				"@leafygreen-ui/tokens": "^0.5.3"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.17.2",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.2.tgz",
+					"integrity": "sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==",
+					"requires": {
+						"regenerator-runtime": "^0.13.4"
+					}
+				},
+				"@emotion/cache": {
+					"version": "11.7.1",
+					"resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.7.1.tgz",
+					"integrity": "sha512-r65Zy4Iljb8oyjtLeCuBH8Qjiy107dOYC6SJq7g7GV5UCQWMObY4SJDPGFjiiVpPrOJ2hmJOoBiYTC7hwx9E2A==",
+					"requires": {
+						"@emotion/memoize": "^0.7.4",
+						"@emotion/sheet": "^1.1.0",
+						"@emotion/utils": "^1.0.0",
+						"@emotion/weak-memoize": "^0.2.5",
+						"stylis": "4.0.13"
+					}
+				},
+				"@emotion/css": {
+					"version": "11.7.1",
+					"resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.7.1.tgz",
+					"integrity": "sha512-RUUgPlMZunlc7SE5A6Hg+VWRzb2cU6O9xlV78KCFgcnl25s7Qz/20oQg71iKudpLqk7xj0vhbJlwcJJMT0BOZg==",
+					"requires": {
+						"@emotion/babel-plugin": "^11.7.1",
+						"@emotion/cache": "^11.7.1",
+						"@emotion/serialize": "^1.0.0",
+						"@emotion/sheet": "^1.0.3",
+						"@emotion/utils": "^1.0.0"
+					}
+				},
+				"@emotion/serialize": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.0.2.tgz",
+					"integrity": "sha512-95MgNJ9+/ajxU7QIAruiOAdYNjxZX7G2mhgrtDWswA21VviYIRP1R5QilZ/bDY42xiKsaktP4egJb3QdYQZi1A==",
+					"requires": {
+						"@emotion/hash": "^0.8.0",
+						"@emotion/memoize": "^0.7.4",
+						"@emotion/unitless": "^0.7.5",
+						"@emotion/utils": "^1.0.0",
+						"csstype": "^3.0.2"
+					}
+				},
+				"@emotion/sheet": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.1.0.tgz",
+					"integrity": "sha512-u0AX4aSo25sMAygCuQTzS+HsImZFuS8llY8O7b9MDRzbJM0kVJlAz6KNDqcG7pOuQZJmj/8X/rAW+66kMnMW+g=="
+				},
+				"@emotion/utils": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.0.0.tgz",
+					"integrity": "sha512-mQC2b3XLDs6QCW+pDQDiyO/EdGZYOygE8s5N5rrzjSI4M3IejPE/JPndCBwRT9z982aqQNi6beWs1UeayrQxxA=="
+				},
+				"@leafygreen-ui/emotion": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/@leafygreen-ui/emotion/-/emotion-4.0.0.tgz",
+					"integrity": "sha512-nr2g6OFsy+psaMto3H4HQ1ivM1tCwd9k1bbR5WH4U7YibDagfBekFTwlhohmC/K7hUM/eDVPGw0w4zQyC+BwZg==",
+					"requires": {
+						"@emotion/css": "^11.1.3",
+						"@emotion/react": "^11.4.0",
+						"@emotion/server": "^11.4.0"
+					}
+				},
+				"@leafygreen-ui/lib": {
+					"version": "9.1.0",
+					"resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-9.1.0.tgz",
+					"integrity": "sha512-JH3mnoCZNtUcJfXrvVG4I3PAIm1ehlR1H5WkDqkjengcf/iVMo7+AluzwfTCQb2fqQgohURs+qY4vEhJe+9+2g==",
+					"requires": {
+						"@leafygreen-ui/emotion": "^4.0.0",
+						"facepaint": "^1.2.1",
+						"polished": "^4.1.3",
+						"prop-types": "^15.0.0"
+					}
+				},
+				"csstype": {
+					"version": "3.0.10",
+					"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.10.tgz",
+					"integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA=="
+				},
+				"polished": {
+					"version": "4.1.4",
+					"resolved": "https://registry.npmjs.org/polished/-/polished-4.1.4.tgz",
+					"integrity": "sha512-Nq5Mbza+Auo7N3sQb1QMFaQiDO+4UexWuSGR7Cjb4Sw11SZIJcrrFtiZ+L0jT9MBsUsxDboHVASbCLbE1rnECg==",
+					"requires": {
+						"@babel/runtime": "^7.16.7"
+					}
+				}
+			}
+		},
+		"@leafygreen-ui/code": {
+			"version": "9.4.0",
+			"resolved": "https://registry.npmjs.org/@leafygreen-ui/code/-/code-9.4.0.tgz",
+			"integrity": "sha512-n1ZU5iFGg75B2lBQxGee2Pf6tHtaf5HHXPwIMb6Vgaz+t0WDnheEz3kaNyfpeMiU9CgenQp4N4655rkuzhWBRg==",
+			"requires": {
+				"@leafygreen-ui/a11y": "^1.2.2",
+				"@leafygreen-ui/hooks": "^7.1.1",
+				"@leafygreen-ui/icon": "^11.6.0",
+				"@leafygreen-ui/icon-button": "^9.1.6",
+				"@leafygreen-ui/leafygreen-provider": "^2.1.3",
+				"@leafygreen-ui/lib": "^9.0.1",
+				"@leafygreen-ui/palette": "^3.2.2",
+				"@leafygreen-ui/select": "^3.1.0",
+				"@leafygreen-ui/tokens": "^0.5.3",
+				"clipboard": "^2.0.6",
+				"highlight.js": "^11.0.0",
+				"highlightjs-graphql": "^1.0.1",
+				"highlightjs-line-numbers.js": "^2.7.0"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.17.2",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.2.tgz",
+					"integrity": "sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==",
+					"requires": {
+						"regenerator-runtime": "^0.13.4"
+					}
+				},
+				"@emotion/cache": {
+					"version": "11.7.1",
+					"resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.7.1.tgz",
+					"integrity": "sha512-r65Zy4Iljb8oyjtLeCuBH8Qjiy107dOYC6SJq7g7GV5UCQWMObY4SJDPGFjiiVpPrOJ2hmJOoBiYTC7hwx9E2A==",
+					"requires": {
+						"@emotion/memoize": "^0.7.4",
+						"@emotion/sheet": "^1.1.0",
+						"@emotion/utils": "^1.0.0",
+						"@emotion/weak-memoize": "^0.2.5",
+						"stylis": "4.0.13"
+					}
+				},
+				"@emotion/css": {
+					"version": "11.7.1",
+					"resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.7.1.tgz",
+					"integrity": "sha512-RUUgPlMZunlc7SE5A6Hg+VWRzb2cU6O9xlV78KCFgcnl25s7Qz/20oQg71iKudpLqk7xj0vhbJlwcJJMT0BOZg==",
+					"requires": {
+						"@emotion/babel-plugin": "^11.7.1",
+						"@emotion/cache": "^11.7.1",
+						"@emotion/serialize": "^1.0.0",
+						"@emotion/sheet": "^1.0.3",
+						"@emotion/utils": "^1.0.0"
+					}
+				},
+				"@emotion/serialize": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.0.2.tgz",
+					"integrity": "sha512-95MgNJ9+/ajxU7QIAruiOAdYNjxZX7G2mhgrtDWswA21VviYIRP1R5QilZ/bDY42xiKsaktP4egJb3QdYQZi1A==",
+					"requires": {
+						"@emotion/hash": "^0.8.0",
+						"@emotion/memoize": "^0.7.4",
+						"@emotion/unitless": "^0.7.5",
+						"@emotion/utils": "^1.0.0",
+						"csstype": "^3.0.2"
+					}
+				},
+				"@emotion/sheet": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.1.0.tgz",
+					"integrity": "sha512-u0AX4aSo25sMAygCuQTzS+HsImZFuS8llY8O7b9MDRzbJM0kVJlAz6KNDqcG7pOuQZJmj/8X/rAW+66kMnMW+g=="
+				},
+				"@emotion/utils": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.0.0.tgz",
+					"integrity": "sha512-mQC2b3XLDs6QCW+pDQDiyO/EdGZYOygE8s5N5rrzjSI4M3IejPE/JPndCBwRT9z982aqQNi6beWs1UeayrQxxA=="
+				},
+				"@leafygreen-ui/emotion": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/@leafygreen-ui/emotion/-/emotion-4.0.0.tgz",
+					"integrity": "sha512-nr2g6OFsy+psaMto3H4HQ1ivM1tCwd9k1bbR5WH4U7YibDagfBekFTwlhohmC/K7hUM/eDVPGw0w4zQyC+BwZg==",
+					"requires": {
+						"@emotion/css": "^11.1.3",
+						"@emotion/react": "^11.4.0",
+						"@emotion/server": "^11.4.0"
+					}
+				},
+				"@leafygreen-ui/lib": {
+					"version": "9.1.0",
+					"resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-9.1.0.tgz",
+					"integrity": "sha512-JH3mnoCZNtUcJfXrvVG4I3PAIm1ehlR1H5WkDqkjengcf/iVMo7+AluzwfTCQb2fqQgohURs+qY4vEhJe+9+2g==",
+					"requires": {
+						"@leafygreen-ui/emotion": "^4.0.0",
+						"facepaint": "^1.2.1",
+						"polished": "^4.1.3",
+						"prop-types": "^15.0.0"
+					}
+				},
+				"csstype": {
+					"version": "3.0.10",
+					"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.10.tgz",
+					"integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA=="
+				},
+				"highlight.js": {
+					"version": "11.4.0",
+					"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-11.4.0.tgz",
+					"integrity": "sha512-nawlpCBCSASs7EdvZOYOYVkJpGmAOKMYZgZtUqSRqodZE0GRVcFKwo1RcpeOemqh9hyttTdd5wDBwHkuSyUfnA=="
+				},
+				"polished": {
+					"version": "4.1.4",
+					"resolved": "https://registry.npmjs.org/polished/-/polished-4.1.4.tgz",
+					"integrity": "sha512-Nq5Mbza+Auo7N3sQb1QMFaQiDO+4UexWuSGR7Cjb4Sw11SZIJcrrFtiZ+L0jT9MBsUsxDboHVASbCLbE1rnECg==",
+					"requires": {
+						"@babel/runtime": "^7.16.7"
+					}
+				}
+			}
+		},
+		"@leafygreen-ui/hooks": {
+			"version": "7.2.0",
+			"resolved": "https://registry.npmjs.org/@leafygreen-ui/hooks/-/hooks-7.2.0.tgz",
+			"integrity": "sha512-0EOqwVEWdRIqhOWRUEiX2EVIIEcyzD+9Y7kJGgkecJFmQQs7wb1HqJwElrfyxbOR09ji7iVQwrpHl25qceHDaA==",
+			"requires": {
+				"lodash": "^4.17.21"
 			}
 		},
 		"@leafygreen-ui/icon": {
-			"version": "4.3.0",
-			"resolved": "https://registry.npmjs.org/@leafygreen-ui/icon/-/icon-4.3.0.tgz",
-			"integrity": "sha512-6DOFKxj3U0hp2yQEq/Yq19qIiIIUXwRj2fH1ddOJFYLtAoeFOCSeuF6rE2dqXrXW/puQdjgpXV60w9J8gyXGog=="
-		},
-		"@leafygreen-ui/lib": {
-			"version": "4.4.1",
-			"resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-4.4.1.tgz",
-			"integrity": "sha512-ZVa/LlcoWBXLpks5XQ6MsM/f3cMqxxsqD8iQlGkGncJZN8cJ7NnxqtyY7QsbGSHNQzSNJbOtHxg6dpYRuAWcPw==",
+			"version": "11.6.1",
+			"resolved": "https://registry.npmjs.org/@leafygreen-ui/icon/-/icon-11.6.1.tgz",
+			"integrity": "sha512-IEnZyKubtIC7V3zcXM3GQFNaBpA1mAN1FAmFl3BWGtxoQ5h1lBhffhg0VQB048CsfMBFzfdNcT+ErlzXr7hfFw==",
 			"requires": {
-				"@leafygreen-ui/emotion": "^2.0.1",
-				"@testing-library/react": "^8.0.1",
-				"facepaint": "^1.2.1",
-				"polished": "^2.3.0"
+				"@leafygreen-ui/lib": "^9.0.1"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.17.2",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.2.tgz",
+					"integrity": "sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==",
+					"requires": {
+						"regenerator-runtime": "^0.13.4"
+					}
+				},
+				"@emotion/cache": {
+					"version": "11.7.1",
+					"resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.7.1.tgz",
+					"integrity": "sha512-r65Zy4Iljb8oyjtLeCuBH8Qjiy107dOYC6SJq7g7GV5UCQWMObY4SJDPGFjiiVpPrOJ2hmJOoBiYTC7hwx9E2A==",
+					"requires": {
+						"@emotion/memoize": "^0.7.4",
+						"@emotion/sheet": "^1.1.0",
+						"@emotion/utils": "^1.0.0",
+						"@emotion/weak-memoize": "^0.2.5",
+						"stylis": "4.0.13"
+					}
+				},
+				"@emotion/css": {
+					"version": "11.7.1",
+					"resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.7.1.tgz",
+					"integrity": "sha512-RUUgPlMZunlc7SE5A6Hg+VWRzb2cU6O9xlV78KCFgcnl25s7Qz/20oQg71iKudpLqk7xj0vhbJlwcJJMT0BOZg==",
+					"requires": {
+						"@emotion/babel-plugin": "^11.7.1",
+						"@emotion/cache": "^11.7.1",
+						"@emotion/serialize": "^1.0.0",
+						"@emotion/sheet": "^1.0.3",
+						"@emotion/utils": "^1.0.0"
+					}
+				},
+				"@emotion/serialize": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.0.2.tgz",
+					"integrity": "sha512-95MgNJ9+/ajxU7QIAruiOAdYNjxZX7G2mhgrtDWswA21VviYIRP1R5QilZ/bDY42xiKsaktP4egJb3QdYQZi1A==",
+					"requires": {
+						"@emotion/hash": "^0.8.0",
+						"@emotion/memoize": "^0.7.4",
+						"@emotion/unitless": "^0.7.5",
+						"@emotion/utils": "^1.0.0",
+						"csstype": "^3.0.2"
+					}
+				},
+				"@emotion/sheet": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.1.0.tgz",
+					"integrity": "sha512-u0AX4aSo25sMAygCuQTzS+HsImZFuS8llY8O7b9MDRzbJM0kVJlAz6KNDqcG7pOuQZJmj/8X/rAW+66kMnMW+g=="
+				},
+				"@emotion/utils": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.0.0.tgz",
+					"integrity": "sha512-mQC2b3XLDs6QCW+pDQDiyO/EdGZYOygE8s5N5rrzjSI4M3IejPE/JPndCBwRT9z982aqQNi6beWs1UeayrQxxA=="
+				},
+				"@leafygreen-ui/emotion": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/@leafygreen-ui/emotion/-/emotion-4.0.0.tgz",
+					"integrity": "sha512-nr2g6OFsy+psaMto3H4HQ1ivM1tCwd9k1bbR5WH4U7YibDagfBekFTwlhohmC/K7hUM/eDVPGw0w4zQyC+BwZg==",
+					"requires": {
+						"@emotion/css": "^11.1.3",
+						"@emotion/react": "^11.4.0",
+						"@emotion/server": "^11.4.0"
+					}
+				},
+				"@leafygreen-ui/lib": {
+					"version": "9.1.0",
+					"resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-9.1.0.tgz",
+					"integrity": "sha512-JH3mnoCZNtUcJfXrvVG4I3PAIm1ehlR1H5WkDqkjengcf/iVMo7+AluzwfTCQb2fqQgohURs+qY4vEhJe+9+2g==",
+					"requires": {
+						"@leafygreen-ui/emotion": "^4.0.0",
+						"facepaint": "^1.2.1",
+						"polished": "^4.1.3",
+						"prop-types": "^15.0.0"
+					}
+				},
+				"csstype": {
+					"version": "3.0.10",
+					"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.10.tgz",
+					"integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA=="
+				},
+				"polished": {
+					"version": "4.1.4",
+					"resolved": "https://registry.npmjs.org/polished/-/polished-4.1.4.tgz",
+					"integrity": "sha512-Nq5Mbza+Auo7N3sQb1QMFaQiDO+4UexWuSGR7Cjb4Sw11SZIJcrrFtiZ+L0jT9MBsUsxDboHVASbCLbE1rnECg==",
+					"requires": {
+						"@babel/runtime": "^7.16.7"
+					}
+				}
+			}
+		},
+		"@leafygreen-ui/icon-button": {
+			"version": "9.1.7",
+			"resolved": "https://registry.npmjs.org/@leafygreen-ui/icon-button/-/icon-button-9.1.7.tgz",
+			"integrity": "sha512-MX9lDYzhalor+jlVgnvC9BHMoku7cUHnmF42ZeorHsmsNzAbLTQz3SS0kgqRoRh7VFdFfzdBpYiNNAth+VaRPg==",
+			"requires": {
+				"@leafygreen-ui/a11y": "^1.2.2",
+				"@leafygreen-ui/box": "^3.0.6",
+				"@leafygreen-ui/emotion": "^4.0.0",
+				"@leafygreen-ui/lib": "^9.0.1",
+				"@leafygreen-ui/palette": "^3.2.2"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.17.2",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.2.tgz",
+					"integrity": "sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==",
+					"requires": {
+						"regenerator-runtime": "^0.13.4"
+					}
+				},
+				"@emotion/cache": {
+					"version": "11.7.1",
+					"resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.7.1.tgz",
+					"integrity": "sha512-r65Zy4Iljb8oyjtLeCuBH8Qjiy107dOYC6SJq7g7GV5UCQWMObY4SJDPGFjiiVpPrOJ2hmJOoBiYTC7hwx9E2A==",
+					"requires": {
+						"@emotion/memoize": "^0.7.4",
+						"@emotion/sheet": "^1.1.0",
+						"@emotion/utils": "^1.0.0",
+						"@emotion/weak-memoize": "^0.2.5",
+						"stylis": "4.0.13"
+					}
+				},
+				"@emotion/css": {
+					"version": "11.7.1",
+					"resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.7.1.tgz",
+					"integrity": "sha512-RUUgPlMZunlc7SE5A6Hg+VWRzb2cU6O9xlV78KCFgcnl25s7Qz/20oQg71iKudpLqk7xj0vhbJlwcJJMT0BOZg==",
+					"requires": {
+						"@emotion/babel-plugin": "^11.7.1",
+						"@emotion/cache": "^11.7.1",
+						"@emotion/serialize": "^1.0.0",
+						"@emotion/sheet": "^1.0.3",
+						"@emotion/utils": "^1.0.0"
+					}
+				},
+				"@emotion/serialize": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.0.2.tgz",
+					"integrity": "sha512-95MgNJ9+/ajxU7QIAruiOAdYNjxZX7G2mhgrtDWswA21VviYIRP1R5QilZ/bDY42xiKsaktP4egJb3QdYQZi1A==",
+					"requires": {
+						"@emotion/hash": "^0.8.0",
+						"@emotion/memoize": "^0.7.4",
+						"@emotion/unitless": "^0.7.5",
+						"@emotion/utils": "^1.0.0",
+						"csstype": "^3.0.2"
+					}
+				},
+				"@emotion/sheet": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.1.0.tgz",
+					"integrity": "sha512-u0AX4aSo25sMAygCuQTzS+HsImZFuS8llY8O7b9MDRzbJM0kVJlAz6KNDqcG7pOuQZJmj/8X/rAW+66kMnMW+g=="
+				},
+				"@emotion/utils": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.0.0.tgz",
+					"integrity": "sha512-mQC2b3XLDs6QCW+pDQDiyO/EdGZYOygE8s5N5rrzjSI4M3IejPE/JPndCBwRT9z982aqQNi6beWs1UeayrQxxA=="
+				},
+				"@leafygreen-ui/emotion": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/@leafygreen-ui/emotion/-/emotion-4.0.0.tgz",
+					"integrity": "sha512-nr2g6OFsy+psaMto3H4HQ1ivM1tCwd9k1bbR5WH4U7YibDagfBekFTwlhohmC/K7hUM/eDVPGw0w4zQyC+BwZg==",
+					"requires": {
+						"@emotion/css": "^11.1.3",
+						"@emotion/react": "^11.4.0",
+						"@emotion/server": "^11.4.0"
+					}
+				},
+				"@leafygreen-ui/lib": {
+					"version": "9.1.0",
+					"resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-9.1.0.tgz",
+					"integrity": "sha512-JH3mnoCZNtUcJfXrvVG4I3PAIm1ehlR1H5WkDqkjengcf/iVMo7+AluzwfTCQb2fqQgohURs+qY4vEhJe+9+2g==",
+					"requires": {
+						"@leafygreen-ui/emotion": "^4.0.0",
+						"facepaint": "^1.2.1",
+						"polished": "^4.1.3",
+						"prop-types": "^15.0.0"
+					}
+				},
+				"csstype": {
+					"version": "3.0.10",
+					"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.10.tgz",
+					"integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA=="
+				},
+				"polished": {
+					"version": "4.1.4",
+					"resolved": "https://registry.npmjs.org/polished/-/polished-4.1.4.tgz",
+					"integrity": "sha512-Nq5Mbza+Auo7N3sQb1QMFaQiDO+4UexWuSGR7Cjb4Sw11SZIJcrrFtiZ+L0jT9MBsUsxDboHVASbCLbE1rnECg==",
+					"requires": {
+						"@babel/runtime": "^7.16.7"
+					}
+				}
+			}
+		},
+		"@leafygreen-ui/leafygreen-provider": {
+			"version": "2.1.3",
+			"resolved": "https://registry.npmjs.org/@leafygreen-ui/leafygreen-provider/-/leafygreen-provider-2.1.3.tgz",
+			"integrity": "sha512-PTLZrCwGL+nVIMliwF7gNct7Q6U6/V61bggkShwbQHt0kkT5e089+WdCOs/750yX4aq0j+8a+/50pGHeWTPeHg==",
+			"requires": {
+				"@leafygreen-ui/hooks": "^7.0.0",
+				"@leafygreen-ui/lib": "^9.0.0"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.17.2",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.2.tgz",
+					"integrity": "sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==",
+					"requires": {
+						"regenerator-runtime": "^0.13.4"
+					}
+				},
+				"@emotion/cache": {
+					"version": "11.7.1",
+					"resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.7.1.tgz",
+					"integrity": "sha512-r65Zy4Iljb8oyjtLeCuBH8Qjiy107dOYC6SJq7g7GV5UCQWMObY4SJDPGFjiiVpPrOJ2hmJOoBiYTC7hwx9E2A==",
+					"requires": {
+						"@emotion/memoize": "^0.7.4",
+						"@emotion/sheet": "^1.1.0",
+						"@emotion/utils": "^1.0.0",
+						"@emotion/weak-memoize": "^0.2.5",
+						"stylis": "4.0.13"
+					}
+				},
+				"@emotion/css": {
+					"version": "11.7.1",
+					"resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.7.1.tgz",
+					"integrity": "sha512-RUUgPlMZunlc7SE5A6Hg+VWRzb2cU6O9xlV78KCFgcnl25s7Qz/20oQg71iKudpLqk7xj0vhbJlwcJJMT0BOZg==",
+					"requires": {
+						"@emotion/babel-plugin": "^11.7.1",
+						"@emotion/cache": "^11.7.1",
+						"@emotion/serialize": "^1.0.0",
+						"@emotion/sheet": "^1.0.3",
+						"@emotion/utils": "^1.0.0"
+					}
+				},
+				"@emotion/serialize": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.0.2.tgz",
+					"integrity": "sha512-95MgNJ9+/ajxU7QIAruiOAdYNjxZX7G2mhgrtDWswA21VviYIRP1R5QilZ/bDY42xiKsaktP4egJb3QdYQZi1A==",
+					"requires": {
+						"@emotion/hash": "^0.8.0",
+						"@emotion/memoize": "^0.7.4",
+						"@emotion/unitless": "^0.7.5",
+						"@emotion/utils": "^1.0.0",
+						"csstype": "^3.0.2"
+					}
+				},
+				"@emotion/sheet": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.1.0.tgz",
+					"integrity": "sha512-u0AX4aSo25sMAygCuQTzS+HsImZFuS8llY8O7b9MDRzbJM0kVJlAz6KNDqcG7pOuQZJmj/8X/rAW+66kMnMW+g=="
+				},
+				"@emotion/utils": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.0.0.tgz",
+					"integrity": "sha512-mQC2b3XLDs6QCW+pDQDiyO/EdGZYOygE8s5N5rrzjSI4M3IejPE/JPndCBwRT9z982aqQNi6beWs1UeayrQxxA=="
+				},
+				"@leafygreen-ui/emotion": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/@leafygreen-ui/emotion/-/emotion-4.0.0.tgz",
+					"integrity": "sha512-nr2g6OFsy+psaMto3H4HQ1ivM1tCwd9k1bbR5WH4U7YibDagfBekFTwlhohmC/K7hUM/eDVPGw0w4zQyC+BwZg==",
+					"requires": {
+						"@emotion/css": "^11.1.3",
+						"@emotion/react": "^11.4.0",
+						"@emotion/server": "^11.4.0"
+					}
+				},
+				"@leafygreen-ui/lib": {
+					"version": "9.1.0",
+					"resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-9.1.0.tgz",
+					"integrity": "sha512-JH3mnoCZNtUcJfXrvVG4I3PAIm1ehlR1H5WkDqkjengcf/iVMo7+AluzwfTCQb2fqQgohURs+qY4vEhJe+9+2g==",
+					"requires": {
+						"@leafygreen-ui/emotion": "^4.0.0",
+						"facepaint": "^1.2.1",
+						"polished": "^4.1.3",
+						"prop-types": "^15.0.0"
+					}
+				},
+				"csstype": {
+					"version": "3.0.10",
+					"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.10.tgz",
+					"integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA=="
+				},
+				"polished": {
+					"version": "4.1.4",
+					"resolved": "https://registry.npmjs.org/polished/-/polished-4.1.4.tgz",
+					"integrity": "sha512-Nq5Mbza+Auo7N3sQb1QMFaQiDO+4UexWuSGR7Cjb4Sw11SZIJcrrFtiZ+L0jT9MBsUsxDboHVASbCLbE1rnECg==",
+					"requires": {
+						"@babel/runtime": "^7.16.7"
+					}
+				}
 			}
 		},
 		"@leafygreen-ui/palette": {
-			"version": "2.0.1",
-			"resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-2.0.1.tgz",
-			"integrity": "sha512-xwD6kOokWvaygxF0T2gnf77HEu68G7EXr1ZrNiNtZzg80Y1V2hikhUNoESWij6g/A6qJZvAiwpseflVo3PnlHQ=="
+			"version": "3.3.1",
+			"resolved": "https://registry.npmjs.org/@leafygreen-ui/palette/-/palette-3.3.1.tgz",
+			"integrity": "sha512-XaCkbrZN1pQjll3opoeNTsOXc++MqL6mrkmWf1uPsDYnwTeTPpUH0HN68lgGtjl1sqbOnMJGen+Az17EuYahOw=="
 		},
-		"@leafygreen-ui/syntax": {
-			"version": "2.7.0",
-			"resolved": "https://registry.npmjs.org/@leafygreen-ui/syntax/-/syntax-2.7.0.tgz",
-			"integrity": "sha512-bQRIFKPUwZsne39R49eQN5qEl556w88N/FjJfzAU/LjR2OVp+W5sWhx1PiacwCq+J1r/7wu/PKUh5rV/dpSgmQ==",
+		"@leafygreen-ui/popover": {
+			"version": "7.2.2",
+			"resolved": "https://registry.npmjs.org/@leafygreen-ui/popover/-/popover-7.2.2.tgz",
+			"integrity": "sha512-MtrRHBh5Rw3hY7aQRzPa9209HY2kVCtMY5nOqS3R4JQDqD5VoC5HfYAiSQ7BJRgI9GFZ81sEVfPIYZsNQoqXpg==",
 			"requires": {
-				"@leafygreen-ui/lib": "^4.3.0",
-				"@leafygreen-ui/palette": "^2.0.1",
-				"highlight.js": "^9.15.6",
-				"highlightjs-graphql": "^1.0.1"
+				"@leafygreen-ui/hooks": "^7.0.0",
+				"@leafygreen-ui/leafygreen-provider": "^2.1.3",
+				"@leafygreen-ui/lib": "^9.0.0",
+				"@leafygreen-ui/portal": "^4.0.0",
+				"lodash": "^4.17.21",
+				"react-transition-group": "^4.4.1"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.17.2",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.2.tgz",
+					"integrity": "sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==",
+					"requires": {
+						"regenerator-runtime": "^0.13.4"
+					}
+				},
+				"@emotion/cache": {
+					"version": "11.7.1",
+					"resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.7.1.tgz",
+					"integrity": "sha512-r65Zy4Iljb8oyjtLeCuBH8Qjiy107dOYC6SJq7g7GV5UCQWMObY4SJDPGFjiiVpPrOJ2hmJOoBiYTC7hwx9E2A==",
+					"requires": {
+						"@emotion/memoize": "^0.7.4",
+						"@emotion/sheet": "^1.1.0",
+						"@emotion/utils": "^1.0.0",
+						"@emotion/weak-memoize": "^0.2.5",
+						"stylis": "4.0.13"
+					}
+				},
+				"@emotion/css": {
+					"version": "11.7.1",
+					"resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.7.1.tgz",
+					"integrity": "sha512-RUUgPlMZunlc7SE5A6Hg+VWRzb2cU6O9xlV78KCFgcnl25s7Qz/20oQg71iKudpLqk7xj0vhbJlwcJJMT0BOZg==",
+					"requires": {
+						"@emotion/babel-plugin": "^11.7.1",
+						"@emotion/cache": "^11.7.1",
+						"@emotion/serialize": "^1.0.0",
+						"@emotion/sheet": "^1.0.3",
+						"@emotion/utils": "^1.0.0"
+					}
+				},
+				"@emotion/serialize": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.0.2.tgz",
+					"integrity": "sha512-95MgNJ9+/ajxU7QIAruiOAdYNjxZX7G2mhgrtDWswA21VviYIRP1R5QilZ/bDY42xiKsaktP4egJb3QdYQZi1A==",
+					"requires": {
+						"@emotion/hash": "^0.8.0",
+						"@emotion/memoize": "^0.7.4",
+						"@emotion/unitless": "^0.7.5",
+						"@emotion/utils": "^1.0.0",
+						"csstype": "^3.0.2"
+					}
+				},
+				"@emotion/sheet": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.1.0.tgz",
+					"integrity": "sha512-u0AX4aSo25sMAygCuQTzS+HsImZFuS8llY8O7b9MDRzbJM0kVJlAz6KNDqcG7pOuQZJmj/8X/rAW+66kMnMW+g=="
+				},
+				"@emotion/utils": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.0.0.tgz",
+					"integrity": "sha512-mQC2b3XLDs6QCW+pDQDiyO/EdGZYOygE8s5N5rrzjSI4M3IejPE/JPndCBwRT9z982aqQNi6beWs1UeayrQxxA=="
+				},
+				"@leafygreen-ui/emotion": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/@leafygreen-ui/emotion/-/emotion-4.0.0.tgz",
+					"integrity": "sha512-nr2g6OFsy+psaMto3H4HQ1ivM1tCwd9k1bbR5WH4U7YibDagfBekFTwlhohmC/K7hUM/eDVPGw0w4zQyC+BwZg==",
+					"requires": {
+						"@emotion/css": "^11.1.3",
+						"@emotion/react": "^11.4.0",
+						"@emotion/server": "^11.4.0"
+					}
+				},
+				"@leafygreen-ui/lib": {
+					"version": "9.1.0",
+					"resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-9.1.0.tgz",
+					"integrity": "sha512-JH3mnoCZNtUcJfXrvVG4I3PAIm1ehlR1H5WkDqkjengcf/iVMo7+AluzwfTCQb2fqQgohURs+qY4vEhJe+9+2g==",
+					"requires": {
+						"@leafygreen-ui/emotion": "^4.0.0",
+						"facepaint": "^1.2.1",
+						"polished": "^4.1.3",
+						"prop-types": "^15.0.0"
+					}
+				},
+				"csstype": {
+					"version": "3.0.10",
+					"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.10.tgz",
+					"integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA=="
+				},
+				"polished": {
+					"version": "4.1.4",
+					"resolved": "https://registry.npmjs.org/polished/-/polished-4.1.4.tgz",
+					"integrity": "sha512-Nq5Mbza+Auo7N3sQb1QMFaQiDO+4UexWuSGR7Cjb4Sw11SZIJcrrFtiZ+L0jT9MBsUsxDboHVASbCLbE1rnECg==",
+					"requires": {
+						"@babel/runtime": "^7.16.7"
+					}
+				}
+			}
+		},
+		"@leafygreen-ui/portal": {
+			"version": "4.0.2",
+			"resolved": "https://registry.npmjs.org/@leafygreen-ui/portal/-/portal-4.0.2.tgz",
+			"integrity": "sha512-j4DlxoGvLHl+4cC6xau8WL/Hmf4WiMn9nQc8TLsPW5DWe2DNy62nkcldxuU4aje846Vf9Dx3vlOm0panfEG0RQ==",
+			"requires": {
+				"@leafygreen-ui/hooks": "^7.1.1",
+				"@leafygreen-ui/lib": "^9.0.0"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.17.2",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.2.tgz",
+					"integrity": "sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==",
+					"requires": {
+						"regenerator-runtime": "^0.13.4"
+					}
+				},
+				"@emotion/cache": {
+					"version": "11.7.1",
+					"resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.7.1.tgz",
+					"integrity": "sha512-r65Zy4Iljb8oyjtLeCuBH8Qjiy107dOYC6SJq7g7GV5UCQWMObY4SJDPGFjiiVpPrOJ2hmJOoBiYTC7hwx9E2A==",
+					"requires": {
+						"@emotion/memoize": "^0.7.4",
+						"@emotion/sheet": "^1.1.0",
+						"@emotion/utils": "^1.0.0",
+						"@emotion/weak-memoize": "^0.2.5",
+						"stylis": "4.0.13"
+					}
+				},
+				"@emotion/css": {
+					"version": "11.7.1",
+					"resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.7.1.tgz",
+					"integrity": "sha512-RUUgPlMZunlc7SE5A6Hg+VWRzb2cU6O9xlV78KCFgcnl25s7Qz/20oQg71iKudpLqk7xj0vhbJlwcJJMT0BOZg==",
+					"requires": {
+						"@emotion/babel-plugin": "^11.7.1",
+						"@emotion/cache": "^11.7.1",
+						"@emotion/serialize": "^1.0.0",
+						"@emotion/sheet": "^1.0.3",
+						"@emotion/utils": "^1.0.0"
+					}
+				},
+				"@emotion/serialize": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.0.2.tgz",
+					"integrity": "sha512-95MgNJ9+/ajxU7QIAruiOAdYNjxZX7G2mhgrtDWswA21VviYIRP1R5QilZ/bDY42xiKsaktP4egJb3QdYQZi1A==",
+					"requires": {
+						"@emotion/hash": "^0.8.0",
+						"@emotion/memoize": "^0.7.4",
+						"@emotion/unitless": "^0.7.5",
+						"@emotion/utils": "^1.0.0",
+						"csstype": "^3.0.2"
+					}
+				},
+				"@emotion/sheet": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.1.0.tgz",
+					"integrity": "sha512-u0AX4aSo25sMAygCuQTzS+HsImZFuS8llY8O7b9MDRzbJM0kVJlAz6KNDqcG7pOuQZJmj/8X/rAW+66kMnMW+g=="
+				},
+				"@emotion/utils": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.0.0.tgz",
+					"integrity": "sha512-mQC2b3XLDs6QCW+pDQDiyO/EdGZYOygE8s5N5rrzjSI4M3IejPE/JPndCBwRT9z982aqQNi6beWs1UeayrQxxA=="
+				},
+				"@leafygreen-ui/emotion": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/@leafygreen-ui/emotion/-/emotion-4.0.0.tgz",
+					"integrity": "sha512-nr2g6OFsy+psaMto3H4HQ1ivM1tCwd9k1bbR5WH4U7YibDagfBekFTwlhohmC/K7hUM/eDVPGw0w4zQyC+BwZg==",
+					"requires": {
+						"@emotion/css": "^11.1.3",
+						"@emotion/react": "^11.4.0",
+						"@emotion/server": "^11.4.0"
+					}
+				},
+				"@leafygreen-ui/lib": {
+					"version": "9.1.0",
+					"resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-9.1.0.tgz",
+					"integrity": "sha512-JH3mnoCZNtUcJfXrvVG4I3PAIm1ehlR1H5WkDqkjengcf/iVMo7+AluzwfTCQb2fqQgohURs+qY4vEhJe+9+2g==",
+					"requires": {
+						"@leafygreen-ui/emotion": "^4.0.0",
+						"facepaint": "^1.2.1",
+						"polished": "^4.1.3",
+						"prop-types": "^15.0.0"
+					}
+				},
+				"csstype": {
+					"version": "3.0.10",
+					"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.10.tgz",
+					"integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA=="
+				},
+				"polished": {
+					"version": "4.1.4",
+					"resolved": "https://registry.npmjs.org/polished/-/polished-4.1.4.tgz",
+					"integrity": "sha512-Nq5Mbza+Auo7N3sQb1QMFaQiDO+4UexWuSGR7Cjb4Sw11SZIJcrrFtiZ+L0jT9MBsUsxDboHVASbCLbE1rnECg==",
+					"requires": {
+						"@babel/runtime": "^7.16.7"
+					}
+				}
+			}
+		},
+		"@leafygreen-ui/ripple": {
+			"version": "1.1.2",
+			"resolved": "https://registry.npmjs.org/@leafygreen-ui/ripple/-/ripple-1.1.2.tgz",
+			"integrity": "sha512-hc664vE6FLg8YnpB9HYng+lBh8MarUiaew7bP7Dc5gju1WH727ZAuu0xWa0UiXphgY7S6+QQotpB3CVFIv8bOQ==",
+			"requires": {
+				"@leafygreen-ui/palette": "^3.2.2",
+				"polished": "^4.1.3"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.17.2",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.2.tgz",
+					"integrity": "sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==",
+					"requires": {
+						"regenerator-runtime": "^0.13.4"
+					}
+				},
+				"polished": {
+					"version": "4.1.4",
+					"resolved": "https://registry.npmjs.org/polished/-/polished-4.1.4.tgz",
+					"integrity": "sha512-Nq5Mbza+Auo7N3sQb1QMFaQiDO+4UexWuSGR7Cjb4Sw11SZIJcrrFtiZ+L0jT9MBsUsxDboHVASbCLbE1rnECg==",
+					"requires": {
+						"@babel/runtime": "^7.16.7"
+					}
+				}
+			}
+		},
+		"@leafygreen-ui/select": {
+			"version": "3.1.0",
+			"resolved": "https://registry.npmjs.org/@leafygreen-ui/select/-/select-3.1.0.tgz",
+			"integrity": "sha512-gcTYv+86C0pLJ4SaDvgKbmXEQAABkLe+7HfaobnjLnlHqa5/93w43g5WPq1xFgWHiHezckQnSIZcXDABLkl5gw==",
+			"requires": {
+				"@leafygreen-ui/button": "^12.0.4",
+				"@leafygreen-ui/emotion": "^4.0.0",
+				"@leafygreen-ui/hooks": "^7.1.1",
+				"@leafygreen-ui/icon": "^11.6.0",
+				"@leafygreen-ui/lib": "^9.0.1",
+				"@leafygreen-ui/palette": "^3.2.2",
+				"@leafygreen-ui/popover": "^7.2.2",
+				"@leafygreen-ui/tokens": "0.5.3",
+				"@types/react-is": "^17.0.0",
+				"polished": "^4.1.3",
+				"react-is": "^17.0.1"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.17.2",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.2.tgz",
+					"integrity": "sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==",
+					"requires": {
+						"regenerator-runtime": "^0.13.4"
+					}
+				},
+				"@emotion/cache": {
+					"version": "11.7.1",
+					"resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.7.1.tgz",
+					"integrity": "sha512-r65Zy4Iljb8oyjtLeCuBH8Qjiy107dOYC6SJq7g7GV5UCQWMObY4SJDPGFjiiVpPrOJ2hmJOoBiYTC7hwx9E2A==",
+					"requires": {
+						"@emotion/memoize": "^0.7.4",
+						"@emotion/sheet": "^1.1.0",
+						"@emotion/utils": "^1.0.0",
+						"@emotion/weak-memoize": "^0.2.5",
+						"stylis": "4.0.13"
+					}
+				},
+				"@emotion/css": {
+					"version": "11.7.1",
+					"resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.7.1.tgz",
+					"integrity": "sha512-RUUgPlMZunlc7SE5A6Hg+VWRzb2cU6O9xlV78KCFgcnl25s7Qz/20oQg71iKudpLqk7xj0vhbJlwcJJMT0BOZg==",
+					"requires": {
+						"@emotion/babel-plugin": "^11.7.1",
+						"@emotion/cache": "^11.7.1",
+						"@emotion/serialize": "^1.0.0",
+						"@emotion/sheet": "^1.0.3",
+						"@emotion/utils": "^1.0.0"
+					}
+				},
+				"@emotion/serialize": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.0.2.tgz",
+					"integrity": "sha512-95MgNJ9+/ajxU7QIAruiOAdYNjxZX7G2mhgrtDWswA21VviYIRP1R5QilZ/bDY42xiKsaktP4egJb3QdYQZi1A==",
+					"requires": {
+						"@emotion/hash": "^0.8.0",
+						"@emotion/memoize": "^0.7.4",
+						"@emotion/unitless": "^0.7.5",
+						"@emotion/utils": "^1.0.0",
+						"csstype": "^3.0.2"
+					}
+				},
+				"@emotion/sheet": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.1.0.tgz",
+					"integrity": "sha512-u0AX4aSo25sMAygCuQTzS+HsImZFuS8llY8O7b9MDRzbJM0kVJlAz6KNDqcG7pOuQZJmj/8X/rAW+66kMnMW+g=="
+				},
+				"@emotion/utils": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.0.0.tgz",
+					"integrity": "sha512-mQC2b3XLDs6QCW+pDQDiyO/EdGZYOygE8s5N5rrzjSI4M3IejPE/JPndCBwRT9z982aqQNi6beWs1UeayrQxxA=="
+				},
+				"@leafygreen-ui/emotion": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/@leafygreen-ui/emotion/-/emotion-4.0.0.tgz",
+					"integrity": "sha512-nr2g6OFsy+psaMto3H4HQ1ivM1tCwd9k1bbR5WH4U7YibDagfBekFTwlhohmC/K7hUM/eDVPGw0w4zQyC+BwZg==",
+					"requires": {
+						"@emotion/css": "^11.1.3",
+						"@emotion/react": "^11.4.0",
+						"@emotion/server": "^11.4.0"
+					}
+				},
+				"@leafygreen-ui/lib": {
+					"version": "9.1.0",
+					"resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-9.1.0.tgz",
+					"integrity": "sha512-JH3mnoCZNtUcJfXrvVG4I3PAIm1ehlR1H5WkDqkjengcf/iVMo7+AluzwfTCQb2fqQgohURs+qY4vEhJe+9+2g==",
+					"requires": {
+						"@leafygreen-ui/emotion": "^4.0.0",
+						"facepaint": "^1.2.1",
+						"polished": "^4.1.3",
+						"prop-types": "^15.0.0"
+					}
+				},
+				"csstype": {
+					"version": "3.0.10",
+					"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.10.tgz",
+					"integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA=="
+				},
+				"polished": {
+					"version": "4.1.4",
+					"resolved": "https://registry.npmjs.org/polished/-/polished-4.1.4.tgz",
+					"integrity": "sha512-Nq5Mbza+Auo7N3sQb1QMFaQiDO+4UexWuSGR7Cjb4Sw11SZIJcrrFtiZ+L0jT9MBsUsxDboHVASbCLbE1rnECg==",
+					"requires": {
+						"@babel/runtime": "^7.16.7"
+					}
+				},
+				"react-is": {
+					"version": "17.0.2",
+					"resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+					"integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w=="
+				}
+			}
+		},
+		"@leafygreen-ui/tokens": {
+			"version": "0.5.3",
+			"resolved": "https://registry.npmjs.org/@leafygreen-ui/tokens/-/tokens-0.5.3.tgz",
+			"integrity": "sha512-3K51WA5F23GXpRNi2h4VWF5rIhWXaLK4vEocJCXmwG+2Bdo3uIS43VQmbT4KqVv9e25gzYNuJLBi7hyS6v1naw==",
+			"requires": {
+				"@leafygreen-ui/lib": "^9.0.0"
+			},
+			"dependencies": {
+				"@babel/runtime": {
+					"version": "7.17.2",
+					"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.2.tgz",
+					"integrity": "sha512-hzeyJyMA1YGdJTuWU0e/j4wKXrU4OMFvY2MSlaI9B7VQb0r5cxTE3EAIS2Q7Tn2RIcDkRvTA/v2JsAEhxe99uw==",
+					"requires": {
+						"regenerator-runtime": "^0.13.4"
+					}
+				},
+				"@emotion/cache": {
+					"version": "11.7.1",
+					"resolved": "https://registry.npmjs.org/@emotion/cache/-/cache-11.7.1.tgz",
+					"integrity": "sha512-r65Zy4Iljb8oyjtLeCuBH8Qjiy107dOYC6SJq7g7GV5UCQWMObY4SJDPGFjiiVpPrOJ2hmJOoBiYTC7hwx9E2A==",
+					"requires": {
+						"@emotion/memoize": "^0.7.4",
+						"@emotion/sheet": "^1.1.0",
+						"@emotion/utils": "^1.0.0",
+						"@emotion/weak-memoize": "^0.2.5",
+						"stylis": "4.0.13"
+					}
+				},
+				"@emotion/css": {
+					"version": "11.7.1",
+					"resolved": "https://registry.npmjs.org/@emotion/css/-/css-11.7.1.tgz",
+					"integrity": "sha512-RUUgPlMZunlc7SE5A6Hg+VWRzb2cU6O9xlV78KCFgcnl25s7Qz/20oQg71iKudpLqk7xj0vhbJlwcJJMT0BOZg==",
+					"requires": {
+						"@emotion/babel-plugin": "^11.7.1",
+						"@emotion/cache": "^11.7.1",
+						"@emotion/serialize": "^1.0.0",
+						"@emotion/sheet": "^1.0.3",
+						"@emotion/utils": "^1.0.0"
+					}
+				},
+				"@emotion/serialize": {
+					"version": "1.0.2",
+					"resolved": "https://registry.npmjs.org/@emotion/serialize/-/serialize-1.0.2.tgz",
+					"integrity": "sha512-95MgNJ9+/ajxU7QIAruiOAdYNjxZX7G2mhgrtDWswA21VviYIRP1R5QilZ/bDY42xiKsaktP4egJb3QdYQZi1A==",
+					"requires": {
+						"@emotion/hash": "^0.8.0",
+						"@emotion/memoize": "^0.7.4",
+						"@emotion/unitless": "^0.7.5",
+						"@emotion/utils": "^1.0.0",
+						"csstype": "^3.0.2"
+					}
+				},
+				"@emotion/sheet": {
+					"version": "1.1.0",
+					"resolved": "https://registry.npmjs.org/@emotion/sheet/-/sheet-1.1.0.tgz",
+					"integrity": "sha512-u0AX4aSo25sMAygCuQTzS+HsImZFuS8llY8O7b9MDRzbJM0kVJlAz6KNDqcG7pOuQZJmj/8X/rAW+66kMnMW+g=="
+				},
+				"@emotion/utils": {
+					"version": "1.0.0",
+					"resolved": "https://registry.npmjs.org/@emotion/utils/-/utils-1.0.0.tgz",
+					"integrity": "sha512-mQC2b3XLDs6QCW+pDQDiyO/EdGZYOygE8s5N5rrzjSI4M3IejPE/JPndCBwRT9z982aqQNi6beWs1UeayrQxxA=="
+				},
+				"@leafygreen-ui/emotion": {
+					"version": "4.0.0",
+					"resolved": "https://registry.npmjs.org/@leafygreen-ui/emotion/-/emotion-4.0.0.tgz",
+					"integrity": "sha512-nr2g6OFsy+psaMto3H4HQ1ivM1tCwd9k1bbR5WH4U7YibDagfBekFTwlhohmC/K7hUM/eDVPGw0w4zQyC+BwZg==",
+					"requires": {
+						"@emotion/css": "^11.1.3",
+						"@emotion/react": "^11.4.0",
+						"@emotion/server": "^11.4.0"
+					}
+				},
+				"@leafygreen-ui/lib": {
+					"version": "9.1.0",
+					"resolved": "https://registry.npmjs.org/@leafygreen-ui/lib/-/lib-9.1.0.tgz",
+					"integrity": "sha512-JH3mnoCZNtUcJfXrvVG4I3PAIm1ehlR1H5WkDqkjengcf/iVMo7+AluzwfTCQb2fqQgohURs+qY4vEhJe+9+2g==",
+					"requires": {
+						"@leafygreen-ui/emotion": "^4.0.0",
+						"facepaint": "^1.2.1",
+						"polished": "^4.1.3",
+						"prop-types": "^15.0.0"
+					}
+				},
+				"csstype": {
+					"version": "3.0.10",
+					"resolved": "https://registry.npmjs.org/csstype/-/csstype-3.0.10.tgz",
+					"integrity": "sha512-2u44ZG2OcNUO9HDp/Jl8C07x6pU/eTR3ncV91SiK3dhG9TWvRVsCoJw14Ckx5DgWkzGA3waZWO3d7pgqpUI/XA=="
+				},
+				"polished": {
+					"version": "4.1.4",
+					"resolved": "https://registry.npmjs.org/polished/-/polished-4.1.4.tgz",
+					"integrity": "sha512-Nq5Mbza+Auo7N3sQb1QMFaQiDO+4UexWuSGR7Cjb4Sw11SZIJcrrFtiZ+L0jT9MBsUsxDboHVASbCLbE1rnECg==",
+					"requires": {
+						"@babel/runtime": "^7.16.7"
+					}
+				}
 			}
 		},
 		"@mrmlnc/readdir-enhanced": {
@@ -1307,11 +2608,6 @@
 				"prop-types": "^15.6.1",
 				"react-lifecycles-compat": "^3.0.4"
 			}
-		},
-		"@sheerun/mutationobserver-shim": {
-			"version": "0.3.3",
-			"resolved": "https://registry.npmjs.org/@sheerun/mutationobserver-shim/-/mutationobserver-shim-0.3.3.tgz",
-			"integrity": "sha512-DetpxZw1fzPD5xUBrIAoplLChO2VB8DlL5Gg+I1IR9b2wPqYIca2WSUxL5g1vLeR4MsQq1NeWriXAVffV+U1Fw=="
 		},
 		"@storybook/addon-knobs": {
 			"version": "5.3.18",
@@ -2149,27 +3445,6 @@
 				"loader-utils": "^1.2.3"
 			}
 		},
-		"@testing-library/dom": {
-			"version": "5.6.1",
-			"resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-5.6.1.tgz",
-			"integrity": "sha512-Y1T2bjtvQMewffn1CJ28kpgnuvPYKsBcZMagEH0ppfEMZPDc8AkkEnTk4smrGZKw0cblNB3lhM2FMnpfLExlHg==",
-			"requires": {
-				"@babel/runtime": "^7.5.5",
-				"@sheerun/mutationobserver-shim": "^0.3.2",
-				"aria-query": "3.0.0",
-				"pretty-format": "^24.8.0",
-				"wait-for-expect": "^1.2.0"
-			}
-		},
-		"@testing-library/react": {
-			"version": "8.0.9",
-			"resolved": "https://registry.npmjs.org/@testing-library/react/-/react-8.0.9.tgz",
-			"integrity": "sha512-I7zd+MW5wk8rQA5VopZgBfxGKUd91jgZ6Vzj2gMqFf2iGGtKwvI5SVTrIJcSFaOXK88T2EUsbsIKugDtoqOcZQ==",
-			"requires": {
-				"@babel/runtime": "^7.5.5",
-				"@testing-library/dom": "^5.6.1"
-			}
-		},
 		"@types/anymatch": {
 			"version": "1.3.1",
 			"resolved": "https://registry.npmjs.org/@types/anymatch/-/anymatch-1.3.1.tgz",
@@ -2255,28 +3530,6 @@
 			"integrity": "sha512-iTs9HReBu7evG77Q4EC8hZnqRt57irBDkK9nvmHroiOIVwYMQc4IvYvdRgwKfYepunIY7Oh/dBuuld+Gj9uo6w==",
 			"dev": true
 		},
-		"@types/istanbul-lib-coverage": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.2.tgz",
-			"integrity": "sha512-rsZg7eL+Xcxsxk2XlBt9KcG8nOp9iYdKCOikY9x2RFJCyOdNj4MKPQty0e8oZr29vVAzKXr1BmR+kZauti3o1w=="
-		},
-		"@types/istanbul-lib-report": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/@types/istanbul-lib-report/-/istanbul-lib-report-3.0.0.tgz",
-			"integrity": "sha512-plGgXAPfVKFoYfa9NpYDAkseG+g6Jr294RqeqcqDixSbU34MZVJRi/P+7Y8GDpzkEwLaGZZOpKIEmeVZNtKsrg==",
-			"requires": {
-				"@types/istanbul-lib-coverage": "*"
-			}
-		},
-		"@types/istanbul-reports": {
-			"version": "1.1.2",
-			"resolved": "https://registry.npmjs.org/@types/istanbul-reports/-/istanbul-reports-1.1.2.tgz",
-			"integrity": "sha512-P/W9yOX/3oPZSpaYOCQzGqgCQRXn0FFO/V8bWrCQs+wLmvVVxk6CRBXALEvNs9OHIatlnlFokfhuDo2ug01ciw==",
-			"requires": {
-				"@types/istanbul-lib-coverage": "*",
-				"@types/istanbul-lib-report": "*"
-			}
-		},
 		"@types/json-schema": {
 			"version": "7.0.7",
 			"resolved": "https://registry.npmjs.org/@types/json-schema/-/json-schema-7.0.7.tgz",
@@ -2308,8 +3561,7 @@
 		"@types/prop-types": {
 			"version": "15.7.3",
 			"resolved": "https://registry.npmjs.org/@types/prop-types/-/prop-types-15.7.3.tgz",
-			"integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==",
-			"dev": true
+			"integrity": "sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw=="
 		},
 		"@types/q": {
 			"version": "1.5.4",
@@ -2331,7 +3583,6 @@
 			"version": "16.9.35",
 			"resolved": "https://registry.npmjs.org/@types/react/-/react-16.9.35.tgz",
 			"integrity": "sha512-q0n0SsWcGc8nDqH2GJfWQWUOmZSJhXV64CjVN5SvcNti3TdEaA3AH0D8DwNmMdzjMAC/78tB8nAZIlV8yTz+zQ==",
-			"dev": true,
 			"requires": {
 				"@types/prop-types": "*",
 				"csstype": "^2.2.0"
@@ -2342,6 +3593,14 @@
 			"resolved": "https://registry.npmjs.org/@types/react-color/-/react-color-3.0.1.tgz",
 			"integrity": "sha512-J6mYm43Sid9y+OjZ7NDfJ2VVkeeuTPNVImNFITgQNXodHteKfl/t/5pAR5Z9buodZ2tCctsZjgiMlQOpfntakw==",
 			"dev": true,
+			"requires": {
+				"@types/react": "*"
+			}
+		},
+		"@types/react-is": {
+			"version": "17.0.3",
+			"resolved": "https://registry.npmjs.org/@types/react-is/-/react-is-17.0.3.tgz",
+			"integrity": "sha512-aBTIWg1emtu95bLTLx0cpkxwGW3ueZv71nE2YFBpL8k/z5czEW8yYpOo8Dp+UUAFAtKwNaOsh/ioSeQnWlZcfw==",
 			"requires": {
 				"@types/react": "*"
 			}
@@ -2461,19 +3720,6 @@
 					"dev": true
 				}
 			}
-		},
-		"@types/yargs": {
-			"version": "13.0.9",
-			"resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-13.0.9.tgz",
-			"integrity": "sha512-xrvhZ4DZewMDhoH1utLtOAwYQy60eYFoXeje30TzM3VOvQlBwQaEpKFq5m34k1wOw2AKIi2pwtiAjdmhvlBUzg==",
-			"requires": {
-				"@types/yargs-parser": "*"
-			}
-		},
-		"@types/yargs-parser": {
-			"version": "15.0.0",
-			"resolved": "https://registry.npmjs.org/@types/yargs-parser/-/yargs-parser-15.0.0.tgz",
-			"integrity": "sha512-FA/BWv8t8ZWJ+gEOnLLd8ygxH/2UFbAvgEonyfN6yWGLKc7zVjbpl2Y4CTjid9h2RfgPP6SEt6uHwEOply00yw=="
 		},
 		"@webassemblyjs/ast": {
 			"version": "1.9.0",
@@ -2876,7 +4122,8 @@
 		"ansi-regex": {
 			"version": "4.1.0",
 			"resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.0.tgz",
-			"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg=="
+			"integrity": "sha512-1apePfXM1UOSqw0o9IiFAovVz9M5S1Dg+4TrDwfMewQ6p/rmMueb7tWZjQ1rx4Loy1ArBggoqGpfqqdI4rondg==",
+			"dev": true
 		},
 		"ansi-styles": {
 			"version": "3.2.1",
@@ -2967,15 +4214,6 @@
 			"dev": true,
 			"requires": {
 				"sprintf-js": "~1.0.2"
-			}
-		},
-		"aria-query": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/aria-query/-/aria-query-3.0.0.tgz",
-			"integrity": "sha1-ZbP8wcoRVajJrmTW7uKX8V1RM8w=",
-			"requires": {
-				"ast-types-flow": "0.0.7",
-				"commander": "^2.11.0"
 			}
 		},
 		"arr-diff": {
@@ -3153,11 +4391,6 @@
 			"integrity": "sha512-XTZ7xGML849LkQP86sWdQzfhwbt3YwIO6MqbX9mUNYY98VKaaVZP7YNNm70IpwecbkkxmfC5IYAzOQ/2p29zRA==",
 			"dev": true
 		},
-		"ast-types-flow": {
-			"version": "0.0.7",
-			"resolved": "https://registry.npmjs.org/ast-types-flow/-/ast-types-flow-0.0.7.tgz",
-			"integrity": "sha1-9wtzXGvKGlycItmCw+Oef+ujva0="
-		},
 		"async-each": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/async-each/-/async-each-1.0.3.tgz",
@@ -3332,6 +4565,7 @@
 			"version": "10.0.33",
 			"resolved": "https://registry.npmjs.org/babel-plugin-emotion/-/babel-plugin-emotion-10.0.33.tgz",
 			"integrity": "sha512-bxZbTTGz0AJQDHm8k6Rf3RQJ8tX2scsfsRyKVgAbiUPUNIRtlK+7JxP+TAd1kRLABFxe0CFm2VdK4ePkoA9FxQ==",
+			"dev": true,
 			"requires": {
 				"@babel/helper-module-imports": "^7.0.0",
 				"@emotion/hash": "0.8.0",
@@ -3469,7 +4703,8 @@
 		"babel-plugin-syntax-jsx": {
 			"version": "6.18.0",
 			"resolved": "https://registry.npmjs.org/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz",
-			"integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY="
+			"integrity": "sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=",
+			"dev": true
 		},
 		"babel-plugin-transform-inline-consecutive-adds": {
 			"version": "0.4.3",
@@ -4466,8 +5701,6 @@
 			"version": "2.0.6",
 			"resolved": "https://registry.npmjs.org/clipboard/-/clipboard-2.0.6.tgz",
 			"integrity": "sha512-g5zbiixBRk/wyKakSwCKd7vQXDjFnAMGHoEyBogG/bw9kTD9GvdAvaoRR1ALcEzt3pVKxZR0pViekPMIS0QyGg==",
-			"dev": true,
-			"optional": true,
 			"requires": {
 				"good-listener": "^1.2.2",
 				"select": "^1.1.2",
@@ -4624,7 +5857,8 @@
 		"commander": {
 			"version": "2.20.3",
 			"resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
-			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ=="
+			"integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
+			"dev": true
 		},
 		"commondir": {
 			"version": "1.0.1",
@@ -4967,28 +6201,6 @@
 				}
 			}
 		},
-		"create-emotion": {
-			"version": "10.0.27",
-			"resolved": "https://registry.npmjs.org/create-emotion/-/create-emotion-10.0.27.tgz",
-			"integrity": "sha512-fIK73w82HPPn/RsAij7+Zt8eCE8SptcJ3WoRMfxMtjteYxud8GDTKKld7MYwAX2TVhrw29uR1N/bVGxeStHILg==",
-			"requires": {
-				"@emotion/cache": "^10.0.27",
-				"@emotion/serialize": "^0.11.15",
-				"@emotion/sheet": "0.9.4",
-				"@emotion/utils": "0.11.3"
-			}
-		},
-		"create-emotion-server": {
-			"version": "10.0.27",
-			"resolved": "https://registry.npmjs.org/create-emotion-server/-/create-emotion-server-10.0.27.tgz",
-			"integrity": "sha512-1EbZgdjiho9ue1BSTpAez8SIdfbTXomtz0bg+LPOEvf/5OV7xqCGJaoSCDCB+y7kZ73hwoEhLsoPmqKSGIQMXg==",
-			"requires": {
-				"@emotion/utils": "0.11.3",
-				"html-tokenize": "^2.0.0",
-				"multipipe": "^1.0.2",
-				"through": "^2.3.8"
-			}
-		},
 		"create-hash": {
 			"version": "1.2.0",
 			"resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.2.0.tgz",
@@ -5320,9 +6532,7 @@
 		"delegate": {
 			"version": "3.2.0",
 			"resolved": "https://registry.npmjs.org/delegate/-/delegate-3.2.0.tgz",
-			"integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw==",
-			"dev": true,
-			"optional": true
+			"integrity": "sha512-IofjkYBZaZivn0V8nnsMJGBr4jVLxHDheKSW88PyxS5QC4Vo9ZbZVvhzlSxY87fVq3STR6r+4cGepyHkcWOQSw=="
 		},
 		"delegates": {
 			"version": "1.0.0",
@@ -5487,7 +6697,6 @@
 			"version": "5.1.4",
 			"resolved": "https://registry.npmjs.org/dom-helpers/-/dom-helpers-5.1.4.tgz",
 			"integrity": "sha512-TjMyeVUvNEnOnhzs6uAn9Ya47GmMo3qq7m+Lr/3ON0Rs5kHvb8I+SQYjLUSYn7qhEm0QjW0yrBkvz9yOrwwz1A==",
-			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.8.7",
 				"csstype": "^2.6.7"
@@ -5752,15 +6961,6 @@
 			"resolved": "https://registry.npmjs.org/emojis-list/-/emojis-list-3.0.0.tgz",
 			"integrity": "sha512-/kyM18EfinwXZbno9FyUGeFh87KC8HRQBQGildHZbEuRyWFOmv1U10o9BBp8XVZDVNNuQKyIGIu5ZYAAXJ0V2Q==",
 			"dev": true
-		},
-		"emotion": {
-			"version": "10.0.27",
-			"resolved": "https://registry.npmjs.org/emotion/-/emotion-10.0.27.tgz",
-			"integrity": "sha512-2xdDzdWWzue8R8lu4G76uWX5WhyQuzATon9LmNeCy/2BHVC6dsEpfhN1a0qhELgtDVdjyEA6J8Y/VlI5ZnaH0g==",
-			"requires": {
-				"babel-plugin-emotion": "^10.0.27",
-				"create-emotion": "^10.0.27"
-			}
 		},
 		"emotion-theming": {
 			"version": "10.0.27",
@@ -7452,8 +8652,6 @@
 			"version": "1.2.2",
 			"resolved": "https://registry.npmjs.org/good-listener/-/good-listener-1.2.2.tgz",
 			"integrity": "sha1-1TswzfkxPf+33JoNR3CWqm0UXFA=",
-			"dev": true,
-			"optional": true,
 			"requires": {
 				"delegate": "^3.1.2"
 			}
@@ -7635,15 +8833,15 @@
 			"integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
 			"dev": true
 		},
-		"highlight.js": {
-			"version": "9.18.1",
-			"resolved": "https://registry.npmjs.org/highlight.js/-/highlight.js-9.18.1.tgz",
-			"integrity": "sha512-OrVKYz70LHsnCgmbXctv/bfuvntIKDz177h0Co37DQ5jamGZLVmoCVMtjMtNZY3X9DrCcKfklHPNeA0uPZhSJg=="
-		},
 		"highlightjs-graphql": {
 			"version": "1.0.1",
 			"resolved": "https://registry.npmjs.org/highlightjs-graphql/-/highlightjs-graphql-1.0.1.tgz",
 			"integrity": "sha512-g5kt/orsUJTjIt5pgs/uvi78kXndpCtYwzE7H3D0d07r3ETs9oHSZHD0EGaRPndiQ/4EYXt12rnsDkljn3ilAA=="
+		},
+		"highlightjs-line-numbers.js": {
+			"version": "2.8.0",
+			"resolved": "https://registry.npmjs.org/highlightjs-line-numbers.js/-/highlightjs-line-numbers.js-2.8.0.tgz",
+			"integrity": "sha512-TEf1gw0c8mb8nan0QwliqS7obT4cpUd9hzsGzsZLweteNnWea/VIqy5/aQqsa5wnz9lnvmtAkS1ZtDTjB/goYQ=="
 		},
 		"hmac-drbg": {
 			"version": "1.0.1",
@@ -7660,7 +8858,6 @@
 			"version": "3.3.2",
 			"resolved": "https://registry.npmjs.org/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz",
 			"integrity": "sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==",
-			"dev": true,
 			"requires": {
 				"react-is": "^16.7.0"
 			}
@@ -9028,7 +10225,6 @@
 			"version": "1.4.0",
 			"resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
 			"integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
-			"dev": true,
 			"requires": {
 				"js-tokens": "^3.0.0 || ^4.0.0"
 			}
@@ -10418,14 +11614,6 @@
 				"ts-pnp": "^1.1.2"
 			}
 		},
-		"polished": {
-			"version": "2.3.3",
-			"resolved": "https://registry.npmjs.org/polished/-/polished-2.3.3.tgz",
-			"integrity": "sha512-59V4fDbdxtH4I1m9TWxFsoGJbC8nnOpUYo5uFmvMfKp9Qh+6suo4VMUle1TGIIUZIGxfkW+Rs485zPk0wcwR2Q==",
-			"requires": {
-				"@babel/runtime": "^7.2.0"
-			}
-		},
 		"popper.js": {
 			"version": "1.16.1",
 			"resolved": "https://registry.npmjs.org/popper.js/-/popper.js-1.16.1.tgz",
@@ -10616,17 +11804,6 @@
 				"utila": "~0.4"
 			}
 		},
-		"pretty-format": {
-			"version": "24.9.0",
-			"resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-24.9.0.tgz",
-			"integrity": "sha512-00ZMZUiHaJrNfk33guavqgvfJS30sLYf0f8+Srklv0AMPodGGHcoHgksZ3OThYnIvOd+8yMCn0YiEOogjlgsnA==",
-			"requires": {
-				"@jest/types": "^24.9.0",
-				"ansi-regex": "^4.0.0",
-				"ansi-styles": "^3.2.0",
-				"react-is": "^16.8.4"
-			}
-		},
 		"pretty-hrtime": {
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/pretty-hrtime/-/pretty-hrtime-1.0.3.tgz",
@@ -10708,7 +11885,6 @@
 			"version": "15.7.2",
 			"resolved": "https://registry.npmjs.org/prop-types/-/prop-types-15.7.2.tgz",
 			"integrity": "sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==",
-			"dev": true,
 			"requires": {
 				"loose-envify": "^1.4.0",
 				"object-assign": "^4.1.1",
@@ -11531,7 +12707,6 @@
 			"version": "4.4.1",
 			"resolved": "https://registry.npmjs.org/react-transition-group/-/react-transition-group-4.4.1.tgz",
 			"integrity": "sha512-Djqr7OQ2aPUiYurhPalTrVy9ddmFCCzwhqQmtN+J3+3DzLO209Fdr70QrN8Z3DsglWql6iY1lDWAfpFiBtuKGw==",
-			"dev": true,
 			"requires": {
 				"@babel/runtime": "^7.5.5",
 				"dom-helpers": "^5.0.1",
@@ -11939,9 +13114,7 @@
 		"select": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/select/-/select-1.1.2.tgz",
-			"integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0=",
-			"dev": true,
-			"optional": true
+			"integrity": "sha1-DnNQrN7ICxEIUoeG7B1EGNEbOW0="
 		},
 		"semver": {
 			"version": "5.7.1",
@@ -12864,6 +14037,11 @@
 				}
 			}
 		},
+		"stylis": {
+			"version": "4.0.13",
+			"resolved": "https://registry.npmjs.org/stylis/-/stylis-4.0.13.tgz",
+			"integrity": "sha512-xGPXiFVl4YED9Jh7Euv2V220mriG9u4B2TA6Ybjc1catrstKD2PpIdU3U0RKpkVBC2EhmL/F0sPCr9vrFTNRag=="
+		},
 		"supports-color": {
 			"version": "5.5.0",
 			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
@@ -13127,9 +14305,7 @@
 		"tiny-emitter": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/tiny-emitter/-/tiny-emitter-2.1.0.tgz",
-			"integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q==",
-			"dev": true,
-			"optional": true
+			"integrity": "sha512-NB6Dk1A9xgQPMoGqC5CVXn123gWyte215ONT5Pp5a0yt4nlEoO1ZWeCwpncaekPHXO60i47ihFnZPiRPjRMq4Q=="
 		},
 		"tinycolor2": {
 			"version": "1.4.1",
@@ -13596,11 +14772,6 @@
 			"version": "2.0.1",
 			"resolved": "https://registry.npmjs.org/void-elements/-/void-elements-2.0.1.tgz",
 			"integrity": "sha1-wGavtYK7HLQSjWDqkjkulNXp2+w="
-		},
-		"wait-for-expect": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/wait-for-expect/-/wait-for-expect-1.3.0.tgz",
-			"integrity": "sha512-8fJU7jiA96HfGPt+P/UilelSAZfhMBJ52YhKzlmZQvKEZU2EcD1GQ0yqGB6liLdHjYtYAoGVigYwdxr5rktvzA=="
 		},
 		"warning": {
 			"version": "4.0.3",

--- a/packages/browser-repl/package.json
+++ b/packages/browser-repl/package.json
@@ -38,9 +38,6 @@
     ]
   },
   "dependencies": {
-    "@leafygreen-ui/code": "^9.4.0",
-    "@leafygreen-ui/icon": "^11.6.1",
-    "@leafygreen-ui/palette": "^3.3.1",
     "@mongosh/browser-runtime-core": "0.0.0-dev.0",
     "@mongosh/errors": "0.0.0-dev.0",
     "@mongosh/history": "0.0.0-dev.0",
@@ -58,6 +55,9 @@
     "@babel/preset-env": "^7.9.5",
     "@babel/preset-react": "^7.9.4",
     "@babel/preset-typescript": "^7.9.0",
+    "@leafygreen-ui/code": "^9.4.0",
+    "@leafygreen-ui/icon": "^11.6.1",
+    "@leafygreen-ui/palette": "^3.3.1",
     "@storybook/addon-knobs": "^5.3.10",
     "@storybook/react": "^5.3.1",
     "@types/classnames": "^2.2.11",
@@ -88,6 +88,9 @@
     "webpack-visualizer-plugin": "^0.1.11"
   },
   "peerDependencies": {
+    "@leafygreen-ui/code": "^9.4.0",
+    "@leafygreen-ui/icon": "^11.6.1",
+    "@leafygreen-ui/palette": "^3.3.1",
     "mongodb-ace-theme": "^0.0.1",
     "prop-types": "^15.7.2",
     "react": "^16.12.0",

--- a/packages/browser-repl/package.json
+++ b/packages/browser-repl/package.json
@@ -38,9 +38,9 @@
     ]
   },
   "dependencies": {
-    "@leafygreen-ui/icon": "^4.0.0",
-    "@leafygreen-ui/palette": "^2.0.0",
-    "@leafygreen-ui/syntax": "^2.2.0",
+    "@leafygreen-ui/code": "^9.4.0",
+    "@leafygreen-ui/icon": "^11.6.1",
+    "@leafygreen-ui/palette": "^3.3.1",
     "@mongosh/browser-runtime-core": "0.0.0-dev.0",
     "@mongosh/errors": "0.0.0-dev.0",
     "@mongosh/history": "0.0.0-dev.0",

--- a/packages/browser-repl/src/components/utils/syntax-highlight.less
+++ b/packages/browser-repl/src/components/utils/syntax-highlight.less
@@ -1,5 +1,5 @@
 .syntax-highlight {
-  pre, code {
+  * {
     background: transparent;
     border: 0px transparent;
     padding: 0px;

--- a/packages/browser-repl/src/components/utils/syntax-highlight.spec.tsx
+++ b/packages/browser-repl/src/components/utils/syntax-highlight.spec.tsx
@@ -4,18 +4,18 @@ import { shallow } from '../../../testing/enzyme';
 import { SyntaxHighlight } from './syntax-highlight';
 
 describe('<SyntaxHighlight />', () => {
-  it('renders Syntax', () => {
+  it('renders Code', () => {
     const wrapper = shallow(<SyntaxHighlight code={'some code'} />);
-    expect(wrapper.find('Syntax')).to.have.lengthOf(1);
+    expect(wrapper.find('Code')).to.have.lengthOf(1);
   });
 
-  it('passes code to Syntax', () => {
+  it('passes code to Code', () => {
     const wrapper = shallow(<SyntaxHighlight code={'some code'} />);
-    expect(wrapper.find('Syntax').children().text()).to.contain('some code');
+    expect(wrapper.find('Code').children().text()).to.contain('some code');
   });
 
   it('uses javascript as language', () => {
     const wrapper = shallow(<SyntaxHighlight code={'some code'} />);
-    expect(wrapper.find('Syntax').prop('language')).to.equal('javascript');
+    expect(wrapper.find('Code').prop('language')).to.equal('javascript');
   });
 });

--- a/packages/browser-repl/src/components/utils/syntax-highlight.tsx
+++ b/packages/browser-repl/src/components/utils/syntax-highlight.tsx
@@ -15,9 +15,9 @@ export class SyntaxHighlight extends Component<SyntaxHighlightProps> {
 
   render(): JSX.Element {
     return (<div className={styles['syntax-highlight']}>
-      {/* <pre> */}
+      <pre>
         <Code language="javascript" darkMode>{this.props.code}</Code>
-      {/* </pre> */}
+      </pre>
     </div>);
   }
 }

--- a/packages/browser-repl/src/components/utils/syntax-highlight.tsx
+++ b/packages/browser-repl/src/components/utils/syntax-highlight.tsx
@@ -1,8 +1,6 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
-import classnames from 'classnames';
-
-import Syntax from '@leafygreen-ui/syntax';
+import Code from '@leafygreen-ui/code';
 
 const styles = require('./syntax-highlight.less');
 
@@ -16,8 +14,10 @@ export class SyntaxHighlight extends Component<SyntaxHighlightProps> {
   };
 
   render(): JSX.Element {
-    return (<div className={classnames(styles['syntax-highlight'])}>
-      <pre><Syntax language="javascript" variant="dark">{this.props.code}</Syntax></pre>
+    return (<div className={styles['syntax-highlight']}>
+      {/* <pre> */}
+        <Code language="javascript" darkMode>{this.props.code}</Code>
+      {/* </pre> */}
     </div>);
   }
 }

--- a/packages/browser-repl/src/components/utils/syntax-highlight.tsx
+++ b/packages/browser-repl/src/components/utils/syntax-highlight.tsx
@@ -14,12 +14,13 @@ export class SyntaxHighlight extends Component<SyntaxHighlightProps> {
   };
 
   render(): JSX.Element {
-    return (<div className={styles['syntax-highlight']}>
-      <pre>
-        <Code language="javascript" darkMode>{this.props.code}</Code>
-      </pre>
-    </div>);
+    return (
+      <Code
+        language="javascript"
+        darkMode
+        className={styles['syntax-highlight']}
+        copyable={false}
+      >{this.props.code}</Code>
+    );
   }
 }
-
-

--- a/packages/shell-api/src/shell-instance-state.ts
+++ b/packages/shell-api/src/shell-instance-state.ts
@@ -148,7 +148,6 @@ export default class ShellInstanceState {
   constructor(initialServiceProvider: ServiceProvider, messageBus: any = new EventEmitter(), cliOptions: ShellCliOptions = {}) {
     this.initialServiceProvider = initialServiceProvider;
     this.messageBus = messageBus;
-    console.log('here');
     this.shellApi = new ShellApi(this);
     this.shellBson = constructShellBson(initialServiceProvider.bsonLibrary, (msg: string) => {
       void this.shellApi.print(`Warning: ${msg}`);

--- a/packages/shell-api/src/shell-instance-state.ts
+++ b/packages/shell-api/src/shell-instance-state.ts
@@ -148,6 +148,7 @@ export default class ShellInstanceState {
   constructor(initialServiceProvider: ServiceProvider, messageBus: any = new EventEmitter(), cliOptions: ShellCliOptions = {}) {
     this.initialServiceProvider = initialServiceProvider;
     this.messageBus = messageBus;
+    console.log('here');
     this.shellApi = new ShellApi(this);
     this.shellBson = constructShellBson(initialServiceProvider.bsonLibrary, (msg: string) => {
       void this.shellApi.print(`Warning: ${msg}`);


### PR DESCRIPTION
This is part of [COMPASS-5422](https://jira.mongodb.org/browse/COMPASS-5422) - which COMPASS-5512 depends on.
This doesn't solve the full issue of how to better use the `browser-repl` with better dependency management in Compass (and potentially other places), which I'm still investigating. This won't close that ticket yet.
This pr unblocks the Compass fix. It bumps the leafygreen versions to a version which uses the newer emotion version which Compass needs to align on.

The `Syntax` component in Leafygreen has been deprecated, so this replaces the functionality with a `Code` component. https://www.mongodb.design/component/code/example/

Before:
<img width="1298" alt="Screen Shot 2022-02-16 at 11 20 35 AM" src="https://user-images.githubusercontent.com/1791149/154309233-b9aadcde-e9ce-4e37-a08e-ee98b4e9a324.png">


After:
<img width="1302" alt="Screen Shot 2022-02-16 at 11 07 17 AM" src="https://user-images.githubusercontent.com/1791149/154308527-a6c9d361-7ba2-4105-ba9d-b79600897bc5.png">

(^ They should look the same)