### PR TITLE
feat(cli-repl): pass through sspiHostnameCanonicalization to driver MONGOSH-856

### DIFF
--- a/packages/cli-repl/src/arg-mapper.spec.ts
+++ b/packages/cli-repl/src/arg-mapper.spec.ts
@@ -321,7 +321,7 @@ describe('arg-mapper.mapCliToDriver', () => {
       it('is not mapped to authMechanismProperties', () => {
         expect(mapCliToDriver(cliOptions)).to.deep.equal({
           authMechanismProperties: {
-            CANONICALIZE_HOSTNAME: 'none'
+            CANONICALIZE_HOST_NAME: 'none'
           },
           driverInfo: {
             name: 'mongosh',

--- a/packages/cli-repl/src/arg-mapper.spec.ts
+++ b/packages/cli-repl/src/arg-mapper.spec.ts
@@ -337,7 +337,7 @@ describe('arg-mapper.mapCliToDriver', () => {
       it('is mapped to authMechanismProperties', () => {
         expect(mapCliToDriver(cliOptions)).to.deep.equal({
           authMechanismProperties: {
-            gssapiCanonicalizeHostName: 'forward'
+            CANONICALIZE_HOST_NAME: 'forward'
           },
           driverInfo: {
             name: 'mongosh',
@@ -353,7 +353,7 @@ describe('arg-mapper.mapCliToDriver', () => {
       it('is mapped to authMechanismProperties', () => {
         expect(mapCliToDriver(cliOptions)).to.deep.equal({
           authMechanismProperties: {
-            gssapiCanonicalizeHostName: true
+            CANONICALIZE_HOST_NAME: true
           },
           driverInfo: {
             name: 'mongosh',

--- a/packages/cli-repl/src/arg-mapper.spec.ts
+++ b/packages/cli-repl/src/arg-mapper.spec.ts
@@ -320,6 +320,9 @@ describe('arg-mapper.mapCliToDriver', () => {
 
       it('is not mapped to authMechanismProperties', () => {
         expect(mapCliToDriver(cliOptions)).to.deep.equal({
+          authMechanismProperties: {
+            CANONICALIZE_HOSTNAME: 'none'
+          },
           driverInfo: {
             name: 'mongosh',
             version: packageJSON.version
@@ -334,7 +337,7 @@ describe('arg-mapper.mapCliToDriver', () => {
       it('is mapped to authMechanismProperties', () => {
         expect(mapCliToDriver(cliOptions)).to.deep.equal({
           authMechanismProperties: {
-            gssapiCanonicalizeHostName: 'true'
+            gssapiCanonicalizeHostName: 'forward'
           },
           driverInfo: {
             name: 'mongosh',
@@ -344,17 +347,19 @@ describe('arg-mapper.mapCliToDriver', () => {
       });
     });
 
-    context('with a value of forwardAndReverse', () => {
-      const cliOptions: CliOptions = { sspiHostnameCanonicalization: 'forwardAndReverse' };
+    context('with a value of true', () => {
+      const cliOptions: CliOptions = { sspiHostnameCanonicalization: 'true' };
 
       it('is mapped to authMechanismProperties', () => {
-        try {
-          mapCliToDriver(cliOptions);
-        } catch (e) {
-          expect(e.message).to.contain('forwardAndReverse is not supported');
-          return;
-        }
-        expect.fail('expected error');
+        expect(mapCliToDriver(cliOptions)).to.deep.equal({
+          authMechanismProperties: {
+            gssapiCanonicalizeHostName: true
+          },
+          driverInfo: {
+            name: 'mongosh',
+            version: packageJSON.version
+          }
+        });
       });
     });
   });


### PR DESCRIPTION
MONGOSH-856

Pass down `sspiHostnameCanonicalization` to the driver as-is
and let the driver do the validation. We still map `true` and
`false` from strings to booleans and an empty string to `undefined`,
since the driver would otherwise reject those values.