### PR TITLE
Fix problem caused by GraalJS limitation on Proxy methods invocation

### DIFF
--- a/packages/shell-api/src/database.ts
+++ b/packages/shell-api/src/database.ts
@@ -90,6 +90,18 @@ export default class Database extends ShellApiWithMongoClass {
         }
 
         return collections[prop];
+      },
+      getOwnPropertyDescriptor: (target, prop): PropertyDescriptor | undefined => {
+        // Workaround for Java Shell.
+        // GraalJS library doesn't allow invoking methods of objects wrapped in Proxy.
+        // Database.getName method is used in MongoShellEvaluator to check
+        // whether we should update current database in ShellInstanceState.
+        // More about the issue and the workaround: https://github.com/oracle/graaljs/issues/441#issuecomment-823890292
+        return prop === 'getName' ? {
+          configurable: true,
+          enumerable: true,
+          value: () => target.getName()
+        } : Object.getOwnPropertyDescriptor(target, prop);
       }
     });
     return proxy;


### PR DESCRIPTION
I'm trying to update GraalJS library.
Currently tests with new GraalJS version don't pass because of two problems, this is one of them.
The problem existed before but it just didn't show up because the assertion in GraalJS used to be written incorrectly.