### PR TITLE
chore(cli-repl): avoid deprecated count in --shell test

### DIFF
--- a/packages/cli-repl/src/cli-repl.spec.ts
+++ b/packages/cli-repl/src/cli-repl.spec.ts
@@ -1067,7 +1067,7 @@ describe('CliRepl', () => {
         expect(output).to.match(/Inserted: ObjectId\("[a-z0-9]{24}"\)/);
         expect(exitCode).to.equal(null);
 
-        input.write('print("doc count", insertTestCollection.count())\n');
+        input.write('print("doc count", insertTestCollection.countDocuments())\n');
         await waitEval(cliRepl.bus);
         expect(output).to.include('doc count 1');
 


### PR DESCRIPTION
`.count()` is deprecated and should not be used, and makes this
test currently fail in `apiStrict` mode because it uses the `count`
command since the recent driver version bump to 4.4.0.