### PR TITLE
fix(node-runtime-worker-thread): externalize system-ca and deps

### DIFF
--- a/packages/node-runtime-worker-thread/.depcheckrc
+++ b/packages/node-runtime-worker-thread/.depcheckrc
@@ -1,2 +1,2 @@
-ignores: ['webpack-cli']
+ignores: ['webpack-cli', 'system-ca']
 skip-missing: true

--- a/packages/node-runtime-worker-thread/package-lock.json
+++ b/packages/node-runtime-worker-thread/package-lock.json
@@ -2356,6 +2356,16 @@
 				"yallist": "^4.0.0"
 			}
 		},
+		"macos-export-certificate-and-key": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/macos-export-certificate-and-key/-/macos-export-certificate-and-key-1.1.1.tgz",
+			"integrity": "sha512-J2g0dJRLG3DghmdCkbJnif/zPmSylj6ql//xBYff5allzNlHPnWxRoyho9XznBYLbPJw4jZlKjMO69jtV8VC7Q==",
+			"optional": true,
+			"requires": {
+				"bindings": "^1.5.0",
+				"node-addon-api": "^4.3.0"
+			}
+		},
 		"make-dir": {
 			"version": "2.1.0",
 			"resolved": "https://registry.npmjs.org/make-dir/-/make-dir-2.1.0.tgz",
@@ -2653,6 +2663,12 @@
 			"integrity": "sha512-Yd3UES5mWCSqR+qNT93S3UoYUkqAZ9lLg8a7g9rimsWmYGK8cVToA4/sF3RrshdyV3sAGMXVUmpMYOw+dLpOuw==",
 			"dev": true
 		},
+		"node-addon-api": {
+			"version": "4.3.0",
+			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
+			"integrity": "sha512-73sE9+3UaLYYFmDsFZnqCInzPyh3MqIwZO9cw58yIqAZhONrrabrYyYe3TuIqtIiOuTXVhsGau8hcrhhwSsDIQ==",
+			"optional": true
+		},
 		"node-environment-flags": {
 			"version": "1.0.6",
 			"resolved": "https://registry.npmjs.org/node-environment-flags/-/node-environment-flags-1.0.6.tgz",
@@ -2662,6 +2678,12 @@
 				"object.getownpropertydescriptors": "^2.0.3",
 				"semver": "^5.7.0"
 			}
+		},
+		"node-forge": {
+			"version": "1.2.1",
+			"resolved": "https://registry.npmjs.org/node-forge/-/node-forge-1.2.1.tgz",
+			"integrity": "sha512-Fcvtbb+zBcZXbTTVwqGA5W+MKBj56UjVRevvchv5XrcyXbmNdesfZL37nlcWOfpgHhgmxApw3tQbTr4CqNmX4w==",
+			"optional": true
 		},
 		"node-libs-browser": {
 			"version": "2.2.1",
@@ -3713,6 +3735,15 @@
 			"dev": true,
 			"requires": {
 				"has-flag": "^3.0.0"
+			}
+		},
+		"system-ca": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/system-ca/-/system-ca-1.0.2.tgz",
+			"integrity": "sha512-/6CCJOKB5Fpi0x7/DCbV7uiFPgwGCeJsAaSondXS2DjLBv7ER2worVGvQWJqPM0kgOKO6auaCcSWpJKnrDmXjw==",
+			"requires": {
+				"macos-export-certificate-and-key": "^1.1.1",
+				"win-export-certificate-and-key": "^1.1.1"
 			}
 		},
 		"tapable": {
@@ -4871,6 +4902,17 @@
 			"dev": true,
 			"requires": {
 				"string-width": "^1.0.2 || 2"
+			}
+		},
+		"win-export-certificate-and-key": {
+			"version": "1.1.1",
+			"resolved": "https://registry.npmjs.org/win-export-certificate-and-key/-/win-export-certificate-and-key-1.1.1.tgz",
+			"integrity": "sha512-wvF1DKlbt/PLOSdnKzIqv0Ipj+87n2VYOJFbkqBoN7l3l244reT7Lf6+Dnu86bYVWoVpq3ZZG417OLNHFnkP6A==",
+			"optional": true,
+			"requires": {
+				"bindings": "^1.5.0",
+				"node-addon-api": "^4.3.0",
+				"node-forge": "^1.2.1"
 			}
 		},
 		"worker-farm": {

--- a/packages/node-runtime-worker-thread/package.json
+++ b/packages/node-runtime-worker-thread/package.json
@@ -42,6 +42,7 @@
     "webpack-cli": "^4.3.1"
   },
   "dependencies": {
-    "interruptor": "^1.0.1"
+    "interruptor": "^1.0.1",
+    "system-ca": "^1.0.2"
   }
 }

--- a/packages/node-runtime-worker-thread/webpack.config.js
+++ b/packages/node-runtime-worker-thread/webpack.config.js
@@ -44,6 +44,7 @@ const config = {
     snappy: 'commonjs2 snappy',
     interruptor: 'commonjs2 interruptor',
     'os-dns-native': 'commonjs2 os-dns-native',
+    'system-ca': 'commonjs2 system-ca'
   }
 };
 


### PR DESCRIPTION
COMPASS-4105

In order to be usable in Compass, system-ca and its addon dependencies
need to be externalized in the webpack configuration.

Theoretically, it might be enough to only externalize the addons;
however, since system-ca prefers to use worker threads for loading
certificates asynchronously on macOS and Windows, and we need to
externalize *something*, it makes sense to do it on the system-ca
level.