### PR TITLE
chore(ci): bump publish task timeout to 1d

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -8206,7 +8206,7 @@ tasks:
   - name: release_publish
     tags: ["publish"]
     git_tag_only: true
-    exec_timeout_secs: 10800
+    exec_timeout_secs: 86400
     depends_on:
       - name: compile_ts
         variant: linux

--- a/.evergreen/evergreen.yml.in
+++ b/.evergreen/evergreen.yml.in
@@ -836,7 +836,7 @@ tasks:
   - name: release_publish
     tags: ["publish"]
     git_tag_only: true
-    exec_timeout_secs: 10800
+    exec_timeout_secs: 86400
     depends_on:
       - name: compile_ts
         variant: linux


### PR DESCRIPTION
The mongosh 1.2.0 failed because the publishing task failed after
three hours (!). This is a good reminder to poke the build team
about BUILD-13863 again, but for now, it seems like we have to
set the timeout to something that seems really unrealistically high.