### PR TITLE
chore: bump typescript to 4.6.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2645,6 +2645,21 @@
         "to-fast-properties": "^2.0.0"
       }
     },
+    "@cspotcode/source-map-consumer": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-consumer/-/source-map-consumer-0.8.0.tgz",
+      "integrity": "sha512-41qniHzTU8yAGbCp04ohlmSrZf8bkf/iJsl3V0dRGsQN/5GFfx+LbCSsCpp2gqrqjTVg/K6O8ycoV35JIwAzAg==",
+      "dev": true
+    },
+    "@cspotcode/source-map-support": {
+      "version": "0.7.0",
+      "resolved": "https://registry.npmjs.org/@cspotcode/source-map-support/-/source-map-support-0.7.0.tgz",
+      "integrity": "sha512-X4xqRHqN8ACt2aHVe51OxeA2HjbcL4MqFqXkrmQszJ1NOUuUu5u6Vqx/0lZSVNku7velL5FC/s5uEAj1lsBMhA==",
+      "dev": true,
+      "requires": {
+        "@cspotcode/source-map-consumer": "0.8.0"
+      }
+    },
     "@eslint/eslintrc": {
       "version": "0.4.3",
       "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-0.4.3.tgz",
@@ -6221,6 +6236,30 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@tootallnate/once/-/once-1.1.2.tgz",
       "integrity": "sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==",
+      "dev": true
+    },
+    "@tsconfig/node10": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node10/-/node10-1.0.8.tgz",
+      "integrity": "sha512-6XFfSQmMgq0CFLY1MslA/CPUfhIL919M1rMsa5lP2P097N2Wd1sSX0tx1u4olM16fLNhtHZpRhedZJphNJqmZg==",
+      "dev": true
+    },
+    "@tsconfig/node12": {
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node12/-/node12-1.0.9.tgz",
+      "integrity": "sha512-/yBMcem+fbvhSREH+s14YJi18sp7J9jpuhYByADT2rypfajMZZN4WQ6zBGgBKp53NKmqI36wFYDb3yaMPurITw==",
+      "dev": true
+    },
+    "@tsconfig/node14": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node14/-/node14-1.0.1.tgz",
+      "integrity": "sha512-509r2+yARFfHHE7T6Puu2jjkoycftovhXRqW328PDXTVGKihlb1P8Z9mMZH04ebyajfRY7dedfGynlrFHJUQCg==",
+      "dev": true
+    },
+    "@tsconfig/node16": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@tsconfig/node16/-/node16-1.0.2.tgz",
+      "integrity": "sha512-eZxlbI8GZscaGS7kkc/trHTT5xgrjH3/1n2JDwusC9iahPKWMRvRjJSAN5mCXviuTGQ/lHnhvv8Q1YTpnfz9gA==",
       "dev": true
     },
     "@types/bl": {
@@ -24289,17 +24328,38 @@
       }
     },
     "ts-node": {
-      "version": "9.1.1",
-      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-9.1.1.tgz",
-      "integrity": "sha512-hPlt7ZACERQGf03M253ytLY3dHbGNGrAq9qIHWUY9XHYl1z7wYngSr3OQ5xmui8o2AaxsONxIzjafLUiWBo1Fg==",
+      "version": "10.7.0",
+      "resolved": "https://registry.npmjs.org/ts-node/-/ts-node-10.7.0.tgz",
+      "integrity": "sha512-TbIGS4xgJoX2i3do417KSaep1uRAW/Lu+WAL2doDHC0D6ummjirVOXU5/7aiZotbQ5p1Zp9tP7U6cYhA0O7M8A==",
       "dev": true,
       "requires": {
+        "@cspotcode/source-map-support": "0.7.0",
+        "@tsconfig/node10": "^1.0.7",
+        "@tsconfig/node12": "^1.0.7",
+        "@tsconfig/node14": "^1.0.0",
+        "@tsconfig/node16": "^1.0.2",
+        "acorn": "^8.4.1",
+        "acorn-walk": "^8.1.1",
         "arg": "^4.1.0",
         "create-require": "^1.1.0",
         "diff": "^4.0.1",
         "make-error": "^1.1.1",
-        "source-map-support": "^0.5.17",
+        "v8-compile-cache-lib": "^3.0.0",
         "yn": "3.1.1"
+      },
+      "dependencies": {
+        "acorn": {
+          "version": "8.7.0",
+          "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.7.0.tgz",
+          "integrity": "sha512-V/LGr1APy+PXIwKebEWrkZPwoeoF+w1jiOBUmuxuiUIaOHtob8Qc9BTrYo7VuI5fR8tqsy+buA2WFooR5olqvQ==",
+          "dev": true
+        },
+        "acorn-walk": {
+          "version": "8.2.0",
+          "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.2.0.tgz",
+          "integrity": "sha512-k+iyHEuPgSw6SbuDpGQM+06HQUa04DZ3o+F6CSzXMvvI5KMvnaEqXe+YVe555R9nn6GPt404fos4wcgpw12SDA==",
+          "dev": true
+        }
       }
     },
     "ts-sinon": {
@@ -24478,9 +24538,9 @@
       }
     },
     "typescript": {
-      "version": "4.2.4",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.2.4.tgz",
-      "integrity": "sha512-V+evlYHZnQkaz8TRBuxTA92yZBPotr5H+WhQ7bD3hZUndx5tGOa1fuCgeSjxAzM1RiN5IzvadIXTVefuuwZCRg==",
+      "version": "4.6.2",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.6.2.tgz",
+      "integrity": "sha512-HM/hFigTBHZhLXshn9sN37H085+hQGeJHJ/X7LpBWLID/fbc2acUMfU+lGD98X81sKP+pFa9f0DZmCwB9GnbAg==",
       "dev": true
     },
     "ua-parser-js": {
@@ -24890,6 +24950,12 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",
       "integrity": "sha512-usZBT3PW+LOjM25wbqIlZwPeJV+3OSz3M1k1Ws8snlW39dZyYL9lOGC5FgPVHfk0jKmjiDV8Z0mIbVQPiwFs7g==",
+      "dev": true
+    },
+    "v8-compile-cache-lib": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.0.tgz",
+      "integrity": "sha512-mpSYqfsFvASnSn5qMiwrr4VKfumbPyONLCOPmsR3A6pTY/r0+tSaVbgPWSAIuzbk3lCTa+FForeTiO+wBQGkjA==",
       "dev": true
     },
     "validate-npm-package-license": {

--- a/package.json
+++ b/package.json
@@ -138,9 +138,9 @@
     "tar": "^6.0.1",
     "tar-fs": "^2.1.0",
     "tmp-promise": "^3.0.2",
-    "ts-node": "^9.1.1",
+    "ts-node": "^10.7.0",
     "ts-sinon": "^1.2.0",
-    "typescript": "^4.2.4",
+    "typescript": "^4.6.2",
     "uuid": "^3.3.3",
     "which": "^2.0.2",
     "yaml": "^1.10.0"

--- a/packages/async-rewriter2/src/async-writer-babel.spec.ts
+++ b/packages/async-rewriter2/src/async-writer-babel.spec.ts
@@ -891,7 +891,7 @@ describe('AsyncWriter', () => {
       (() => {
         try {
           throw new Error('generic error');
-        } catch (err: any) {
+        } catch (err) {
           return ({ caught: err });
         }
       })();`);
@@ -903,7 +903,7 @@ describe('AsyncWriter', () => {
       (() => {
         try {
           throw new Error('generic error');
-        } catch ({ message }: any) {
+        } catch ({ message }) {
           return ({ caught: message });
         }
       })();`);
@@ -916,7 +916,7 @@ describe('AsyncWriter', () => {
       (() => {
         try {
           throw [ 'foo' ];
-        } catch ([message]: any) {
+        } catch ([message]) {
           return ({ caught: message });
         }
       })();`);
@@ -928,7 +928,7 @@ describe('AsyncWriter', () => {
       (() => {
         try {
           throw [ 'foo' ];
-        } catch ([message]: any) {
+        } catch ([message]) {
           message = 42;
           return ({ caught: message });
         }
@@ -942,7 +942,7 @@ describe('AsyncWriter', () => {
         (() => {
           try {
             throw new Error('generic error');
-          } catch (err: any) {
+          } catch (err) {
             throw err;
           }
         })();`);
@@ -957,7 +957,7 @@ describe('AsyncWriter', () => {
       (() => {
         try {
           throw new Error('generic error');
-        } catch (err: any) {
+        } catch (err) {
           return ({ caught: err });
         } finally {
           return 'finally';
@@ -971,7 +971,7 @@ describe('AsyncWriter', () => {
       (() => {
         try {
           throw new Error('first error');
-        } catch (err: any) {
+        } catch (err) {
           throw new Error('second error');
         } finally {
           return 'finally';
@@ -984,7 +984,7 @@ describe('AsyncWriter', () => {
       const result = runTranspiledCode(`
       (() => {
         try {
-        } catch (err: any) {
+        } catch (err) {
           return 'catch';
         } finally {
           return 'finally';
@@ -1022,7 +1022,7 @@ describe('AsyncWriter', () => {
       (() => {
         try {
           throw null;
-        } catch (err: any) {
+        } catch (err) {
           return ({ caught: err });
         }
       })();`);
@@ -1034,7 +1034,7 @@ describe('AsyncWriter', () => {
       (() => {
         try {
           throw null;
-        } catch (err: any) {
+        } catch (err) {
           return ({ caught: err });
         } finally {
           return 'finally';
@@ -1049,7 +1049,7 @@ describe('AsyncWriter', () => {
         (() => {
           try {
             throwUncatchable();
-          } catch (err: any) {
+          } catch (err) {
             return ({ caught: err });
           }
         })();`);

--- a/packages/async-rewriter2/src/async-writer-babel.spec.ts
+++ b/packages/async-rewriter2/src/async-writer-babel.spec.ts
@@ -100,7 +100,7 @@ describe('AsyncWriter', () => {
       try {
         await runTranspiledCode('Promise.reject(42)');
         expect.fail('missed exception');
-      } catch (err) {
+      } catch (err: any) {
         expect(err).to.equal(42);
       }
     });
@@ -122,7 +122,7 @@ describe('AsyncWriter', () => {
       try {
         runTranspiledCode("'use strict'; delete Object.prototype");
         expect.fail('missed exception');
-      } catch (err) {
+      } catch (err: any) {
         expect(err.name).to.equal('TypeError');
       }
     });
@@ -864,7 +864,7 @@ describe('AsyncWriter', () => {
       try {
         await runTranspiledCode('(async () => { var foo; foo(); })()');
         expect.fail('missed exception');
-      } catch (err) {
+      } catch (err: any) {
         expect(err.message).to.equal('foo is not a function');
       }
     });
@@ -891,7 +891,7 @@ describe('AsyncWriter', () => {
       (() => {
         try {
           throw new Error('generic error');
-        } catch (err) {
+        } catch (err: any) {
           return ({ caught: err });
         }
       })();`);
@@ -903,7 +903,7 @@ describe('AsyncWriter', () => {
       (() => {
         try {
           throw new Error('generic error');
-        } catch ({ message }) {
+        } catch ({ message }: any) {
           return ({ caught: message });
         }
       })();`);
@@ -916,7 +916,7 @@ describe('AsyncWriter', () => {
       (() => {
         try {
           throw [ 'foo' ];
-        } catch ([message]) {
+        } catch ([message]: any) {
           return ({ caught: message });
         }
       })();`);
@@ -928,7 +928,7 @@ describe('AsyncWriter', () => {
       (() => {
         try {
           throw [ 'foo' ];
-        } catch ([message]) {
+        } catch ([message]: any) {
           message = 42;
           return ({ caught: message });
         }
@@ -942,12 +942,12 @@ describe('AsyncWriter', () => {
         (() => {
           try {
             throw new Error('generic error');
-          } catch (err) {
+          } catch (err: any) {
             throw err;
           }
         })();`);
         expect.fail('missed exception');
-      } catch (err) {
+      } catch (err: any) {
         expect(err.message).to.equal('generic error');
       }
     });
@@ -957,7 +957,7 @@ describe('AsyncWriter', () => {
       (() => {
         try {
           throw new Error('generic error');
-        } catch (err) {
+        } catch (err: any) {
           return ({ caught: err });
         } finally {
           return 'finally';
@@ -971,7 +971,7 @@ describe('AsyncWriter', () => {
       (() => {
         try {
           throw new Error('first error');
-        } catch (err) {
+        } catch (err: any) {
           throw new Error('second error');
         } finally {
           return 'finally';
@@ -984,7 +984,7 @@ describe('AsyncWriter', () => {
       const result = runTranspiledCode(`
       (() => {
         try {
-        } catch (err) {
+        } catch (err: any) {
           return 'catch';
         } finally {
           return 'finally';
@@ -1022,7 +1022,7 @@ describe('AsyncWriter', () => {
       (() => {
         try {
           throw null;
-        } catch (err) {
+        } catch (err: any) {
           return ({ caught: err });
         }
       })();`);
@@ -1034,7 +1034,7 @@ describe('AsyncWriter', () => {
       (() => {
         try {
           throw null;
-        } catch (err) {
+        } catch (err: any) {
           return ({ caught: err });
         } finally {
           return 'finally';
@@ -1049,12 +1049,12 @@ describe('AsyncWriter', () => {
         (() => {
           try {
             throwUncatchable();
-          } catch (err) {
+          } catch (err: any) {
             return ({ caught: err });
           }
         })();`);
         expect.fail('missed exception');
-      } catch (err) {
+      } catch (err: any) {
         expect(err.message).to.equal('uncatchable!');
       }
     });
@@ -1068,7 +1068,7 @@ describe('AsyncWriter', () => {
           } catch { }
         })();`);
         expect.fail('missed exception');
-      } catch (err) {
+      } catch (err: any) {
         expect(err.message).to.equal('uncatchable!');
       }
     });
@@ -1082,7 +1082,7 @@ describe('AsyncWriter', () => {
           } catch { } finally { return; }
         })();`);
         expect.fail('missed exception');
-      } catch (err) {
+      } catch (err: any) {
         expect(err.message).to.equal('uncatchable!');
       }
     });
@@ -1096,7 +1096,7 @@ describe('AsyncWriter', () => {
           } finally { return; }
         })();`);
         expect.fail('missed exception');
-      } catch (err) {
+      } catch (err: any) {
         expect(err.message).to.equal('uncatchable!');
       }
     });
@@ -1114,7 +1114,7 @@ describe('AsyncWriter', () => {
           }
         })();`);
         expect.fail('missed exception');
-      } catch (err) {
+      } catch (err: any) {
         expect(err.message).to.equal('uncatchable!');
       }
     });

--- a/packages/async-rewriter2/src/async-writer-babel.ts
+++ b/packages/async-rewriter2/src/async-writer-babel.ts
@@ -71,7 +71,7 @@ export default class AsyncWriter {
           { customErrorBuilder: babel.types.identifier('MongoshAsyncWriterError') }
         ]
       ], { code: true, ast: false })?.code as string;
-    } catch (e) {
+    } catch (e: any) {
       e.message = e.message.replace('unknown: ', '');
       throw e;
     }

--- a/packages/async-rewriter2/src/stages/transform-maybe-await.ts
+++ b/packages/async-rewriter2/src/stages/transform-maybe-await.ts
@@ -79,7 +79,7 @@ export default ({ types: t }: { types: typeof BabelTypes }): babel.PluginObj<{ f
     async () => {
       try {
         ORIGINAL_CODE;
-      } catch (err: any) {
+      } catch (err) {
         if (FUNCTION_STATE_IDENTIFIER === "sync") {
           SYNC_RETURN_VALUE_IDENTIFIER = err;
           FUNCTION_STATE_IDENTIFIER = "threw";
@@ -122,7 +122,7 @@ export default ({ types: t }: { types: typeof BabelTypes }): babel.PluginObj<{ f
   const rethrowTemplate = babel.template.statement(`
     try {
       ORIGINAL_CODE;
-    } catch (err: any) {
+    } catch (err) {
       throw err;
     }
   `);

--- a/packages/async-rewriter2/src/stages/transform-maybe-await.ts
+++ b/packages/async-rewriter2/src/stages/transform-maybe-await.ts
@@ -79,7 +79,7 @@ export default ({ types: t }: { types: typeof BabelTypes }): babel.PluginObj<{ f
     async () => {
       try {
         ORIGINAL_CODE;
-      } catch (err) {
+      } catch (err: any) {
         if (FUNCTION_STATE_IDENTIFIER === "sync") {
           SYNC_RETURN_VALUE_IDENTIFIER = err;
           FUNCTION_STATE_IDENTIFIER = "threw";
@@ -122,7 +122,7 @@ export default ({ types: t }: { types: typeof BabelTypes }): babel.PluginObj<{ f
   const rethrowTemplate = babel.template.statement(`
     try {
       ORIGINAL_CODE;
-    } catch (err) {
+    } catch (err: any) {
       throw err;
     }
   `);

--- a/packages/browser-repl/src/components/utils/inspect.ts
+++ b/packages/browser-repl/src/components/utils/inspect.ts
@@ -23,13 +23,13 @@ function tryAddInspect(obj: any, stringifier: (this: any, depth: any, options: a
       value: function(...args: [any, any]) {
         try {
           return stringifier.call(this, ...args);
-        } catch (err) {
+        } catch (err: any) {
           console.warn('Could not inspect bson object', { obj: this, err });
           return utilInspect(this, { customInspect: false });
         }
       }
     });
-  } catch (err) {
+  } catch (err: any) {
     console.warn('Could not add inspect key to object', { obj, err });
   }
 }

--- a/packages/build/src/barque.spec.ts
+++ b/packages/build/src/barque.spec.ts
@@ -77,7 +77,7 @@ describe('Barque', () => {
             let releasedUrls;
             try {
               releasedUrls = await barque.releaseToBarque(variant, url);
-            } catch (err) {
+            } catch (err: any) {
               if (process.platform === 'win32' && err.message.includes('ENOENT')) {
                 return; // Cannot spawn the fake curator on Windows
               }
@@ -99,7 +99,7 @@ describe('Barque', () => {
 
         try {
           await barque.releaseToBarque('debian-x64', debUrl);
-        } catch (error) {
+        } catch (error: any) {
           expect(error.message).to.include(`Curator is unable to upload ${debUrl},ubuntu1804,amd64 to barque`);
           expect(barque.createCuratorDir).to.have.been.called;
           expect(barque.extractLatestCurator).to.have.been.called;
@@ -114,7 +114,7 @@ describe('Barque', () => {
       config.platform = 'macos';
       try {
         barque = new Barque(config);
-      } catch (e) {
+      } catch (e: any) {
         expect(e.message).to.contain('only supported on linux');
         return;
       }
@@ -139,7 +139,7 @@ describe('Barque', () => {
       let accessErr: Error | undefined = undefined;
       try {
         await fs.access(curatorDirPath);
-      } catch (e) {
+      } catch (e: any) {
         accessErr = e;
       }
       expect(accessErr).to.be.undefined;
@@ -192,7 +192,7 @@ describe('Barque', () => {
             'https://repo.mongodb.org/apt/dist/package1.deb',
             'https://repo.mongodb.org/apt/dist/package2.deb',
           ], 5, 1);
-        } catch (e) {
+        } catch (e: any) {
           expect(e.message).to.contain('the following packages are still not available');
           expect(e.message).to.contain('package2.deb');
         }
@@ -234,7 +234,7 @@ describe('Barque', () => {
       let accessErr: Error | undefined = undefined;
       try {
         await fs.access(curatorPath);
-      } catch (e) {
+      } catch (e: any) {
         accessErr = e;
       }
       expect(accessErr).to.be.undefined;

--- a/packages/build/src/barque.ts
+++ b/packages/build/src/barque.ts
@@ -173,7 +173,7 @@ export class Barque {
                 });
               console.info(`Result for curator with ${args.join(' ')}`, result);
               return this.computePublishedPackageUrl(ppa, architecture, version, edition, packageUrl);
-            } catch (error) {
+            } catch (error: any) {
               console.error(`Curator with ${args.join(' ')} failed`, error);
               throw new Error(`Curator is unable to upload ${packageUrl},${ppa},${architecture} to barque ${error}`);
             }

--- a/packages/build/src/evergreen/artifacts.spec.ts
+++ b/packages/build/src/evergreen/artifacts.spec.ts
@@ -26,7 +26,7 @@ describe('evergreen artifacts', () => {
           'wrong',
           tmpDir
         );
-      } catch (e) {
+      } catch (e: any) {
         return expect(e).to.not.be.undefined;
       }
       expect.fail('Expected error');

--- a/packages/build/src/evergreen/rest-api.spec.ts
+++ b/packages/build/src/evergreen/rest-api.spec.ts
@@ -30,7 +30,7 @@ describe('evergreen rest-api', () => {
     it('throws an error when the configuration file does not exist', async() => {
       try {
         await EvergreenApi.fromUserConfiguration('kasldjflasjk dfalsd jfsdfk');
-      } catch (e) {
+      } catch (e: any) {
         expect(e.message).to.contain('Could not find local evergreen configuration');
         return;
       }
@@ -46,7 +46,7 @@ describe('evergreen rest-api', () => {
         const configFile = await writeEvergreenConfiguration(YAML.stringify(data));
         try {
           await EvergreenApi.fromUserConfiguration(configFile);
-        } catch (e) {
+        } catch (e: any) {
           expect(e.message).to.contain(key);
         }
       });
@@ -131,7 +131,7 @@ describe('evergreen rest-api', () => {
 
       try {
         await api.getTasks('mongosh', 'sha');
-      } catch (e) {
+      } catch (e: any) {
         expect(e.message).to.equal('Unexpected response status: 404 - ERR: Not found');
         return;
       }

--- a/packages/build/src/git/repository-status.spec.ts
+++ b/packages/build/src/git/repository-status.spec.ts
@@ -44,7 +44,7 @@ describe('git repository-status', () => {
       getRepositoryStatus.returns(status);
       try {
         verifyGitStatus('root', getRepositoryStatus, spawnSync);
-      } catch (e) {
+      } catch (e: any) {
         expect(e.message).to.contain('Could not determine local repository information');
         return;
       }
@@ -64,7 +64,7 @@ describe('git repository-status', () => {
       getRepositoryStatus.returns(status);
       try {
         verifyGitStatus('root', getRepositoryStatus, spawnSync);
-      } catch (e) {
+      } catch (e: any) {
         expect(e.message).to.contain('The current branch does not match');
         return;
       }
@@ -84,7 +84,7 @@ describe('git repository-status', () => {
       getRepositoryStatus.returns(status);
       try {
         verifyGitStatus('root', getRepositoryStatus, spawnSync);
-      } catch (e) {
+      } catch (e: any) {
         expect(e.message).to.contain('The branch you are on is not tracking any remote branch.');
         return;
       }
@@ -104,7 +104,7 @@ describe('git repository-status', () => {
       getRepositoryStatus.returns(status);
       try {
         verifyGitStatus('root', getRepositoryStatus, spawnSync);
-      } catch (e) {
+      } catch (e: any) {
         expect(e.message).to.contain('Your local repository is not clean or diverged from the remote branch');
         return;
       }
@@ -124,7 +124,7 @@ describe('git repository-status', () => {
       getRepositoryStatus.returns(status);
       try {
         verifyGitStatus('root', getRepositoryStatus, spawnSync);
-      } catch (e) {
+      } catch (e: any) {
         expect(e.message).to.contain('Your local repository is not clean or diverged from the remote branch');
         return;
       }
@@ -144,7 +144,7 @@ describe('git repository-status', () => {
       getRepositoryStatus.returns(status);
       try {
         verifyGitStatus('root', getRepositoryStatus, spawnSync);
-      } catch (e) {
+      } catch (e: any) {
         expect(e.message).to.contain('You have local tags that are not pushed to the remote');
         return;
       }

--- a/packages/build/src/helpers/spawn-sync.spec.ts
+++ b/packages/build/src/helpers/spawn-sync.spec.ts
@@ -11,7 +11,7 @@ describe('npm-packages spawnSync', () => {
   it('throws on ENOENT error', () => {
     try {
       spawnSync('notaprogram', [], { encoding: 'utf8' });
-    } catch (e) {
+    } catch (e: any) {
       return expect(e).to.not.be.undefined;
     }
     expect.fail('Expected error');
@@ -20,7 +20,7 @@ describe('npm-packages spawnSync', () => {
   it('throws on non-zero exit code', () => {
     try {
       spawnSync('bash', ['-c', 'exit 1'], { encoding: 'utf8' });
-    } catch (e) {
+    } catch (e: any) {
       return expect(e).to.not.be.undefined;
     }
     expect.fail('Expected error');

--- a/packages/build/src/homebrew/generate-formula.spec.ts
+++ b/packages/build/src/homebrew/generate-formula.spec.ts
@@ -101,7 +101,7 @@ end`;
         homebrewCore
       );
       expect.fail('expected error');
-    } catch (e) {
+    } catch (e: any) {
       expect(e.message).to.contain('is lower than');
     }
     expect(getFileContent).to.have.been.calledOnce;

--- a/packages/build/src/local/trigger-release-draft.spec.ts
+++ b/packages/build/src/local/trigger-release-draft.spec.ts
@@ -141,7 +141,7 @@ describe('local trigger-release-draft', () => {
           confirm,
           spawnSync
         );
-      } catch (e) {
+      } catch (e: any) {
         expect(e.message).to.contain('Could not find a previous draft or release tag.');
         expect(verifyGitStatus).to.have.been.called;
         expect(choose).to.not.have.been.called;
@@ -174,7 +174,7 @@ describe('local trigger-release-draft', () => {
           confirm,
           spawnSync
         );
-      } catch (e) {
+      } catch (e: any) {
         expect(e.message).to.contain('User aborted');
         expect(verifyGitStatus).to.have.been.called;
         expect(choose).to.not.have.been.called;
@@ -217,7 +217,7 @@ describe('local trigger-release-draft', () => {
     it('fails on unknown bump type', () => {
       try {
         computeNextTagNameFn(releaseTag, 'what' as any);
-      } catch (e) {
+      } catch (e: any) {
         expect(e.message).to.contain('unexpected bump type');
         return;
       }

--- a/packages/build/src/local/trigger-release-publish.spec.ts
+++ b/packages/build/src/local/trigger-release-publish.spec.ts
@@ -60,7 +60,7 @@ describe('local trigger-release-publish', () => {
           verifyEvergreenStatus,
           spawnSync
         );
-      } catch (e) {
+      } catch (e: any) {
         expect(e.message).to.contain('Failed to find a prior tag to release from');
         expect(verifyGitStatus).to.have.been.called;
         expect(confirm).to.not.have.been.called;
@@ -91,7 +91,7 @@ describe('local trigger-release-publish', () => {
           verifyEvergreenStatus,
           spawnSync
         );
-      } catch (e) {
+      } catch (e: any) {
         expect(e.message).to.contain('but it\'s not a draft');
         expect(verifyGitStatus).to.have.been.called;
         expect(confirm).to.not.have.been.called;
@@ -125,7 +125,7 @@ describe('local trigger-release-publish', () => {
           verifyEvergreenStatus,
           spawnSync
         );
-      } catch (e) {
+      } catch (e: any) {
         expect(e).to.equal(expectedError);
         expect(verifyGitStatus).to.have.been.called;
         expect(confirm).to.have.been.called;
@@ -156,7 +156,7 @@ describe('local trigger-release-publish', () => {
           verifyEvergreenStatus,
           spawnSync
         );
-      } catch (e) {
+      } catch (e: any) {
         expect(e.message).to.contain('User aborted');
         expect(verifyGitStatus).to.have.been.called;
         expect(confirm).to.have.been.called;
@@ -213,7 +213,7 @@ describe('local trigger-release-publish', () => {
       getTasks.rejects(expectedError);
       try {
         await verifyEvergreenStatusFn(exampleTag, evergreenProvider);
-      } catch (e) {
+      } catch (e: any) {
         expect(e).to.equal(expectedError);
         return;
       }
@@ -225,7 +225,7 @@ describe('local trigger-release-publish', () => {
       const confirm = sinon.stub().resolves(false);
       try {
         await verifyEvergreenStatusFn(exampleTag, evergreenProvider, confirm);
-      } catch (e) {
+      } catch (e: any) {
         expect(e.message).to.contain('Some Evergreen tasks were not successful');
         expect(getTasks).to.have.been.calledWith('mongosh', 'sha', 'v0.8.2-draft.5');
         return;

--- a/packages/build/src/npm-packages/publish.spec.ts
+++ b/packages/build/src/npm-packages/publish.spec.ts
@@ -25,7 +25,7 @@ describe('npm-packages publishNpmPackages', () => {
         markBumpedFilesAsAssumeUnchanged,
         spawnSync
       );
-    } catch (e) {
+    } catch (e: any) {
       expect(markBumpedFilesAsAssumeUnchanged).to.not.have.been.called;
       expect(spawnSync).to.not.have.been.called;
       return;
@@ -44,7 +44,7 @@ describe('npm-packages publishNpmPackages', () => {
         markBumpedFilesAsAssumeUnchanged,
         spawnSync
       );
-    } catch (e) {
+    } catch (e: any) {
       expect(markBumpedFilesAsAssumeUnchanged).to.not.have.been.called;
       expect(spawnSync).to.not.have.been.called;
       return;
@@ -87,7 +87,7 @@ describe('npm-packages publishNpmPackages', () => {
         markBumpedFilesAsAssumeUnchanged,
         spawnSync
       );
-    } catch (e) {
+    } catch (e: any) {
       expect(markBumpedFilesAsAssumeUnchanged).to.have.been.calledWith(packages, true);
       expect(spawnSync).to.have.been.called;
       expect(markBumpedFilesAsAssumeUnchanged).to.have.been.calledWith(packages, false);

--- a/packages/build/src/packaging/notary-service.ts
+++ b/packages/build/src/packaging/notary-service.ts
@@ -54,7 +54,7 @@ export async function notarizeArtifact(
   } finally {
     try {
       await fs.unlink(authTokenFile);
-    } catch (e) {
+    } catch (e: any) {
       console.error('mongosh: Failed to remove auth token file', e);
     }
   }

--- a/packages/build/src/packaging/package/create-package.spec.ts
+++ b/packages/build/src/packaging/package/create-package.spec.ts
@@ -41,7 +41,7 @@ describe('archive create-archive', () => {
     it('throws an error for an unknown variant', async() => {
       try {
         await createPackage(tmpPkg.tarballDir, 'nope' as any, tmpPkg.pkgConfig);
-      } catch (e) {
+      } catch (e: any) {
         expect(e).to.not.be.undefined;
         return;
       }

--- a/packages/build/src/packaging/package/redhat.spec.ts
+++ b/packages/build/src/packaging/package/redhat.spec.ts
@@ -78,7 +78,7 @@ describe('tarball redhat', () => {
         outFile,
         execFileStub as any
       );
-    } catch (e) {
+    } catch (e: any) {
       expect(e.message).to.contain('Don’t know which RPM from');
       return;
     }

--- a/packages/build/src/packaging/package/zip.spec.ts
+++ b/packages/build/src/packaging/package/zip.spec.ts
@@ -56,7 +56,7 @@ describe('package zip', () => {
 
     try {
       await createZipPackage(tmpPkg.pkgConfig, path.join(tmpPkg.tarballDir, 'outfile.zip'), execFileStub);
-    } catch (e) {
+    } catch (e: any) {
       return expect(e).to.equal(expectedError);
     }
     expect.fail('Expected error');

--- a/packages/build/src/packaging/package/zip.ts
+++ b/packages/build/src/packaging/package/zip.ts
@@ -20,8 +20,8 @@ export async function createZipPackage(
   const tmpDir = await createCompressedArchiveContents(filename, pkg);
   try {
     await execFile('zip', ['-r', outFile, '.'], { cwd: tmpDir });
-  } catch (err) {
-    if (err.code === 'ENOENT') {
+  } catch (err: any) {
+    if (err?.code === 'ENOENT') {
       await execFile('7z', ['a', outFile, '.'], { cwd: tmpDir });
     } else {
       throw err;

--- a/packages/build/src/run-draft.spec.ts
+++ b/packages/build/src/run-draft.spec.ts
@@ -117,7 +117,7 @@ describe('draft', () => {
           ensureGithubReleaseExistsAndUpdateChangelog,
           notarizeArtifact
         );
-      } catch (e) {
+      } catch (e: any) {
         expect(e.message).to.contain('Missing package information from config');
         expect(ensureGithubReleaseExistsAndUpdateChangelog).to.not.have.been.called;
         expect(downloadArtifactFromEvergreen).to.not.have.been.called;

--- a/packages/build/src/run-publish.spec.ts
+++ b/packages/build/src/run-publish.spec.ts
@@ -82,7 +82,7 @@ describe('publish', () => {
             publishToHomebrew,
             shouldDoPublicRelease
           );
-        } catch (e) {
+        } catch (e: any) {
           return expect(e.message).to.contain('Could not find prior draft tag');
         }
         expect.fail('Expected error');
@@ -105,7 +105,7 @@ describe('publish', () => {
             publishToHomebrew,
             shouldDoPublicRelease
           );
-        } catch (e) {
+        } catch (e: any) {
           return expect(e.message).to.contain('Version mismatch');
         }
         expect.fail('Expected error');
@@ -128,7 +128,7 @@ describe('publish', () => {
             publishToHomebrew,
             shouldDoPublicRelease
           );
-        } catch (e) {
+        } catch (e: any) {
           return expect(e.message).to.contain('Missing package name');
         }
         expect.fail('Expected error');

--- a/packages/cli-repl/src/arg-mapper.ts
+++ b/packages/cli-repl/src/arg-mapper.ts
@@ -102,8 +102,8 @@ export function getTlsCertificateSelector(
   try {
     const { passphrase, pfx } = exportCertificateAndPrivateKey(search);
     return { passphrase, pfx };
-  } catch (err) {
-    throw new MongoshInvalidInputError(`Could not resolve certificate specification '${selector}': ${err.message}`);
+  } catch (err: any) {
+    throw new MongoshInvalidInputError(`Could not resolve certificate specification '${selector}': ${err?.message}`);
   }
 }
 

--- a/packages/cli-repl/src/arg-parser.spec.ts
+++ b/packages/cli-repl/src/arg-parser.spec.ts
@@ -224,7 +224,7 @@ describe('arg-parser', () => {
           it('raises an error', () => {
             try {
               parseCliArgs(argv);
-            } catch (err) {
+            } catch (err: any) {
               return expect(
                 stripAnsi(err.message)
               ).to.contain('Error parsing command line: unrecognized option: --what');
@@ -325,7 +325,7 @@ describe('arg-parser', () => {
           it('throws an error since it is not yet supported', () => {
             try {
               parseCliArgs(argv);
-            } catch (e) {
+            } catch (e: any) {
               expect(e).to.be.instanceOf(MongoshUnimplementedError);
               expect(e.message).to.include('Argument --gssapiHostName is not yet supported in mongosh');
               return;
@@ -494,7 +494,7 @@ describe('arg-parser', () => {
           it('throws an error since it is not yet supported', () => {
             try {
               parseCliArgs(argv);
-            } catch (e) {
+            } catch (e: any) {
               expect(e).to.be.instanceOf(MongoshUnimplementedError);
               expect(e.message).to.include('Argument --tlsFIPSMode is not yet supported in mongosh');
               return;

--- a/packages/cli-repl/src/async-repl.ts
+++ b/packages/cli-repl/src/async-repl.ts
@@ -119,7 +119,7 @@ export function start(opts: AsyncREPLOptions): REPLServer {
               let interruptHandled = false;
               try {
                 interruptHandled = await onAsyncSigint();
-              } catch (e) {
+              } catch (e: any) {
                 // ignore
               } finally {
                 // Reject with an exception similar to one thrown by Node.js
@@ -172,7 +172,7 @@ export function start(opts: AsyncREPLOptions): REPLServer {
           process.nextTick(() => repl.emit('exit'));
         }
       }
-    } catch (err) {
+    } catch (err: any) {
       try {
         if (isRecoverableError(input)) {
           repl.emit(evalFinish, { input, success: false, err, recoverable: true } as EvalFinishEvent);
@@ -180,14 +180,14 @@ export function start(opts: AsyncREPLOptions): REPLServer {
         }
         repl.emit(evalFinish, { input, success: false, err, recoverable: false } as EvalFinishEvent);
         return callback(err);
-      } catch (callbackErr) {
+      } catch (callbackErr: any) {
         return callback(wrapCallbackError(callbackErr));
       }
     }
     try {
       repl.emit(evalFinish, { input, success: true } as EvalFinishEvent);
       return callback(null, result);
-    } catch (callbackErr) {
+    } catch (callbackErr: any) {
       return callback(wrapCallbackError(callbackErr));
     }
   };

--- a/packages/cli-repl/src/cli-repl.spec.ts
+++ b/packages/cli-repl/src/cli-repl.spec.ts
@@ -35,7 +35,7 @@ describe('CliRepl', () => {
     try {
       await cliRepl.start(host, {});
       expect.fail('Expected start() to also exit immediately');
-    } catch (err) {
+    } catch (err: any) {
       expect(err.message).to.include('onExit() unexpectedly returned');
     }
   }
@@ -195,7 +195,7 @@ describe('CliRepl', () => {
         try {
           // calling exit will not "exit" since we are not stopping the process
           await cliRepl.exit(1);
-        } catch (e) {
+        } catch (e: any) {
           const [emitted] = await onerror;
           expect(emitted).to.be.instanceOf(MongoshInternalError);
           await eventually(async() => {
@@ -333,7 +333,7 @@ describe('CliRepl', () => {
         try {
           await fs.stat(oldlogfile);
           expect.fail('missed exception');
-        } catch (err) {
+        } catch (err: any) {
           expect(err.code).to.equal('ENOENT');
         }
       });
@@ -475,7 +475,7 @@ describe('CliRepl', () => {
           cliRepl = new CliRepl(cliReplOptions);
           try {
             await cliRepl.start('', {});
-          } catch (err) {
+          } catch (err: any) {
             expect(err.message).to.include('uh oh');
           }
           expect(output).to.include('Loading file');
@@ -495,7 +495,7 @@ describe('CliRepl', () => {
           cliRepl = new CliRepl(cliReplOptions);
           try {
             await cliRepl.start('', {});
-          } catch (err) {
+          } catch (err: any) {
             expect(err.message).to.include('oh no');
           }
           expect(output).not.to.include('oh no');
@@ -721,7 +721,7 @@ describe('CliRepl', () => {
       try {
         await cliRepl.start(await testServer.connectionString(), { auth });
         threw = false;
-      } catch (err) {
+      } catch (err: any) {
         expect(err.message).to.equal('Authentication failed.');
       }
       expect(threw).to.be.true;
@@ -742,7 +742,7 @@ describe('CliRepl', () => {
       try {
         await cliRepl.start(cs.href, {});
         threw = false;
-      } catch (err) {
+      } catch (err: any) {
         expect(err.message).to.equal('Authentication failed.');
       }
       expect(threw).to.be.true;

--- a/packages/cli-repl/src/cli-repl.ts
+++ b/packages/cli-repl/src/cli-repl.ts
@@ -187,7 +187,7 @@ class CliRepl implements MongoshIOProvider {
 
     try {
       await this.shellHomeDirectory.ensureExists();
-    } catch (err) {
+    } catch (err: any) {
       this.warnAboutInaccessibleFile(err);
     }
 
@@ -207,7 +207,7 @@ class CliRepl implements MongoshIOProvider {
     let analyticsSetupError: Error | null = null;
     try {
       this.setupAnalytics();
-    } catch (err) {
+    } catch (err: any) {
       // Need to delay emitting the error on the bus so that logging is in place
       // as well
       analyticsSetupError = err;
@@ -229,7 +229,7 @@ class CliRepl implements MongoshIOProvider {
 
     try {
       this.config = await this.configDirectory.generateOrReadConfig(this.config);
-    } catch (err) {
+    } catch (err: any) {
       this.warnAboutInaccessibleFile(err);
     }
 
@@ -359,7 +359,7 @@ class CliRepl implements MongoshIOProvider {
       try {
         this.bus.emit('mongosh:mongoshrc-load');
         await this.mongoshRepl.loadExternalFile(mongoshrcPath);
-      } catch (err) {
+      } catch (err: any) {
         this.output.write(this.clr('Error while running ~/.mongoshrc.js:\n', 'mongosh:warning'));
         this.output.write(this.mongoshRepl.writer(err) + '\n');
       }
@@ -403,8 +403,8 @@ class CliRepl implements MongoshIOProvider {
       try {
         fileContents = await fs.readFile(filename, 'utf8');
         break;
-      } catch (err) {
-        if (err.code !== 'ENOENT') {
+      } catch (err: any) {
+        if (err?.code !== 'ENOENT') {
           this.bus.emit('mongosh:error', err, 'config');
         }
       }
@@ -426,9 +426,9 @@ class CliRepl implements MongoshIOProvider {
         }
       }
       return config;
-    } catch (err) {
+    } catch (err: any) {
       this.bus.emit('mongosh:error', err, 'config');
-      const msg = `Warning: Could not parse global configuration file at ${filename}: ${err.message}\n`;
+      const msg = `Warning: Could not parse global configuration file at ${filename}: ${err?.message}\n`;
       this.output.write(this.clr(msg, 'mongosh:warning'));
       return {};
     }
@@ -492,7 +492,7 @@ class CliRepl implements MongoshIOProvider {
     }
     try {
       await this.configDirectory.writeConfigFile(this.config);
-    } catch (err) {
+    } catch (err: any) {
       this.warnAboutInaccessibleFile(err, this.configDirectory.path());
     }
     return 'success';
@@ -584,7 +584,7 @@ class CliRepl implements MongoshIOProvider {
       } finally {
         this.output.write('\n');
       }
-    } catch (error) {
+    } catch (error: any) {
       await this._fatalError(error);
     }
     return ''; // unreachable
@@ -661,8 +661,8 @@ class CliRepl implements MongoshIOProvider {
   async startMongocryptd(): Promise<AutoEncryptionOptions['extraOptions']> {
     try {
       return await this.mongocryptdManager.start();
-    } catch (e) {
-      if (e.code === 'ENOENT') {
+    } catch (e: any) {
+      if (e?.code === 'ENOENT') {
         throw new MongoshRuntimeError('Could not find a working mongocryptd - ensure your local installation works correctly. See the mongosh log file for additional information. Please also refer to the documentation: https://docs.mongodb.com/manual/reference/security-client-side-encryption-appendix/');
       }
       throw e;

--- a/packages/cli-repl/src/config-directory.spec.ts
+++ b/packages/cli-repl/src/config-directory.spec.ts
@@ -46,7 +46,7 @@ describe('home directory management', () => {
       try {
         await fs.access(base);
         threw = false;
-      } catch (err) {
+      } catch (err: any) {
         expect(err.code).to.equal('ENOENT');
       }
       expect(threw).to.be.true;
@@ -82,7 +82,7 @@ describe('home directory management', () => {
       try {
         await manager.writeConfigFile(new ExampleConfig());
         threw = false;
-      } catch (err) {
+      } catch (err: any) {
         expect(err.code).to.equal('EISDIR');
       }
       expect(threw).to.be.true;
@@ -123,7 +123,7 @@ describe('home directory management', () => {
         try {
           await manager.generateOrReadConfig({ someProperty: 3 });
           threw = false;
-        } catch (err) {
+        } catch (err: any) {
           expect(err.code).to.be.oneOf(['EPERM', 'EACCES']);
         }
         expect(threw).to.be.true;

--- a/packages/cli-repl/src/config-directory.ts
+++ b/packages/cli-repl/src/config-directory.ts
@@ -97,8 +97,8 @@ export class ConfigManager<Config> extends EventEmitter {
     try {
       try {
         fd = await fs.open(this.path(), 'r');
-      } catch (err) {
-        if (err.code !== 'ENOENT') {
+      } catch (err: any) {
+        if (err?.code !== 'ENOENT') {
           this.emit('error', err);
           throw err;
         }
@@ -110,7 +110,7 @@ export class ConfigManager<Config> extends EventEmitter {
           const config: Config = EJSON.parse(await fd.readFile({ encoding: 'utf8' })) as any;
           this.emit('update-config', config);
           return { ...defaultConfig, ...config };
-        } catch (err) {
+        } catch (err: any) {
           this.emit('error', err);
           return defaultConfig;
         }
@@ -132,7 +132,7 @@ export class ConfigManager<Config> extends EventEmitter {
     await this.shellHomeDirectory.ensureExists();
     try {
       await fs.writeFile(this.path(), EJSON.stringify(config), { mode: 0o600 });
-    } catch (err) {
+    } catch (err: any) {
       this.emit('error', err);
       throw err;
     }

--- a/packages/cli-repl/src/mongocryptd-manager.spec.ts
+++ b/packages/cli-repl/src/mongocryptd-manager.spec.ts
@@ -116,7 +116,7 @@ describe('MongocryptdManager', () => {
     try {
       await makeManager().start();
       expect.fail('missed exception');
-    } catch (e) {
+    } catch (e: any) {
       expect(e.code).to.equal('ERR_INVALID_ARG_VALUE');
     }
   });
@@ -126,7 +126,7 @@ describe('MongocryptdManager', () => {
     try {
       await makeManager().start();
       expect.fail('missed exception');
-    } catch (e) {
+    } catch (e: any) {
       expect(e.name).to.equal('MongoshInternalError');
     }
   });
@@ -136,7 +136,7 @@ describe('MongocryptdManager', () => {
     try {
       await makeManager().start();
       expect.fail('missed exception');
-    } catch (e) {
+    } catch (e: any) {
       expect(e.name).to.equal('MongoshInternalError');
     }
     const nostdoutErrors = events.filter(({ event, data }) => {
@@ -163,7 +163,7 @@ describe('MongocryptdManager', () => {
     try {
       await fs.stat(pidfile);
       expect.fail('missed exception');
-    } catch (e) {
+    } catch (e: any) {
       expect(e.code).to.equal('ENOENT');
     }
   });

--- a/packages/cli-repl/src/mongocryptd-manager.ts
+++ b/packages/cli-repl/src/mongocryptd-manager.ts
@@ -113,7 +113,7 @@ export class MongocryptdManager {
         const logEntry = parseAnyLogEntry(line);
         this.bus.emit('mongosh:mongocryptd-log', { pid, logEntry });
         yield logEntry;
-      } catch (error) {
+      } catch (error: any) {
         this.bus.emit('mongosh:mongocryptd-error', { pid, cause: 'parse', error });
         break;
       }
@@ -164,7 +164,7 @@ export class MongocryptdManager {
       this.bus.emit('mongosh:mongocryptd-tryspawn', { spawnPath, path: this.path });
       try {
         proc = this._spawnMongocryptdProcess(spawnPath);
-      } catch (error) {
+      } catch (error: any) {
         // Spawn can fail both synchronously and asynchronously.
         // We log the error either way and just try the next one.
         lastError = error;
@@ -213,7 +213,7 @@ export class MongocryptdManager {
           serverSelectionTimeoutMS: this.idleShutdownTimeoutSecs * 1000
         }, {}, this.bus);
         await sp.runCommandWithCheck('admin', { isMaster: 1 });
-      } catch (error) {
+      } catch (error: any) {
         this.bus.emit('mongosh:mongocryptd-error', { cause: 'ping', error });
       } finally {
         if (sp !== undefined) {
@@ -241,8 +241,8 @@ export class MongocryptdManager {
           let size = 0;
           try {
             size = (await fs.stat(path.join(dirent.name, 'mongocryptd.pid'))).size;
-          } catch (err) {
-            if (err.code !== 'ENOENT') {
+          } catch (err: any) {
+            if (err?.code !== 'ENOENT') {
               throw err;
             }
           }
@@ -256,7 +256,7 @@ export class MongocryptdManager {
           await fs.rmdir(dir, { recursive: true });
         }
       }
-    } catch (error) {
+    } catch (error: any) {
       this.bus.emit('mongosh:mongocryptd-error', { cause: 'cleanup', error });
     }
   }

--- a/packages/cli-repl/src/mongosh-repl.ts
+++ b/packages/cli-repl/src/mongosh-repl.ts
@@ -358,11 +358,11 @@ class MongoshNodeRepl implements EvaluationListener {
           originalHistory = null;
         }
       });
-    } catch (err) {
+    } catch (err: any) {
       // repl.setupHistory() only reports failure when something went wrong
       // *after* the file was already opened for the first time. If the initial
       // open fails, it will print a warning to the REPL and report success to us.
-      const warn = new MongoshWarning('Error processing history file: ' + err.message);
+      const warn = new MongoshWarning('Error processing history file: ' + err?.message);
       this.output.write(this.writer(warn) + '\n');
     }
 
@@ -436,7 +436,7 @@ class MongoshNodeRepl implements EvaluationListener {
       if (!result) {
         throw new MongoshCommandFailed('adminCommand getLog unexpectedly returned no result');
       }
-    } catch (error) {
+    } catch (error: any) {
       this.bus.emit('mongosh:error', error, 'repl');
       return;
     }
@@ -452,7 +452,7 @@ class MongoshNodeRepl implements EvaluationListener {
       try {
         const entry: LogEntry = parseAnyLogEntry(logLine);
         text += `   ${entry.timestamp}: ${entry.message}\n`;
-      } catch (e) {
+      } catch (e: any) {
         text += `   Unexpected log line format: ${logLine}\n`;
       }
     });
@@ -522,7 +522,7 @@ class MongoshNodeRepl implements EvaluationListener {
       return Object.fromEntries(
         Object.entries(rawValue)
           .filter(([key]) => !key.startsWith('_')));
-    } catch (err) {
+    } catch (err: any) {
       if (this.runtimeState().instanceState.interrupted.isSet()) {
         interrupted = true;
         this.bus.emit('mongosh:eval-interrupted');
@@ -908,7 +908,7 @@ function isErrorLike(value: any): boolean {
       (value.message !== undefined && typeof value.stack === 'string') ||
       (value.code !== undefined && value.errmsg !== undefined)
     );
-  } catch (err) {
+  } catch (err: any) {
     throw new MongoshInternalError(err?.message || String(err));
   }
 }

--- a/packages/cli-repl/src/run.ts
+++ b/packages/cli-repl/src/run.ts
@@ -102,8 +102,8 @@ import stream from 'stream';
       });
       await repl.start(driverUri, driverOptions);
     }
-  } catch (e) {
-    console.error(`${e.name}: ${e.message}`);
+  } catch (e: any) {
+    console.error(`${e?.name}: ${e?.message}`);
     if (repl !== undefined) {
       repl.bus.emit('mongosh:error', e, 'startup');
     }

--- a/packages/cli-repl/src/smoke-tests.ts
+++ b/packages/cli-repl/src/smoke-tests.ts
@@ -64,7 +64,7 @@ async function runSmokeTest(executable: string, args: string[], input: string, o
   try {
     assert.match(stdout, output);
     console.error({ status: 'success', input, output, stdout, executable, args: args.map(arg => redactURICredentials(arg)) });
-  } catch (err) {
+  } catch (err: any) {
     console.error({ status: 'failure', input, output, stdout, executable, args: args.map(arg => redactURICredentials(arg)) });
     throw err;
   }

--- a/packages/cli-repl/test/e2e-auth.spec.ts
+++ b/packages/cli-repl/test/e2e-auth.spec.ts
@@ -58,7 +58,7 @@ function createAssertUserAuth(db, connectionString, dbName): Function {
         return c;
       }
       await c.close();
-    } catch (e) {
+    } catch (e: any) {
       expect.fail(`Could not authenticate user to initialize test: ${e.message}`);
     }
   };

--- a/packages/cli-repl/test/e2e-aws.spec.ts
+++ b/packages/cli-repl/test/e2e-aws.spec.ts
@@ -74,7 +74,7 @@ describe('e2e AWS AUTH', () => {
       if (result.status === 0) {
         awsCliFound = true;
       }
-    } catch (e) {
+    } catch (e: any) {
       // pass
     }
     if (!awsCliFound) {

--- a/packages/cli-repl/test/e2e-editor.spec.ts
+++ b/packages/cli-repl/test/e2e-editor.spec.ts
@@ -38,7 +38,7 @@ describe('external editor e2e', () => {
     await TestShell.killall.call(this);
     try {
       await promisify(rimraf)(homedir);
-    } catch (err) {
+    } catch (err: any) {
       // On Windows in CI, this can fail with EPERM for some reason.
       // If it does, just log the error instead of failing all tests.
       console.error('Could not remove fake home directory:', err);

--- a/packages/cli-repl/test/e2e-tls.spec.ts
+++ b/packages/cli-repl/test/e2e-tls.spec.ts
@@ -74,7 +74,7 @@ describe('e2e TLS', () => {
     after(async function() {
       try {
         await promisify(rimraf)(homedir);
-      } catch (err) {
+      } catch (err: any) {
         // On Windows in CI, this can fail with EPERM for some reason.
         // If it does, just log the error instead of failing all tests.
         console.error('Could not remove fake home directory:', err);

--- a/packages/cli-repl/test/e2e.spec.ts
+++ b/packages/cli-repl/test/e2e.spec.ts
@@ -867,7 +867,7 @@ describe('e2e', function() {
       await TestShell.killall.call(this);
       try {
         await promisify(rimraf)(homedir);
-      } catch (err) {
+      } catch (err: any) {
         // On Windows in CI, this can fail with EPERM for some reason.
         // If it does, just log the error instead of failing all tests.
         console.error('Could not remove fake home directory:', err);

--- a/packages/cli-repl/test/repl-helpers.ts
+++ b/packages/cli-repl/test/repl-helpers.ts
@@ -32,7 +32,7 @@ function useTmpdir(): { readonly path: string } {
   afterEach(async() => {
     try {
       await promisify(rimraf)(tmpdir);
-    } catch (err) {
+    } catch (err: any) {
       // On Windows in CI, this can fail with EPERM for some reason.
       // If it does, just log the error instead of failing all tests.
       console.error('Could not remove fake home directory:', err);

--- a/packages/editor/src/editor.spec.ts
+++ b/packages/editor/src/editor.spec.ts
@@ -30,7 +30,7 @@ function useTmpdir(): { readonly path: string } {
   afterEach(async() => {
     try {
       await promisify(rimraf)(tmpdir);
-    } catch (err) {
+    } catch (err: any) {
       // On Windows in CI, this can fail with EPERM for some reason.
       // If it does, just log the error instead of failing all tests.
       console.error('Could not remove fake home directory:', err);
@@ -52,7 +52,7 @@ const fakeExternalEditor = async(
     script = `(async () => {
       const tmpDoc = process.argv[process.argv.length - 1];
       const { promises: { writeFile } } = require('fs');
-  
+
       await writeFile(tmpDoc, ${JSON.stringify(output)}, { mode: 0o600 });
     })()`;
   } else {
@@ -427,7 +427,7 @@ describe('Editor', () => {
         editor = makeEditor();
         try {
           await editor.runEditCommand('');
-        } catch (error) {
+        } catch (error: any) {
           expect(error.message).to.include('Command failed with an error: please define an external editor');
         }
       });
@@ -440,7 +440,7 @@ describe('Editor', () => {
 
         try {
           await editor.runEditCommand('function() {}');
-        } catch (error) {
+        } catch (error: any) {
           expect(error.message).to.include('failed with an exit code 1');
         }
       });

--- a/packages/editor/src/editor.ts
+++ b/packages/editor/src/editor.ts
@@ -83,7 +83,7 @@ export class Editor {
       });
 
       return hasMongodbExtension ? 'mongodb' : 'js';
-    } catch (error) {
+    } catch (error: any) {
       this.messageBus.emit('mongosh-editor:read-vscode-extensions-failed', {
         vscodeDir: this._vscodeDir,
         error: error as Error

--- a/packages/errors/scripts/extract-errors.ts
+++ b/packages/errors/scripts/extract-errors.ts
@@ -68,7 +68,7 @@ async function isDirectory(path: string): Promise<boolean> {
   try {
     const stat = await fs.lstat(path);
     return stat.isDirectory();
-  } catch (e) {
+  } catch (e: any) {
     return false;
   }
 }
@@ -77,7 +77,7 @@ async function isFile(path: string): Promise<boolean> {
   try {
     const stat = await fs.lstat(path);
     return stat.isFile();
-  } catch (e) {
+  } catch (e: any) {
     return false;
   }
 }

--- a/packages/i18n/src/translator.spec.ts
+++ b/packages/i18n/src/translator.spec.ts
@@ -122,7 +122,7 @@ describe('Translator', () => {
       try {
         translator.__('testing.testing.testing');
         fail('expected error');
-      } catch (e) {
+      } catch (e: any) {
         expect(e).to.be.instanceOf(MongoshInternalError);
       }
     });

--- a/packages/node-runtime-worker-thread/src/index.spec.ts
+++ b/packages/node-runtime-worker-thread/src/index.spec.ts
@@ -47,7 +47,7 @@ describe('WorkerRuntime', () => {
 
       try {
         await runtime.evaluate('1+1');
-      } catch (e) {
+      } catch (e: any) {
         err = e;
       }
 
@@ -66,7 +66,7 @@ describe('WorkerRuntime', () => {
 
       try {
         await runtime.evaluate('1+1');
-      } catch (e) {
+      } catch (e: any) {
         err = e;
       }
 
@@ -91,7 +91,7 @@ describe('WorkerRuntime', () => {
 
         try {
           await runtime.evaluate('throw new TypeError("Oh no, types!")');
-        } catch (e) {
+        } catch (e: any) {
           err = e;
         }
 
@@ -189,7 +189,7 @@ describe('WorkerRuntime', () => {
       try {
         process.kill(pid, 0);
         return true;
-      } catch (e) {
+      } catch (e: any) {
         return false;
       }
     }
@@ -223,7 +223,7 @@ describe('WorkerRuntime', () => {
             await runtime.terminate();
           })()
         ]);
-      } catch (e) {
+      } catch (e: any) {
         err = e;
       }
       expect(err).to.be.instanceof(Error);
@@ -250,7 +250,7 @@ describe('WorkerRuntime', () => {
             await runtime.interrupt();
           })()
         ]);
-      } catch (e) {
+      } catch (e: any) {
         err = e;
       }
 
@@ -275,7 +275,7 @@ describe('WorkerRuntime', () => {
             await runtime.interrupt();
           })()
         ]);
-      } catch (e) {
+      } catch (e: any) {
         err = e;
       }
 
@@ -298,7 +298,7 @@ describe('WorkerRuntime', () => {
             await runtime.interrupt();
           })()
         ]);
-      } catch (e) {
+      } catch (e: any) {
         // ignore
       }
 

--- a/packages/node-runtime-worker-thread/src/lock.spec.ts
+++ b/packages/node-runtime-worker-thread/src/lock.spec.ts
@@ -30,7 +30,7 @@ describe('Lock', () => {
     try {
       // eslint-disable-next-line @typescript-eslint/no-floating-promises
       lock.lock();
-    } catch (e) {
+    } catch (e: any) {
       err = e;
     } finally {
       lock.unlock();

--- a/packages/node-runtime-worker-thread/src/rpc.spec.ts
+++ b/packages/node-runtime-worker-thread/src/rpc.spec.ts
@@ -115,7 +115,7 @@ describe('rpc', () => {
     try {
       // eslint-disable-next-line @typescript-eslint/await-thenable
       await caller.throws();
-    } catch (e) {
+    } catch (e: any) {
       err = e;
     }
 
@@ -144,7 +144,7 @@ describe('rpc', () => {
 
     try {
       await caller.callMe((a: number, b: number) => a + b);
-    } catch (e) {
+    } catch (e: any) {
       err = e;
     }
 
@@ -171,7 +171,7 @@ describe('rpc', () => {
 
     try {
       await caller.returnsFunction();
-    } catch (e) {
+    } catch (e: any) {
       err = e;
     }
 
@@ -217,7 +217,7 @@ describe('rpc', () => {
               caller[cancel]();
             })()
           ]);
-        } catch (e) {
+        } catch (e: any) {
           err = e;
         }
         expect(err).to.be.instanceof(Error);

--- a/packages/node-runtime-worker-thread/src/rpc.ts
+++ b/packages/node-runtime-worker-thread/src/rpc.ts
@@ -98,7 +98,7 @@ function getRPCOptions(messageBus: RPCMessageBus): PostmsgRpcOptions {
         // that was executing the method.
         try {
           data.res = serialize(data.res);
-        } catch (e) {
+        } catch (e: any) {
           data.res = serialize({
             type: RPCMessageTypes.Error,
             payload: serializeError(e)
@@ -141,7 +141,7 @@ export function exposeAll<O>(obj: O, messageBus: RPCMessageBus): Exposed<O> {
       async(...args: unknown[]) => {
         try {
           return { type: RPCMessageTypes.Message, payload: await val(...args) };
-        } catch (e) {
+        } catch (e: any) {
           // If server (whatever is executing the exposed method) throws during
           // the execution, we want to propagate error to the client (whatever
           // issued the call) and re-throw there. We will do this with a special

--- a/packages/node-runtime-worker-thread/src/spawn-child-from-source.spec.ts
+++ b/packages/node-runtime-worker-thread/src/spawn-child-from-source.spec.ts
@@ -23,7 +23,7 @@ describe('spawnChildFromSource', () => {
         // @ts-expect-error
         stdio: 'ignore'
       });
-    } catch (e) {
+    } catch (e: any) {
       err = e;
     }
 
@@ -58,7 +58,7 @@ describe('spawnChildFromSource', () => {
         'ignore',
         'ignore'
       );
-    } catch (e) {
+    } catch (e: any) {
       err = e;
     }
 
@@ -77,7 +77,7 @@ describe('spawnChildFromSource', () => {
         {},
         10
       );
-    } catch (e) {
+    } catch (e: any) {
       err = e;
     }
 

--- a/packages/node-runtime-worker-thread/src/worker-runtime.spec.ts
+++ b/packages/node-runtime-worker-thread/src/worker-runtime.spec.ts
@@ -82,7 +82,7 @@ describe('worker', () => {
 
     try {
       await evaluate('1 + 1');
-    } catch (e) {
+    } catch (e: any) {
       err = e;
     }
 
@@ -384,7 +384,7 @@ describe('worker', () => {
         let err: Error;
         try {
           await evaluate('throw new TypeError("Oh no, types!")');
-        } catch (e) {
+        } catch (e: any) {
           err = e;
         }
 
@@ -404,7 +404,7 @@ describe('worker', () => {
         let err: Error;
         try {
           await evaluate('throw Object.assign(new TypeError("Oh no, types!"), { errInfo: { message: "wrong type :S" } })');
-        } catch (e) {
+        } catch (e: any) {
           err = e;
         }
 
@@ -440,7 +440,7 @@ describe('worker', () => {
             evaluate('sleep(50); 1+1'),
             evaluate('sleep(50); 1+1')
           ]);
-        } catch (e) {
+        } catch (e: any) {
           err = e;
         }
 
@@ -653,7 +653,7 @@ describe('worker', () => {
               interrupt(handle);
             })()
           ]);
-        } catch (e) {
+        } catch (e: any) {
           err = e;
         }
 
@@ -681,7 +681,7 @@ describe('worker', () => {
             await interrupt();
           })()
         ]);
-      } catch (e) {
+      } catch (e: any) {
         err = e;
       }
 

--- a/packages/service-provider-core/src/uri-generator.spec.ts
+++ b/packages/service-provider-core/src/uri-generator.spec.ts
@@ -32,7 +32,7 @@ describe('uri-generator.generate-uri', () => {
       try {
         generateUri({ connectionSpecifier: undefined, host: 'localhost:27018', port: '27019' });
         expect.fail('expected error');
-      } catch (e) {
+      } catch (e: any) {
         expect(e).to.be.instanceOf(MongoshInvalidInputError);
         expect(e.code).to.equal(CommonErrors.InvalidArgument);
       }
@@ -60,7 +60,7 @@ describe('uri-generator.generate-uri', () => {
           try {
             generateUri(options);
             expect.fail('expected error');
-          } catch (e) {
+          } catch (e: any) {
             expect(e).to.be.instanceOf(MongoshInvalidInputError);
             expect(e.code).to.equal(CommonErrors.InvalidArgument);
           }
@@ -75,7 +75,7 @@ describe('uri-generator.generate-uri', () => {
           try {
             generateUri(options);
             expect.fail('expected error');
-          } catch (e) {
+          } catch (e: any) {
             expect(e.name).to.equal('MongoshInvalidInputError');
             expect(e.code).to.equal(CommonErrors.InvalidArgument);
           }
@@ -99,7 +99,7 @@ describe('uri-generator.generate-uri', () => {
           it('throws an error', () => {
             try {
               generateUri(options);
-            } catch (e) {
+            } catch (e: any) {
               expect(e.name).to.equal('MongoshInvalidInputError');
               expect(e.code).to.equal(CommonErrors.InvalidArgument);
               expect(e.message).to.contain('--gssapiServiceName parameter or the SERVICE_NAME');
@@ -168,7 +168,7 @@ describe('uri-generator.generate-uri', () => {
       it('throws an error', () => {
         try {
           generateUri(options);
-        } catch (e) {
+        } catch (e: any) {
           expect(e.name).to.equal('MongoshInvalidInputError');
           expect(e.code).to.equal(CommonErrors.InvalidArgument);
           expect(e.message).to.contain('gssapiServiceName query parameter is not supported');
@@ -206,7 +206,7 @@ describe('uri-generator.generate-uri', () => {
         try {
           generateUri(options);
           expect.fail('expected error');
-        } catch (e) {
+        } catch (e: any) {
           expect(e).to.be.instanceOf(MongoshInvalidInputError);
           expect(e.code).to.equal(CommonErrors.InvalidArgument);
         }
@@ -257,7 +257,7 @@ describe('uri-generator.generate-uri', () => {
         try {
           generateUri(options);
           expect.fail('expected error');
-        } catch (e) {
+        } catch (e: any) {
           expect(e).to.be.instanceOf(MongoshInvalidInputError);
           expect(e.code).to.equal(CommonErrors.InvalidArgument);
         }
@@ -273,7 +273,7 @@ describe('uri-generator.generate-uri', () => {
           try {
             generateUri(options);
             expect.fail('expected error');
-          } catch (e) {
+          } catch (e: any) {
             expect(e).to.be.instanceOf(MongoshInvalidInputError);
             expect(e.code).to.equal(CommonErrors.InvalidArgument);
           }
@@ -297,7 +297,7 @@ describe('uri-generator.generate-uri', () => {
           try {
             generateUri(options);
             expect.fail('expected error');
-          } catch (e) {
+          } catch (e: any) {
             expect(e).to.be.instanceOf(MongoshInvalidInputError);
             expect(e.code).to.equal(CommonErrors.InvalidArgument);
           }
@@ -321,7 +321,7 @@ describe('uri-generator.generate-uri', () => {
           try {
             generateUri(options);
             expect.fail('expected error');
-          } catch (e) {
+          } catch (e: any) {
             expect(e).to.be.instanceOf(MongoshInvalidInputError);
             expect(e.code).to.equal(CommonErrors.InvalidArgument);
           }
@@ -391,7 +391,7 @@ describe('uri-generator.generate-uri', () => {
     it('returns the uri', () => {
       try {
         generateUri(options);
-      } catch (e) {
+      } catch (e: any) {
         expect(e.message).to.contain('Invalid URI: /x');
         expect(e).to.be.instanceOf(MongoshInvalidInputError);
         expect(e.code).to.equal(CommonErrors.InvalidArgument);
@@ -407,7 +407,7 @@ describe('uri-generator.generate-uri', () => {
     it('returns the uri', () => {
       try {
         generateUri(options);
-      } catch (e) {
+      } catch (e: any) {
         expect(e.message).to.contain('The --host argument contains an invalid character: $');
         expect(e).to.be.instanceOf(MongoshInvalidInputError);
         expect(e.code).to.equal(CommonErrors.InvalidArgument);

--- a/packages/service-provider-server/src/cli-service-provider.integration.spec.ts
+++ b/packages/service-provider-server/src/cli-service-provider.integration.spec.ts
@@ -75,7 +75,7 @@ describe('CliServiceProvider [integration]', function() {
       try {
         await serviceProvider.runCommandWithCheck('admin', { ping: 1 });
         expect.fail('missed exception');
-      } catch (err) {
+      } catch (err: any) {
         expect(err.name).to.equal('MongoNotConnectedError');
       }
       await reconnect();

--- a/packages/service-provider-server/src/cli-service-provider.spec.ts
+++ b/packages/service-provider-server/src/cli-service-provider.spec.ts
@@ -355,7 +355,7 @@ describe('CliServiceProvider', () => {
     it('executes the command against the database and throws if ok: 0', async() => {
       try {
         await serviceProvider.runCommandWithCheck('admin', { ismaster: 1 });
-      } catch (e) {
+      } catch (e: any) {
         expect(e.message).to.include(JSON.stringify({ ismaster: 1 }));
         expect(e.name).to.equal('MongoshCommandFailed');
         expect(e.code).to.equal(CommonErrors.CommandFailed);

--- a/packages/service-provider-server/src/cli-service-provider.ts
+++ b/packages/service-provider-server/src/cli-service-provider.ts
@@ -206,7 +206,7 @@ class CliServiceProvider extends ServiceProviderCore implements ServiceProvider 
     this.platform = ReplPlatform.CLI;
     try {
       this.initialDb = (mongoClient as any).s.options.dbName || DEFAULT_DB;
-    } catch (err) {
+    } catch (err: any) {
       this.initialDb = DEFAULT_DB;
     }
     this.currentClientOptions = clientOptions;
@@ -236,8 +236,8 @@ class CliServiceProvider extends ServiceProviderCore implements ServiceProvider 
       buildInfo = await this.runCommandWithCheck('admin', {
         buildInfo: 1
       }, this.baseCmdOptions);
-    } catch (e) {
-      if (e.message.includes('not supported for auto encryption')) {
+    } catch (e: unknown) {
+      if ((e as Error)?.message.includes('not supported for auto encryption')) {
         const options = { ...this.currentClientOptions };
         delete options.autoEncryption;
         const unencrypted =

--- a/packages/shell-api/src/bulk.spec.ts
+++ b/packages/shell-api/src/bulk.spec.ts
@@ -208,7 +208,7 @@ describe('Bulk API', () => {
               try {
                 bulk.getOperations();
                 fail('expected error');
-              } catch (e) {
+              } catch (e: any) {
                 expect(e.name).to.equal('MongoshInvalidInputError');
                 expect(e.code).to.equal(CommonErrors.InvalidOperation);
               }

--- a/packages/shell-api/src/change-stream-cursor.spec.ts
+++ b/packages/shell-api/src/change-stream-cursor.spec.ts
@@ -240,7 +240,7 @@ describe('ChangeStreamCursor', () => {
         try {
           await nextPromise;
           expect.fail('missed exception');
-        } catch (err) {
+        } catch (err: any) {
           expect(err.name).to.equal('MongoshInterruptedError');
         }
       });
@@ -297,7 +297,7 @@ describe('ChangeStreamCursor', () => {
       try {
         await cursor.isExhausted();
         expect.fail('missed exception');
-      } catch (err) {
+      } catch (err: any) {
         expect(err.name).to.equal('MongoshInvalidInputError');
       }
     });

--- a/packages/shell-api/src/collection.spec.ts
+++ b/packages/shell-api/src/collection.spec.ts
@@ -521,7 +521,7 @@ describe('Collection', () => {
             returnDocument: 'somethingelse' as any
           });
           expect.fail('missed exception');
-        } catch (error) {
+        } catch (error: any) {
           expect(error).to.be.instanceOf(MongoshInvalidInputError);
           expect(error.message).to.contain("returnDocument needs to be either 'before' or 'after'");
           expect(error.code).to.equal(CommonErrors.InvalidArgument);
@@ -596,7 +596,7 @@ describe('Collection', () => {
             returnDocument: 'somethingelse' as any
           });
           expect.fail('missed exception');
-        } catch (error) {
+        } catch (error: any) {
           expect(error).to.be.instanceOf(MongoshInvalidInputError);
           expect(error.message).to.contain("returnDocument needs to be either 'before' or 'after'");
           expect(error.code).to.equal(CommonErrors.InvalidArgument);
@@ -1278,7 +1278,7 @@ describe('Collection', () => {
       it('throws if no query is provided', async() => {
         try {
           await collection.findAndModify({} as any);
-        } catch (e) {
+        } catch (e: any) {
           return expect(e.name).to.equal('MongoshInvalidInputError');
         }
         expect.fail('MongoshInvalidInputError not thrown for findAndModify');
@@ -1286,7 +1286,7 @@ describe('Collection', () => {
       it('throws if no argument is provided', async() => {
         try {
           await (collection.findAndModify as any)();
-        } catch (e) {
+        } catch (e: any) {
           return expect(e.name).to.equal('MongoshInvalidInputError');
         }
         expect.fail('MongoshInvalidInputError not thrown for findAndModify');
@@ -1395,7 +1395,7 @@ describe('Collection', () => {
         try {
           await collection.renameCollection({} as any);
           expect.fail('expected error');
-        } catch (e) {
+        } catch (e: any) {
           expect(e.message).to.include('type string');
           expect(e.name).to.equal('MongoshInvalidInputError');
           expect(e.code).to.equal(CommonErrors.InvalidArgument);
@@ -1856,7 +1856,7 @@ describe('Collection', () => {
         serviceProvider.watch.throws(expectedError);
         try {
           await collection.watch();
-        } catch (e) {
+        } catch (e: any) {
           expect(e).to.equal(expectedError);
           return;
         }
@@ -1951,7 +1951,7 @@ describe('Collection', () => {
           collection[method].returnsPromise) {
           try {
             await collection[method](...args);
-          } catch (e) {
+          } catch (e: any) {
             expect.fail(`Collection.${method} failed, error thrown ${e.message}`);
           }
           expect(serviceProvider[method].calledOnce).to.equal(true, `expected sp.${method} to be called but it was not`);
@@ -1966,7 +1966,7 @@ describe('Collection', () => {
         const customI = exceptions[method].i || 3;
         try {
           await collection[method](...customA);
-        } catch (e) {
+        } catch (e: any) {
           expect.fail(`${method} failed, error thrown ${e.stack}`);
         }
         expect(serviceProvider[customM].called).to.equal(true, `expecting sp.${customM} to be called but it was not`);

--- a/packages/shell-api/src/collection.ts
+++ b/packages/shell-api/src/collection.ts
@@ -512,8 +512,8 @@ export default class Collection extends ShellApiWithMongoClass {
       return {
         ok: 1
       };
-    } catch (e) {
-      if (e.name === 'MongoError') {
+    } catch (e: any) {
+      if (e?.name === 'MongoError') {
         return {
           ok: 0,
           errmsg: e.errmsg,
@@ -1167,13 +1167,13 @@ export default class Collection extends ShellApiWithMongoClass {
           dropIndexes: this._name,
           index: indexes,
         });
-    } catch (error) {
+    } catch (error: any) {
       // If indexes is an array and we're failing because of that, we fall back to
       // trying to drop all the indexes individually because that's what's supported
       // on mongod 4.0. In the java-shell, error properties are unavailable,
       // so we are a bit more generous there in terms of situation in which we retry.
-      if ((error.codeName === 'IndexNotFound' || error.codeName === undefined) &&
-          (error.errmsg === 'invalid index name spec' || error.errmsg === undefined) &&
+      if ((error?.codeName === 'IndexNotFound' || error?.codeName === undefined) &&
+          (error?.errmsg === 'invalid index name spec' || error?.errmsg === undefined) &&
           Array.isArray(indexes) &&
           indexes.length > 0 &&
           (await this._database.version()).match(/^4\.0\./)) {
@@ -1185,7 +1185,7 @@ export default class Collection extends ShellApiWithMongoClass {
         return all.sort((a, b) => b.nIndexesWas - a.nIndexesWas)[0];
       }
 
-      if (error.codeName === 'IndexNotFound') {
+      if (error?.codeName === 'IndexNotFound') {
         return {
           ok: error.ok,
           errmsg: error.errmsg,
@@ -1337,8 +1337,8 @@ export default class Collection extends ShellApiWithMongoClass {
         this._name,
         await this._database._baseOptions()
       );
-    } catch (error) {
-      if (error.codeName === 'NamespaceNotFound') {
+    } catch (error: any) {
+      if (error?.codeName === 'NamespaceNotFound') {
         this._mongo._instanceState.messageBus.emit(
           'mongosh:warn',
           {

--- a/packages/shell-api/src/cursor.spec.ts
+++ b/packages/shell-api/src/cursor.spec.ts
@@ -97,7 +97,7 @@ describe('Cursor', () => {
         try {
           shellApiCursor.addOption(4);
           expect.fail('expected error');
-        } catch (e) {
+        } catch (e: any) {
           expect(e).to.be.instanceOf(MongoshUnimplementedError);
           expect(e.message).to.contain('the slaveOk option is not supported.');
           expect(e.code).to.equal(CommonErrors.NotImplemented);
@@ -108,7 +108,7 @@ describe('Cursor', () => {
         try {
           shellApiCursor.addOption(123123);
           expect.fail('expected error');
-        } catch (e) {
+        } catch (e: any) {
           expect(e).to.be.instanceOf(MongoshInvalidInputError);
           expect(e.message).to.contain('Unknown option flag number: 123123');
           expect(e.code).to.equal(CommonErrors.InvalidArgument);
@@ -730,7 +730,7 @@ describe('Cursor', () => {
         try {
           shellApiCursor.maxScan();
           expect.fail('expected error');
-        } catch (e) {
+        } catch (e: any) {
           expect(e).to.be.instanceOf(MongoshDeprecatedError);
           expect(e.message).to.contain('`maxScan()` was removed because it was deprecated in MongoDB 4.0');
         }

--- a/packages/shell-api/src/database.spec.ts
+++ b/packages/shell-api/src/database.spec.ts
@@ -431,7 +431,7 @@ describe('Database', () => {
         try {
           database.getCollection('');
           expect.fail('expected error');
-        } catch (e) {
+        } catch (e: any) {
           expect(e).to.be.instanceOf(MongoshInvalidInputError);
           expect(e.message).to.contain('Invalid collection name:');
           expect(e.code).to.equal(CommonErrors.InvalidArgument);
@@ -442,7 +442,7 @@ describe('Database', () => {
         try {
           database.getCollection('foo$bar');
           expect.fail('expected error');
-        } catch (e) {
+        } catch (e: any) {
           expect(e).to.be.instanceOf(MongoshInvalidInputError);
           expect(e.message).to.contain('Invalid collection name:');
           expect(e.code).to.equal(CommonErrors.InvalidArgument);
@@ -453,7 +453,7 @@ describe('Database', () => {
         try {
           database.getCollection('foo\0bar');
           expect.fail('expected error');
-        } catch (e) {
+        } catch (e: any) {
           expect(e).to.be.instanceOf(MongoshInvalidInputError);
           expect(e.message).to.contain('Invalid collection name:');
           expect(e.code).to.equal(CommonErrors.InvalidArgument);
@@ -657,7 +657,7 @@ describe('Database', () => {
                 { role: 'root', db: 'admin' }
               ]
             });
-          } catch (e) {
+          } catch (e: any) {
             expect(e).to.be.instanceOf(MongoshInvalidInputError);
             expect(e.message).to.contain('Cannot set password');
             return;
@@ -2360,7 +2360,7 @@ describe('Database', () => {
           try {
             database[method]();
             expect.fail('expected error');
-          } catch (e) {
+          } catch (e: any) {
             expect(e).to.be.instanceOf(MongoshDeprecatedError);
             expect(e.message).to.contain(`\`${method}()\` was removed because it was deprecated in MongoDB 4.0`);
           }
@@ -2536,7 +2536,7 @@ describe('Database', () => {
         serviceProvider.watch.throws(expectedError);
         try {
           await database.watch();
-        } catch (e) {
+        } catch (e: any) {
           expect(e).to.equal(expectedError);
           return;
         }
@@ -2660,7 +2660,7 @@ describe('Database', () => {
             database[method].returnsPromise) {
           try {
             await database[method](...args);
-          } catch (e) {
+          } catch (e: any) {
             expect.fail(`${method} failed, error thrown ${e.message}`);
           }
           expect(serviceProvider.runCommandWithCheck.called).to.be.true;
@@ -2675,7 +2675,7 @@ describe('Database', () => {
         const customI = exceptions[method].i || 2;
         try {
           await database[method](...customA);
-        } catch (e) {
+        } catch (e: any) {
           expect.fail(`${method} failed, error thrown ${e.message}`);
         }
         expect(serviceProvider[customM].called).to.equal(true, `expecting ${customM} to be called but it was not`);

--- a/packages/shell-api/src/database.ts
+++ b/packages/shell-api/src/database.ts
@@ -217,7 +217,7 @@ export default class Database extends ShellApiWithMongoClass {
         cmd,
         await this._baseOptions()
       );
-    } catch (e) {
+    } catch (e: any) {
       return e;
     }
   }
@@ -909,8 +909,8 @@ export default class Database extends ShellApiWithMongoClass {
         }
       );
       return this._cachedHello;
-    } catch (err) {
-      if (err.codeName === 'CommandNotFound') {
+    } catch (err: any) {
+      if (err?.codeName === 'CommandNotFound') {
         const result = await this.isMaster();
         delete result.ismaster;
         this._cachedHello = result;
@@ -1008,8 +1008,8 @@ export default class Database extends ShellApiWithMongoClass {
     for (const c of colls) {
       try {
         result[c] = await this.getCollection(c).stats({ scale });
-      } catch (error) {
-        result[c] = { ok: 0, errmsg: error.message };
+      } catch (error: any) {
+        result[c] = { ok: 0, errmsg: error?.message };
       }
     }
     return new CommandResult('StatsResult', result);
@@ -1063,7 +1063,7 @@ export default class Database extends ShellApiWithMongoClass {
       result = await this._runAdminCommand(
         { getFreeMonitoringStatus: 1 }
       );
-    } catch (err) {
+    } catch (err: any) {
       error = err;
     }
     if (error && error.codeName === 'Unauthorized' || (result && !result.ok && result.codeName === 'Unauthorized')) {
@@ -1403,7 +1403,7 @@ export default class Database extends ShellApiWithMongoClass {
     let replInfo;
     try {
       replInfo = await this.getReplicationInfo();
-    } catch (error) {
+    } catch (error: any) {
       const helloResult = await this.hello();
       if (helloResult.arbiterOnly) {
         return new CommandResult('StatsResult', { message: 'cannot provide replication status from an arbiter' });

--- a/packages/shell-api/src/decorators.ts
+++ b/packages/shell-api/src/decorators.ts
@@ -244,7 +244,7 @@ function wrapWithApiChecks<T extends(...args: any[]) => any>(fn: T, className: s
           interrupt?.promise ?? new Promise<never>(() => {}),
           fn.call(this, ...args)
         ]);
-      } catch (e) {
+      } catch (e: any) {
         throw instanceState?.transformError(e) ?? e;
       } finally {
         if (instanceState) {
@@ -267,7 +267,7 @@ function wrapWithApiChecks<T extends(...args: any[]) => any>(fn: T, className: s
           instanceState.apiCallDepth++;
         }
         result = fn.call(this, ...args);
-      } catch (e) {
+      } catch (e: any) {
         throw instanceState?.transformError(e) ?? e;
       } finally {
         if (instanceState) {

--- a/packages/shell-api/src/field-level-encryption.spec.ts
+++ b/packages/shell-api/src/field-level-encryption.spec.ts
@@ -250,7 +250,7 @@ describe('Field Level Encryption', () => {
         libmongoc.createDataKey.resolves(raw);
         try {
           await keyVault.createKey('aws' as any, ['altkey']);
-        } catch (e) {
+        } catch (e: any) {
           expect(e).to.be.instanceOf(MongoshInvalidInputError);
           expect(e.message).to.contain('requires masterKey to be given as second argument');
           return;
@@ -262,7 +262,7 @@ describe('Field Level Encryption', () => {
         libmongoc.createDataKey.resolves(raw);
         try {
           await keyVault.createKey('local', ['altkey'] as any, ['altkeyx']);
-        } catch (e) {
+        } catch (e: any) {
           expect(e).to.be.instanceOf(MongoshInvalidInputError);
           expect(e.message).to.contain('array for the masterKey and keyAltNames');
           return;
@@ -274,7 +274,7 @@ describe('Field Level Encryption', () => {
         libmongoc.createDataKey.resolves(raw);
         try {
           await keyVault.createKey('aws', 'oldstyle');
-        } catch (e) {
+        } catch (e: any) {
           expect(e).to.be.instanceOf(MongoshInvalidInputError);
           expect(e.message).to.contain('For AWS please use createKey');
           return;
@@ -286,7 +286,7 @@ describe('Field Level Encryption', () => {
         libmongoc.createDataKey.resolves(raw);
         try {
           await keyVault.createKey('aws', 'oldstyle', ['altname']);
-        } catch (e) {
+        } catch (e: any) {
           expect(e).to.be.instanceOf(MongoshInvalidInputError);
           expect(e.message).to.contain('For AWS please use createKey');
           return;
@@ -440,7 +440,7 @@ describe('Field Level Encryption', () => {
       };
       try {
         void new Mongo(instanceState, 'localhost:27017', localKmsOptions, undefined, sp);
-      } catch (e) {
+      } catch (e: any) {
         return expect(e.message).to.contain('explicitEncryptionOnly and schemaMap are mutually exclusive');
       }
       expect.fail('Expected error');
@@ -466,7 +466,7 @@ describe('Field Level Encryption', () => {
       clientEncryption = new ClientEncryption(mongo);
       try {
         void new KeyVault(clientEncryption);
-      } catch (e) {
+      } catch (e: any) {
         return expect(e.message).to.contain('FLE options must be passed to the Mongo object');
       }
       expect.fail('Expected error');
@@ -598,7 +598,7 @@ srDVjIT3LsvTqw==`
           case 'kmip':
             try {
               await keyVault.createKey('kmip', undefined);
-            } catch (err) {
+            } catch (err: any) {
               // See above, we don't attempt to successfully encrypt/decrypt
               // when using KMIP
               expect(err.message).to.include('KMS request failed');

--- a/packages/shell-api/src/helpers.spec.ts
+++ b/packages/shell-api/src/helpers.spec.ts
@@ -28,7 +28,7 @@ describe('assertArgsDefinedType', () => {
   it('allows to specify an argument must be defined', () => {
     try {
       assertArgsDefinedType([1, undefined], [true, true], 'helper.test');
-    } catch (e) {
+    } catch (e: any) {
       expect(e.message).to.contain('Missing required argument at position 1');
       expect(e.message).to.contain('helper.test');
       return;
@@ -39,7 +39,7 @@ describe('assertArgsDefinedType', () => {
     [null, 2, {}].forEach(value => {
       try {
         assertArgsDefinedType([1, value], [true, 'string'], 'helper.test');
-      } catch (e) {
+      } catch (e: any) {
         expect(e.message).to.contain('Argument at position 1 must be of type string');
         expect(e.message).to.contain('helper.test');
         return;
@@ -52,7 +52,7 @@ describe('assertArgsDefinedType', () => {
     [null, {}].forEach(value => {
       try {
         assertArgsDefinedType([1, value], [true, ['number', 'string']]);
-      } catch (e) {
+      } catch (e: any) {
         return expect(e.message).to.contain('Argument at position 1 must be of type number or string');
       }
       expect.fail('Expected error');
@@ -65,7 +65,7 @@ describe('assertArgsDefinedType', () => {
     expect(() => assertArgsDefinedType([1, 'test'], [true, [undefined, 'string']])).to.not.throw;
     try {
       assertArgsDefinedType([1, 2], [true, [undefined, 'string']]);
-    } catch (e) {
+    } catch (e: any) {
       return expect(e.message).to.contain('Argument at position 1 must be of type string');
     }
     expect.fail('Expected error');
@@ -212,7 +212,7 @@ describe('getPrintableShardStatus', () => {
     await configDatabase.getCollection('version').drop();
     try {
       await getPrintableShardStatus(configDatabase, false);
-    } catch (err) {
+    } catch (err: any) {
       expect(err.name).to.equal('MongoshInvalidInputError');
       return;
     }

--- a/packages/shell-api/src/helpers.ts
+++ b/packages/shell-api/src/helpers.ts
@@ -268,7 +268,7 @@ export async function getPrintableShardStatus(configDB: Database, verbose: boole
       try {
         const balancerStatus = await configDB.adminCommand({ balancerStatus: 1 });
         balancerRunning = balancerStatus.inBalancerRound ? 'yes' : 'no';
-      } catch (err) {
+      } catch (err: any) {
         // pass, ignore all error messages
       }
       balancerRes['Currently running'] = balancerRunning;

--- a/packages/shell-api/src/integration.spec.ts
+++ b/packages/shell-api/src/integration.spec.ts
@@ -997,7 +997,7 @@ describe('Shell API (integration)', function() {
         try {
           await collection.updateOne({}, { $inc: { '$x.y': 1 } });
           expect.fail('missed exception');
-        } catch (err) {
+        } catch (err: any) {
           expect(err.name).to.equal('MongoServerError');
         }
         await collection.updateOne({}, [
@@ -1041,7 +1041,7 @@ describe('Shell API (integration)', function() {
         try {
           await collection.validate({ full: true, background: true });
           expect.fail('missed exception');
-        } catch (err) {
+        } catch (err: any) {
           expect(err.name).to.equal('MongoServerError');
         }
       });
@@ -1053,7 +1053,7 @@ describe('Shell API (integration)', function() {
       it('fails for non-sharded dbs', async() => {
         try {
           await database.printShardingStatus();
-        } catch (err) {
+        } catch (err: any) {
           expect(err.name).to.equal('MongoshInvalidInputError');
           return;
         }
@@ -1531,7 +1531,7 @@ describe('Shell API (integration)', function() {
         try {
           await (await collection.find()).explain('foo');
           expect.fail('missed exception');
-        } catch (err) {
+        } catch (err: any) {
           expect(err.name).to.equal('MongoServerError');
         }
       });
@@ -1841,7 +1841,7 @@ describe('Shell API (integration)', function() {
             await bulk.execute();
             try {
               await bulk.execute();
-            } catch (err) {
+            } catch (err: any) {
               expect(err.name).to.equal('MongoBatchReExecutionError');
               return;
             }
@@ -1852,7 +1852,7 @@ describe('Shell API (integration)', function() {
             bulk.insert({ x: 1 });
             try {
               bulk.getOperations();
-            } catch (err) {
+            } catch (err: any) {
               expect(err.name).to.equal('MongoshInvalidInputError');
               return;
             }
@@ -1862,7 +1862,7 @@ describe('Shell API (integration)', function() {
             bulk = await collection[m]();
             try {
               await bulk.execute();
-            } catch (err) {
+            } catch (err: any) {
               expect(err.name).to.include('Error');
               return;
             }
@@ -1873,7 +1873,7 @@ describe('Shell API (integration)', function() {
             bulk.find({}).update({ x: 1 });
             try {
               await bulk.execute();
-            } catch (err) {
+            } catch (err: any) {
               expect(err.name).to.include('BulkWriteError');
               return;
             }
@@ -1952,7 +1952,7 @@ describe('Shell API (integration)', function() {
         try {
           // eslint-disable-next-line new-cap
           await shellApi.Mongo(`${await testServer.connectionString()}/?replicaSet=notexist&serverSelectionTimeoutMS=100`);
-        } catch (e) {
+        } catch (e: any) {
           expect(e.message).to.match(/Server selection timed out.+\(is \?tls=true missing from the connection string\?\)$/);
         }
       });
@@ -1961,7 +1961,7 @@ describe('Shell API (integration)', function() {
         try {
           // eslint-disable-next-line new-cap
           await shellApi.Mongo(`${await testServer.connectionString()}/?replicaSet=notexist&serverSelectionTimeoutMS=100&tls=false`);
-        } catch (e) {
+        } catch (e: any) {
           expect(e.message).to.match(/Server selection timed out[^()]+$/);
         }
       });
@@ -2240,7 +2240,7 @@ describe('Shell API (integration)', function() {
         // eslint-disable-next-line no-constant-condition
         await (await collection.find({ $where: function() { while (true); } })).next();
         expect.fail('missed exception');
-      } catch (err) {
+      } catch (err: any) {
         expect(err.codeName).to.equal('MaxTimeMSExpired');
       }
     });
@@ -2251,7 +2251,7 @@ describe('Shell API (integration)', function() {
         // eslint-disable-next-line no-constant-condition
         await (await collection.find({ $where: function() { while (true); } }, {}, { maxTimeMS: 100 })).next();
         expect.fail('missed exception');
-      } catch (err) {
+      } catch (err: any) {
         expect(err.codeName).to.equal('MaxTimeMSExpired');
       }
     });
@@ -2281,7 +2281,7 @@ describe('Shell API (integration)', function() {
       try {
         await (await collection.find()).forEach(() => { calls++; throw error; });
         expect.fail('missed exception');
-      } catch (err) {
+      } catch (err: any) {
         expect(err).to.equal(error);
       }
       expect(calls).to.equal(1);
@@ -2297,7 +2297,7 @@ describe('Shell API (integration)', function() {
         try {
           await cursor.tryNext();
           expect.fail('missed exception');
-        } catch (err) {
+        } catch (err: any) {
           expect(err).to.equal(error);
         }
       }
@@ -2311,7 +2311,7 @@ describe('Shell API (integration)', function() {
       try {
         mongo.setSlaveOk();
         expect.fail('Expected error');
-      } catch (e) {
+      } catch (e: any) {
         expect(e.message).to.contain('slaveOk is deprecated');
       }
       const events = await deprecatedCall;
@@ -2331,7 +2331,7 @@ describe('Shell API (integration)', function() {
       try {
         await database.printShardingStatus();
         expect.fail('Expected error');
-      } catch (e) {
+      } catch (e: any) {
         expect(e.message).to.contain('This db does not have sharding enabled');
       }
       expect(events.length).to.be.greaterThan(1);
@@ -2357,7 +2357,7 @@ describe('Shell API (integration)', function() {
       try {
         await database.runCommand({ ping: 1 });
         expect.fail('missed exceptino');
-      } catch (e) {
+      } catch (e: any) {
         expect(e.name).to.equal('MongoshInterruptedError');
       }
       await instanceState.onResumeExecution();

--- a/packages/shell-api/src/interruptor.spec.ts
+++ b/packages/shell-api/src/interruptor.spec.ts
@@ -69,7 +69,7 @@ describe('interruptor', () => {
       instanceState.interrupted.set();
       try {
         await database.runCommand({ some: 1 });
-      } catch (e) {
+      } catch (e: any) {
         expect(e.name).to.equal('MongoshInterruptedError');
         expect(serviceProvider.runCommand).to.not.have.been.called;
         expect(serviceProvider.runCommandWithCheck).to.not.have.been.called;
@@ -92,7 +92,7 @@ describe('interruptor', () => {
 
       try {
         await runCommand;
-      } catch (e) {
+      } catch (e: any) {
         expect(e.name).to.equal('MongoshInterruptedError');
         expect(serviceProvider.runCommandWithCheck).to.have.been.called;
         return;

--- a/packages/shell-api/src/mongo-errors.spec.ts
+++ b/packages/shell-api/src/mongo-errors.spec.ts
@@ -93,7 +93,7 @@ describe('mongo-errors', () => {
       try {
         await collection.insertOne({ fails: true });
         expect.fail('expected error');
-      } catch (e) {
+      } catch (e: any) {
         expect(e).to.equal(error);
         expect(e.message).to.contain('not primary and secondaryOk=false');
         expect(e.message).to.contain('db.getMongo().setReadPref()');

--- a/packages/shell-api/src/mongo.spec.ts
+++ b/packages/shell-api/src/mongo.spec.ts
@@ -371,7 +371,7 @@ describe('Mongo', () => {
         serviceProvider.getReadConcern.throws(expectedError);
         try {
           mongo.getReadConcern();
-        } catch (caughtError) {
+        } catch (caughtError: any) {
           return expect(caughtError).to.be.instanceOf(MongoshInternalError);
         }
         expect.fail();
@@ -398,7 +398,7 @@ describe('Mongo', () => {
         serviceProvider.getWriteConcern.throws(expectedError);
         try {
           mongo.getWriteConcern();
-        } catch (caughtError) {
+        } catch (caughtError: any) {
           return expect(caughtError).to.be.instanceOf(MongoshInternalError);
         }
         expect.fail();
@@ -423,7 +423,7 @@ describe('Mongo', () => {
         serviceProvider.resetConnectionOptions.throws(expectedError);
         try {
           await mongo.setReadPref('primary');
-        } catch (caughtError) {
+        } catch (caughtError: any) {
           return expect(caughtError).to.equal(expectedError);
         }
         expect.fail();
@@ -445,7 +445,7 @@ describe('Mongo', () => {
         serviceProvider.resetConnectionOptions.throws(expectedError);
         try {
           await mongo.setReadConcern('majority');
-        } catch (caughtError) {
+        } catch (caughtError: any) {
           return expect(caughtError).to.equal(expectedError);
         }
         expect.fail();
@@ -471,7 +471,7 @@ describe('Mongo', () => {
         serviceProvider.resetConnectionOptions.throws(expectedError);
         try {
           await mongo.setWriteConcern('majority');
-        } catch (caughtError) {
+        } catch (caughtError: any) {
           return expect(caughtError).to.equal(expectedError);
         }
         expect.fail();
@@ -495,7 +495,7 @@ describe('Mongo', () => {
         serviceProvider.startSession.throws(expectedError);
         try {
           mongo.startSession();
-        } catch (caughtError) {
+        } catch (caughtError: any) {
           return expect(caughtError).to.equal(expectedError);
         }
         expect.fail();
@@ -566,7 +566,7 @@ describe('Mongo', () => {
         try {
           mongo.setCausalConsistency();
           expect.fail('expected error');
-        } catch (e) {
+        } catch (e: any) {
           expect(e).to.be.instanceOf(MongoshUnimplementedError);
           expect(e.metadata?.driverCaused).to.equal(true);
           expect(e.metadata?.api).to.equal('Mongo.setCausalConsistency');
@@ -578,7 +578,7 @@ describe('Mongo', () => {
         try {
           mongo.isCausalConsistency();
           expect.fail('expected error');
-        } catch (e) {
+        } catch (e: any) {
           expect(e).to.be.instanceOf(MongoshUnimplementedError);
           expect(e.metadata?.driverCaused).to.equal(true);
           expect(e.metadata?.api).to.equal('Mongo.isCausalConsistency');
@@ -615,7 +615,7 @@ describe('Mongo', () => {
       it('setSlaveOk', () => {
         try {
           mongo.setSlaveOk();
-        } catch (e) {
+        } catch (e: any) {
           return expect(e).to.be.instanceOf(MongoshDeprecatedError);
         }
         expect.fail();
@@ -691,7 +691,7 @@ describe('Mongo', () => {
         serviceProvider.watch.throws(expectedError);
         try {
           await mongo.watch();
-        } catch (e) {
+        } catch (e: any) {
           expect(e).to.equal(expectedError);
           return;
         }
@@ -702,7 +702,7 @@ describe('Mongo', () => {
       it('throws an error if no FLE options were provided', () => {
         try {
           mongo.getClientEncryption();
-        } catch (e) {
+        } catch (e: any) {
           expect(e.name).to.equal('MongoshInvalidInputError');
           return;
         }
@@ -772,7 +772,7 @@ describe('Mongo', () => {
             });
             await (await mongo.getDB('test').getCollection('coll').find()).toArray();
             expect.fail('missed exception');
-          } catch (err) {
+          } catch (err: any) {
             expect(err.name).to.match(/MongoServer(Selection)?Error/);
           }
         });

--- a/packages/shell-api/src/mongo.ts
+++ b/packages/shell-api/src/mongo.ts
@@ -177,7 +177,7 @@ export default class Mongo extends ShellApiClass {
     const parentProvider = this._instanceState.initialServiceProvider;
     try {
       this.__serviceProvider = await parentProvider.getNewConnection(this._uri, mongoClientOptions);
-    } catch (e) {
+    } catch (e: any) {
       // If the initial provider had TLS enabled, and we're not able to connect,
       // and the new URL does not contain a SSL/TLS indicator, we add a notice
       // about the fact that the behavior differs from the legacy shell here.
@@ -230,8 +230,8 @@ export default class Mongo extends ShellApiClass {
       const previousDb = this._instanceState.context.db;
       previousDbName = previousDb?.getName?.();
       previousDbMongo = previousDb?._mongo;
-    } catch (e) {
-      if (e.code !== ShellApiErrors.NotConnected) {
+    } catch (e: any) {
+      if (e?.code !== ShellApiErrors.NotConnected) {
         throw e;
       }
     }

--- a/packages/shell-api/src/no-db.spec.ts
+++ b/packages/shell-api/src/no-db.spec.ts
@@ -10,7 +10,7 @@ describe('NoDatabase', () => {
   it('throws for show', () => {
     try {
       nodb._mongo.show('dbs');
-    } catch (e) {
+    } catch (e: any) {
       return expect(e.name).to.equal('MongoshInvalidInputError');
     }
     expect.fail('no error thrown for NoDb._mongo.use');
@@ -18,7 +18,7 @@ describe('NoDatabase', () => {
   it('throws for nomongo.use', () => {
     try {
       nomongo.use('test');
-    } catch (e) {
+    } catch (e: any) {
       return expect(e.name).to.equal('MongoshInvalidInputError');
     }
     expect.fail('no error thrown for NoDb');

--- a/packages/shell-api/src/replica-set.spec.ts
+++ b/packages/shell-api/src/replica-set.spec.ts
@@ -291,7 +291,7 @@ describe('ReplicaSet', () => {
           try {
             await rs.reconfig(configDoc);
             expect.fail('missed exception');
-          } catch (err) {
+          } catch (err: any) {
             expect(err.message).to.equal('Reconfig failed: {"ok":0}');
           }
           expect(evaluationListener.onPrint).to.have.been.calledWith([
@@ -731,7 +731,7 @@ describe('ReplicaSet', () => {
         try {
           await rs.reconfigForPSASet(3, config);
           expect.fail('missed exception');
-        } catch (err) {
+        } catch (err: any) {
           expect(err.message).to.equal('[COMMON-10001] Node at index 3 does not exist in the new config');
         }
       });
@@ -741,7 +741,7 @@ describe('ReplicaSet', () => {
         try {
           await rs.reconfigForPSASet(2, config);
           expect.fail('missed exception');
-        } catch (err) {
+        } catch (err: any) {
           expect(err.message).to.equal('[COMMON-10001] Node at index 2 must have { votes: 1 } in the new config (actual: { votes: 0 })');
         }
       });
@@ -751,7 +751,7 @@ describe('ReplicaSet', () => {
         try {
           await rs.reconfigForPSASet(2, config);
           expect.fail('missed exception');
-        } catch (err) {
+        } catch (err: any) {
           expect(err.message).to.equal('[COMMON-10001] Node at index 2 must have { votes: 0 } in the old config (actual: { votes: 1 })');
         }
       });
@@ -819,7 +819,7 @@ describe('ReplicaSet', () => {
         try {
           await rs.reconfigForPSASet(2, config);
           expect.fail('missed exception');
-        } catch (err) {
+        } catch (err: any) {
           expect(err.message).to.equal('Reconfig failed: {"ok":0}');
         }
         expect(evaluationListener.onPrint).to.have.been.calledWith([
@@ -882,7 +882,7 @@ describe('ReplicaSet', () => {
       try {
         await rs.status();
         expect.fail();
-      } catch (error) {
+      } catch (error: any) {
         expect(error.message).to.include('no replset config');
       }
       const result = await rs.initiate(cfg);
@@ -1074,7 +1074,7 @@ describe('ReplicaSet', () => {
         try {
           await rs.add(secondary);
           expect.fail('missed assertion');
-        } catch (err) {
+        } catch (err: any) {
           expect(err.codeName).to.equal('NewReplicaSetConfigurationIncompatible');
         }
       }

--- a/packages/shell-api/src/replica-set.ts
+++ b/packages/shell-api/src/replica-set.ts
@@ -62,8 +62,8 @@ export default class ReplicaSet extends ShellApiWithMongoClass {
         throw new MongoshRuntimeError('Documented returned from command replSetGetConfig does not contain \'config\'', CommonErrors.CommandFailed);
       }
       return result.config;
-    } catch (error) {
-      if (error.codeName === 'CommandNotFound' || error.codeName === 'APIStrictError') {
+    } catch (error: any) {
+      if (error?.codeName === 'CommandNotFound' || error?.codeName === 'APIStrictError') {
         const doc = await this._database.getSiblingDB('local').getCollection('system.replset').findOne() as ReplSetConfig | null;
         if (doc === null) {
           throw new MongoshRuntimeError('No documents in local.system.replset', CommonErrors.CommandFailed);
@@ -132,7 +132,7 @@ export default class ReplicaSet extends ShellApiWithMongoClass {
         }
         result = [ 'success', await runReconfig() ];
         break;
-      } catch (err) {
+      } catch (err: any) {
         result = [ 'error', err ];
       }
     }
@@ -209,7 +209,7 @@ export default class ReplicaSet extends ShellApiWithMongoClass {
 
     try {
       return await this.reconfig(config, options);
-    } catch (e) {
+    } catch (e: any) {
       // If this did not work out, print the attempted command to give the user
       // a chance to complete the second reconfig manually.
       await print('Second reconfig did not succeed, giving up');

--- a/packages/shell-api/src/session.spec.ts
+++ b/packages/shell-api/src/session.spec.ts
@@ -91,7 +91,7 @@ describe('Session', () => {
         try {
           session.getDatabase('');
           expect.fail('expected error');
-        } catch (e) {
+        } catch (e: any) {
           expect(e).to.be.instanceOf(MongoshInvalidInputError);
           expect(e.code).to.equal(CommonErrors.InvalidArgument);
         }
@@ -189,7 +189,7 @@ describe('Session', () => {
         expect(session.hasEnded()).to.be.true;
         try {
           await session.getDatabase(databaseName).getCollection('coll').insertOne({});
-        } catch (e) {
+        } catch (e: any) {
           return expect(e.message).to.include('expired sessions');
         }
         expect.fail('Error not thrown');
@@ -210,7 +210,7 @@ describe('Session', () => {
           expect(s.hasEnded()).to.be.true;
           try {
             await s.getDatabase(databaseName).getCollection('coll').insertOne({});
-          } catch (e) {
+          } catch (e: any) {
             expect(e.message).to.include('expired sessions');
             continue;
           }
@@ -222,7 +222,7 @@ describe('Session', () => {
         await session.endSession();
         try {
           await session.getDatabase(databaseName).getCollection('coll').insertOne({});
-        } catch (e) {
+        } catch (e: any) {
           return expect(e.message).to.include('expired');
         }
         expect.fail('Error not thrown');
@@ -236,7 +236,7 @@ describe('Session', () => {
           try {
             await session.getDatabase(databaseName).getCollection('coll').insertOne({});
             expect.fail('missed exception');
-          } catch (e) {
+          } catch (e: any) {
             expect(e.message).to.include('snapshot'); // Cannot do writes with snapshot: true
           }
           expect(session._session.snapshotEnabled).to.equal(true);
@@ -250,7 +250,7 @@ describe('Session', () => {
         session.startTransaction();
         try {
           session.startTransaction();
-        } catch (e) {
+        } catch (e: any) {
           return expect(e.message).to.include('in progress');
         }
         expect.fail('Error not thrown');
@@ -259,7 +259,7 @@ describe('Session', () => {
         session = mongo.startSession();
         try {
           await session.abortTransaction();
-        } catch (e) {
+        } catch (e: any) {
           return expect(e.message).to.include('transaction started');
         }
         expect.fail('Error not thrown');
@@ -268,7 +268,7 @@ describe('Session', () => {
         session = mongo.startSession();
         try {
           await session.commitTransaction();
-        } catch (e) {
+        } catch (e: any) {
           return expect(e.message).to.include('transaction started');
         }
         expect.fail('Error not thrown');
@@ -351,7 +351,7 @@ describe('Session', () => {
         await mongo.setReadConcern('majority');
         try {
           await session.getDatabase(databaseName).getCollection('coll').insertOne({});
-        } catch (e) {
+        } catch (e: any) {
           return expect(e.message).to.include('expired');
         }
       });
@@ -361,7 +361,7 @@ describe('Session', () => {
         await mongo.getDB(databaseName).auth('anna', 'pwd');
         try {
           await session.getDatabase(databaseName).getCollection('coll').insertOne({});
-        } catch (e) {
+        } catch (e: any) {
           await mongo.getDB(databaseName).logout();
           return expect(e.message).to.include('expired');
         }

--- a/packages/shell-api/src/shard.spec.ts
+++ b/packages/shell-api/src/shard.spec.ts
@@ -1372,7 +1372,7 @@ describe('Shard', () => {
       it('fails when running against an unsharded collection', async() => {
         try {
           await db.getCollection('test').getShardDistribution();
-        } catch (err) {
+        } catch (err: any) {
           expect(err.name).to.equal('MongoshInvalidInputError');
           return;
         }

--- a/packages/shell-api/src/shard.ts
+++ b/packages/shell-api/src/shard.ts
@@ -60,8 +60,8 @@ export default class Shard extends ShellApiWithMongoClass {
     }
     try {
       return await this._database._runAdminCommand(cmd);
-    } catch (error) {
-      if (error.codeName === 'CommandNotFound') {
+    } catch (error: any) {
+      if (error?.codeName === 'CommandNotFound') {
         error.message = `${error.message}. Are you connected to mongos?`;
       }
       throw error;
@@ -125,8 +125,8 @@ export default class Shard extends ShellApiWithMongoClass {
     }
     try {
       return await this._database._runAdminCommand({ ...cmd, ...options });
-    } catch (error) {
-      if (error.codeName === 'CommandNotFound') {
+    } catch (error: any) {
+      if (error?.codeName === 'CommandNotFound') {
         error.message = `${error.message}. Are you connected to mongos?`;
       }
       throw error;
@@ -174,8 +174,8 @@ export default class Shard extends ShellApiWithMongoClass {
     this._emitShardApiCall('addShardTag', { shard, tag });
     try {
       return await this.addShardToZone(shard, tag);
-    } catch (error) {
-      if (error.codeName === 'CommandNotFound') {
+    } catch (error: any) {
+      if (error?.codeName === 'CommandNotFound') {
         error.message = `${error.message}. This method aliases to addShardToZone which exists only for server versions > 3.4.`;
       }
       throw error;
@@ -211,8 +211,8 @@ export default class Shard extends ShellApiWithMongoClass {
         max,
         zone
       );
-    } catch (error) {
-      if (error.codeName === 'CommandNotFound') {
+    } catch (error: any) {
+      if (error?.codeName === 'CommandNotFound') {
         error.message = `${error.message}. This method aliases to updateZoneKeyRange which exists only for server versions > 3.4.`;
       }
       throw error;
@@ -236,8 +236,8 @@ export default class Shard extends ShellApiWithMongoClass {
     this._emitShardApiCall('removeTagRange', { ns, min, max });
     try {
       return await this.updateZoneKeyRange(ns, min, max, null);
-    } catch (error) {
-      if (error.codeName === 'CommandNotFound') {
+    } catch (error: any) {
+      if (error?.codeName === 'CommandNotFound') {
         error.message = `${error.message}. This method aliases to updateZoneKeyRange which exists only for server versions > 3.4.`;
       }
       throw error;
@@ -266,8 +266,8 @@ export default class Shard extends ShellApiWithMongoClass {
     this._emitShardApiCall('removeTagRange', { shard, tag });
     try {
       return await this.removeShardFromZone(shard, tag);
-    } catch (error) {
-      if (error.codeName === 'CommandNotFound') {
+    } catch (error: any) {
+      if (error?.codeName === 'CommandNotFound') {
         error.message = `${error.message}. This method aliases to removeShardFromZone which exists only for server versions > 3.4.`;
       }
       throw error;

--- a/packages/shell-api/src/shell-api.spec.ts
+++ b/packages/shell-api/src/shell-api.spec.ts
@@ -238,7 +238,7 @@ describe('ShellApi', () => {
         serviceProvider.platform = ReplPlatform.Browser;
         try {
           await instanceState.shellApi.Mongo('uri');
-        } catch (e) {
+        } catch (e: any) {
           return expect(e.name).to.equal('MongoshUnimplementedError');
         }
         expect.fail('MongoshInvalidInputError not thrown for Mongo');
@@ -355,7 +355,7 @@ describe('ShellApi', () => {
                 }
               }
             } as any);
-          } catch (e) {
+          } catch (e: any) {
             return expect(e.message).to.contain('required property');
           }
           expect.fail('failed to throw expected error');
@@ -365,7 +365,7 @@ describe('ShellApi', () => {
             await instanceState.shellApi.Mongo('dbname', {
               keyVaultNamespace: 'encryption.dataKeys'
             } as any);
-          } catch (e) {
+          } catch (e: any) {
             return expect(e.message).to.contain('required property');
           }
           expect.fail('failed to throw expected error');
@@ -382,7 +382,7 @@ describe('ShellApi', () => {
               },
               unknownKey: 1
             } as any);
-          } catch (e) {
+          } catch (e: any) {
             return expect(e.message).to.contain('unknownKey');
           }
           expect.fail('failed to throw expected error');
@@ -424,7 +424,7 @@ describe('ShellApi', () => {
         serviceProvider.platform = ReplPlatform.CLI;
         try {
           await (instanceState.shellApi as any).connect();
-        } catch (e) {
+        } catch (e: any) {
           return expect(e.name).to.equal('MongoshInvalidInputError');
         }
         expect.fail('MongoshInvalidInputError not thrown for connect');
@@ -513,7 +513,7 @@ describe('ShellApi', () => {
         serviceProvider.platform = ReplPlatform.Browser;
         try {
           await instanceState.shellApi.Mongo('mongodb://127.0.0.1:27017');
-        } catch (e) {
+        } catch (e: any) {
           return expect(e.name).to.equal('MongoshUnimplementedError');
         }
         expect.fail('MongoshInvalidInputError not thrown for Mongo');
@@ -559,7 +559,7 @@ describe('ShellApi', () => {
           try {
             await instanceState.context[cmd]();
             expect.fail('missed exception');
-          } catch (e) {
+          } catch (e: any) {
             // We should be getting an exception because we’re not actually exiting.
             expect(e.message).to.contain('onExit listener returned');
           }
@@ -570,7 +570,7 @@ describe('ShellApi', () => {
           try {
             await instanceState.context[cmd](1);
             expect.fail('missed exception');
-          } catch (e) {
+          } catch (e: any) {
             // We should be getting an exception because we’re not actually exiting.
             expect(e.message).to.contain('onExit listener returned');
           }
@@ -602,7 +602,7 @@ describe('ShellApi', () => {
         try {
           await instanceState.context.passwordPrompt();
           expect.fail('missed exception');
-        } catch (err) {
+        } catch (err: any) {
           expect(err.message).to.equal('[COMMON-90002] passwordPrompt() is not available in this shell');
         }
       });

--- a/packages/shell-api/src/shell-bson.spec.ts
+++ b/packages/shell-api/src/shell-bson.spec.ts
@@ -39,7 +39,7 @@ describe('Shell BSON', () => {
     it('errors for missing arg 1', () => {
       try {
         (shellBson.DBRef as any)();
-      } catch (e) {
+      } catch (e: any) {
         return expect(e.message).to.contain('Missing required argument');
       }
       expect.fail('Expecting error, nothing thrown');
@@ -47,7 +47,7 @@ describe('Shell BSON', () => {
     it('errors for missing arg 2', () => {
       try {
         (shellBson.DBRef as any)('ns');
-      } catch (e) {
+      } catch (e: any) {
         return expect(e.message).to.contain('Missing required argument');
       }
       expect.fail('Expecting error, nothing thrown');
@@ -55,7 +55,7 @@ describe('Shell BSON', () => {
     it('errors for wrong type of arg 1', () => {
       try {
         (shellBson.DBRef as any)(1, 'oid');
-      } catch (e) {
+      } catch (e: any) {
         return expect(e.message).to.contain('string, got number');
       }
       expect.fail('Expecting error, nothing thrown');
@@ -63,7 +63,7 @@ describe('Shell BSON', () => {
     it('errors for wrong type of arg 3', () => {
       try {
         (shellBson.DBRef as any)('ns', 'oid', 1);
-      } catch (e) {
+      } catch (e: any) {
         return expect(e.message).to.contain('string, got number');
       }
       expect.fail('Expecting error, nothing thrown');
@@ -153,7 +153,7 @@ describe('Shell BSON', () => {
     it('errors for wrong type of arg 1', () => {
       try {
         (shellBson.ObjectId as any)(Symbol('foo'));
-      } catch (e) {
+      } catch (e: any) {
         return expect(e.message).to.contain('object, got symbol');
       }
       expect.fail('Expecting error, nothing thrown');
@@ -199,7 +199,7 @@ describe('Shell BSON', () => {
     it('errors for wrong type of arg 1', () => {
       try {
         (shellBson.Timestamp as any)('1');
-      } catch (e) {
+      } catch (e: any) {
         return expect(e.message).to.contain('object, got string');
       }
       expect.fail('Expecting error, nothing thrown');
@@ -207,7 +207,7 @@ describe('Shell BSON', () => {
     it('errors for wrong type of arg 2', () => {
       try {
         (shellBson.Timestamp as any)(1, '2');
-      } catch (e) {
+      } catch (e: any) {
         return expect(e.message).to.contain('number, got string');
       }
       expect.fail('Expecting error, nothing thrown');
@@ -250,7 +250,7 @@ describe('Shell BSON', () => {
     it('errors for wrong type of arg 1', () => {
       try {
         (shellBson.Code as any)(1);
-      } catch (e) {
+      } catch (e: any) {
         return expect(e.message).to.contain('function, got number');
       }
       expect.fail('Expecting error, nothing thrown');
@@ -258,7 +258,7 @@ describe('Shell BSON', () => {
     it('errors for wrong type of arg 1', () => {
       try {
         (shellBson.Code as any)('code', 1);
-      } catch (e) {
+      } catch (e: any) {
         return expect(e.message).to.contain('object, got number');
       }
       expect.fail('Expecting error, nothing thrown');
@@ -304,7 +304,7 @@ describe('Shell BSON', () => {
 
       try {
         shellBson.ISODate('"');
-      } catch (e) {
+      } catch (e: any) {
         expect(e).to.be.instanceOf(MongoshInvalidInputError);
         expect(e.message).to.contain('"\\"" is not a valid ISODate');
         expect(e.code).to.equal(CommonErrors.InvalidArgument);
@@ -327,7 +327,7 @@ describe('Shell BSON', () => {
     it('errors for missing arg 1', () => {
       try {
         (shellBson.BinData as any)();
-      } catch (e) {
+      } catch (e: any) {
         return expect(e.message).to.contain('Missing required argument');
       }
       expect.fail('Expecting error, nothing thrown');
@@ -335,7 +335,7 @@ describe('Shell BSON', () => {
     it('errors for missing arg 2', () => {
       try {
         (shellBson.BinData as any)(0);
-      } catch (e) {
+      } catch (e: any) {
         return expect(e.message).to.contain('Missing required argument');
       }
       expect.fail('Expecting error, nothing thrown');
@@ -343,7 +343,7 @@ describe('Shell BSON', () => {
     it('errors for wrong type of arg 1', () => {
       try {
         (shellBson.BinData as any)('1', 'abc');
-      } catch (e) {
+      } catch (e: any) {
         return expect(e.message).to.contain('number, got string');
       }
       expect.fail('Expecting error, nothing thrown');
@@ -351,7 +351,7 @@ describe('Shell BSON', () => {
     it('errors for wrong type of arg 2', () => {
       try {
         (shellBson.BinData as any)(0, 1);
-      } catch (e) {
+      } catch (e: any) {
         return expect(e.message).to.contain('string, got number');
       }
       expect.fail('Expecting error, nothing thrown');
@@ -383,7 +383,7 @@ describe('Shell BSON', () => {
     it('errors for missing arg 1', () => {
       try {
         (shellBson.HexData as any)();
-      } catch (e) {
+      } catch (e: any) {
         return expect(e.message).to.contain('Missing required argument');
       }
       expect.fail('Expecting error, nothing thrown');
@@ -391,7 +391,7 @@ describe('Shell BSON', () => {
     it('errors for missing arg 2', () => {
       try {
         (shellBson.HexData as any)(0);
-      } catch (e) {
+      } catch (e: any) {
         return expect(e.message).to.contain('Missing required argument');
       }
       expect.fail('Expecting error, nothing thrown');
@@ -399,7 +399,7 @@ describe('Shell BSON', () => {
     it('errors for wrong type of arg 1', () => {
       try {
         (shellBson.HexData as any)('1', 'abc');
-      } catch (e) {
+      } catch (e: any) {
         return expect(e.message).to.contain('number, got string');
       }
       expect.fail('Expecting error, nothing thrown');
@@ -407,7 +407,7 @@ describe('Shell BSON', () => {
     it('errors for wrong type of arg 2', () => {
       try {
         (shellBson.HexData as any)(0, 1);
-      } catch (e) {
+      } catch (e: any) {
         return expect(e.message).to.contain('string, got number');
       }
       expect.fail('Expecting error, nothing thrown');
@@ -447,7 +447,7 @@ describe('Shell BSON', () => {
     it('errors for wrong type of arg 1', () => {
       try {
         (shellBson.UUID as any)(1);
-      } catch (e) {
+      } catch (e: any) {
         return expect(e.message).to.contain('string, got number');
       }
       expect.fail('Expecting error, nothing thrown');
@@ -478,7 +478,7 @@ describe('Shell BSON', () => {
     it('errors for missing arg 1', () => {
       try {
         (shellBson.MD5 as any)();
-      } catch (e) {
+      } catch (e: any) {
         return expect(e.message).to.contain('Missing required argument');
       }
       expect.fail('Expecting error, nothing thrown');
@@ -486,7 +486,7 @@ describe('Shell BSON', () => {
     it('errors for wrong type of arg 1', () => {
       try {
         (shellBson.MD5 as any)(1);
-      } catch (e) {
+      } catch (e: any) {
         return expect(e.message).to.contain('string, got number');
       }
       expect.fail('Expecting error, nothing thrown');
@@ -499,7 +499,7 @@ describe('Shell BSON', () => {
     it('errors for missing arg', () => {
       try {
         (shellBson.bsonsize as any)();
-      } catch (e) {
+      } catch (e: any) {
         return expect(e.message).to.contain('Missing required argument');
       }
       expect.fail('Expecting error, nothing thrown');
@@ -507,7 +507,7 @@ describe('Shell BSON', () => {
     it('errors for wrong type of arg 1', () => {
       try {
         (shellBson.bsonsize as any)(1);
-      } catch (e) {
+      } catch (e: any) {
         return expect(e.message).to.contain('object, got number');
       }
       expect.fail('Expecting error, nothing thrown');
@@ -543,7 +543,7 @@ describe('Shell BSON', () => {
     it('errors for wrong type of arg 1', () => {
       try {
         (shellBson.NumberLong as any)({});
-      } catch (e) {
+      } catch (e: any) {
         return expect(e.message).to.match(/string or number or Long or Int32, got object.+\(NumberLong\)/);
       }
       expect.fail('Expecting error, nothing thrown');
@@ -575,7 +575,7 @@ describe('Shell BSON', () => {
     it('errors for wrong type of arg 1', () => {
       try {
         (shellBson.NumberDecimal as any)({});
-      } catch (e) {
+      } catch (e: any) {
         return expect(e.message).to.match(/string or number or Long or Int32 or Decimal128, got object.+\(NumberDecimal\)/);
       }
       expect.fail('Expecting error, nothing thrown');
@@ -608,7 +608,7 @@ describe('Shell BSON', () => {
     it('errors for wrong type of arg 1', () => {
       try {
         (shellBson.NumberInt as any)({});
-      } catch (e) {
+      } catch (e: any) {
         return expect(e.message).to.match(/string or number or Long or Int32, got object.+\(NumberInt\)/);
       }
       expect.fail('Expecting error, nothing thrown');
@@ -658,7 +658,7 @@ describe('Shell BSON', () => {
         delete shellProperties.toBSON; // toBSON is something we add for MaxKey/MinKey as a shell-specific extension
         try {
           expect(shellProperties).to.deep.equal(bsonProperties);
-        } catch (err) {
+        } catch (err: any) {
           err.message += ` (${key})`;
           throw err;
         }

--- a/packages/shell-api/src/shell-instance-state.ts
+++ b/packages/shell-api/src/shell-instance-state.ts
@@ -265,8 +265,8 @@ export default class ShellInstanceState {
   get currentServiceProvider(): ServiceProvider {
     try {
       return this.currentDb._mongo._serviceProvider;
-    } catch (err) {
-      if (err.code === ShellApiErrors.NotConnected) {
+    } catch (err: any) {
+      if (err?.code === ShellApiErrors.NotConnected) {
         return this.initialServiceProvider;
       }
       throw err;
@@ -348,10 +348,10 @@ export default class ShellInstanceState {
           const collectionNames = await this.currentDb._getCollectionNamesForCompletion();
           return collectionNames.filter((name) =>
             name.toLowerCase().startsWith(collName.toLowerCase()));
-        } catch (err) {
+        } catch (err: any) {
           if (
-            err.code === ShellApiErrors.NotConnected ||
-            err.codeName === 'Unauthorized'
+            err?.code === ShellApiErrors.NotConnected ||
+            err?.codeName === 'Unauthorized'
           ) {
             return [];
           }
@@ -363,10 +363,10 @@ export default class ShellInstanceState {
           const dbNames = await this.currentDb._mongo._getDatabaseNamesForCompletion();
           return dbNames.filter((name) =>
             name.toLowerCase().startsWith(dbName.toLowerCase()));
-        } catch (err) {
+        } catch (err: any) {
           if (
-            err.code === ShellApiErrors.NotConnected ||
-            err.codeName === 'Unauthorized'
+            err?.code === ShellApiErrors.NotConnected ||
+            err?.codeName === 'Unauthorized'
           ) {
             return [];
           }
@@ -391,7 +391,7 @@ export default class ShellInstanceState {
           mongo: m,
           resume: await m._suspend()
         };
-      } catch (e) {
+      } catch (e: any) {
         return {
           mongo: m,
           resume: null
@@ -413,7 +413,7 @@ export default class ShellInstanceState {
       try {
         await r.resume();
         return true;
-      } catch (e) {
+      } catch (e: any) {
         return false;
       }
     }) ?? [];

--- a/packages/shell-evaluator/src/shell-evaluator.ts
+++ b/packages/shell-evaluator/src/shell-evaluator.ts
@@ -77,7 +77,7 @@ class ShellEvaluator<EvaluationResultType = ShellResult> {
 
     try {
       return await originalEval(rewrittenInput, context, filename);
-    } catch (err) {
+    } catch (err: any) {
       throw this.instanceState.transformError(err);
     }
   }

--- a/packages/snippet-manager/src/snippet-manager.spec.ts
+++ b/packages/snippet-manager/src/snippet-manager.spec.ts
@@ -340,13 +340,13 @@ describe('SnippetManager', () => {
     try {
       await snippetManager.runSnippetCommand(['help', 'mongodb-example']);
       expect.fail('missed exception');
-    } catch (err) {
+    } catch (err: any) {
       expect(err.message).to.equal('No help information available for "mongodb-example"');
     }
     try {
       await snippetManager.runSnippetCommand(['help', 'alhjgfakjhf']);
       expect.fail('missed exception');
-    } catch (err) {
+    } catch (err: any) {
       expect(err.message).to.equal('Unknown snippet "alhjgfakjhf"');
     }
   });
@@ -371,7 +371,7 @@ describe('SnippetManager', () => {
     try {
       await snippetManager.runSnippetCommand(['install', 'unknownsnippet']);
       expect.fail('missed exception');
-    } catch (err) {
+    } catch (err: any) {
       expect(err.message).to.equal('Unknown snippet "unknownsnippet"');
     }
   });
@@ -381,7 +381,7 @@ describe('SnippetManager', () => {
       indexData.indexFileVersion = 20000;
       await snippetManager.runSnippetCommand(['refresh']);
       expect.fail('missed exception');
-    } catch (err) {
+    } catch (err: any) {
       expect(err.message).to.equal(`The specified index file ${indexURL} is not a valid index file: "indexFileVersion" must be less than or equal to 1`);
     }
   });
@@ -392,7 +392,7 @@ describe('SnippetManager', () => {
       indexURL = `${baseURL}/404`;
       await snippetManager.runSnippetCommand(['refresh']);
       expect.fail('missed exception');
-    } catch (err) {
+    } catch (err: any) {
       expect(err.message).to.equal(`The specified index file ${indexURL} could not be read: Not Found`);
     }
   });
@@ -403,7 +403,7 @@ describe('SnippetManager', () => {
       indexURL = `${baseURL}/notindexfile`;
       await snippetManager.runSnippetCommand(['refresh']);
       expect.fail('missed exception');
-    } catch (err) {
+    } catch (err: any) {
       expect(err.message).to.equal(`The specified index file ${indexURL} could not be parsed: Decompression failed`);
     }
   });
@@ -414,7 +414,7 @@ describe('SnippetManager', () => {
       indexURL = `${baseURL}/notindexfile2`;
       await snippetManager.runSnippetCommand(['refresh']);
       expect.fail('missed exception');
-    } catch (err) {
+    } catch (err: any) {
       expect(err.message).to.equal(`The specified index file ${indexURL} could not be parsed: buffer length 13 must === bson size 544501582`);
     }
   });
@@ -535,7 +535,7 @@ describe('SnippetManager', () => {
     try {
       await snippetManager.runSnippetCommand(['install', 'tarballed-example']);
       expect.fail('missed exception');
-    } catch (err) {
+    } catch (err: any) {
       expect(err.message).to.equal('Unknown snippet "tarballed-example"');
     }
   });
@@ -555,7 +555,7 @@ describe('SnippetManager', () => {
     try {
       await snippetManager.runSnippetCommand(['install', 'snippet-without-installation-candidate']);
       expect.fail('missed exception');
-    } catch (err) {
+    } catch (err: any) {
       expect(err.message).to.match(/^Command failed:.+npm/);
       expect(err.message).to.include('E404');
     }
@@ -567,7 +567,7 @@ describe('SnippetManager', () => {
     try {
       await snippetManager.runSnippetCommand(['install', 'bson-example']);
       expect.fail('missed exception');
-    } catch (err) {
+    } catch (err: any) {
       expect(err.name).to.equal('SyntaxError');
       expect(err.message).to.include('JSON');
     }
@@ -589,7 +589,7 @@ describe('SnippetManager', () => {
       try {
         await snippetManager.runSnippetCommand(['install', 'bson-example']);
         expect.fail('missed exception');
-      } catch (err) {
+      } catch (err: any) {
         expect(err.message).to.equal('Stopped by user request');
       }
     });
@@ -632,7 +632,7 @@ describe('SnippetManager', () => {
       try {
         await snippetManager.runSnippetCommand(['install', 'bson-example']);
         expect.fail('missed exception');
-      } catch (err) {
+      } catch (err: any) {
         expect(err.message).to.equal(`Failed to download npm: ${registryURL}/npm/latest: Not Found`);
       }
     });
@@ -644,7 +644,7 @@ describe('SnippetManager', () => {
       try {
         await snippetManager.runSnippetCommand(['install', 'bson-example']);
         expect.fail('missed exception');
-      } catch (err) {
+      } catch (err: any) {
         expect(err.message).to.equal(`Failed to download npm: ${registryURL}/npm/latest: Registry returned no download source`);
       }
     });
@@ -656,7 +656,7 @@ describe('SnippetManager', () => {
       try {
         await snippetManager.runSnippetCommand(['install', 'bson-example']);
         expect.fail('missed exception');
-      } catch (err) {
+      } catch (err: any) {
         expect(err.message).to.equal(`Failed to download npm: ${baseURL}/notfound.tgz: Not Found`);
       }
     });
@@ -723,7 +723,7 @@ describe('SnippetManager', () => {
     try {
       await snippetManager.loadAllSnippets('always'); // yes exception
       expect.fail('missed exception');
-    } catch (err) {
+    } catch (err: any) {
       expect(err.code).to.equal('ENOENT');
     }
   });
@@ -742,7 +742,7 @@ describe('SnippetManager', () => {
       try {
         await snippetManager.runSnippetCommand(['install', 'bson-example', 'tarballed-example']);
         expect.fail('missed exception');
-      } catch (err) {
+      } catch (err: any) {
         expect(err.message).to.equal('interrupted');
       }
       expect(contextObject.load).to.have.callCount(1);
@@ -784,7 +784,7 @@ describe('SnippetManager', () => {
       try {
         await npmPromise;
         expect.fail('missed exception');
-      } catch (err) {
+      } catch (err: any) {
         expect(err.message).to.equal('interrupted');
       }
 

--- a/packages/snippet-manager/src/snippet-manager.ts
+++ b/packages/snippet-manager/src/snippet-manager.ts
@@ -250,8 +250,8 @@ export class SnippetManager implements ShellPlugin {
           let data;
           try {
             data = await unpackBSON<Omit<SnippetIndexFile, 'sourceURL'>>(rawData);
-          } catch (err) {
-            this.messageBus.emit('mongosh-snippets:fetch-index-error', { action: 'parse-fetched', url, error: err.message });
+          } catch (err: any) {
+            this.messageBus.emit('mongosh-snippets:fetch-index-error', { action: 'parse-fetched', url, error: err?.message });
             throw new MongoshRuntimeError(`The specified index file ${url} could not be parsed: ${err.message}`);
           }
           const { error } = indexFileSchema.validate(data, { allowUnknown: true });
@@ -264,8 +264,8 @@ export class SnippetManager implements ShellPlugin {
         // If possible, write the result to disk for caching.
         try {
           await fs.writeFile(cachePath, await packBSON({ repoData }));
-        } catch (err) {
-          this.messageBus.emit('mongosh-snippets:fetch-index-error', { action: 'save', error: err.message });
+        } catch (err: any) {
+          this.messageBus.emit('mongosh-snippets:fetch-index-error', { action: 'save', error: err?.message });
         }
       }
       this.messageBus.emit('mongosh-snippets:fetch-index-done');
@@ -306,8 +306,8 @@ export class SnippetManager implements ShellPlugin {
     let pjson = {};
     try {
       pjson = JSON.parse(await fs.readFile(path.join(this.installdir, 'package.json'), 'utf8'));
-    } catch (err) {
-      this.messageBus.emit('mongosh-snippets:package-json-edit-error', { error: err.message });
+    } catch (err: any) {
+      this.messageBus.emit('mongosh-snippets:package-json-edit-error', { error: err?.message });
       if (err.code !== 'ENOENT') {
         throw err;
       }
@@ -386,7 +386,7 @@ export class SnippetManager implements ShellPlugin {
     let installedPackages;
     try {
       installedPackages = await this.editPackageJSON((pjson) => Object.keys(pjson.dependencies ?? {}));
-    } catch (err) {
+    } catch (err: any) {
       if (autoloadMode === 'only-autoload') {
         return; // Could not load snippets. The user will be aware of this soon enough, most likely.
       }

--- a/scripts/gather-licenses.ts
+++ b/scripts/gather-licenses.ts
@@ -38,7 +38,7 @@ async function getPackageInfo(packagePath: string): Promise<Package> {
   let packageJSON: PackageJSON;
   try {
     packageJSON = JSON.parse(await fs.readFile(packageJSONPath, 'utf8'));
-  } catch (e) {
+  } catch (e: any) {
     throw new Error(`Could not read ${packageJSONPath}: ${e.message}`);
   }
   // Normalize the 'contributors' list.
@@ -78,7 +78,7 @@ export async function gatherLicenses(startPath: string): Promise<Package[]> {
           if (!path.isAbsolute(resolved)) {
             continue; // Node.js builtin
           }
-        } catch (err) {
+        } catch (err: any) {
           resolved = await findUp(async directory => {
             const candidate = path.join(directory, 'node_modules', dep, 'package.json');
             return await findUp.exists(candidate) ? candidate : undefined;
@@ -100,7 +100,7 @@ export async function gatherLicenses(startPath: string): Promise<Package[]> {
               if (name && version) {
                 return candidate;
               }
-            } catch (e) {
+            } catch (e: any) {
               // Ignore errors, just return undefined to continue
               // traversal
             }

--- a/testing/eventually.ts
+++ b/testing/eventually.ts
@@ -14,7 +14,7 @@ export async function eventually(fn: Function, opts: { frequency?: number; timeo
     try {
       await fn();
       return;
-    } catch (e) {
+    } catch (e: any) {
       err = e;
     }
 

--- a/testing/integration-testing-hooks.ts
+++ b/testing/integration-testing-hooks.ts
@@ -24,7 +24,7 @@ function ciLog(...args: any[]) {
 async function statIfExists(path: string): Promise<ReturnType<typeof fs.stat> | undefined> {
   try {
     return await fs.stat(path);
-  } catch (err) {
+  } catch (err: any) {
     if (err.code === 'ENOENT') {
       return undefined;
     }
@@ -45,7 +45,7 @@ async function tryExtensions(base: string): Promise<[ string, Error ]> {
     try {
       await fs.stat(base + ext);
       return [ base + ext, lastErr ];
-    } catch (err) {
+    } catch (err: any) {
       lastErr = err;
       ciLog('File does not exist or is inaccessible', base + ext);
     }
@@ -181,7 +181,7 @@ export async function clearMlaunch({ killAllMongod = false } = {}) {
         } else {
           await execFile('killall', [proc]);
         }
-      } catch (err) {
+      } catch (err: any) {
         console.warn(`Cleaning up ${proc} instances failed:`, err);
       }
     }
@@ -192,12 +192,12 @@ export async function clearMlaunch({ killAllMongod = false } = {}) {
       const fullPath = path.join(tmpdir, name);
       try {
         await execMlaunch('kill', '--dir', fullPath);
-      } catch (err) {
+      } catch (err: any) {
         console.warn(`mlaunch kill in ${fullPath} failed:`, err);
       }
       try {
         await promisify(rimraf)(fullPath);
-      } catch (err) {
+      } catch (err: any) {
         console.warn(`Removing ${fullPath} failed:`, err);
       }
     }
@@ -359,7 +359,7 @@ class MlaunchSetup extends MongodSetup {
     await execMlaunch('stop', '--dir', this._mlaunchdir);
     try {
       await promisify(rimraf)(this._mlaunchdir);
-    } catch (err) {
+    } catch (err: any) {
       console.error(`Cannot remove directory ${this._mlaunchdir}`, err);
     }
   }
@@ -554,7 +554,7 @@ export function skipIfEnvServerVersion(semverCondition: string): void {
     if (!testServerVersion) {
       try {
         testServerVersion = await getInstalledMongodVersion();
-      } catch(e) {
+      } catch(e: any) {
         // no explicitly specified version but also no local mongod installation
         testServerVersion = '9999.9999.9999';
       }


### PR DESCRIPTION
- Only `catch` statements have changed in the actual source code
- The changes for source files were made manually, and usually adjusted the code to be a bit more resilient (e.g. `err?.message` instead of `err.message`)
- The changes for tests files were done by adding `: any` with a regexp