### PR TITLE
chore: reduce collStats command usage MONGOSH-1157

### DIFF
--- a/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/service/JavaServiceProvider.kt
+++ b/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/service/JavaServiceProvider.kt
@@ -474,15 +474,6 @@ internal class JavaServiceProvider(private val client: MongoClient,
     }
 
     @HostAccess.Export
-    override fun isCapped(database: String, collection: String): Value = promise {
-        getDatabase(database, null).flatMap { db ->
-            val doc = db.runCommand(Document("collStats", collection))
-            if (doc.containsKey("capped") && doc["capped"] is Boolean) Right<Boolean>(doc["capped"] as Boolean)
-            else Left<Boolean>(CommandException("Cannot find boolean property 'capped'. Response $doc", ""))
-        }
-    }
-
-    @HostAccess.Export
     override fun getIndexes(database: String, collection: String, options: Value?): Value = promise {
         getDatabase(database, null).map { db ->
             db.getCollection(collection).listIndexes()

--- a/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/service/JavaServiceProvider.kt
+++ b/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/service/JavaServiceProvider.kt
@@ -491,13 +491,6 @@ internal class JavaServiceProvider(private val client: MongoClient,
     }
 
     @HostAccess.Export
-    override fun stats(database: String, collection: String, options: Value?): Value = promise<Any?> {
-        getDatabase(database, null).map { db ->
-            db.runCommand(Document("collStats", collection))
-        }
-    }
-
-    @HostAccess.Export
     override fun remove(database: String, collection: String, query: Value, options: Value?): Value = deleteMany(database, collection, query, options)
 
     @HostAccess.Export

--- a/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/service/ReadableServiceProvider.kt
+++ b/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/service/ReadableServiceProvider.kt
@@ -14,7 +14,6 @@ internal interface ReadableServiceProvider {
     fun estimatedDocumentCount(database: String, collection: String, options: Value?): Value
     fun find(database: String, collection: String, filter: Value?, options: Value?): Cursor
     fun getTopology(): Value
-    fun isCapped(database: String, collection: String): Value
     fun getIndexes(database: String, collection: String, options: Value?): Value
     fun listCollections(database: String, filter: Value?, options: Value?): Value
     fun stats(database: String, collection: String, options: Value?): Value

--- a/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/service/ReadableServiceProvider.kt
+++ b/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/service/ReadableServiceProvider.kt
@@ -16,5 +16,4 @@ internal interface ReadableServiceProvider {
     fun getTopology(): Value
     fun getIndexes(database: String, collection: String, options: Value?): Value
     fun listCollections(database: String, filter: Value?, options: Value?): Value
-    fun stats(database: String, collection: String, options: Value?): Value
 }

--- a/packages/java-shell/src/test/resources/collection/isCapped.expected.txt
+++ b/packages/java-shell/src/test/resources/collection/isCapped.expected.txt
@@ -1,1 +1,3 @@
 false
+{ "ok": 1 }
+true

--- a/packages/java-shell/src/test/resources/collection/isCapped.js
+++ b/packages/java-shell/src/test/resources/collection/isCapped.js
@@ -2,6 +2,10 @@
 db.coll.deleteMany({});
 db.coll.insertOne({a: 1});
 // command
-db.coll.isCapped()
+wasCapped = db.coll.isCapped()
+// command
+db.coll.convertToCapped(10240)
+// command
+isCapped = db.coll.isCapped()
 // clear
 db.coll.drop();

--- a/packages/service-provider-core/src/readable.ts
+++ b/packages/service-provider-core/src/readable.ts
@@ -155,20 +155,6 @@ export default interface Readable {
   getTopology(): any;
 
   /**
-   * Is the collection capped?
-   *
-   * @param {String} database - The database name.
-   * @param {String} collection - The collection name.
-   * @param {DbOptions} dbOptions - The database options
-   *
-   * @returns {Promise} The promise of the result.
-   */
-  isCapped(
-    database: string,
-    collection: string,
-    dbOptions?: DbOptions): Promise<boolean>;
-
-  /**
    * Returns an array that holds a list of documents that identify and
    * describe the existing indexes on the collection.
    *

--- a/packages/service-provider-core/src/readable.ts
+++ b/packages/service-provider-core/src/readable.ts
@@ -7,7 +7,6 @@ import type {
   EstimatedDocumentCountOptions,
   FindOptions,
   ListCollectionsOptions,
-  CollStatsOptions,
   ListIndexesOptions,
   AggregationCursor,
   FindCursor,
@@ -191,23 +190,6 @@ export default interface Readable {
    * Create a ReadPreference object from a set of options
    */
   readPreferenceFromOptions(options?: Omit<ReadPreferenceFromOptions, 'session'>): ReadPreferenceLike | undefined;
-
-  /**
-   * Get all the collection statistics.
-   *
-   * @param {String} database - The db name.
-   * @param {String} collection - The collection name.
-   * @param {Object} options - The count options.
-   * @param {DbOptions} dbOptions - The database options
-   *
-   * @return {Promise} returns Promise
-   */
-  stats(
-    database: string,
-    collection: string,
-    options?: CollStatsOptions,
-    dbOptions?: DbOptions
-  ): Promise<Document>;
 
   /**
    * Start a change stream cursor on either the client, db, or collection.

--- a/packages/service-provider-server/src/cli-service-provider.integration.spec.ts
+++ b/packages/service-provider-server/src/cli-service-provider.integration.spec.ts
@@ -405,20 +405,6 @@ describe('CliServiceProvider [integration]', function() {
     });
   });
 
-  describe('#isCapped', () => {
-    context('for regular collections', () => {
-      let result;
-
-      beforeEach(async() => {
-        result = await serviceProvider.isCapped('music', 'bands');
-      });
-
-      it('returns false', () => {
-        expect(result).to.equal(false);
-      });
-    });
-  });
-
   describe('#listDatabases', () => {
     let result;
 

--- a/packages/service-provider-server/src/cli-service-provider.integration.spec.ts
+++ b/packages/service-provider-server/src/cli-service-provider.integration.spec.ts
@@ -591,32 +591,6 @@ describe('CliServiceProvider [integration]', function() {
     });
   });
 
-  describe('stats', () => {
-    it('returns collection stats', async() => {
-      const collName = 'coll1';
-      await db.createCollection(collName);
-
-      const stats = await serviceProvider.stats(
-        dbName,
-        collName
-      );
-
-      expect(Object.keys(stats)).to.contain.members([
-        'ns',
-        'size',
-        'count',
-        'storageSize',
-        'capped',
-        'wiredTiger',
-        'nindexes',
-        'indexDetails',
-        'totalIndexSize',
-        'indexSizes',
-        'ok'
-      ]);
-    });
-  });
-
   describe('#listCollections', () => {
     it('returns the list of collections', async() => {
       await db.createCollection('coll1');

--- a/packages/service-provider-server/src/cli-service-provider.spec.ts
+++ b/packages/service-provider-server/src/cli-service-provider.spec.ts
@@ -543,26 +543,6 @@ describe('CliServiceProvider', () => {
     });
   });
 
-  describe('#stats', () => {
-    let options;
-    let expectedResult;
-
-    beforeEach(() => {
-      options = { ...DEFAULT_BASE_OPTS, scale: 1 };
-      expectedResult = { ok: 1 };
-
-      collectionStub = stubInterface<Collection>();
-      collectionStub.stats.resolves(expectedResult);
-      serviceProvider = new CliServiceProvider(createClientStub(collectionStub), bus);
-    });
-
-    it('executes the command against the database', async() => {
-      const result = await serviceProvider.stats('db1', 'coll1', options);
-      expect(result).to.deep.equal(expectedResult);
-      expect(collectionStub.stats).to.have.been.calledWith(options);
-    });
-  });
-
   describe('#renameCollection', () => {
     let dbStub: StubbedInstance<Db>;
     let clientStub: StubbedInstance<MongoClient>;

--- a/packages/service-provider-server/src/cli-service-provider.ts
+++ b/packages/service-provider-server/src/cli-service-provider.ts
@@ -36,7 +36,6 @@ import {
   BulkWriteOptions,
   BulkWriteResult,
   ClientSessionOptions,
-  CollStatsOptions,
   Collection,
   CountDocumentsOptions,
   CountOptions,
@@ -990,26 +989,6 @@ class CliServiceProvider extends ServiceProviderCore implements ServiceProvider 
     return await this.db(database, dbOptions).listCollections(
       filter, options
     ).toArray();
-  }
-
-  /**
-   * Get all the collection statistics.
-   *
-   * @param {String} database - The db name.
-   * @param {String} collection - The collection name.
-   * @param {Object} options - The count options.
-   * @param {Object} dbOptions - The database options
-   * @return {Promise} returns Promise
-   */
-  async stats(
-    database: string,
-    collection: string,
-    options: CollStatsOptions = {},
-    dbOptions?: DbOptions): Promise<Document> {
-    options = { ...this.baseCmdOptions, ...options };
-    return await this.db(database, dbOptions)
-      .collection(collection)
-      .stats(options as { scale: 1 });
   }
 
   /**

--- a/packages/service-provider-server/src/cli-service-provider.ts
+++ b/packages/service-provider-server/src/cli-service-provider.ts
@@ -732,21 +732,6 @@ class CliServiceProvider extends ServiceProviderCore implements ServiceProvider 
   }
 
   /**
-   * Is the collection capped?
-   *
-   * @param {String} database - The database name.
-   * @param {String} collection - The collection name.
-   * @param dbOptions
-   * @returns {Promise} The promise of the result.
-   */
-  isCapped(
-    database: string,
-    collection: string,
-    dbOptions?: DbOptions): Promise<boolean> {
-    return this.db(database, dbOptions).collection(collection).isCapped();
-  }
-
-  /**
    * Deprecated remove command.
    *
    * @param {String} database - The db name.

--- a/packages/shell-api/src/abstract-cursor.ts
+++ b/packages/shell-api/src/abstract-cursor.ts
@@ -53,7 +53,7 @@ export abstract class AbstractCursor<CursorType extends ServiceProviderAggregati
   }
 
   @returnsPromise
-  async close(options: Document): Promise<void> {
+  async close(options: Document = {}): Promise<void> {
     await this._cursor.close(options);
   }
 
@@ -83,7 +83,9 @@ export abstract class AbstractCursor<CursorType extends ServiceProviderAggregati
 
   async* [Symbol.asyncIterator]() {
     let doc;
-    while ((doc = await this.tryNext()) !== null) {
+    // !== null should suffice, but some stubs in our tests return 'undefined'
+    // eslint-disable-next-line eqeqeq
+    while ((doc = await this.tryNext()) != null) {
       yield doc;
     }
   }

--- a/packages/shell-api/src/collection.ts
+++ b/packages/shell-api/src/collection.ts
@@ -1231,6 +1231,15 @@ export default class Collection extends ShellApiWithMongoClass {
     return this.dropIndexes(index);
   }
 
+  async _getSingleStorageStatValue(key: string): Promise<number> {
+    const cursor = await this.aggregate([
+      { $collStats: { storageStats: {} } },
+      { $group: { _id: null, value: { $sum: `$storageStats.${key}` } } }
+    ]);
+    const [{ value }] = await cursor.toArray();
+    return value;
+  }
+
   /**
    * Returns the total size of all indexes for the collection.
    *
@@ -1247,8 +1256,7 @@ export default class Collection extends ShellApiWithMongoClass {
       );
     }
 
-    const stats = await this._mongo._serviceProvider.stats(this._database._name, this._name, await this._database._baseOptions());
-    return stats.totalIndexSize;
+    return this._getSingleStorageStatValue('totalIndexSize');
   }
 
   /**
@@ -1297,8 +1305,8 @@ export default class Collection extends ShellApiWithMongoClass {
   @apiVersions([])
   async dataSize(): Promise<number> {
     this._emitCollectionApiCall('dataSize');
-    const stats = await this._mongo._serviceProvider.stats(this._database._name, this._name, await this._database._baseOptions());
-    return stats.size;
+
+    return this._getSingleStorageStatValue('size');
   }
 
   /**
@@ -1310,8 +1318,8 @@ export default class Collection extends ShellApiWithMongoClass {
   @apiVersions([])
   async storageSize(): Promise<number> {
     this._emitCollectionApiCall('storageSize');
-    const stats = await this._mongo._serviceProvider.stats(this._database._name, this._name, await this._database._baseOptions());
-    return stats.storageSize;
+
+    return this._getSingleStorageStatValue('storageSize');
   }
 
   /**
@@ -1323,8 +1331,8 @@ export default class Collection extends ShellApiWithMongoClass {
   @apiVersions([])
   async totalSize(): Promise<number> {
     this._emitCollectionApiCall('totalSize');
-    const stats = await this._mongo._serviceProvider.stats(this._database._name, this._name, await this._database._baseOptions());
-    return (Number(stats.storageSize) || 0) + (Number(stats.totalIndexSize) || 0);
+
+    return this._getSingleStorageStatValue('totalSize');
   }
 
   /**
@@ -1454,6 +1462,8 @@ export default class Collection extends ShellApiWithMongoClass {
     options.indexDetails = options.indexDetails || false;
 
     this._emitCollectionApiCall('stats', { options });
+    // TODO(MONGOSH-1157): Adjust along the lines of the mongos code in
+    // https://github.com/mongodb/mongo/blob/master/src/mongo/s/commands/cluster_coll_stats_cmd.cpp
     const result = await this._database._runCommand(
       {
         collStats: this._name, scale: options.scale
@@ -1465,6 +1475,7 @@ export default class Collection extends ShellApiWithMongoClass {
         CommonErrors.CommandFailed
       );
     }
+
     let filterIndexName = options.indexDetailsName;
     if (!filterIndexName && options.indexDetailsKey) {
       const indexes = await this._mongo._serviceProvider.getIndexes(this._database._name, this._name, await this._database._baseOptions());
@@ -1509,14 +1520,7 @@ export default class Collection extends ShellApiWithMongoClass {
   @apiVersions([])
   async latencyStats(options: Document = {}): Promise<Document[]> {
     this._emitCollectionApiCall('latencyStats', { options });
-    const pipeline = [{ $collStats: { latencyStats: options } }];
-    const providerCursor = this._mongo._serviceProvider.aggregate(
-      this._database._name,
-      this._name,
-      pipeline,
-      await this._database._baseOptions()
-    );
-    return await providerCursor.toArray();
+    return await (await this.aggregate([{ $collStats: { latencyStats: options } }])).toArray();
   }
 
   @returnsPromise

--- a/packages/shell-api/src/collection.ts
+++ b/packages/shell-api/src/collection.ts
@@ -751,7 +751,13 @@ export default class Collection extends ShellApiWithMongoClass {
   @apiVersions([1])
   async isCapped(): Promise<boolean> {
     this._emitCollectionApiCall('isCapped');
-    return this._mongo._serviceProvider.isCapped(this._database._name, this._name);
+
+    // Not implemented using the Node.js driver helper to make this easier for the java shell
+    const colls = await this._database._listCollections({ name: this._name }, { nameOnly: false });
+    if (colls.length === 0) {
+      throw new MongoshRuntimeError(`collection ${this.getFullName()} not found`);
+    }
+    return !!(colls[0]?.options?.capped);
   }
 
   /**

--- a/packages/shell-api/src/database.ts
+++ b/packages/shell-api/src/database.ts
@@ -151,7 +151,7 @@ export default class Database extends ShellApiWithMongoClass {
     );
   }
 
-  private async _listCollections(filter: Document, options: ListCollectionsOptions): Promise<Document[]> {
+  async _listCollections(filter: Document, options: ListCollectionsOptions): Promise<Document[]> {
     return await this._mongo._serviceProvider.listCollections(
       this._name,
       filter,

--- a/packages/shell-api/src/integration.spec.ts
+++ b/packages/shell-api/src/integration.spec.ts
@@ -378,10 +378,7 @@ describe('Shell API (integration)', function() {
       beforeEach(async() => {
         await serviceProvider.createCollection(dbName, collectionName);
 
-        expect(await serviceProvider.isCapped(
-          dbName,
-          collectionName
-        )).to.be.false;
+        expect(await collection.isCapped()).to.be.false;
 
         result = await collection.convertToCapped(
           1000
@@ -393,10 +390,7 @@ describe('Shell API (integration)', function() {
       });
 
       it('converts the collection', async() => {
-        expect(await serviceProvider.isCapped(
-          dbName,
-          collectionName
-        )).to.be.true;
+        expect(await collection.isCapped()).to.be.true;
       });
     });
 


### PR DESCRIPTION
Note: It looks like these will not be deprecated with a deprecation warning in 6.0 yet.
I still wanted to share the work that I’d done so far, partially also because it’s
good cleanup for our `ServiceProvider` API.

---

##### chore: drop isCapped from ServiceProvider interface

Instead of using a custom ServiceProvider method for getting the
`collection.isCapped()` information, use the shared `listCollections`
interface instead.

This reduces the ServiceProvider API surface and avoids
diverging implementations for the method, in particular
avoids an instance of the eventually-to-be-deprecated `collStats`
command in the java-shell.

##### chore: drop stats from ServiceProvider interface MONGOSH-1157

Remove `.stats()` from the service provider interface (which
has the nice side effect of reducing its API surface) and
replace corresponding calls by `$collStats` aggregations.
