### PR TITLE
fix: use user id and anonymous id as segment identity MONGOSH-1143

### DIFF
--- a/packages/cli-repl/README.md
+++ b/packages/cli-repl/README.md
@@ -99,8 +99,8 @@ bus.emit('mongosh:connect', {
 })
 ```
 
-### bus.on('mongosh:new-user', userID, enableTelemetry)
-Where `userID` is a [BSON ObjectID][object-id] and `enableTelemetry` is a boolean flag.
+### bus.on('mongosh:new-user', telemetryAnonymousId, enableTelemetry)
+Where `telemetryAnonymousId` is a [BSON ObjectID][object-id] and `enableTelemetry` is a boolean flag.
 This is used for telemetry tracking when the user initially uses mongosh.
 
 Example:
@@ -108,14 +108,16 @@ Example:
 bus.emit('mongosh:new-user', '12394dfjvnaw3uw3erdf', true)
 ```
 
-### bus.on('mongosh:update-user', id, enableTelemetry)
-Where `userID` is a [BSON ObjectID][object-id] and `enableTelemetry` is a boolean flag.
-This is used internally to update telemetry preferences and userID in the
+### bus.on('mongosh:update-user', telemetryUserIdentity, enableTelemetry)
+Initially, we used `userId` as Segment user identifier, but this usage is being deprecated.
+The `anonymousId` should be used instead. We keep sending `userId` to Segment for old users though to preserve their analytics.
+Where `userID`/`anonymousId` is a [BSON ObjectID][object-id] and `enableTelemetry` is a boolean flag.
+This is used internally to update telemetry preferences and `userID`/`anonymousId` in the
 logger.
 
 Example:
 ```js
-bus.emit('mongosh:update-user', '12394dfjvnaw3uw3erdf', false)
+bus.emit('mongosh:update-user', { userId: undefined, anonymousId: '12394dfjvnaw3uw3erdf' } , false)
 ```
 
 ### bus.on('mongosh:error', error)

--- a/packages/cli-repl/test/e2e.spec.ts
+++ b/packages/cli-repl/test/e2e.spec.ts
@@ -884,7 +884,7 @@ describe('e2e', function() {
       describe('config file', () => {
         it('sets up a config file', async() => {
           const config = await readConfig();
-          expect(config.userId).to.match(/^[a-f0-9]{24}$/);
+          expect(config.telemetryAnonymousId).to.match(/^[a-f0-9]{24}$/);
           expect(config.enableTelemetry).to.be.true;
           expect(config.disableGreetingMessage).to.be.true;
         });

--- a/packages/java-shell/package-lock.json
+++ b/packages/java-shell/package-lock.json
@@ -708,9 +708,9 @@
 			"dev": true
 		},
 		"has-symbols": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.2.tgz",
-			"integrity": "sha512-chXa79rL/UC2KlX17jo3vRGz0azaWEx5tGqZg5pO3NUyEJVB17dMruQlzCCOfUvElghKcm5194+BCRvi2Rv/Gw==",
+			"version": "1.0.3",
+			"resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
+			"integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
 			"dev": true
 		},
 		"has-tostringtag": {

--- a/packages/logging/src/analytics-helpers.spec.ts
+++ b/packages/logging/src/analytics-helpers.spec.ts
@@ -17,18 +17,18 @@ describe('ToggleableAnalytics', () => {
     const toggleable = new ToggleableAnalytics(target);
     expect(events).to.have.lengthOf(0);
 
-    toggleable.identify({ userId: 'me', traits: { platform: '1234' } });
-    toggleable.track({ userId: 'me', event: 'something', properties: { mongosh_version: '1.2.3' } });
+    toggleable.identify({ anonymousId: 'me', traits: { platform: '1234' } });
+    toggleable.track({ anonymousId: 'me', event: 'something', properties: { mongosh_version: '1.2.3' } });
     expect(events).to.have.lengthOf(0);
 
     toggleable.enable();
     expect(events).to.have.lengthOf(2);
 
-    toggleable.track({ userId: 'me', event: 'something2', properties: { mongosh_version: '1.2.3' } });
+    toggleable.track({ anonymousId: 'me', event: 'something2', properties: { mongosh_version: '1.2.3' } });
     expect(events).to.have.lengthOf(3);
 
     toggleable.pause();
-    toggleable.track({ userId: 'me', event: 'something3', properties: { mongosh_version: '1.2.3' } });
+    toggleable.track({ anonymousId: 'me', event: 'something3', properties: { mongosh_version: '1.2.3' } });
     expect(events).to.have.lengthOf(3);
 
     toggleable.disable();
@@ -36,9 +36,9 @@ describe('ToggleableAnalytics', () => {
     toggleable.enable();
 
     expect(events).to.deep.equal([
-      [ 'identify', { userId: 'me', traits: { platform: '1234' } } ],
-      [ 'track', { userId: 'me', event: 'something', properties: { mongosh_version: '1.2.3' } } ],
-      [ 'track', { userId: 'me', event: 'something2', properties: { mongosh_version: '1.2.3' } } ]
+      [ 'identify', { anonymousId: 'me', traits: { platform: '1234' } } ],
+      [ 'track', { anonymousId: 'me', event: 'something', properties: { mongosh_version: '1.2.3' } } ],
+      [ 'track', { anonymousId: 'me', event: 'something2', properties: { mongosh_version: '1.2.3' } } ]
     ]);
   });
 });

--- a/packages/logging/src/analytics-helpers.ts
+++ b/packages/logging/src/analytics-helpers.ts
@@ -3,12 +3,14 @@
  */
 export interface MongoshAnalytics {
   identify(message: {
-    userId: string,
+    userId?: string,
+    anonymousId: string,
     traits: { platform: string }
   }): void;
 
   track(message: {
-    userId: string,
+    userId?: string,
+    anonymousId: string,
     event: string,
     properties: {
       // eslint-disable-next-line camelcase

--- a/packages/logging/src/setup-logger-and-telemetry.spec.ts
+++ b/packages/logging/src/setup-logger-and-telemetry.spec.ts
@@ -10,7 +10,7 @@ describe('setupLoggerAndTelemetry', () => {
   let analyticsOutput: ['identify'|'track'|'log', any][];
   let bus: MongoshBus;
 
-  const userId = '53defe995fa47e6c13102d9d';
+  const telemetryAnonymousId = '53defe995fa47e6c13102d9d';
   const logId = '5fb3c20ee1507e894e5340f3';
 
   const logger = new MongoLogWriter(logId, `/tmp/${logId}_log`, {
@@ -36,9 +36,8 @@ describe('setupLoggerAndTelemetry', () => {
     expect(logOutput).to.have.lengthOf(0);
     expect(analyticsOutput).to.be.empty;
 
-    bus.emit('mongosh:new-user', userId);
-
-    bus.emit('mongosh:update-user', userId);
+    bus.emit('mongosh:new-user', telemetryAnonymousId);
+    bus.emit('mongosh:update-user', { anonymousId: telemetryAnonymousId });
     bus.emit('mongosh:connect', {
       uri: 'mongodb://localhost/',
       is_localhost: true,
@@ -121,7 +120,7 @@ describe('setupLoggerAndTelemetry', () => {
     expect(logOutput[i++].msg).to.equal('User updated');
     expect(logOutput[i].msg).to.equal('Connecting to server');
     expect(logOutput[i].attr.session_id).to.equal('5fb3c20ee1507e894e5340f3');
-    expect(logOutput[i].attr.userId).to.equal('53defe995fa47e6c13102d9d');
+    expect(logOutput[i].attr.telemetryAnonymousId).to.equal('53defe995fa47e6c13102d9d');
     expect(logOutput[i].attr.connectionUri).to.equal('mongodb://localhost/');
     expect(logOutput[i].attr.is_localhost).to.equal(true);
     expect(logOutput[i].attr.is_atlas).to.equal(false);
@@ -215,7 +214,7 @@ describe('setupLoggerAndTelemetry', () => {
       [
         'identify',
         {
-          userId: '53defe995fa47e6c13102d9d',
+          anonymousId: '53defe995fa47e6c13102d9d',
           traits: {
             platform: process.platform,
             arch: process.arch
@@ -225,7 +224,7 @@ describe('setupLoggerAndTelemetry', () => {
       [
         'identify',
         {
-          userId: '53defe995fa47e6c13102d9d',
+          anonymousId: '53defe995fa47e6c13102d9d',
           traits: {
             platform: process.platform,
             arch: process.arch
@@ -235,7 +234,7 @@ describe('setupLoggerAndTelemetry', () => {
       [
         'track',
         {
-          userId: '53defe995fa47e6c13102d9d',
+          anonymousId: '53defe995fa47e6c13102d9d',
           event: 'New Connection',
           properties: {
             mongosh_version: '1.0.0',
@@ -249,7 +248,7 @@ describe('setupLoggerAndTelemetry', () => {
       [
         'track',
         {
-          userId: '53defe995fa47e6c13102d9d',
+          anonymousId: '53defe995fa47e6c13102d9d',
           event: 'Error',
           properties: {
             mongosh_version: '1.0.0',
@@ -263,7 +262,7 @@ describe('setupLoggerAndTelemetry', () => {
       [
         'track',
         {
-          userId: '53defe995fa47e6c13102d9d',
+          anonymousId: '53defe995fa47e6c13102d9d',
           event: 'Error',
           properties: {
             mongosh_version: '1.0.0',
@@ -277,7 +276,7 @@ describe('setupLoggerAndTelemetry', () => {
       [
         'track',
         {
-          userId: '53defe995fa47e6c13102d9d',
+          anonymousId: '53defe995fa47e6c13102d9d',
           event: 'Use',
           properties: { mongosh_version: '1.0.0' }
         }
@@ -285,7 +284,7 @@ describe('setupLoggerAndTelemetry', () => {
       [
         'track',
         {
-          userId: '53defe995fa47e6c13102d9d',
+          anonymousId: '53defe995fa47e6c13102d9d',
           event: 'Show',
           properties: {
             mongosh_version: '1.0.0',
@@ -302,7 +301,7 @@ describe('setupLoggerAndTelemetry', () => {
             nested: true,
             shell: true
           },
-          userId: '53defe995fa47e6c13102d9d'
+          anonymousId: '53defe995fa47e6c13102d9d'
         }
       ],
       [
@@ -313,7 +312,7 @@ describe('setupLoggerAndTelemetry', () => {
             mongosh_version: '1.0.0',
             nested: false
           },
-          userId: '53defe995fa47e6c13102d9d'
+          anonymousId: '53defe995fa47e6c13102d9d'
         }
       ],
       [
@@ -323,7 +322,7 @@ describe('setupLoggerAndTelemetry', () => {
           properties: {
             mongosh_version: '1.0.0',
           },
-          userId: '53defe995fa47e6c13102d9d'
+          anonymousId: '53defe995fa47e6c13102d9d'
         }
       ],
       [
@@ -333,7 +332,7 @@ describe('setupLoggerAndTelemetry', () => {
           properties: {
             mongosh_version: '1.0.0',
           },
-          userId: '53defe995fa47e6c13102d9d'
+          anonymousId: '53defe995fa47e6c13102d9d'
         }
       ],
       [
@@ -344,13 +343,13 @@ describe('setupLoggerAndTelemetry', () => {
             mongosh_version: '1.0.0',
             shell: true
           },
-          userId: '53defe995fa47e6c13102d9d'
+          anonymousId: '53defe995fa47e6c13102d9d'
         }
       ],
       [
         'track',
         {
-          userId: '53defe995fa47e6c13102d9d',
+          anonymousId: '53defe995fa47e6c13102d9d',
           event: 'Snippet Install',
           properties: {
             mongosh_version: '1.0.0'
@@ -365,7 +364,7 @@ describe('setupLoggerAndTelemetry', () => {
     expect(logOutput).to.have.lengthOf(0);
     expect(analyticsOutput).to.be.empty;
 
-    bus.emit('mongosh:new-user', userId);
+    bus.emit('mongosh:new-user', telemetryAnonymousId);
 
     logOutput = [];
     analyticsOutput = [];
@@ -394,7 +393,7 @@ describe('setupLoggerAndTelemetry', () => {
       [
         'track',
         {
-          userId: '53defe995fa47e6c13102d9d',
+          anonymousId: '53defe995fa47e6c13102d9d',
           event: 'Deprecated Method',
           properties: {
             mongosh_version: '1.0.0',
@@ -406,7 +405,7 @@ describe('setupLoggerAndTelemetry', () => {
       [
         'track',
         {
-          userId: '53defe995fa47e6c13102d9d',
+          anonymousId: '53defe995fa47e6c13102d9d',
           event: 'Deprecated Method',
           properties: {
             mongosh_version: '1.0.0',
@@ -418,7 +417,7 @@ describe('setupLoggerAndTelemetry', () => {
       [
         'track',
         {
-          userId: '53defe995fa47e6c13102d9d',
+          anonymousId: '53defe995fa47e6c13102d9d',
           event: 'Deprecated Method',
           properties: {
             mongosh_version: '1.0.0',
@@ -430,7 +429,7 @@ describe('setupLoggerAndTelemetry', () => {
       [
         'track',
         {
-          userId: '53defe995fa47e6c13102d9d',
+          anonymousId: '53defe995fa47e6c13102d9d',
           event: 'API Call',
           properties: {
             mongosh_version: '1.0.0',
@@ -443,7 +442,7 @@ describe('setupLoggerAndTelemetry', () => {
       [
         'track',
         {
-          userId: '53defe995fa47e6c13102d9d',
+          anonymousId: '53defe995fa47e6c13102d9d',
           event: 'API Call',
           properties: {
             mongosh_version: '1.0.0',
@@ -455,7 +454,7 @@ describe('setupLoggerAndTelemetry', () => {
       ],
     ]);
 
-    bus.emit('mongosh:new-user', userId);
+    bus.emit('mongosh:new-user', telemetryAnonymousId);
     logOutput = [];
     analyticsOutput = [];
 

--- a/packages/logging/src/setup-logger-and-telemetry.ts
+++ b/packages/logging/src/setup-logger-and-telemetry.ts
@@ -120,17 +120,15 @@ export function setupLoggerAndTelemetry(
   });
 
   bus.on('mongosh:update-user', function(updatedTelemetryUserIdentity: TelemetryUserIdentity) {
-    const telemetryIdentifyArg: {
-      userId?: string;
-      anonymousId: string;
-      traits: any;
-    } = {
-      anonymousId: updatedTelemetryUserIdentity.anonymousId,
+    telemetryUserIdentity = updatedTelemetryUserIdentity;
+
+    const telemetryIdentifyArg: TelemetryUserIdentity & { traits: any } = {
+      anonymousId: telemetryUserIdentity.anonymousId,
       traits: userTraits
     };
 
-    if (updatedTelemetryUserIdentity?.userId) {
-      telemetryIdentifyArg.userId = updatedTelemetryUserIdentity?.userId;
+    if (telemetryUserIdentity?.userId) {
+      telemetryIdentifyArg.userId = telemetryUserIdentity.userId;
     }
 
     analytics.identify(telemetryIdentifyArg);

--- a/packages/logging/src/setup-logger-and-telemetry.ts
+++ b/packages/logging/src/setup-logger-and-telemetry.ts
@@ -120,8 +120,6 @@ export function setupLoggerAndTelemetry(
   });
 
   bus.on('mongosh:update-user', function(updatedTelemetryUserIdentity: TelemetryUserIdentity) {
-    console.log(updatedTelemetryUserIdentity);
-
     const telemetryIdentifyArg: {
       userId?: string;
       anonymousId: string;

--- a/packages/logging/src/setup-logger-and-telemetry.ts
+++ b/packages/logging/src/setup-logger-and-telemetry.ts
@@ -29,7 +29,8 @@ import type {
   SnippetsTransformErrorEvent,
   EditorRunEditCommandEvent,
   EditorReadVscodeExtensionsDoneEvent,
-  EditorReadVscodeExtensionsFailedEvent
+  EditorReadVscodeExtensionsFailedEvent,
+  TelemetryUserIdentity
 } from '@mongosh/types';
 import { inspect } from 'util';
 import { MongoLogWriter, mongoLogId } from 'mongodb-log-writer';
@@ -72,7 +73,7 @@ export function setupLoggerAndTelemetry(
   userTraits: any,
   mongosh_version: string): void {
   const { logId } = log;
-  let userId: string;
+  let telemetryUserIdentity: TelemetryUserIdentity;
 
   // We emit different analytics events for loading files and evaluating scripts
   // depending on whether we're already in the REPL or not yet. We store the
@@ -93,11 +94,17 @@ export function setupLoggerAndTelemetry(
   bus.on('mongosh:connect', function(args: ConnectEvent) {
     const connectionUri = redactURICredentials(args.uri);
     const { uri: _uri, ...argsWithoutUri } = args; // eslint-disable-line @typescript-eslint/no-unused-vars
-    const params = { session_id: logId, userId, connectionUri, ...argsWithoutUri };
+    const params = {
+      session_id: logId,
+      userId: telemetryUserIdentity?.userId,
+      telemetryAnonymousId: telemetryUserIdentity?.anonymousId,
+      connectionUri,
+      ...argsWithoutUri
+    };
     log.info('MONGOSH', mongoLogId(1_000_000_004), 'connect', 'Connecting to server', params);
 
     analytics.track({
-      userId,
+      ...telemetryUserIdentity,
       event: 'New Connection',
       properties: {
         mongosh_version,
@@ -107,14 +114,28 @@ export function setupLoggerAndTelemetry(
     });
   });
 
-  bus.on('mongosh:new-user', function(id: string) {
-    userId = id;
-    analytics.identify({ userId, traits: userTraits });
+  bus.on('mongosh:new-user', function(anonymousId: string) {
+    telemetryUserIdentity = { anonymousId };
+    analytics.identify({ ...telemetryUserIdentity, traits: userTraits });
   });
 
-  bus.on('mongosh:update-user', function(id: string) {
-    userId = id;
-    analytics.identify({ userId, traits: userTraits });
+  bus.on('mongosh:update-user', function(updatedTelemetryUserIdentity: TelemetryUserIdentity) {
+    console.log(updatedTelemetryUserIdentity);
+
+    const telemetryIdentifyArg: {
+      userId?: string;
+      anonymousId: string;
+      traits: any;
+    } = {
+      anonymousId: updatedTelemetryUserIdentity.anonymousId,
+      traits: userTraits
+    };
+
+    if (updatedTelemetryUserIdentity?.userId) {
+      telemetryIdentifyArg.userId = updatedTelemetryUserIdentity?.userId;
+    }
+
+    analytics.identify(telemetryIdentifyArg);
     log.info('MONGOSH', mongoLogId(1_000_000_005), 'config', 'User updated');
   });
 
@@ -127,7 +148,7 @@ export function setupLoggerAndTelemetry(
 
     if (error.name.includes('Mongosh')) {
       analytics.track({
-        userId,
+        ...telemetryUserIdentity,
         event: 'Error',
         properties: {
           mongosh_version,
@@ -152,7 +173,7 @@ export function setupLoggerAndTelemetry(
     log.info('MONGOSH', mongoLogId(1_000_000_008), 'shell-api', 'Used "use" command', args);
 
     analytics.track({
-      userId,
+      ...telemetryUserIdentity,
       event: 'Use',
       properties: {
         mongosh_version
@@ -164,7 +185,7 @@ export function setupLoggerAndTelemetry(
     log.info('MONGOSH', mongoLogId(1_000_000_009), 'shell-api', 'Used "show" command', args);
 
     analytics.track({
-      userId,
+      ...telemetryUserIdentity,
       event: 'Show',
       properties: {
         mongosh_version,
@@ -192,7 +213,7 @@ export function setupLoggerAndTelemetry(
     log.info('MONGOSH', mongoLogId(1_000_000_012), 'shell-api', 'Loading file via load()', args);
 
     analytics.track({
-      userId,
+      ...telemetryUserIdentity,
       event: hasStartedMongoshRepl ? 'Script Loaded' : 'Script Loaded CLI',
       properties: {
         mongosh_version,
@@ -206,7 +227,7 @@ export function setupLoggerAndTelemetry(
     log.info('MONGOSH', mongoLogId(1_000_000_013), 'repl', 'Evaluating script passed on the command line');
 
     analytics.track({
-      userId,
+      ...telemetryUserIdentity,
       event: 'Script Evaluated',
       properties: {
         mongosh_version,
@@ -219,7 +240,7 @@ export function setupLoggerAndTelemetry(
     log.info('MONGOSH', mongoLogId(1_000_000_014), 'repl', 'Loading .mongoshrc.js');
 
     analytics.track({
-      userId,
+      ...telemetryUserIdentity,
       event: 'Mongoshrc Loaded',
       properties: {
         mongosh_version
@@ -231,7 +252,7 @@ export function setupLoggerAndTelemetry(
     log.info('MONGOSH', mongoLogId(1_000_000_015), 'repl', 'Warning about .mongorc.js/.mongoshrc.js mismatch');
 
     analytics.track({
-      userId,
+      ...telemetryUserIdentity,
       event: 'Mongorc Warning',
       properties: {
         mongosh_version
@@ -307,7 +328,7 @@ export function setupLoggerAndTelemetry(
 
     if (ev.args[0] === 'install') {
       analytics.track({
-        userId,
+        ...telemetryUserIdentity,
         event: 'Snippet Install',
         properties: {
           mongosh_version
@@ -343,7 +364,7 @@ export function setupLoggerAndTelemetry(
       log.warn('MONGOSH', mongoLogId(1_000_000_033), 'shell-api', 'Deprecated API call', entry);
 
       analytics.track({
-        userId,
+        ...telemetryUserIdentity,
         event: 'Deprecated Method',
         properties: {
           mongosh_version,
@@ -353,7 +374,7 @@ export function setupLoggerAndTelemetry(
     }
     for (const [entry, count] of apiCalls) {
       analytics.track({
-        userId,
+        ...telemetryUserIdentity,
         event: 'API Call',
         properties: {
           mongosh_version,

--- a/packages/logging/src/setup-logger-and-telemetry.ts
+++ b/packages/logging/src/setup-logger-and-telemetry.ts
@@ -116,7 +116,7 @@ export function setupLoggerAndTelemetry(
 
   bus.on('mongosh:new-user', function(anonymousId: string) {
     telemetryUserIdentity = { anonymousId };
-    analytics.identify({ ...telemetryUserIdentity, traits: userTraits });
+    analytics.identify({ anonymousId, traits: userTraits });
   });
 
   bus.on('mongosh:update-user', function(updatedTelemetryUserIdentity: TelemetryUserIdentity) {

--- a/packages/types/src/index.spec.ts
+++ b/packages/types/src/index.spec.ts
@@ -4,7 +4,8 @@ import { expect } from 'chai';
 describe('config validation', () => {
   it('validates config option values', async() => {
     const { validate } = CliUserConfigValidator as any;
-    expect(await validate('userId', 'foo')).to.equal(null);
+    expect(await validate('userId', 'foo')).to.equal(undefined);
+    expect(await validate('telemetryAnonymousId', 'foo')).to.equal(null);
     expect(await validate('disableGreetingMessage', 'foo')).to.equal(null);
     expect(await validate('inspectDepth', 'foo')).to.equal('inspectDepth must be a positive integer');
     expect(await validate('inspectDepth', -1)).to.equal('inspectDepth must be a positive integer');

--- a/packages/types/src/index.spec.ts
+++ b/packages/types/src/index.spec.ts
@@ -4,7 +4,7 @@ import { expect } from 'chai';
 describe('config validation', () => {
   it('validates config option values', async() => {
     const { validate } = CliUserConfigValidator as any;
-    expect(await validate('userId', 'foo')).to.equal(undefined);
+    expect(await validate('userId', 'foo')).to.equal(null);
     expect(await validate('telemetryAnonymousId', 'foo')).to.equal(null);
     expect(await validate('disableGreetingMessage', 'foo')).to.equal(null);
     expect(await validate('inspectDepth', 'foo')).to.equal('inspectDepth must be a positive integer');

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -167,6 +167,11 @@ export interface EditorReadVscodeExtensionsFailedEvent {
   error: Error;
 }
 
+export interface TelemetryUserIdentity {
+  userId?: string;
+  anonymousId: string;
+}
+
 export interface MongoshBusEventsMap extends ConnectEventMap {
   /**
    * Signals a connection to a MongoDB instance has been established
@@ -180,7 +185,7 @@ export interface MongoshBusEventsMap extends ConnectEventMap {
   /**
    * Signals a change of the user telemetry settings.
    */
-  'mongosh:update-user': (id: string) => void;
+  'mongosh:update-user': (identity: TelemetryUserIdentity) => void;
   /**
    * Signals an error that should be logged or potentially tracked by analytics.
    */
@@ -412,7 +417,8 @@ export class SnippetShellUserConfigValidator extends ShellUserConfigValidator {
 }
 
 export class CliUserConfig extends SnippetShellUserConfig {
-  userId = '';
+  userId?: string;
+  telemetryAnonymousId = '';
   disableGreetingMessage = false;
   forceDisableTelemetry = false;
   inspectCompact: number | boolean = 3;
@@ -427,6 +433,7 @@ export class CliUserConfigValidator extends SnippetShellUserConfigValidator {
   static async validate<K extends keyof CliUserConfig>(key: K, value: CliUserConfig[K]): Promise<string | null> {
     switch (key) {
       case 'userId':
+      case 'telemetryAnonymousId':
       case 'disableGreetingMessage':
         return null; // Not modifiable by the user anyway.
       case 'inspectCompact':


### PR DESCRIPTION
In `mongosh`, we don't have MongoDB user identifiers. We randomly generate an ID the first time the product is run and then we use that as a user id. The `userId` should not be a random UUID, it should store only AUID. The randomly generated UUID should be sent as `anonymousId`.

To not break statistics for existing users:
- We should leave all current users with the tracking they have.
- For new users, we should use the `anonymousID` field and fill it with a random UUID.

That being said:
- If `userId` exists we send it to segment. We also copy userId to `anonymousId` and send it to Segment as well.
- If `userId` does not exist we do not create a new one, we only generate a random UUID and send it to Segment as `anonymousId`.