### PR TITLE
chore: bump ace autocompleter to 0.11.0 COMPASS-5556

### DIFF
--- a/packages/autocomplete/package-lock.json
+++ b/packages/autocomplete/package-lock.json
@@ -614,9 +614,9 @@
 			}
 		},
 		"mongodb-ace-autocompleter": {
-			"version": "0.10.0",
-			"resolved": "https://registry.npmjs.org/mongodb-ace-autocompleter/-/mongodb-ace-autocompleter-0.10.0.tgz",
-			"integrity": "sha512-dDC9ZtPtRYPInxJ1Pw54HF5Jnyz15zVM1tpGOMpk0tPyTqVrWAngfn9CjrxuGDGAguLqv6WhDOYwnlx15Hx+UQ==",
+			"version": "0.11.0",
+			"resolved": "https://registry.npmjs.org/mongodb-ace-autocompleter/-/mongodb-ace-autocompleter-0.11.0.tgz",
+			"integrity": "sha512-utGCP+CtqR5nnrl8VD7VPKtxMawcur8o1PGPEDX8GzBmdhormsmE3svQqYTQvxeyO/05w7/rK1/gUmiFK/sqCQ==",
 			"requires": {
 				"semver": "^7.3.5"
 			},

--- a/packages/autocomplete/package.json
+++ b/packages/autocomplete/package.json
@@ -32,7 +32,7 @@
   },
   "dependencies": {
     "@mongosh/shell-api": "0.0.0-dev.0",
-    "mongodb-ace-autocompleter": "^0.10.0",
+    "mongodb-ace-autocompleter": "^0.11.0",
     "semver": "^7.3.2"
   }
 }


### PR DESCRIPTION
bump ace-autocomplete version using npm@6