### PR TITLE
fix(packaging): create RPMs without .build-id entries MONGOSH-1159

### DIFF
--- a/packaging/rpm-template/SPECS/mongodb-mongosh.spec
+++ b/packaging/rpm-template/SPECS/mongodb-mongosh.spec
@@ -1,5 +1,7 @@
 # https://rpm-packaging-guide.github.io/#what-is-a-spec-file
 %define _binary_payload w2.xzdio
+# https://jira.mongodb.org/browse/MONGOSH-1159
+%define _build_id_links none
 # Work around https://salsa.debian.org/debian/debhelper/-/commit/8f29a0726bdebcb01b6fd768fde8016fcd5dc3f4
 # (only relevant when building from Debian/Ubuntu)
 %undefine _libexecdir


### PR DESCRIPTION
This makes the RPMs looks like they did before f2ab09af6100,
and resolves a conflict with the server RPMs.

Evergreen: https://spruce.mongodb.com/version/623219c261837d42053fd295/tasks (no automatic builds for PRs right now because of a github outage)