### PR TITLE
chore: restructure evergreen build variants

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -5130,7 +5130,7 @@ tasks:
   - name: check
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -5161,7 +5161,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -5178,7 +5178,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -5195,7 +5195,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -5212,7 +5212,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -5229,7 +5229,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -5246,7 +5246,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -5263,7 +5263,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -5280,7 +5280,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -5297,7 +5297,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -5314,7 +5314,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -5331,7 +5331,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -5348,7 +5348,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -5365,7 +5365,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -5382,7 +5382,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -5399,7 +5399,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -5416,7 +5416,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -5433,7 +5433,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -5450,7 +5450,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -5467,7 +5467,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -5484,7 +5484,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -5501,7 +5501,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -5518,7 +5518,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -5535,7 +5535,7 @@ tasks:
     tags: ["unit-test","mlatest"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -5552,7 +5552,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -5569,7 +5569,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -5586,7 +5586,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -5603,7 +5603,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -5620,7 +5620,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -5637,7 +5637,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -5654,7 +5654,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -5671,7 +5671,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -5688,7 +5688,7 @@ tasks:
     tags: ["unit-test","mlatest"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -5705,7 +5705,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -5722,7 +5722,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -5739,7 +5739,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -5756,7 +5756,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -5773,7 +5773,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -5790,7 +5790,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -5807,7 +5807,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -5824,7 +5824,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -5841,7 +5841,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -5858,7 +5858,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -5875,7 +5875,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -5892,7 +5892,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -5909,7 +5909,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -5926,7 +5926,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -5943,7 +5943,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -5960,7 +5960,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -5977,7 +5977,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -5994,7 +5994,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -6011,7 +6011,7 @@ tasks:
     tags: ["unit-test","mlatest"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -6028,7 +6028,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -6045,7 +6045,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -6062,7 +6062,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -6079,7 +6079,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -6096,7 +6096,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -6113,7 +6113,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -6130,7 +6130,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -6147,7 +6147,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -6164,7 +6164,7 @@ tasks:
     tags: ["unit-test","mlatest"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -6181,7 +6181,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -6198,7 +6198,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -6215,7 +6215,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -6232,7 +6232,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -6249,7 +6249,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -6266,7 +6266,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -6283,7 +6283,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -6300,7 +6300,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -6317,7 +6317,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -6334,7 +6334,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -6351,7 +6351,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -6368,7 +6368,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -6385,7 +6385,7 @@ tasks:
     tags: ["unit-test","mlatest"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -6402,7 +6402,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -6419,7 +6419,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -6436,7 +6436,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -6453,7 +6453,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -6470,7 +6470,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -6487,7 +6487,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -6504,7 +6504,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -6521,7 +6521,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -6538,7 +6538,7 @@ tasks:
     tags: ["unit-test","mlatest"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -6555,7 +6555,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -6572,7 +6572,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -6589,7 +6589,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -6606,7 +6606,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -6623,7 +6623,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -6640,7 +6640,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -6657,7 +6657,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -6674,7 +6674,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -6691,7 +6691,7 @@ tasks:
     tags: ["unit-test","mlatest"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -6708,7 +6708,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -6725,7 +6725,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -6742,7 +6742,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -6759,7 +6759,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -6776,7 +6776,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -6793,7 +6793,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -6810,7 +6810,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -6827,7 +6827,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -6844,7 +6844,7 @@ tasks:
     tags: ["unit-test","mlatest"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -6861,7 +6861,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -6878,7 +6878,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -6895,7 +6895,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -6912,7 +6912,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -6929,7 +6929,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -6946,7 +6946,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -6963,7 +6963,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -6980,7 +6980,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -6997,7 +6997,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -7014,7 +7014,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -7031,7 +7031,7 @@ tasks:
     tags: ["unit-test","mlatest"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -7048,7 +7048,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -7065,7 +7065,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -7082,7 +7082,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -7099,7 +7099,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -7116,7 +7116,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -7133,7 +7133,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -7150,7 +7150,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -7167,7 +7167,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -7184,7 +7184,7 @@ tasks:
     tags: ["unit-test","mlatest"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -7201,7 +7201,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -7218,7 +7218,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -7235,7 +7235,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -7252,7 +7252,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -7269,7 +7269,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -7286,7 +7286,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -7303,7 +7303,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -7320,7 +7320,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -7337,7 +7337,7 @@ tasks:
     tags: ["unit-test","mlatest"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -7354,7 +7354,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -7371,7 +7371,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -7388,7 +7388,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -7405,7 +7405,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -7422,7 +7422,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -7439,7 +7439,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -7456,7 +7456,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -7473,7 +7473,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -7490,7 +7490,7 @@ tasks:
     tags: ["unit-test","mlatest"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -7507,7 +7507,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -7524,7 +7524,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -7541,7 +7541,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -7558,7 +7558,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -7575,7 +7575,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -7592,7 +7592,7 @@ tasks:
     tags: ["unit-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -7613,7 +7613,7 @@ tasks:
     tags: ["extra-integration-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -7626,7 +7626,7 @@ tasks:
     tags: ["extra-integration-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -7637,7 +7637,7 @@ tasks:
     tags: ["extra-integration-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -7651,7 +7651,7 @@ tasks:
   - name: compile_artifact
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -8048,7 +8048,7 @@ tasks:
     tags: ["smoke-test"]
     depends_on:
       - name: package_and_upload_artifact_debian_x64
-        variant: linux
+        variant: linux_package
     commands:
       - func: checkout
       - func: get_artifact_url
@@ -8062,7 +8062,7 @@ tasks:
     tags: ["smoke-test"]
     depends_on:
       - name: package_and_upload_artifact_debian_x64
-        variant: linux
+        variant: linux_package
     commands:
       - func: checkout
       - func: get_artifact_url
@@ -8076,7 +8076,7 @@ tasks:
     tags: ["smoke-test"]
     depends_on:
       - name: package_and_upload_artifact_debian_x64
-        variant: linux
+        variant: linux_package
     commands:
       - func: checkout
       - func: get_artifact_url
@@ -8090,7 +8090,7 @@ tasks:
     tags: ["smoke-test"]
     depends_on:
       - name: package_and_upload_artifact_debian_x64
-        variant: linux
+        variant: linux_package
     commands:
       - func: checkout
       - func: get_artifact_url
@@ -8104,7 +8104,7 @@ tasks:
     tags: ["smoke-test"]
     depends_on:
       - name: package_and_upload_artifact_rhel7_x64
-        variant: linux
+        variant: linux_package
     commands:
       - func: checkout
       - func: get_artifact_url
@@ -8118,7 +8118,7 @@ tasks:
     tags: ["smoke-test"]
     depends_on:
       - name: package_and_upload_artifact_rhel7_x64
-        variant: linux
+        variant: linux_package
     commands:
       - func: checkout
       - func: get_artifact_url
@@ -8132,7 +8132,7 @@ tasks:
     tags: ["smoke-test"]
     depends_on:
       - name: package_and_upload_artifact_rhel8_x64
-        variant: linux
+        variant: linux_package
     commands:
       - func: checkout
       - func: get_artifact_url
@@ -8146,7 +8146,7 @@ tasks:
     tags: ["smoke-test"]
     depends_on:
       - name: package_and_upload_artifact_rhel8_x64
-        variant: linux
+        variant: linux_package
     commands:
       - func: checkout
       - func: get_artifact_url
@@ -8160,7 +8160,7 @@ tasks:
     tags: ["smoke-test"]
     depends_on:
       - name: package_and_upload_artifact_suse_x64
-        variant: linux
+        variant: linux_package
     commands:
       - func: checkout
       - func: get_artifact_url
@@ -8174,7 +8174,7 @@ tasks:
     tags: ["smoke-test"]
     depends_on:
       - name: package_and_upload_artifact_suse_x64
-        variant: linux
+        variant: linux_package
     commands:
       - func: checkout
       - func: get_artifact_url
@@ -8188,7 +8188,7 @@ tasks:
     tags: ["smoke-test"]
     depends_on:
       - name: package_and_upload_artifact_amzn1_x64
-        variant: linux
+        variant: linux_package
     commands:
       - func: checkout
       - func: get_artifact_url
@@ -8202,7 +8202,7 @@ tasks:
     tags: ["smoke-test"]
     depends_on:
       - name: package_and_upload_artifact_debian_arm64
-        variant: linux
+        variant: linux_package
     commands:
       - func: checkout
       - func: get_artifact_url
@@ -8214,7 +8214,7 @@ tasks:
     tags: ["smoke-test"]
     depends_on:
       - name: package_and_upload_artifact_rhel8_arm64
-        variant: linux
+        variant: linux_package
     commands:
       - func: checkout
       - func: get_artifact_url
@@ -8226,7 +8226,7 @@ tasks:
     tags: ["smoke-test"]
     depends_on:
       - name: package_and_upload_artifact_amzn2_arm64
-        variant: linux
+        variant: linux_package
     commands:
       - func: checkout
       - func: get_artifact_url
@@ -8238,7 +8238,7 @@ tasks:
     tags: ["smoke-test"]
     depends_on:
       - name: package_and_upload_artifact_rhel8_ppc64le
-        variant: linux
+        variant: linux_package
     commands:
       - func: checkout
       - func: get_artifact_url
@@ -8250,7 +8250,7 @@ tasks:
     tags: ["smoke-test"]
     depends_on:
       - name: package_and_upload_artifact_rhel7_s390x
-        variant: linux
+        variant: linux_package
     commands:
       - func: checkout
       - func: get_artifact_url
@@ -8327,7 +8327,7 @@ tasks:
     exec_timeout_secs: 86400
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -8339,8 +8339,8 @@ tasks:
 
 # Need to run builds for every possible build variant.
 buildvariants:
-  - name: darwin
-    display_name: "MacOS Mojave"
+  - name: darwin_unit
+    display_name: "MacOS Mojave (Unit tests)"
     run_on: macos-1014
     expansions:
       executable_os_id: darwin-x64
@@ -8452,10 +8452,23 @@ buildvariants:
       - name: test_n14_snippet_manager
       - name: test_n12_types
       - name: test_n14_types
+  - name: darwin
+    display_name: "MacOS Mojave"
+    run_on: macos-1014
+    expansions:
+      executable_os_id: darwin-x64
+    tasks:
       - name: compile_artifact
       - name: e2e_tests_darwin_x64
       - name: package_and_upload_artifact_darwin_x64
       - name: package_and_upload_artifact_darwin_arm64
+  - name: darwin_1100
+    display_name: "MacOS Big Sur"
+    run_on: macos-1100
+    expansions:
+      executable_os_id: darwin-x64
+    tasks:
+      - name: e2e_tests_darwin_x64
   - name: darwin_arm64
     display_name: "MacOS Big Sur (arm64)"
     run_on: macos-1100-arm64
@@ -8466,13 +8479,12 @@ buildvariants:
       # - name: e2e_tests_darwin_arm64
       # No E2E test for now because there are no server releases to run them against
 
-  - name: linux
-    display_name: "Ubuntu 18.04 x64"
+  - name: linux_unit
+    display_name: "Ubuntu 18.04 x64 (Unit tests)"
     run_on: ubuntu1804-small
     tasks:
       - name: compile_ts
       - name: check
-      - name: check_coverage
       - name: test_n12_arg_parser
       - name: test_n14_arg_parser
       - name: test_n12_async_rewriter2
@@ -8598,6 +8610,15 @@ buildvariants:
       - name: test_vscode
       - name: test_connectivity
       - name: test_apistrict
+  - name: linux_coverage
+    display_name: "Coverage Check"
+    run_on: ubuntu1804-small
+    tasks:
+      - name: check_coverage
+  - name: linux_package
+    display_name: "Ubuntu 18.04 x64 (Packaging)"
+    run_on: ubuntu1804-small
+    tasks:
       - name: package_and_upload_artifact_linux_x64
       - name: package_and_upload_artifact_debian_x64
       - name: package_and_upload_artifact_rhel7_x64
@@ -8734,8 +8755,8 @@ buildvariants:
 #    tasks:
 #      - name: e2e_tests_linux_s390x
 
-  - name: win32
-    display_name: "Windows VS 2019"
+  - name: win32_unit
+    display_name: "Windows VS 2019 (Unit tests)"
     run_on: windows-64-vs2019-small
     expansions:
       executable_os_id: win32
@@ -8845,6 +8866,12 @@ buildvariants:
       - name: test_n14_snippet_manager
       - name: test_n12_types
       - name: test_n14_types
+  - name: win32
+    display_name: "Windows VS 2019"
+    run_on: windows-64-vs2019-small
+    expansions:
+      executable_os_id: win32
+    tasks:
       - name: e2e_tests_win32
       - name: package_and_upload_artifact_win32_x64
       - name: package_and_upload_artifact_win32msi_x64
@@ -8877,9 +8904,14 @@ buildvariants:
     tasks:
       - name: pkg_test_ssh_win32_x64
       - name: pkg_test_ssh_win32msi_x64
-  - name: pkg_smoke_tests_macos_x64
-    display_name: "package smoke tests (macos x64)"
+  - name: pkg_smoke_tests_macos_1014_x64
+    display_name: "package smoke tests (macos 10.14 x64)"
     run_on: macos-1014
+    tasks:
+      - name: pkg_test_macos_darwin_x64
+  - name: pkg_smoke_tests_macos_1100_x64
+    display_name: "package smoke tests (macos 11.00 x64)"
+    run_on: macos-1100
     tasks:
       - name: pkg_test_macos_darwin_x64
   - name: pkg_smoke_tests_macos_arm64

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -124,8 +124,8 @@ functions:
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-n12_arg_parser.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-n12_arg_parser.tgz
+        local_file: src/nyc-output-darwin_unit-n12_arg_parser.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-n12_arg_parser.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -133,13 +133,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-n12_arg_parser.tgz
+          tar xvzf nyc-output-darwin_unit-n12_arg_parser.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-n14_arg_parser.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-n14_arg_parser.tgz
+        local_file: src/nyc-output-darwin_unit-n14_arg_parser.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-n14_arg_parser.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -147,13 +147,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-n14_arg_parser.tgz
+          tar xvzf nyc-output-darwin_unit-n14_arg_parser.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-n12_async_rewriter2.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-n12_async_rewriter2.tgz
+        local_file: src/nyc-output-darwin_unit-n12_async_rewriter2.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-n12_async_rewriter2.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -161,13 +161,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-n12_async_rewriter2.tgz
+          tar xvzf nyc-output-darwin_unit-n12_async_rewriter2.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-n14_async_rewriter2.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-n14_async_rewriter2.tgz
+        local_file: src/nyc-output-darwin_unit-n14_async_rewriter2.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-n14_async_rewriter2.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -175,13 +175,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-n14_async_rewriter2.tgz
+          tar xvzf nyc-output-darwin_unit-n14_async_rewriter2.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-n12_autocomplete.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-n12_autocomplete.tgz
+        local_file: src/nyc-output-darwin_unit-n12_autocomplete.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-n12_autocomplete.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -189,13 +189,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-n12_autocomplete.tgz
+          tar xvzf nyc-output-darwin_unit-n12_autocomplete.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-n14_autocomplete.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-n14_autocomplete.tgz
+        local_file: src/nyc-output-darwin_unit-n14_autocomplete.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-n14_autocomplete.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -203,13 +203,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-n14_autocomplete.tgz
+          tar xvzf nyc-output-darwin_unit-n14_autocomplete.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-n12_browser_repl.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-n12_browser_repl.tgz
+        local_file: src/nyc-output-darwin_unit-n12_browser_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-n12_browser_repl.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -217,13 +217,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-n12_browser_repl.tgz
+          tar xvzf nyc-output-darwin_unit-n12_browser_repl.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-n14_browser_repl.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-n14_browser_repl.tgz
+        local_file: src/nyc-output-darwin_unit-n14_browser_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-n14_browser_repl.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -231,13 +231,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-n14_browser_repl.tgz
+          tar xvzf nyc-output-darwin_unit-n14_browser_repl.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-n12_browser_runtime_core.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-n12_browser_runtime_core.tgz
+        local_file: src/nyc-output-darwin_unit-n12_browser_runtime_core.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-n12_browser_runtime_core.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -245,13 +245,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-n12_browser_runtime_core.tgz
+          tar xvzf nyc-output-darwin_unit-n12_browser_runtime_core.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-n14_browser_runtime_core.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-n14_browser_runtime_core.tgz
+        local_file: src/nyc-output-darwin_unit-n14_browser_runtime_core.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-n14_browser_runtime_core.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -259,13 +259,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-n14_browser_runtime_core.tgz
+          tar xvzf nyc-output-darwin_unit-n14_browser_runtime_core.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-n12_browser_runtime_electron.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-n12_browser_runtime_electron.tgz
+        local_file: src/nyc-output-darwin_unit-n12_browser_runtime_electron.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-n12_browser_runtime_electron.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -273,13 +273,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-n12_browser_runtime_electron.tgz
+          tar xvzf nyc-output-darwin_unit-n12_browser_runtime_electron.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-n14_browser_runtime_electron.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-n14_browser_runtime_electron.tgz
+        local_file: src/nyc-output-darwin_unit-n14_browser_runtime_electron.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-n14_browser_runtime_electron.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -287,13 +287,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-n14_browser_runtime_electron.tgz
+          tar xvzf nyc-output-darwin_unit-n14_browser_runtime_electron.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-n12_build.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-n12_build.tgz
+        local_file: src/nyc-output-darwin_unit-n12_build.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-n12_build.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -301,13 +301,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-n12_build.tgz
+          tar xvzf nyc-output-darwin_unit-n12_build.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-n14_build.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-n14_build.tgz
+        local_file: src/nyc-output-darwin_unit-n14_build.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-n14_build.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -315,13 +315,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-n14_build.tgz
+          tar xvzf nyc-output-darwin_unit-n14_build.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-m40xc_n12_cli_repl.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-m40xc_n12_cli_repl.tgz
+        local_file: src/nyc-output-darwin_unit-m40xc_n12_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m40xc_n12_cli_repl.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -329,13 +329,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-m40xc_n12_cli_repl.tgz
+          tar xvzf nyc-output-darwin_unit-m40xc_n12_cli_repl.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-m40xe_n12_cli_repl.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-m40xe_n12_cli_repl.tgz
+        local_file: src/nyc-output-darwin_unit-m40xe_n12_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m40xe_n12_cli_repl.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -343,13 +343,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-m40xe_n12_cli_repl.tgz
+          tar xvzf nyc-output-darwin_unit-m40xe_n12_cli_repl.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-m42xc_n12_cli_repl.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-m42xc_n12_cli_repl.tgz
+        local_file: src/nyc-output-darwin_unit-m42xc_n12_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m42xc_n12_cli_repl.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -357,13 +357,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-m42xc_n12_cli_repl.tgz
+          tar xvzf nyc-output-darwin_unit-m42xc_n12_cli_repl.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-m42xe_n12_cli_repl.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-m42xe_n12_cli_repl.tgz
+        local_file: src/nyc-output-darwin_unit-m42xe_n12_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m42xe_n12_cli_repl.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -371,13 +371,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-m42xe_n12_cli_repl.tgz
+          tar xvzf nyc-output-darwin_unit-m42xe_n12_cli_repl.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-m44xc_n12_cli_repl.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-m44xc_n12_cli_repl.tgz
+        local_file: src/nyc-output-darwin_unit-m44xc_n12_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m44xc_n12_cli_repl.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -385,13 +385,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-m44xc_n12_cli_repl.tgz
+          tar xvzf nyc-output-darwin_unit-m44xc_n12_cli_repl.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-m44xe_n12_cli_repl.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-m44xe_n12_cli_repl.tgz
+        local_file: src/nyc-output-darwin_unit-m44xe_n12_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m44xe_n12_cli_repl.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -399,13 +399,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-m44xe_n12_cli_repl.tgz
+          tar xvzf nyc-output-darwin_unit-m44xe_n12_cli_repl.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-m50xc_n12_cli_repl.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-m50xc_n12_cli_repl.tgz
+        local_file: src/nyc-output-darwin_unit-m50xc_n12_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m50xc_n12_cli_repl.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -413,13 +413,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-m50xc_n12_cli_repl.tgz
+          tar xvzf nyc-output-darwin_unit-m50xc_n12_cli_repl.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-m50xe_n12_cli_repl.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-m50xe_n12_cli_repl.tgz
+        local_file: src/nyc-output-darwin_unit-m50xe_n12_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m50xe_n12_cli_repl.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -427,13 +427,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-m50xe_n12_cli_repl.tgz
+          tar xvzf nyc-output-darwin_unit-m50xe_n12_cli_repl.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-mlatest_n12_cli_repl.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-mlatest_n12_cli_repl.tgz
+        local_file: src/nyc-output-darwin_unit-mlatest_n12_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-mlatest_n12_cli_repl.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -441,13 +441,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-mlatest_n12_cli_repl.tgz
+          tar xvzf nyc-output-darwin_unit-mlatest_n12_cli_repl.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-m40xc_n14_cli_repl.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-m40xc_n14_cli_repl.tgz
+        local_file: src/nyc-output-darwin_unit-m40xc_n14_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m40xc_n14_cli_repl.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -455,13 +455,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-m40xc_n14_cli_repl.tgz
+          tar xvzf nyc-output-darwin_unit-m40xc_n14_cli_repl.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-m40xe_n14_cli_repl.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-m40xe_n14_cli_repl.tgz
+        local_file: src/nyc-output-darwin_unit-m40xe_n14_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m40xe_n14_cli_repl.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -469,13 +469,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-m40xe_n14_cli_repl.tgz
+          tar xvzf nyc-output-darwin_unit-m40xe_n14_cli_repl.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-m42xc_n14_cli_repl.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-m42xc_n14_cli_repl.tgz
+        local_file: src/nyc-output-darwin_unit-m42xc_n14_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m42xc_n14_cli_repl.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -483,13 +483,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-m42xc_n14_cli_repl.tgz
+          tar xvzf nyc-output-darwin_unit-m42xc_n14_cli_repl.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-m42xe_n14_cli_repl.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-m42xe_n14_cli_repl.tgz
+        local_file: src/nyc-output-darwin_unit-m42xe_n14_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m42xe_n14_cli_repl.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -497,13 +497,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-m42xe_n14_cli_repl.tgz
+          tar xvzf nyc-output-darwin_unit-m42xe_n14_cli_repl.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-m44xc_n14_cli_repl.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-m44xc_n14_cli_repl.tgz
+        local_file: src/nyc-output-darwin_unit-m44xc_n14_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m44xc_n14_cli_repl.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -511,13 +511,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-m44xc_n14_cli_repl.tgz
+          tar xvzf nyc-output-darwin_unit-m44xc_n14_cli_repl.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-m44xe_n14_cli_repl.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-m44xe_n14_cli_repl.tgz
+        local_file: src/nyc-output-darwin_unit-m44xe_n14_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m44xe_n14_cli_repl.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -525,13 +525,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-m44xe_n14_cli_repl.tgz
+          tar xvzf nyc-output-darwin_unit-m44xe_n14_cli_repl.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-m50xc_n14_cli_repl.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-m50xc_n14_cli_repl.tgz
+        local_file: src/nyc-output-darwin_unit-m50xc_n14_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m50xc_n14_cli_repl.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -539,13 +539,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-m50xc_n14_cli_repl.tgz
+          tar xvzf nyc-output-darwin_unit-m50xc_n14_cli_repl.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-m50xe_n14_cli_repl.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-m50xe_n14_cli_repl.tgz
+        local_file: src/nyc-output-darwin_unit-m50xe_n14_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m50xe_n14_cli_repl.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -553,13 +553,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-m50xe_n14_cli_repl.tgz
+          tar xvzf nyc-output-darwin_unit-m50xe_n14_cli_repl.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-mlatest_n14_cli_repl.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-mlatest_n14_cli_repl.tgz
+        local_file: src/nyc-output-darwin_unit-mlatest_n14_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-mlatest_n14_cli_repl.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -567,13 +567,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-mlatest_n14_cli_repl.tgz
+          tar xvzf nyc-output-darwin_unit-mlatest_n14_cli_repl.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-n12_editor.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-n12_editor.tgz
+        local_file: src/nyc-output-darwin_unit-n12_editor.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-n12_editor.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -581,13 +581,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-n12_editor.tgz
+          tar xvzf nyc-output-darwin_unit-n12_editor.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-n14_editor.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-n14_editor.tgz
+        local_file: src/nyc-output-darwin_unit-n14_editor.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-n14_editor.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -595,13 +595,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-n14_editor.tgz
+          tar xvzf nyc-output-darwin_unit-n14_editor.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-n12_errors.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-n12_errors.tgz
+        local_file: src/nyc-output-darwin_unit-n12_errors.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-n12_errors.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -609,13 +609,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-n12_errors.tgz
+          tar xvzf nyc-output-darwin_unit-n12_errors.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-n14_errors.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-n14_errors.tgz
+        local_file: src/nyc-output-darwin_unit-n14_errors.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-n14_errors.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -623,13 +623,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-n14_errors.tgz
+          tar xvzf nyc-output-darwin_unit-n14_errors.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-n12_history.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-n12_history.tgz
+        local_file: src/nyc-output-darwin_unit-n12_history.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-n12_history.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -637,13 +637,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-n12_history.tgz
+          tar xvzf nyc-output-darwin_unit-n12_history.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-n14_history.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-n14_history.tgz
+        local_file: src/nyc-output-darwin_unit-n14_history.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-n14_history.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -651,13 +651,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-n14_history.tgz
+          tar xvzf nyc-output-darwin_unit-n14_history.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-n12_i18n.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-n12_i18n.tgz
+        local_file: src/nyc-output-darwin_unit-n12_i18n.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-n12_i18n.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -665,13 +665,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-n12_i18n.tgz
+          tar xvzf nyc-output-darwin_unit-n12_i18n.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-n14_i18n.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-n14_i18n.tgz
+        local_file: src/nyc-output-darwin_unit-n14_i18n.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-n14_i18n.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -679,13 +679,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-n14_i18n.tgz
+          tar xvzf nyc-output-darwin_unit-n14_i18n.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-n12_js_multiline_to_singleline.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-n12_js_multiline_to_singleline.tgz
+        local_file: src/nyc-output-darwin_unit-n12_js_multiline_to_singleline.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-n12_js_multiline_to_singleline.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -693,13 +693,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-n12_js_multiline_to_singleline.tgz
+          tar xvzf nyc-output-darwin_unit-n12_js_multiline_to_singleline.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-n14_js_multiline_to_singleline.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-n14_js_multiline_to_singleline.tgz
+        local_file: src/nyc-output-darwin_unit-n14_js_multiline_to_singleline.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-n14_js_multiline_to_singleline.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -707,13 +707,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-n14_js_multiline_to_singleline.tgz
+          tar xvzf nyc-output-darwin_unit-n14_js_multiline_to_singleline.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-n12_logging.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-n12_logging.tgz
+        local_file: src/nyc-output-darwin_unit-n12_logging.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-n12_logging.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -721,13 +721,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-n12_logging.tgz
+          tar xvzf nyc-output-darwin_unit-n12_logging.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-n14_logging.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-n14_logging.tgz
+        local_file: src/nyc-output-darwin_unit-n14_logging.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-n14_logging.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -735,13 +735,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-n14_logging.tgz
+          tar xvzf nyc-output-darwin_unit-n14_logging.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-m40xc_n12_node_runtime_worker_thread.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-m40xc_n12_node_runtime_worker_thread.tgz
+        local_file: src/nyc-output-darwin_unit-m40xc_n12_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m40xc_n12_node_runtime_worker_thread.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -749,13 +749,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-m40xc_n12_node_runtime_worker_thread.tgz
+          tar xvzf nyc-output-darwin_unit-m40xc_n12_node_runtime_worker_thread.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-m40xe_n12_node_runtime_worker_thread.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-m40xe_n12_node_runtime_worker_thread.tgz
+        local_file: src/nyc-output-darwin_unit-m40xe_n12_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m40xe_n12_node_runtime_worker_thread.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -763,13 +763,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-m40xe_n12_node_runtime_worker_thread.tgz
+          tar xvzf nyc-output-darwin_unit-m40xe_n12_node_runtime_worker_thread.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-m42xc_n12_node_runtime_worker_thread.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-m42xc_n12_node_runtime_worker_thread.tgz
+        local_file: src/nyc-output-darwin_unit-m42xc_n12_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m42xc_n12_node_runtime_worker_thread.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -777,13 +777,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-m42xc_n12_node_runtime_worker_thread.tgz
+          tar xvzf nyc-output-darwin_unit-m42xc_n12_node_runtime_worker_thread.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-m42xe_n12_node_runtime_worker_thread.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-m42xe_n12_node_runtime_worker_thread.tgz
+        local_file: src/nyc-output-darwin_unit-m42xe_n12_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m42xe_n12_node_runtime_worker_thread.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -791,13 +791,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-m42xe_n12_node_runtime_worker_thread.tgz
+          tar xvzf nyc-output-darwin_unit-m42xe_n12_node_runtime_worker_thread.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-m44xc_n12_node_runtime_worker_thread.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-m44xc_n12_node_runtime_worker_thread.tgz
+        local_file: src/nyc-output-darwin_unit-m44xc_n12_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m44xc_n12_node_runtime_worker_thread.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -805,13 +805,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-m44xc_n12_node_runtime_worker_thread.tgz
+          tar xvzf nyc-output-darwin_unit-m44xc_n12_node_runtime_worker_thread.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-m44xe_n12_node_runtime_worker_thread.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-m44xe_n12_node_runtime_worker_thread.tgz
+        local_file: src/nyc-output-darwin_unit-m44xe_n12_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m44xe_n12_node_runtime_worker_thread.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -819,13 +819,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-m44xe_n12_node_runtime_worker_thread.tgz
+          tar xvzf nyc-output-darwin_unit-m44xe_n12_node_runtime_worker_thread.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-m50xc_n12_node_runtime_worker_thread.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-m50xc_n12_node_runtime_worker_thread.tgz
+        local_file: src/nyc-output-darwin_unit-m50xc_n12_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m50xc_n12_node_runtime_worker_thread.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -833,13 +833,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-m50xc_n12_node_runtime_worker_thread.tgz
+          tar xvzf nyc-output-darwin_unit-m50xc_n12_node_runtime_worker_thread.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-m50xe_n12_node_runtime_worker_thread.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-m50xe_n12_node_runtime_worker_thread.tgz
+        local_file: src/nyc-output-darwin_unit-m50xe_n12_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m50xe_n12_node_runtime_worker_thread.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -847,13 +847,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-m50xe_n12_node_runtime_worker_thread.tgz
+          tar xvzf nyc-output-darwin_unit-m50xe_n12_node_runtime_worker_thread.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-mlatest_n12_node_runtime_worker_thread.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-mlatest_n12_node_runtime_worker_thread.tgz
+        local_file: src/nyc-output-darwin_unit-mlatest_n12_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-mlatest_n12_node_runtime_worker_thread.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -861,13 +861,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-mlatest_n12_node_runtime_worker_thread.tgz
+          tar xvzf nyc-output-darwin_unit-mlatest_n12_node_runtime_worker_thread.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-m40xc_n14_node_runtime_worker_thread.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-m40xc_n14_node_runtime_worker_thread.tgz
+        local_file: src/nyc-output-darwin_unit-m40xc_n14_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m40xc_n14_node_runtime_worker_thread.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -875,13 +875,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-m40xc_n14_node_runtime_worker_thread.tgz
+          tar xvzf nyc-output-darwin_unit-m40xc_n14_node_runtime_worker_thread.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-m40xe_n14_node_runtime_worker_thread.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-m40xe_n14_node_runtime_worker_thread.tgz
+        local_file: src/nyc-output-darwin_unit-m40xe_n14_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m40xe_n14_node_runtime_worker_thread.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -889,13 +889,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-m40xe_n14_node_runtime_worker_thread.tgz
+          tar xvzf nyc-output-darwin_unit-m40xe_n14_node_runtime_worker_thread.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-m42xc_n14_node_runtime_worker_thread.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-m42xc_n14_node_runtime_worker_thread.tgz
+        local_file: src/nyc-output-darwin_unit-m42xc_n14_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m42xc_n14_node_runtime_worker_thread.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -903,13 +903,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-m42xc_n14_node_runtime_worker_thread.tgz
+          tar xvzf nyc-output-darwin_unit-m42xc_n14_node_runtime_worker_thread.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-m42xe_n14_node_runtime_worker_thread.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-m42xe_n14_node_runtime_worker_thread.tgz
+        local_file: src/nyc-output-darwin_unit-m42xe_n14_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m42xe_n14_node_runtime_worker_thread.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -917,13 +917,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-m42xe_n14_node_runtime_worker_thread.tgz
+          tar xvzf nyc-output-darwin_unit-m42xe_n14_node_runtime_worker_thread.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-m44xc_n14_node_runtime_worker_thread.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-m44xc_n14_node_runtime_worker_thread.tgz
+        local_file: src/nyc-output-darwin_unit-m44xc_n14_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m44xc_n14_node_runtime_worker_thread.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -931,13 +931,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-m44xc_n14_node_runtime_worker_thread.tgz
+          tar xvzf nyc-output-darwin_unit-m44xc_n14_node_runtime_worker_thread.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-m44xe_n14_node_runtime_worker_thread.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-m44xe_n14_node_runtime_worker_thread.tgz
+        local_file: src/nyc-output-darwin_unit-m44xe_n14_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m44xe_n14_node_runtime_worker_thread.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -945,13 +945,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-m44xe_n14_node_runtime_worker_thread.tgz
+          tar xvzf nyc-output-darwin_unit-m44xe_n14_node_runtime_worker_thread.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-m50xc_n14_node_runtime_worker_thread.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-m50xc_n14_node_runtime_worker_thread.tgz
+        local_file: src/nyc-output-darwin_unit-m50xc_n14_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m50xc_n14_node_runtime_worker_thread.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -959,13 +959,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-m50xc_n14_node_runtime_worker_thread.tgz
+          tar xvzf nyc-output-darwin_unit-m50xc_n14_node_runtime_worker_thread.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-m50xe_n14_node_runtime_worker_thread.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-m50xe_n14_node_runtime_worker_thread.tgz
+        local_file: src/nyc-output-darwin_unit-m50xe_n14_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m50xe_n14_node_runtime_worker_thread.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -973,13 +973,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-m50xe_n14_node_runtime_worker_thread.tgz
+          tar xvzf nyc-output-darwin_unit-m50xe_n14_node_runtime_worker_thread.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-mlatest_n14_node_runtime_worker_thread.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-mlatest_n14_node_runtime_worker_thread.tgz
+        local_file: src/nyc-output-darwin_unit-mlatest_n14_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-mlatest_n14_node_runtime_worker_thread.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -987,13 +987,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-mlatest_n14_node_runtime_worker_thread.tgz
+          tar xvzf nyc-output-darwin_unit-mlatest_n14_node_runtime_worker_thread.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-n12_service_provider_core.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-n12_service_provider_core.tgz
+        local_file: src/nyc-output-darwin_unit-n12_service_provider_core.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-n12_service_provider_core.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1001,13 +1001,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-n12_service_provider_core.tgz
+          tar xvzf nyc-output-darwin_unit-n12_service_provider_core.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-n14_service_provider_core.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-n14_service_provider_core.tgz
+        local_file: src/nyc-output-darwin_unit-n14_service_provider_core.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-n14_service_provider_core.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1015,13 +1015,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-n14_service_provider_core.tgz
+          tar xvzf nyc-output-darwin_unit-n14_service_provider_core.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-m40xc_n12_service_provider_server.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-m40xc_n12_service_provider_server.tgz
+        local_file: src/nyc-output-darwin_unit-m40xc_n12_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m40xc_n12_service_provider_server.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1029,13 +1029,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-m40xc_n12_service_provider_server.tgz
+          tar xvzf nyc-output-darwin_unit-m40xc_n12_service_provider_server.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-m40xe_n12_service_provider_server.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-m40xe_n12_service_provider_server.tgz
+        local_file: src/nyc-output-darwin_unit-m40xe_n12_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m40xe_n12_service_provider_server.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1043,13 +1043,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-m40xe_n12_service_provider_server.tgz
+          tar xvzf nyc-output-darwin_unit-m40xe_n12_service_provider_server.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-m42xc_n12_service_provider_server.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-m42xc_n12_service_provider_server.tgz
+        local_file: src/nyc-output-darwin_unit-m42xc_n12_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m42xc_n12_service_provider_server.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1057,13 +1057,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-m42xc_n12_service_provider_server.tgz
+          tar xvzf nyc-output-darwin_unit-m42xc_n12_service_provider_server.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-m42xe_n12_service_provider_server.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-m42xe_n12_service_provider_server.tgz
+        local_file: src/nyc-output-darwin_unit-m42xe_n12_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m42xe_n12_service_provider_server.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1071,13 +1071,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-m42xe_n12_service_provider_server.tgz
+          tar xvzf nyc-output-darwin_unit-m42xe_n12_service_provider_server.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-m44xc_n12_service_provider_server.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-m44xc_n12_service_provider_server.tgz
+        local_file: src/nyc-output-darwin_unit-m44xc_n12_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m44xc_n12_service_provider_server.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1085,13 +1085,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-m44xc_n12_service_provider_server.tgz
+          tar xvzf nyc-output-darwin_unit-m44xc_n12_service_provider_server.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-m44xe_n12_service_provider_server.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-m44xe_n12_service_provider_server.tgz
+        local_file: src/nyc-output-darwin_unit-m44xe_n12_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m44xe_n12_service_provider_server.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1099,13 +1099,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-m44xe_n12_service_provider_server.tgz
+          tar xvzf nyc-output-darwin_unit-m44xe_n12_service_provider_server.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-m50xc_n12_service_provider_server.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-m50xc_n12_service_provider_server.tgz
+        local_file: src/nyc-output-darwin_unit-m50xc_n12_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m50xc_n12_service_provider_server.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1113,13 +1113,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-m50xc_n12_service_provider_server.tgz
+          tar xvzf nyc-output-darwin_unit-m50xc_n12_service_provider_server.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-m50xe_n12_service_provider_server.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-m50xe_n12_service_provider_server.tgz
+        local_file: src/nyc-output-darwin_unit-m50xe_n12_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m50xe_n12_service_provider_server.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1127,13 +1127,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-m50xe_n12_service_provider_server.tgz
+          tar xvzf nyc-output-darwin_unit-m50xe_n12_service_provider_server.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-mlatest_n12_service_provider_server.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-mlatest_n12_service_provider_server.tgz
+        local_file: src/nyc-output-darwin_unit-mlatest_n12_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-mlatest_n12_service_provider_server.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1141,13 +1141,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-mlatest_n12_service_provider_server.tgz
+          tar xvzf nyc-output-darwin_unit-mlatest_n12_service_provider_server.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-m40xc_n14_service_provider_server.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-m40xc_n14_service_provider_server.tgz
+        local_file: src/nyc-output-darwin_unit-m40xc_n14_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m40xc_n14_service_provider_server.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1155,13 +1155,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-m40xc_n14_service_provider_server.tgz
+          tar xvzf nyc-output-darwin_unit-m40xc_n14_service_provider_server.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-m40xe_n14_service_provider_server.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-m40xe_n14_service_provider_server.tgz
+        local_file: src/nyc-output-darwin_unit-m40xe_n14_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m40xe_n14_service_provider_server.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1169,13 +1169,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-m40xe_n14_service_provider_server.tgz
+          tar xvzf nyc-output-darwin_unit-m40xe_n14_service_provider_server.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-m42xc_n14_service_provider_server.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-m42xc_n14_service_provider_server.tgz
+        local_file: src/nyc-output-darwin_unit-m42xc_n14_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m42xc_n14_service_provider_server.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1183,13 +1183,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-m42xc_n14_service_provider_server.tgz
+          tar xvzf nyc-output-darwin_unit-m42xc_n14_service_provider_server.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-m42xe_n14_service_provider_server.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-m42xe_n14_service_provider_server.tgz
+        local_file: src/nyc-output-darwin_unit-m42xe_n14_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m42xe_n14_service_provider_server.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1197,13 +1197,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-m42xe_n14_service_provider_server.tgz
+          tar xvzf nyc-output-darwin_unit-m42xe_n14_service_provider_server.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-m44xc_n14_service_provider_server.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-m44xc_n14_service_provider_server.tgz
+        local_file: src/nyc-output-darwin_unit-m44xc_n14_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m44xc_n14_service_provider_server.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1211,13 +1211,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-m44xc_n14_service_provider_server.tgz
+          tar xvzf nyc-output-darwin_unit-m44xc_n14_service_provider_server.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-m44xe_n14_service_provider_server.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-m44xe_n14_service_provider_server.tgz
+        local_file: src/nyc-output-darwin_unit-m44xe_n14_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m44xe_n14_service_provider_server.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1225,13 +1225,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-m44xe_n14_service_provider_server.tgz
+          tar xvzf nyc-output-darwin_unit-m44xe_n14_service_provider_server.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-m50xc_n14_service_provider_server.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-m50xc_n14_service_provider_server.tgz
+        local_file: src/nyc-output-darwin_unit-m50xc_n14_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m50xc_n14_service_provider_server.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1239,13 +1239,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-m50xc_n14_service_provider_server.tgz
+          tar xvzf nyc-output-darwin_unit-m50xc_n14_service_provider_server.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-m50xe_n14_service_provider_server.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-m50xe_n14_service_provider_server.tgz
+        local_file: src/nyc-output-darwin_unit-m50xe_n14_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m50xe_n14_service_provider_server.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1253,13 +1253,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-m50xe_n14_service_provider_server.tgz
+          tar xvzf nyc-output-darwin_unit-m50xe_n14_service_provider_server.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-mlatest_n14_service_provider_server.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-mlatest_n14_service_provider_server.tgz
+        local_file: src/nyc-output-darwin_unit-mlatest_n14_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-mlatest_n14_service_provider_server.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1267,13 +1267,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-mlatest_n14_service_provider_server.tgz
+          tar xvzf nyc-output-darwin_unit-mlatest_n14_service_provider_server.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-m40xc_n12_shell_api.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-m40xc_n12_shell_api.tgz
+        local_file: src/nyc-output-darwin_unit-m40xc_n12_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m40xc_n12_shell_api.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1281,13 +1281,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-m40xc_n12_shell_api.tgz
+          tar xvzf nyc-output-darwin_unit-m40xc_n12_shell_api.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-m40xe_n12_shell_api.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-m40xe_n12_shell_api.tgz
+        local_file: src/nyc-output-darwin_unit-m40xe_n12_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m40xe_n12_shell_api.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1295,13 +1295,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-m40xe_n12_shell_api.tgz
+          tar xvzf nyc-output-darwin_unit-m40xe_n12_shell_api.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-m42xc_n12_shell_api.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-m42xc_n12_shell_api.tgz
+        local_file: src/nyc-output-darwin_unit-m42xc_n12_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m42xc_n12_shell_api.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1309,13 +1309,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-m42xc_n12_shell_api.tgz
+          tar xvzf nyc-output-darwin_unit-m42xc_n12_shell_api.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-m42xe_n12_shell_api.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-m42xe_n12_shell_api.tgz
+        local_file: src/nyc-output-darwin_unit-m42xe_n12_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m42xe_n12_shell_api.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1323,13 +1323,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-m42xe_n12_shell_api.tgz
+          tar xvzf nyc-output-darwin_unit-m42xe_n12_shell_api.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-m44xc_n12_shell_api.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-m44xc_n12_shell_api.tgz
+        local_file: src/nyc-output-darwin_unit-m44xc_n12_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m44xc_n12_shell_api.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1337,13 +1337,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-m44xc_n12_shell_api.tgz
+          tar xvzf nyc-output-darwin_unit-m44xc_n12_shell_api.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-m44xe_n12_shell_api.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-m44xe_n12_shell_api.tgz
+        local_file: src/nyc-output-darwin_unit-m44xe_n12_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m44xe_n12_shell_api.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1351,13 +1351,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-m44xe_n12_shell_api.tgz
+          tar xvzf nyc-output-darwin_unit-m44xe_n12_shell_api.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-m50xc_n12_shell_api.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-m50xc_n12_shell_api.tgz
+        local_file: src/nyc-output-darwin_unit-m50xc_n12_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m50xc_n12_shell_api.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1365,13 +1365,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-m50xc_n12_shell_api.tgz
+          tar xvzf nyc-output-darwin_unit-m50xc_n12_shell_api.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-m50xe_n12_shell_api.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-m50xe_n12_shell_api.tgz
+        local_file: src/nyc-output-darwin_unit-m50xe_n12_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m50xe_n12_shell_api.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1379,13 +1379,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-m50xe_n12_shell_api.tgz
+          tar xvzf nyc-output-darwin_unit-m50xe_n12_shell_api.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-mlatest_n12_shell_api.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-mlatest_n12_shell_api.tgz
+        local_file: src/nyc-output-darwin_unit-mlatest_n12_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-mlatest_n12_shell_api.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1393,13 +1393,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-mlatest_n12_shell_api.tgz
+          tar xvzf nyc-output-darwin_unit-mlatest_n12_shell_api.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-m40xc_n14_shell_api.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-m40xc_n14_shell_api.tgz
+        local_file: src/nyc-output-darwin_unit-m40xc_n14_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m40xc_n14_shell_api.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1407,13 +1407,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-m40xc_n14_shell_api.tgz
+          tar xvzf nyc-output-darwin_unit-m40xc_n14_shell_api.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-m40xe_n14_shell_api.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-m40xe_n14_shell_api.tgz
+        local_file: src/nyc-output-darwin_unit-m40xe_n14_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m40xe_n14_shell_api.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1421,13 +1421,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-m40xe_n14_shell_api.tgz
+          tar xvzf nyc-output-darwin_unit-m40xe_n14_shell_api.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-m42xc_n14_shell_api.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-m42xc_n14_shell_api.tgz
+        local_file: src/nyc-output-darwin_unit-m42xc_n14_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m42xc_n14_shell_api.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1435,13 +1435,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-m42xc_n14_shell_api.tgz
+          tar xvzf nyc-output-darwin_unit-m42xc_n14_shell_api.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-m42xe_n14_shell_api.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-m42xe_n14_shell_api.tgz
+        local_file: src/nyc-output-darwin_unit-m42xe_n14_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m42xe_n14_shell_api.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1449,13 +1449,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-m42xe_n14_shell_api.tgz
+          tar xvzf nyc-output-darwin_unit-m42xe_n14_shell_api.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-m44xc_n14_shell_api.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-m44xc_n14_shell_api.tgz
+        local_file: src/nyc-output-darwin_unit-m44xc_n14_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m44xc_n14_shell_api.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1463,13 +1463,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-m44xc_n14_shell_api.tgz
+          tar xvzf nyc-output-darwin_unit-m44xc_n14_shell_api.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-m44xe_n14_shell_api.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-m44xe_n14_shell_api.tgz
+        local_file: src/nyc-output-darwin_unit-m44xe_n14_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m44xe_n14_shell_api.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1477,13 +1477,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-m44xe_n14_shell_api.tgz
+          tar xvzf nyc-output-darwin_unit-m44xe_n14_shell_api.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-m50xc_n14_shell_api.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-m50xc_n14_shell_api.tgz
+        local_file: src/nyc-output-darwin_unit-m50xc_n14_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m50xc_n14_shell_api.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1491,13 +1491,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-m50xc_n14_shell_api.tgz
+          tar xvzf nyc-output-darwin_unit-m50xc_n14_shell_api.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-m50xe_n14_shell_api.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-m50xe_n14_shell_api.tgz
+        local_file: src/nyc-output-darwin_unit-m50xe_n14_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m50xe_n14_shell_api.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1505,13 +1505,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-m50xe_n14_shell_api.tgz
+          tar xvzf nyc-output-darwin_unit-m50xe_n14_shell_api.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-mlatest_n14_shell_api.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-mlatest_n14_shell_api.tgz
+        local_file: src/nyc-output-darwin_unit-mlatest_n14_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-mlatest_n14_shell_api.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1519,13 +1519,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-mlatest_n14_shell_api.tgz
+          tar xvzf nyc-output-darwin_unit-mlatest_n14_shell_api.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-n12_shell_evaluator.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-n12_shell_evaluator.tgz
+        local_file: src/nyc-output-darwin_unit-n12_shell_evaluator.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-n12_shell_evaluator.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1533,13 +1533,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-n12_shell_evaluator.tgz
+          tar xvzf nyc-output-darwin_unit-n12_shell_evaluator.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-n14_shell_evaluator.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-n14_shell_evaluator.tgz
+        local_file: src/nyc-output-darwin_unit-n14_shell_evaluator.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-n14_shell_evaluator.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1547,13 +1547,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-n14_shell_evaluator.tgz
+          tar xvzf nyc-output-darwin_unit-n14_shell_evaluator.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-n12_snippet_manager.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-n12_snippet_manager.tgz
+        local_file: src/nyc-output-darwin_unit-n12_snippet_manager.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-n12_snippet_manager.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1561,13 +1561,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-n12_snippet_manager.tgz
+          tar xvzf nyc-output-darwin_unit-n12_snippet_manager.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-n14_snippet_manager.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-n14_snippet_manager.tgz
+        local_file: src/nyc-output-darwin_unit-n14_snippet_manager.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-n14_snippet_manager.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1575,13 +1575,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-n14_snippet_manager.tgz
+          tar xvzf nyc-output-darwin_unit-n14_snippet_manager.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-n12_types.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-n12_types.tgz
+        local_file: src/nyc-output-darwin_unit-n12_types.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-n12_types.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1589,13 +1589,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-n12_types.tgz
+          tar xvzf nyc-output-darwin_unit-n12_types.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-darwin-n14_types.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin-n14_types.tgz
+        local_file: src/nyc-output-darwin_unit-n14_types.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-n14_types.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1603,13 +1603,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-darwin-n14_types.tgz
+          tar xvzf nyc-output-darwin_unit-n14_types.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-n12_arg_parser.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-n12_arg_parser.tgz
+        local_file: src/nyc-output-linux_unit-n12_arg_parser.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-n12_arg_parser.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1617,13 +1617,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-n12_arg_parser.tgz
+          tar xvzf nyc-output-linux_unit-n12_arg_parser.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-n14_arg_parser.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-n14_arg_parser.tgz
+        local_file: src/nyc-output-linux_unit-n14_arg_parser.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-n14_arg_parser.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1631,13 +1631,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-n14_arg_parser.tgz
+          tar xvzf nyc-output-linux_unit-n14_arg_parser.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-n12_async_rewriter2.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-n12_async_rewriter2.tgz
+        local_file: src/nyc-output-linux_unit-n12_async_rewriter2.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-n12_async_rewriter2.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1645,13 +1645,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-n12_async_rewriter2.tgz
+          tar xvzf nyc-output-linux_unit-n12_async_rewriter2.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-n14_async_rewriter2.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-n14_async_rewriter2.tgz
+        local_file: src/nyc-output-linux_unit-n14_async_rewriter2.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-n14_async_rewriter2.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1659,13 +1659,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-n14_async_rewriter2.tgz
+          tar xvzf nyc-output-linux_unit-n14_async_rewriter2.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-n12_autocomplete.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-n12_autocomplete.tgz
+        local_file: src/nyc-output-linux_unit-n12_autocomplete.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-n12_autocomplete.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1673,13 +1673,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-n12_autocomplete.tgz
+          tar xvzf nyc-output-linux_unit-n12_autocomplete.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-n14_autocomplete.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-n14_autocomplete.tgz
+        local_file: src/nyc-output-linux_unit-n14_autocomplete.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-n14_autocomplete.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1687,13 +1687,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-n14_autocomplete.tgz
+          tar xvzf nyc-output-linux_unit-n14_autocomplete.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-n12_browser_runtime_core.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-n12_browser_runtime_core.tgz
+        local_file: src/nyc-output-linux_unit-n12_browser_runtime_core.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-n12_browser_runtime_core.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1701,13 +1701,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-n12_browser_runtime_core.tgz
+          tar xvzf nyc-output-linux_unit-n12_browser_runtime_core.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-n14_browser_runtime_core.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-n14_browser_runtime_core.tgz
+        local_file: src/nyc-output-linux_unit-n14_browser_runtime_core.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-n14_browser_runtime_core.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1715,13 +1715,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-n14_browser_runtime_core.tgz
+          tar xvzf nyc-output-linux_unit-n14_browser_runtime_core.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-n12_browser_runtime_electron.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-n12_browser_runtime_electron.tgz
+        local_file: src/nyc-output-linux_unit-n12_browser_runtime_electron.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-n12_browser_runtime_electron.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1729,13 +1729,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-n12_browser_runtime_electron.tgz
+          tar xvzf nyc-output-linux_unit-n12_browser_runtime_electron.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-n14_browser_runtime_electron.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-n14_browser_runtime_electron.tgz
+        local_file: src/nyc-output-linux_unit-n14_browser_runtime_electron.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-n14_browser_runtime_electron.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1743,13 +1743,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-n14_browser_runtime_electron.tgz
+          tar xvzf nyc-output-linux_unit-n14_browser_runtime_electron.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-n12_build.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-n12_build.tgz
+        local_file: src/nyc-output-linux_unit-n12_build.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-n12_build.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1757,13 +1757,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-n12_build.tgz
+          tar xvzf nyc-output-linux_unit-n12_build.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-n14_build.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-n14_build.tgz
+        local_file: src/nyc-output-linux_unit-n14_build.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-n14_build.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1771,13 +1771,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-n14_build.tgz
+          tar xvzf nyc-output-linux_unit-n14_build.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m40xc_n12_cli_repl.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m40xc_n12_cli_repl.tgz
+        local_file: src/nyc-output-linux_unit-m40xc_n12_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m40xc_n12_cli_repl.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1785,13 +1785,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m40xc_n12_cli_repl.tgz
+          tar xvzf nyc-output-linux_unit-m40xc_n12_cli_repl.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m40xe_n12_cli_repl.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m40xe_n12_cli_repl.tgz
+        local_file: src/nyc-output-linux_unit-m40xe_n12_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m40xe_n12_cli_repl.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1799,13 +1799,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m40xe_n12_cli_repl.tgz
+          tar xvzf nyc-output-linux_unit-m40xe_n12_cli_repl.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m42xc_n12_cli_repl.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m42xc_n12_cli_repl.tgz
+        local_file: src/nyc-output-linux_unit-m42xc_n12_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m42xc_n12_cli_repl.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1813,13 +1813,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m42xc_n12_cli_repl.tgz
+          tar xvzf nyc-output-linux_unit-m42xc_n12_cli_repl.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m42xe_n12_cli_repl.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m42xe_n12_cli_repl.tgz
+        local_file: src/nyc-output-linux_unit-m42xe_n12_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m42xe_n12_cli_repl.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1827,13 +1827,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m42xe_n12_cli_repl.tgz
+          tar xvzf nyc-output-linux_unit-m42xe_n12_cli_repl.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m44xc_n12_cli_repl.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m44xc_n12_cli_repl.tgz
+        local_file: src/nyc-output-linux_unit-m44xc_n12_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m44xc_n12_cli_repl.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1841,13 +1841,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m44xc_n12_cli_repl.tgz
+          tar xvzf nyc-output-linux_unit-m44xc_n12_cli_repl.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m44xe_n12_cli_repl.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m44xe_n12_cli_repl.tgz
+        local_file: src/nyc-output-linux_unit-m44xe_n12_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m44xe_n12_cli_repl.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1855,13 +1855,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m44xe_n12_cli_repl.tgz
+          tar xvzf nyc-output-linux_unit-m44xe_n12_cli_repl.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m50xc_n12_cli_repl.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m50xc_n12_cli_repl.tgz
+        local_file: src/nyc-output-linux_unit-m50xc_n12_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m50xc_n12_cli_repl.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1869,13 +1869,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m50xc_n12_cli_repl.tgz
+          tar xvzf nyc-output-linux_unit-m50xc_n12_cli_repl.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m50xe_n12_cli_repl.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m50xe_n12_cli_repl.tgz
+        local_file: src/nyc-output-linux_unit-m50xe_n12_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m50xe_n12_cli_repl.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1883,13 +1883,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m50xe_n12_cli_repl.tgz
+          tar xvzf nyc-output-linux_unit-m50xe_n12_cli_repl.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-mlatest_n12_cli_repl.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-mlatest_n12_cli_repl.tgz
+        local_file: src/nyc-output-linux_unit-mlatest_n12_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-mlatest_n12_cli_repl.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1897,13 +1897,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-mlatest_n12_cli_repl.tgz
+          tar xvzf nyc-output-linux_unit-mlatest_n12_cli_repl.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m40xc_n14_cli_repl.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m40xc_n14_cli_repl.tgz
+        local_file: src/nyc-output-linux_unit-m40xc_n14_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m40xc_n14_cli_repl.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1911,13 +1911,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m40xc_n14_cli_repl.tgz
+          tar xvzf nyc-output-linux_unit-m40xc_n14_cli_repl.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m40xe_n14_cli_repl.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m40xe_n14_cli_repl.tgz
+        local_file: src/nyc-output-linux_unit-m40xe_n14_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m40xe_n14_cli_repl.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1925,13 +1925,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m40xe_n14_cli_repl.tgz
+          tar xvzf nyc-output-linux_unit-m40xe_n14_cli_repl.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m42xc_n14_cli_repl.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m42xc_n14_cli_repl.tgz
+        local_file: src/nyc-output-linux_unit-m42xc_n14_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m42xc_n14_cli_repl.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1939,13 +1939,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m42xc_n14_cli_repl.tgz
+          tar xvzf nyc-output-linux_unit-m42xc_n14_cli_repl.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m42xe_n14_cli_repl.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m42xe_n14_cli_repl.tgz
+        local_file: src/nyc-output-linux_unit-m42xe_n14_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m42xe_n14_cli_repl.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1953,13 +1953,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m42xe_n14_cli_repl.tgz
+          tar xvzf nyc-output-linux_unit-m42xe_n14_cli_repl.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m44xc_n14_cli_repl.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m44xc_n14_cli_repl.tgz
+        local_file: src/nyc-output-linux_unit-m44xc_n14_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m44xc_n14_cli_repl.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1967,13 +1967,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m44xc_n14_cli_repl.tgz
+          tar xvzf nyc-output-linux_unit-m44xc_n14_cli_repl.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m44xe_n14_cli_repl.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m44xe_n14_cli_repl.tgz
+        local_file: src/nyc-output-linux_unit-m44xe_n14_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m44xe_n14_cli_repl.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1981,13 +1981,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m44xe_n14_cli_repl.tgz
+          tar xvzf nyc-output-linux_unit-m44xe_n14_cli_repl.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m50xc_n14_cli_repl.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m50xc_n14_cli_repl.tgz
+        local_file: src/nyc-output-linux_unit-m50xc_n14_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m50xc_n14_cli_repl.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -1995,13 +1995,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m50xc_n14_cli_repl.tgz
+          tar xvzf nyc-output-linux_unit-m50xc_n14_cli_repl.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m50xe_n14_cli_repl.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m50xe_n14_cli_repl.tgz
+        local_file: src/nyc-output-linux_unit-m50xe_n14_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m50xe_n14_cli_repl.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2009,13 +2009,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m50xe_n14_cli_repl.tgz
+          tar xvzf nyc-output-linux_unit-m50xe_n14_cli_repl.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-mlatest_n14_cli_repl.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-mlatest_n14_cli_repl.tgz
+        local_file: src/nyc-output-linux_unit-mlatest_n14_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-mlatest_n14_cli_repl.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2023,13 +2023,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-mlatest_n14_cli_repl.tgz
+          tar xvzf nyc-output-linux_unit-mlatest_n14_cli_repl.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-n12_editor.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-n12_editor.tgz
+        local_file: src/nyc-output-linux_unit-n12_editor.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-n12_editor.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2037,13 +2037,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-n12_editor.tgz
+          tar xvzf nyc-output-linux_unit-n12_editor.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-n14_editor.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-n14_editor.tgz
+        local_file: src/nyc-output-linux_unit-n14_editor.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-n14_editor.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2051,13 +2051,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-n14_editor.tgz
+          tar xvzf nyc-output-linux_unit-n14_editor.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-n12_errors.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-n12_errors.tgz
+        local_file: src/nyc-output-linux_unit-n12_errors.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-n12_errors.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2065,13 +2065,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-n12_errors.tgz
+          tar xvzf nyc-output-linux_unit-n12_errors.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-n14_errors.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-n14_errors.tgz
+        local_file: src/nyc-output-linux_unit-n14_errors.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-n14_errors.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2079,13 +2079,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-n14_errors.tgz
+          tar xvzf nyc-output-linux_unit-n14_errors.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-n12_history.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-n12_history.tgz
+        local_file: src/nyc-output-linux_unit-n12_history.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-n12_history.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2093,13 +2093,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-n12_history.tgz
+          tar xvzf nyc-output-linux_unit-n12_history.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-n14_history.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-n14_history.tgz
+        local_file: src/nyc-output-linux_unit-n14_history.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-n14_history.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2107,13 +2107,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-n14_history.tgz
+          tar xvzf nyc-output-linux_unit-n14_history.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-n12_i18n.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-n12_i18n.tgz
+        local_file: src/nyc-output-linux_unit-n12_i18n.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-n12_i18n.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2121,13 +2121,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-n12_i18n.tgz
+          tar xvzf nyc-output-linux_unit-n12_i18n.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-n14_i18n.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-n14_i18n.tgz
+        local_file: src/nyc-output-linux_unit-n14_i18n.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-n14_i18n.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2135,13 +2135,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-n14_i18n.tgz
+          tar xvzf nyc-output-linux_unit-n14_i18n.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m40xc_n12_java_shell.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m40xc_n12_java_shell.tgz
+        local_file: src/nyc-output-linux_unit-m40xc_n12_java_shell.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m40xc_n12_java_shell.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2149,13 +2149,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m40xc_n12_java_shell.tgz
+          tar xvzf nyc-output-linux_unit-m40xc_n12_java_shell.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m40xe_n12_java_shell.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m40xe_n12_java_shell.tgz
+        local_file: src/nyc-output-linux_unit-m40xe_n12_java_shell.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m40xe_n12_java_shell.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2163,13 +2163,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m40xe_n12_java_shell.tgz
+          tar xvzf nyc-output-linux_unit-m40xe_n12_java_shell.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m42xc_n12_java_shell.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m42xc_n12_java_shell.tgz
+        local_file: src/nyc-output-linux_unit-m42xc_n12_java_shell.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m42xc_n12_java_shell.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2177,13 +2177,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m42xc_n12_java_shell.tgz
+          tar xvzf nyc-output-linux_unit-m42xc_n12_java_shell.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m42xe_n12_java_shell.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m42xe_n12_java_shell.tgz
+        local_file: src/nyc-output-linux_unit-m42xe_n12_java_shell.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m42xe_n12_java_shell.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2191,13 +2191,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m42xe_n12_java_shell.tgz
+          tar xvzf nyc-output-linux_unit-m42xe_n12_java_shell.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m44xc_n12_java_shell.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m44xc_n12_java_shell.tgz
+        local_file: src/nyc-output-linux_unit-m44xc_n12_java_shell.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m44xc_n12_java_shell.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2205,13 +2205,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m44xc_n12_java_shell.tgz
+          tar xvzf nyc-output-linux_unit-m44xc_n12_java_shell.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m44xe_n12_java_shell.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m44xe_n12_java_shell.tgz
+        local_file: src/nyc-output-linux_unit-m44xe_n12_java_shell.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m44xe_n12_java_shell.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2219,13 +2219,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m44xe_n12_java_shell.tgz
+          tar xvzf nyc-output-linux_unit-m44xe_n12_java_shell.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m50xc_n12_java_shell.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m50xc_n12_java_shell.tgz
+        local_file: src/nyc-output-linux_unit-m50xc_n12_java_shell.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m50xc_n12_java_shell.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2233,13 +2233,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m50xc_n12_java_shell.tgz
+          tar xvzf nyc-output-linux_unit-m50xc_n12_java_shell.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m50xe_n12_java_shell.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m50xe_n12_java_shell.tgz
+        local_file: src/nyc-output-linux_unit-m50xe_n12_java_shell.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m50xe_n12_java_shell.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2247,13 +2247,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m50xe_n12_java_shell.tgz
+          tar xvzf nyc-output-linux_unit-m50xe_n12_java_shell.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-mlatest_n12_java_shell.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-mlatest_n12_java_shell.tgz
+        local_file: src/nyc-output-linux_unit-mlatest_n12_java_shell.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-mlatest_n12_java_shell.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2261,13 +2261,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-mlatest_n12_java_shell.tgz
+          tar xvzf nyc-output-linux_unit-mlatest_n12_java_shell.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m40xc_n14_java_shell.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m40xc_n14_java_shell.tgz
+        local_file: src/nyc-output-linux_unit-m40xc_n14_java_shell.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m40xc_n14_java_shell.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2275,13 +2275,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m40xc_n14_java_shell.tgz
+          tar xvzf nyc-output-linux_unit-m40xc_n14_java_shell.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m40xe_n14_java_shell.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m40xe_n14_java_shell.tgz
+        local_file: src/nyc-output-linux_unit-m40xe_n14_java_shell.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m40xe_n14_java_shell.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2289,13 +2289,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m40xe_n14_java_shell.tgz
+          tar xvzf nyc-output-linux_unit-m40xe_n14_java_shell.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m42xc_n14_java_shell.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m42xc_n14_java_shell.tgz
+        local_file: src/nyc-output-linux_unit-m42xc_n14_java_shell.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m42xc_n14_java_shell.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2303,13 +2303,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m42xc_n14_java_shell.tgz
+          tar xvzf nyc-output-linux_unit-m42xc_n14_java_shell.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m42xe_n14_java_shell.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m42xe_n14_java_shell.tgz
+        local_file: src/nyc-output-linux_unit-m42xe_n14_java_shell.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m42xe_n14_java_shell.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2317,13 +2317,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m42xe_n14_java_shell.tgz
+          tar xvzf nyc-output-linux_unit-m42xe_n14_java_shell.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m44xc_n14_java_shell.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m44xc_n14_java_shell.tgz
+        local_file: src/nyc-output-linux_unit-m44xc_n14_java_shell.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m44xc_n14_java_shell.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2331,13 +2331,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m44xc_n14_java_shell.tgz
+          tar xvzf nyc-output-linux_unit-m44xc_n14_java_shell.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m44xe_n14_java_shell.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m44xe_n14_java_shell.tgz
+        local_file: src/nyc-output-linux_unit-m44xe_n14_java_shell.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m44xe_n14_java_shell.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2345,13 +2345,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m44xe_n14_java_shell.tgz
+          tar xvzf nyc-output-linux_unit-m44xe_n14_java_shell.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m50xc_n14_java_shell.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m50xc_n14_java_shell.tgz
+        local_file: src/nyc-output-linux_unit-m50xc_n14_java_shell.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m50xc_n14_java_shell.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2359,13 +2359,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m50xc_n14_java_shell.tgz
+          tar xvzf nyc-output-linux_unit-m50xc_n14_java_shell.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m50xe_n14_java_shell.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m50xe_n14_java_shell.tgz
+        local_file: src/nyc-output-linux_unit-m50xe_n14_java_shell.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m50xe_n14_java_shell.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2373,13 +2373,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m50xe_n14_java_shell.tgz
+          tar xvzf nyc-output-linux_unit-m50xe_n14_java_shell.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-mlatest_n14_java_shell.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-mlatest_n14_java_shell.tgz
+        local_file: src/nyc-output-linux_unit-mlatest_n14_java_shell.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-mlatest_n14_java_shell.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2387,13 +2387,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-mlatest_n14_java_shell.tgz
+          tar xvzf nyc-output-linux_unit-mlatest_n14_java_shell.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-n12_js_multiline_to_singleline.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-n12_js_multiline_to_singleline.tgz
+        local_file: src/nyc-output-linux_unit-n12_js_multiline_to_singleline.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-n12_js_multiline_to_singleline.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2401,13 +2401,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-n12_js_multiline_to_singleline.tgz
+          tar xvzf nyc-output-linux_unit-n12_js_multiline_to_singleline.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-n14_js_multiline_to_singleline.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-n14_js_multiline_to_singleline.tgz
+        local_file: src/nyc-output-linux_unit-n14_js_multiline_to_singleline.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-n14_js_multiline_to_singleline.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2415,13 +2415,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-n14_js_multiline_to_singleline.tgz
+          tar xvzf nyc-output-linux_unit-n14_js_multiline_to_singleline.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-n12_logging.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-n12_logging.tgz
+        local_file: src/nyc-output-linux_unit-n12_logging.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-n12_logging.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2429,13 +2429,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-n12_logging.tgz
+          tar xvzf nyc-output-linux_unit-n12_logging.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-n14_logging.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-n14_logging.tgz
+        local_file: src/nyc-output-linux_unit-n14_logging.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-n14_logging.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2443,13 +2443,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-n14_logging.tgz
+          tar xvzf nyc-output-linux_unit-n14_logging.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m40xc_n12_node_runtime_worker_thread.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m40xc_n12_node_runtime_worker_thread.tgz
+        local_file: src/nyc-output-linux_unit-m40xc_n12_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m40xc_n12_node_runtime_worker_thread.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2457,13 +2457,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m40xc_n12_node_runtime_worker_thread.tgz
+          tar xvzf nyc-output-linux_unit-m40xc_n12_node_runtime_worker_thread.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m40xe_n12_node_runtime_worker_thread.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m40xe_n12_node_runtime_worker_thread.tgz
+        local_file: src/nyc-output-linux_unit-m40xe_n12_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m40xe_n12_node_runtime_worker_thread.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2471,13 +2471,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m40xe_n12_node_runtime_worker_thread.tgz
+          tar xvzf nyc-output-linux_unit-m40xe_n12_node_runtime_worker_thread.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m42xc_n12_node_runtime_worker_thread.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m42xc_n12_node_runtime_worker_thread.tgz
+        local_file: src/nyc-output-linux_unit-m42xc_n12_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m42xc_n12_node_runtime_worker_thread.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2485,13 +2485,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m42xc_n12_node_runtime_worker_thread.tgz
+          tar xvzf nyc-output-linux_unit-m42xc_n12_node_runtime_worker_thread.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m42xe_n12_node_runtime_worker_thread.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m42xe_n12_node_runtime_worker_thread.tgz
+        local_file: src/nyc-output-linux_unit-m42xe_n12_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m42xe_n12_node_runtime_worker_thread.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2499,13 +2499,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m42xe_n12_node_runtime_worker_thread.tgz
+          tar xvzf nyc-output-linux_unit-m42xe_n12_node_runtime_worker_thread.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m44xc_n12_node_runtime_worker_thread.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m44xc_n12_node_runtime_worker_thread.tgz
+        local_file: src/nyc-output-linux_unit-m44xc_n12_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m44xc_n12_node_runtime_worker_thread.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2513,13 +2513,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m44xc_n12_node_runtime_worker_thread.tgz
+          tar xvzf nyc-output-linux_unit-m44xc_n12_node_runtime_worker_thread.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m44xe_n12_node_runtime_worker_thread.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m44xe_n12_node_runtime_worker_thread.tgz
+        local_file: src/nyc-output-linux_unit-m44xe_n12_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m44xe_n12_node_runtime_worker_thread.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2527,13 +2527,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m44xe_n12_node_runtime_worker_thread.tgz
+          tar xvzf nyc-output-linux_unit-m44xe_n12_node_runtime_worker_thread.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m50xc_n12_node_runtime_worker_thread.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m50xc_n12_node_runtime_worker_thread.tgz
+        local_file: src/nyc-output-linux_unit-m50xc_n12_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m50xc_n12_node_runtime_worker_thread.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2541,13 +2541,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m50xc_n12_node_runtime_worker_thread.tgz
+          tar xvzf nyc-output-linux_unit-m50xc_n12_node_runtime_worker_thread.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m50xe_n12_node_runtime_worker_thread.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m50xe_n12_node_runtime_worker_thread.tgz
+        local_file: src/nyc-output-linux_unit-m50xe_n12_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m50xe_n12_node_runtime_worker_thread.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2555,13 +2555,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m50xe_n12_node_runtime_worker_thread.tgz
+          tar xvzf nyc-output-linux_unit-m50xe_n12_node_runtime_worker_thread.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-mlatest_n12_node_runtime_worker_thread.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-mlatest_n12_node_runtime_worker_thread.tgz
+        local_file: src/nyc-output-linux_unit-mlatest_n12_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-mlatest_n12_node_runtime_worker_thread.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2569,13 +2569,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-mlatest_n12_node_runtime_worker_thread.tgz
+          tar xvzf nyc-output-linux_unit-mlatest_n12_node_runtime_worker_thread.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m40xc_n14_node_runtime_worker_thread.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m40xc_n14_node_runtime_worker_thread.tgz
+        local_file: src/nyc-output-linux_unit-m40xc_n14_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m40xc_n14_node_runtime_worker_thread.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2583,13 +2583,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m40xc_n14_node_runtime_worker_thread.tgz
+          tar xvzf nyc-output-linux_unit-m40xc_n14_node_runtime_worker_thread.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m40xe_n14_node_runtime_worker_thread.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m40xe_n14_node_runtime_worker_thread.tgz
+        local_file: src/nyc-output-linux_unit-m40xe_n14_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m40xe_n14_node_runtime_worker_thread.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2597,13 +2597,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m40xe_n14_node_runtime_worker_thread.tgz
+          tar xvzf nyc-output-linux_unit-m40xe_n14_node_runtime_worker_thread.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m42xc_n14_node_runtime_worker_thread.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m42xc_n14_node_runtime_worker_thread.tgz
+        local_file: src/nyc-output-linux_unit-m42xc_n14_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m42xc_n14_node_runtime_worker_thread.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2611,13 +2611,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m42xc_n14_node_runtime_worker_thread.tgz
+          tar xvzf nyc-output-linux_unit-m42xc_n14_node_runtime_worker_thread.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m42xe_n14_node_runtime_worker_thread.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m42xe_n14_node_runtime_worker_thread.tgz
+        local_file: src/nyc-output-linux_unit-m42xe_n14_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m42xe_n14_node_runtime_worker_thread.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2625,13 +2625,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m42xe_n14_node_runtime_worker_thread.tgz
+          tar xvzf nyc-output-linux_unit-m42xe_n14_node_runtime_worker_thread.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m44xc_n14_node_runtime_worker_thread.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m44xc_n14_node_runtime_worker_thread.tgz
+        local_file: src/nyc-output-linux_unit-m44xc_n14_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m44xc_n14_node_runtime_worker_thread.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2639,13 +2639,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m44xc_n14_node_runtime_worker_thread.tgz
+          tar xvzf nyc-output-linux_unit-m44xc_n14_node_runtime_worker_thread.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m44xe_n14_node_runtime_worker_thread.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m44xe_n14_node_runtime_worker_thread.tgz
+        local_file: src/nyc-output-linux_unit-m44xe_n14_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m44xe_n14_node_runtime_worker_thread.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2653,13 +2653,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m44xe_n14_node_runtime_worker_thread.tgz
+          tar xvzf nyc-output-linux_unit-m44xe_n14_node_runtime_worker_thread.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m50xc_n14_node_runtime_worker_thread.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m50xc_n14_node_runtime_worker_thread.tgz
+        local_file: src/nyc-output-linux_unit-m50xc_n14_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m50xc_n14_node_runtime_worker_thread.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2667,13 +2667,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m50xc_n14_node_runtime_worker_thread.tgz
+          tar xvzf nyc-output-linux_unit-m50xc_n14_node_runtime_worker_thread.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m50xe_n14_node_runtime_worker_thread.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m50xe_n14_node_runtime_worker_thread.tgz
+        local_file: src/nyc-output-linux_unit-m50xe_n14_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m50xe_n14_node_runtime_worker_thread.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2681,13 +2681,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m50xe_n14_node_runtime_worker_thread.tgz
+          tar xvzf nyc-output-linux_unit-m50xe_n14_node_runtime_worker_thread.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-mlatest_n14_node_runtime_worker_thread.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-mlatest_n14_node_runtime_worker_thread.tgz
+        local_file: src/nyc-output-linux_unit-mlatest_n14_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-mlatest_n14_node_runtime_worker_thread.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2695,13 +2695,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-mlatest_n14_node_runtime_worker_thread.tgz
+          tar xvzf nyc-output-linux_unit-mlatest_n14_node_runtime_worker_thread.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-n12_service_provider_core.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-n12_service_provider_core.tgz
+        local_file: src/nyc-output-linux_unit-n12_service_provider_core.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-n12_service_provider_core.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2709,13 +2709,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-n12_service_provider_core.tgz
+          tar xvzf nyc-output-linux_unit-n12_service_provider_core.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-n14_service_provider_core.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-n14_service_provider_core.tgz
+        local_file: src/nyc-output-linux_unit-n14_service_provider_core.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-n14_service_provider_core.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2723,13 +2723,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-n14_service_provider_core.tgz
+          tar xvzf nyc-output-linux_unit-n14_service_provider_core.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m40xc_n12_service_provider_server.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m40xc_n12_service_provider_server.tgz
+        local_file: src/nyc-output-linux_unit-m40xc_n12_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m40xc_n12_service_provider_server.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2737,13 +2737,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m40xc_n12_service_provider_server.tgz
+          tar xvzf nyc-output-linux_unit-m40xc_n12_service_provider_server.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m40xe_n12_service_provider_server.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m40xe_n12_service_provider_server.tgz
+        local_file: src/nyc-output-linux_unit-m40xe_n12_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m40xe_n12_service_provider_server.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2751,13 +2751,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m40xe_n12_service_provider_server.tgz
+          tar xvzf nyc-output-linux_unit-m40xe_n12_service_provider_server.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m42xc_n12_service_provider_server.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m42xc_n12_service_provider_server.tgz
+        local_file: src/nyc-output-linux_unit-m42xc_n12_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m42xc_n12_service_provider_server.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2765,13 +2765,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m42xc_n12_service_provider_server.tgz
+          tar xvzf nyc-output-linux_unit-m42xc_n12_service_provider_server.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m42xe_n12_service_provider_server.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m42xe_n12_service_provider_server.tgz
+        local_file: src/nyc-output-linux_unit-m42xe_n12_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m42xe_n12_service_provider_server.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2779,13 +2779,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m42xe_n12_service_provider_server.tgz
+          tar xvzf nyc-output-linux_unit-m42xe_n12_service_provider_server.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m44xc_n12_service_provider_server.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m44xc_n12_service_provider_server.tgz
+        local_file: src/nyc-output-linux_unit-m44xc_n12_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m44xc_n12_service_provider_server.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2793,13 +2793,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m44xc_n12_service_provider_server.tgz
+          tar xvzf nyc-output-linux_unit-m44xc_n12_service_provider_server.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m44xe_n12_service_provider_server.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m44xe_n12_service_provider_server.tgz
+        local_file: src/nyc-output-linux_unit-m44xe_n12_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m44xe_n12_service_provider_server.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2807,13 +2807,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m44xe_n12_service_provider_server.tgz
+          tar xvzf nyc-output-linux_unit-m44xe_n12_service_provider_server.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m50xc_n12_service_provider_server.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m50xc_n12_service_provider_server.tgz
+        local_file: src/nyc-output-linux_unit-m50xc_n12_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m50xc_n12_service_provider_server.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2821,13 +2821,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m50xc_n12_service_provider_server.tgz
+          tar xvzf nyc-output-linux_unit-m50xc_n12_service_provider_server.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m50xe_n12_service_provider_server.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m50xe_n12_service_provider_server.tgz
+        local_file: src/nyc-output-linux_unit-m50xe_n12_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m50xe_n12_service_provider_server.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2835,13 +2835,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m50xe_n12_service_provider_server.tgz
+          tar xvzf nyc-output-linux_unit-m50xe_n12_service_provider_server.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-mlatest_n12_service_provider_server.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-mlatest_n12_service_provider_server.tgz
+        local_file: src/nyc-output-linux_unit-mlatest_n12_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-mlatest_n12_service_provider_server.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2849,13 +2849,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-mlatest_n12_service_provider_server.tgz
+          tar xvzf nyc-output-linux_unit-mlatest_n12_service_provider_server.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m40xc_n14_service_provider_server.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m40xc_n14_service_provider_server.tgz
+        local_file: src/nyc-output-linux_unit-m40xc_n14_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m40xc_n14_service_provider_server.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2863,13 +2863,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m40xc_n14_service_provider_server.tgz
+          tar xvzf nyc-output-linux_unit-m40xc_n14_service_provider_server.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m40xe_n14_service_provider_server.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m40xe_n14_service_provider_server.tgz
+        local_file: src/nyc-output-linux_unit-m40xe_n14_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m40xe_n14_service_provider_server.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2877,13 +2877,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m40xe_n14_service_provider_server.tgz
+          tar xvzf nyc-output-linux_unit-m40xe_n14_service_provider_server.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m42xc_n14_service_provider_server.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m42xc_n14_service_provider_server.tgz
+        local_file: src/nyc-output-linux_unit-m42xc_n14_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m42xc_n14_service_provider_server.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2891,13 +2891,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m42xc_n14_service_provider_server.tgz
+          tar xvzf nyc-output-linux_unit-m42xc_n14_service_provider_server.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m42xe_n14_service_provider_server.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m42xe_n14_service_provider_server.tgz
+        local_file: src/nyc-output-linux_unit-m42xe_n14_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m42xe_n14_service_provider_server.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2905,13 +2905,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m42xe_n14_service_provider_server.tgz
+          tar xvzf nyc-output-linux_unit-m42xe_n14_service_provider_server.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m44xc_n14_service_provider_server.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m44xc_n14_service_provider_server.tgz
+        local_file: src/nyc-output-linux_unit-m44xc_n14_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m44xc_n14_service_provider_server.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2919,13 +2919,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m44xc_n14_service_provider_server.tgz
+          tar xvzf nyc-output-linux_unit-m44xc_n14_service_provider_server.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m44xe_n14_service_provider_server.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m44xe_n14_service_provider_server.tgz
+        local_file: src/nyc-output-linux_unit-m44xe_n14_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m44xe_n14_service_provider_server.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2933,13 +2933,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m44xe_n14_service_provider_server.tgz
+          tar xvzf nyc-output-linux_unit-m44xe_n14_service_provider_server.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m50xc_n14_service_provider_server.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m50xc_n14_service_provider_server.tgz
+        local_file: src/nyc-output-linux_unit-m50xc_n14_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m50xc_n14_service_provider_server.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2947,13 +2947,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m50xc_n14_service_provider_server.tgz
+          tar xvzf nyc-output-linux_unit-m50xc_n14_service_provider_server.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m50xe_n14_service_provider_server.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m50xe_n14_service_provider_server.tgz
+        local_file: src/nyc-output-linux_unit-m50xe_n14_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m50xe_n14_service_provider_server.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2961,13 +2961,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m50xe_n14_service_provider_server.tgz
+          tar xvzf nyc-output-linux_unit-m50xe_n14_service_provider_server.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-mlatest_n14_service_provider_server.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-mlatest_n14_service_provider_server.tgz
+        local_file: src/nyc-output-linux_unit-mlatest_n14_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-mlatest_n14_service_provider_server.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2975,13 +2975,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-mlatest_n14_service_provider_server.tgz
+          tar xvzf nyc-output-linux_unit-mlatest_n14_service_provider_server.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m40xc_n12_shell_api.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m40xc_n12_shell_api.tgz
+        local_file: src/nyc-output-linux_unit-m40xc_n12_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m40xc_n12_shell_api.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -2989,13 +2989,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m40xc_n12_shell_api.tgz
+          tar xvzf nyc-output-linux_unit-m40xc_n12_shell_api.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m40xe_n12_shell_api.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m40xe_n12_shell_api.tgz
+        local_file: src/nyc-output-linux_unit-m40xe_n12_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m40xe_n12_shell_api.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3003,13 +3003,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m40xe_n12_shell_api.tgz
+          tar xvzf nyc-output-linux_unit-m40xe_n12_shell_api.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m42xc_n12_shell_api.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m42xc_n12_shell_api.tgz
+        local_file: src/nyc-output-linux_unit-m42xc_n12_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m42xc_n12_shell_api.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3017,13 +3017,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m42xc_n12_shell_api.tgz
+          tar xvzf nyc-output-linux_unit-m42xc_n12_shell_api.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m42xe_n12_shell_api.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m42xe_n12_shell_api.tgz
+        local_file: src/nyc-output-linux_unit-m42xe_n12_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m42xe_n12_shell_api.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3031,13 +3031,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m42xe_n12_shell_api.tgz
+          tar xvzf nyc-output-linux_unit-m42xe_n12_shell_api.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m44xc_n12_shell_api.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m44xc_n12_shell_api.tgz
+        local_file: src/nyc-output-linux_unit-m44xc_n12_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m44xc_n12_shell_api.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3045,13 +3045,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m44xc_n12_shell_api.tgz
+          tar xvzf nyc-output-linux_unit-m44xc_n12_shell_api.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m44xe_n12_shell_api.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m44xe_n12_shell_api.tgz
+        local_file: src/nyc-output-linux_unit-m44xe_n12_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m44xe_n12_shell_api.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3059,13 +3059,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m44xe_n12_shell_api.tgz
+          tar xvzf nyc-output-linux_unit-m44xe_n12_shell_api.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m50xc_n12_shell_api.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m50xc_n12_shell_api.tgz
+        local_file: src/nyc-output-linux_unit-m50xc_n12_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m50xc_n12_shell_api.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3073,13 +3073,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m50xc_n12_shell_api.tgz
+          tar xvzf nyc-output-linux_unit-m50xc_n12_shell_api.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m50xe_n12_shell_api.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m50xe_n12_shell_api.tgz
+        local_file: src/nyc-output-linux_unit-m50xe_n12_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m50xe_n12_shell_api.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3087,13 +3087,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m50xe_n12_shell_api.tgz
+          tar xvzf nyc-output-linux_unit-m50xe_n12_shell_api.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-mlatest_n12_shell_api.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-mlatest_n12_shell_api.tgz
+        local_file: src/nyc-output-linux_unit-mlatest_n12_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-mlatest_n12_shell_api.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3101,13 +3101,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-mlatest_n12_shell_api.tgz
+          tar xvzf nyc-output-linux_unit-mlatest_n12_shell_api.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m40xc_n14_shell_api.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m40xc_n14_shell_api.tgz
+        local_file: src/nyc-output-linux_unit-m40xc_n14_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m40xc_n14_shell_api.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3115,13 +3115,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m40xc_n14_shell_api.tgz
+          tar xvzf nyc-output-linux_unit-m40xc_n14_shell_api.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m40xe_n14_shell_api.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m40xe_n14_shell_api.tgz
+        local_file: src/nyc-output-linux_unit-m40xe_n14_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m40xe_n14_shell_api.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3129,13 +3129,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m40xe_n14_shell_api.tgz
+          tar xvzf nyc-output-linux_unit-m40xe_n14_shell_api.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m42xc_n14_shell_api.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m42xc_n14_shell_api.tgz
+        local_file: src/nyc-output-linux_unit-m42xc_n14_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m42xc_n14_shell_api.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3143,13 +3143,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m42xc_n14_shell_api.tgz
+          tar xvzf nyc-output-linux_unit-m42xc_n14_shell_api.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m42xe_n14_shell_api.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m42xe_n14_shell_api.tgz
+        local_file: src/nyc-output-linux_unit-m42xe_n14_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m42xe_n14_shell_api.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3157,13 +3157,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m42xe_n14_shell_api.tgz
+          tar xvzf nyc-output-linux_unit-m42xe_n14_shell_api.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m44xc_n14_shell_api.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m44xc_n14_shell_api.tgz
+        local_file: src/nyc-output-linux_unit-m44xc_n14_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m44xc_n14_shell_api.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3171,13 +3171,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m44xc_n14_shell_api.tgz
+          tar xvzf nyc-output-linux_unit-m44xc_n14_shell_api.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m44xe_n14_shell_api.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m44xe_n14_shell_api.tgz
+        local_file: src/nyc-output-linux_unit-m44xe_n14_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m44xe_n14_shell_api.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3185,13 +3185,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m44xe_n14_shell_api.tgz
+          tar xvzf nyc-output-linux_unit-m44xe_n14_shell_api.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m50xc_n14_shell_api.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m50xc_n14_shell_api.tgz
+        local_file: src/nyc-output-linux_unit-m50xc_n14_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m50xc_n14_shell_api.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3199,13 +3199,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m50xc_n14_shell_api.tgz
+          tar xvzf nyc-output-linux_unit-m50xc_n14_shell_api.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-m50xe_n14_shell_api.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-m50xe_n14_shell_api.tgz
+        local_file: src/nyc-output-linux_unit-m50xe_n14_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m50xe_n14_shell_api.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3213,13 +3213,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-m50xe_n14_shell_api.tgz
+          tar xvzf nyc-output-linux_unit-m50xe_n14_shell_api.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-mlatest_n14_shell_api.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-mlatest_n14_shell_api.tgz
+        local_file: src/nyc-output-linux_unit-mlatest_n14_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-mlatest_n14_shell_api.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3227,13 +3227,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-mlatest_n14_shell_api.tgz
+          tar xvzf nyc-output-linux_unit-mlatest_n14_shell_api.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-n12_shell_evaluator.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-n12_shell_evaluator.tgz
+        local_file: src/nyc-output-linux_unit-n12_shell_evaluator.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-n12_shell_evaluator.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3241,13 +3241,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-n12_shell_evaluator.tgz
+          tar xvzf nyc-output-linux_unit-n12_shell_evaluator.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-n14_shell_evaluator.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-n14_shell_evaluator.tgz
+        local_file: src/nyc-output-linux_unit-n14_shell_evaluator.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-n14_shell_evaluator.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3255,13 +3255,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-n14_shell_evaluator.tgz
+          tar xvzf nyc-output-linux_unit-n14_shell_evaluator.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-n12_snippet_manager.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-n12_snippet_manager.tgz
+        local_file: src/nyc-output-linux_unit-n12_snippet_manager.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-n12_snippet_manager.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3269,13 +3269,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-n12_snippet_manager.tgz
+          tar xvzf nyc-output-linux_unit-n12_snippet_manager.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-n14_snippet_manager.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-n14_snippet_manager.tgz
+        local_file: src/nyc-output-linux_unit-n14_snippet_manager.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-n14_snippet_manager.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3283,13 +3283,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-n14_snippet_manager.tgz
+          tar xvzf nyc-output-linux_unit-n14_snippet_manager.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-n12_types.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-n12_types.tgz
+        local_file: src/nyc-output-linux_unit-n12_types.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-n12_types.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3297,13 +3297,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-n12_types.tgz
+          tar xvzf nyc-output-linux_unit-n12_types.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux-n14_types.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux-n14_types.tgz
+        local_file: src/nyc-output-linux_unit-n14_types.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-n14_types.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3311,13 +3311,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-linux-n14_types.tgz
+          tar xvzf nyc-output-linux_unit-n14_types.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-n12_arg_parser.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-n12_arg_parser.tgz
+        local_file: src/nyc-output-win32_unit-n12_arg_parser.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-n12_arg_parser.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3325,13 +3325,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-n12_arg_parser.tgz
+          tar xvzf nyc-output-win32_unit-n12_arg_parser.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-n14_arg_parser.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-n14_arg_parser.tgz
+        local_file: src/nyc-output-win32_unit-n14_arg_parser.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-n14_arg_parser.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3339,13 +3339,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-n14_arg_parser.tgz
+          tar xvzf nyc-output-win32_unit-n14_arg_parser.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-n12_async_rewriter2.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-n12_async_rewriter2.tgz
+        local_file: src/nyc-output-win32_unit-n12_async_rewriter2.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-n12_async_rewriter2.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3353,13 +3353,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-n12_async_rewriter2.tgz
+          tar xvzf nyc-output-win32_unit-n12_async_rewriter2.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-n14_async_rewriter2.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-n14_async_rewriter2.tgz
+        local_file: src/nyc-output-win32_unit-n14_async_rewriter2.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-n14_async_rewriter2.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3367,13 +3367,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-n14_async_rewriter2.tgz
+          tar xvzf nyc-output-win32_unit-n14_async_rewriter2.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-n12_autocomplete.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-n12_autocomplete.tgz
+        local_file: src/nyc-output-win32_unit-n12_autocomplete.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-n12_autocomplete.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3381,13 +3381,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-n12_autocomplete.tgz
+          tar xvzf nyc-output-win32_unit-n12_autocomplete.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-n14_autocomplete.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-n14_autocomplete.tgz
+        local_file: src/nyc-output-win32_unit-n14_autocomplete.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-n14_autocomplete.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3395,13 +3395,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-n14_autocomplete.tgz
+          tar xvzf nyc-output-win32_unit-n14_autocomplete.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-n12_browser_runtime_core.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-n12_browser_runtime_core.tgz
+        local_file: src/nyc-output-win32_unit-n12_browser_runtime_core.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-n12_browser_runtime_core.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3409,13 +3409,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-n12_browser_runtime_core.tgz
+          tar xvzf nyc-output-win32_unit-n12_browser_runtime_core.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-n14_browser_runtime_core.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-n14_browser_runtime_core.tgz
+        local_file: src/nyc-output-win32_unit-n14_browser_runtime_core.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-n14_browser_runtime_core.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3423,13 +3423,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-n14_browser_runtime_core.tgz
+          tar xvzf nyc-output-win32_unit-n14_browser_runtime_core.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-n12_browser_runtime_electron.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-n12_browser_runtime_electron.tgz
+        local_file: src/nyc-output-win32_unit-n12_browser_runtime_electron.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-n12_browser_runtime_electron.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3437,13 +3437,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-n12_browser_runtime_electron.tgz
+          tar xvzf nyc-output-win32_unit-n12_browser_runtime_electron.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-n14_browser_runtime_electron.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-n14_browser_runtime_electron.tgz
+        local_file: src/nyc-output-win32_unit-n14_browser_runtime_electron.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-n14_browser_runtime_electron.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3451,13 +3451,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-n14_browser_runtime_electron.tgz
+          tar xvzf nyc-output-win32_unit-n14_browser_runtime_electron.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-n12_build.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-n12_build.tgz
+        local_file: src/nyc-output-win32_unit-n12_build.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-n12_build.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3465,13 +3465,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-n12_build.tgz
+          tar xvzf nyc-output-win32_unit-n12_build.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-n14_build.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-n14_build.tgz
+        local_file: src/nyc-output-win32_unit-n14_build.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-n14_build.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3479,13 +3479,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-n14_build.tgz
+          tar xvzf nyc-output-win32_unit-n14_build.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-m40xc_n12_cli_repl.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-m40xc_n12_cli_repl.tgz
+        local_file: src/nyc-output-win32_unit-m40xc_n12_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m40xc_n12_cli_repl.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3493,13 +3493,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-m40xc_n12_cli_repl.tgz
+          tar xvzf nyc-output-win32_unit-m40xc_n12_cli_repl.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-m40xe_n12_cli_repl.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-m40xe_n12_cli_repl.tgz
+        local_file: src/nyc-output-win32_unit-m40xe_n12_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m40xe_n12_cli_repl.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3507,13 +3507,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-m40xe_n12_cli_repl.tgz
+          tar xvzf nyc-output-win32_unit-m40xe_n12_cli_repl.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-m42xc_n12_cli_repl.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-m42xc_n12_cli_repl.tgz
+        local_file: src/nyc-output-win32_unit-m42xc_n12_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m42xc_n12_cli_repl.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3521,13 +3521,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-m42xc_n12_cli_repl.tgz
+          tar xvzf nyc-output-win32_unit-m42xc_n12_cli_repl.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-m42xe_n12_cli_repl.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-m42xe_n12_cli_repl.tgz
+        local_file: src/nyc-output-win32_unit-m42xe_n12_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m42xe_n12_cli_repl.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3535,13 +3535,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-m42xe_n12_cli_repl.tgz
+          tar xvzf nyc-output-win32_unit-m42xe_n12_cli_repl.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-m44xc_n12_cli_repl.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-m44xc_n12_cli_repl.tgz
+        local_file: src/nyc-output-win32_unit-m44xc_n12_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m44xc_n12_cli_repl.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3549,13 +3549,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-m44xc_n12_cli_repl.tgz
+          tar xvzf nyc-output-win32_unit-m44xc_n12_cli_repl.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-m44xe_n12_cli_repl.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-m44xe_n12_cli_repl.tgz
+        local_file: src/nyc-output-win32_unit-m44xe_n12_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m44xe_n12_cli_repl.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3563,13 +3563,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-m44xe_n12_cli_repl.tgz
+          tar xvzf nyc-output-win32_unit-m44xe_n12_cli_repl.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-m50xc_n12_cli_repl.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-m50xc_n12_cli_repl.tgz
+        local_file: src/nyc-output-win32_unit-m50xc_n12_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m50xc_n12_cli_repl.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3577,13 +3577,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-m50xc_n12_cli_repl.tgz
+          tar xvzf nyc-output-win32_unit-m50xc_n12_cli_repl.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-m50xe_n12_cli_repl.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-m50xe_n12_cli_repl.tgz
+        local_file: src/nyc-output-win32_unit-m50xe_n12_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m50xe_n12_cli_repl.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3591,13 +3591,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-m50xe_n12_cli_repl.tgz
+          tar xvzf nyc-output-win32_unit-m50xe_n12_cli_repl.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-mlatest_n12_cli_repl.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-mlatest_n12_cli_repl.tgz
+        local_file: src/nyc-output-win32_unit-mlatest_n12_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-mlatest_n12_cli_repl.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3605,13 +3605,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-mlatest_n12_cli_repl.tgz
+          tar xvzf nyc-output-win32_unit-mlatest_n12_cli_repl.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-m40xc_n14_cli_repl.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-m40xc_n14_cli_repl.tgz
+        local_file: src/nyc-output-win32_unit-m40xc_n14_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m40xc_n14_cli_repl.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3619,13 +3619,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-m40xc_n14_cli_repl.tgz
+          tar xvzf nyc-output-win32_unit-m40xc_n14_cli_repl.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-m40xe_n14_cli_repl.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-m40xe_n14_cli_repl.tgz
+        local_file: src/nyc-output-win32_unit-m40xe_n14_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m40xe_n14_cli_repl.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3633,13 +3633,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-m40xe_n14_cli_repl.tgz
+          tar xvzf nyc-output-win32_unit-m40xe_n14_cli_repl.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-m42xc_n14_cli_repl.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-m42xc_n14_cli_repl.tgz
+        local_file: src/nyc-output-win32_unit-m42xc_n14_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m42xc_n14_cli_repl.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3647,13 +3647,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-m42xc_n14_cli_repl.tgz
+          tar xvzf nyc-output-win32_unit-m42xc_n14_cli_repl.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-m42xe_n14_cli_repl.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-m42xe_n14_cli_repl.tgz
+        local_file: src/nyc-output-win32_unit-m42xe_n14_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m42xe_n14_cli_repl.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3661,13 +3661,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-m42xe_n14_cli_repl.tgz
+          tar xvzf nyc-output-win32_unit-m42xe_n14_cli_repl.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-m44xc_n14_cli_repl.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-m44xc_n14_cli_repl.tgz
+        local_file: src/nyc-output-win32_unit-m44xc_n14_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m44xc_n14_cli_repl.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3675,13 +3675,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-m44xc_n14_cli_repl.tgz
+          tar xvzf nyc-output-win32_unit-m44xc_n14_cli_repl.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-m44xe_n14_cli_repl.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-m44xe_n14_cli_repl.tgz
+        local_file: src/nyc-output-win32_unit-m44xe_n14_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m44xe_n14_cli_repl.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3689,13 +3689,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-m44xe_n14_cli_repl.tgz
+          tar xvzf nyc-output-win32_unit-m44xe_n14_cli_repl.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-m50xc_n14_cli_repl.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-m50xc_n14_cli_repl.tgz
+        local_file: src/nyc-output-win32_unit-m50xc_n14_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m50xc_n14_cli_repl.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3703,13 +3703,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-m50xc_n14_cli_repl.tgz
+          tar xvzf nyc-output-win32_unit-m50xc_n14_cli_repl.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-m50xe_n14_cli_repl.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-m50xe_n14_cli_repl.tgz
+        local_file: src/nyc-output-win32_unit-m50xe_n14_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m50xe_n14_cli_repl.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3717,13 +3717,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-m50xe_n14_cli_repl.tgz
+          tar xvzf nyc-output-win32_unit-m50xe_n14_cli_repl.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-mlatest_n14_cli_repl.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-mlatest_n14_cli_repl.tgz
+        local_file: src/nyc-output-win32_unit-mlatest_n14_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-mlatest_n14_cli_repl.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3731,13 +3731,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-mlatest_n14_cli_repl.tgz
+          tar xvzf nyc-output-win32_unit-mlatest_n14_cli_repl.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-n12_editor.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-n12_editor.tgz
+        local_file: src/nyc-output-win32_unit-n12_editor.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-n12_editor.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3745,13 +3745,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-n12_editor.tgz
+          tar xvzf nyc-output-win32_unit-n12_editor.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-n14_editor.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-n14_editor.tgz
+        local_file: src/nyc-output-win32_unit-n14_editor.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-n14_editor.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3759,13 +3759,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-n14_editor.tgz
+          tar xvzf nyc-output-win32_unit-n14_editor.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-n12_errors.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-n12_errors.tgz
+        local_file: src/nyc-output-win32_unit-n12_errors.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-n12_errors.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3773,13 +3773,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-n12_errors.tgz
+          tar xvzf nyc-output-win32_unit-n12_errors.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-n14_errors.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-n14_errors.tgz
+        local_file: src/nyc-output-win32_unit-n14_errors.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-n14_errors.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3787,13 +3787,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-n14_errors.tgz
+          tar xvzf nyc-output-win32_unit-n14_errors.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-n12_history.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-n12_history.tgz
+        local_file: src/nyc-output-win32_unit-n12_history.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-n12_history.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3801,13 +3801,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-n12_history.tgz
+          tar xvzf nyc-output-win32_unit-n12_history.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-n14_history.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-n14_history.tgz
+        local_file: src/nyc-output-win32_unit-n14_history.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-n14_history.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3815,13 +3815,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-n14_history.tgz
+          tar xvzf nyc-output-win32_unit-n14_history.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-n12_i18n.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-n12_i18n.tgz
+        local_file: src/nyc-output-win32_unit-n12_i18n.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-n12_i18n.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3829,13 +3829,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-n12_i18n.tgz
+          tar xvzf nyc-output-win32_unit-n12_i18n.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-n14_i18n.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-n14_i18n.tgz
+        local_file: src/nyc-output-win32_unit-n14_i18n.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-n14_i18n.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3843,13 +3843,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-n14_i18n.tgz
+          tar xvzf nyc-output-win32_unit-n14_i18n.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-n12_js_multiline_to_singleline.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-n12_js_multiline_to_singleline.tgz
+        local_file: src/nyc-output-win32_unit-n12_js_multiline_to_singleline.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-n12_js_multiline_to_singleline.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3857,13 +3857,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-n12_js_multiline_to_singleline.tgz
+          tar xvzf nyc-output-win32_unit-n12_js_multiline_to_singleline.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-n14_js_multiline_to_singleline.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-n14_js_multiline_to_singleline.tgz
+        local_file: src/nyc-output-win32_unit-n14_js_multiline_to_singleline.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-n14_js_multiline_to_singleline.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3871,13 +3871,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-n14_js_multiline_to_singleline.tgz
+          tar xvzf nyc-output-win32_unit-n14_js_multiline_to_singleline.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-n12_logging.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-n12_logging.tgz
+        local_file: src/nyc-output-win32_unit-n12_logging.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-n12_logging.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3885,13 +3885,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-n12_logging.tgz
+          tar xvzf nyc-output-win32_unit-n12_logging.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-n14_logging.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-n14_logging.tgz
+        local_file: src/nyc-output-win32_unit-n14_logging.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-n14_logging.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3899,13 +3899,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-n14_logging.tgz
+          tar xvzf nyc-output-win32_unit-n14_logging.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-m40xc_n12_node_runtime_worker_thread.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-m40xc_n12_node_runtime_worker_thread.tgz
+        local_file: src/nyc-output-win32_unit-m40xc_n12_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m40xc_n12_node_runtime_worker_thread.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3913,13 +3913,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-m40xc_n12_node_runtime_worker_thread.tgz
+          tar xvzf nyc-output-win32_unit-m40xc_n12_node_runtime_worker_thread.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-m40xe_n12_node_runtime_worker_thread.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-m40xe_n12_node_runtime_worker_thread.tgz
+        local_file: src/nyc-output-win32_unit-m40xe_n12_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m40xe_n12_node_runtime_worker_thread.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3927,13 +3927,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-m40xe_n12_node_runtime_worker_thread.tgz
+          tar xvzf nyc-output-win32_unit-m40xe_n12_node_runtime_worker_thread.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-m42xc_n12_node_runtime_worker_thread.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-m42xc_n12_node_runtime_worker_thread.tgz
+        local_file: src/nyc-output-win32_unit-m42xc_n12_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m42xc_n12_node_runtime_worker_thread.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3941,13 +3941,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-m42xc_n12_node_runtime_worker_thread.tgz
+          tar xvzf nyc-output-win32_unit-m42xc_n12_node_runtime_worker_thread.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-m42xe_n12_node_runtime_worker_thread.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-m42xe_n12_node_runtime_worker_thread.tgz
+        local_file: src/nyc-output-win32_unit-m42xe_n12_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m42xe_n12_node_runtime_worker_thread.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3955,13 +3955,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-m42xe_n12_node_runtime_worker_thread.tgz
+          tar xvzf nyc-output-win32_unit-m42xe_n12_node_runtime_worker_thread.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-m44xc_n12_node_runtime_worker_thread.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-m44xc_n12_node_runtime_worker_thread.tgz
+        local_file: src/nyc-output-win32_unit-m44xc_n12_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m44xc_n12_node_runtime_worker_thread.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3969,13 +3969,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-m44xc_n12_node_runtime_worker_thread.tgz
+          tar xvzf nyc-output-win32_unit-m44xc_n12_node_runtime_worker_thread.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-m44xe_n12_node_runtime_worker_thread.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-m44xe_n12_node_runtime_worker_thread.tgz
+        local_file: src/nyc-output-win32_unit-m44xe_n12_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m44xe_n12_node_runtime_worker_thread.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3983,13 +3983,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-m44xe_n12_node_runtime_worker_thread.tgz
+          tar xvzf nyc-output-win32_unit-m44xe_n12_node_runtime_worker_thread.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-m50xc_n12_node_runtime_worker_thread.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-m50xc_n12_node_runtime_worker_thread.tgz
+        local_file: src/nyc-output-win32_unit-m50xc_n12_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m50xc_n12_node_runtime_worker_thread.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -3997,13 +3997,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-m50xc_n12_node_runtime_worker_thread.tgz
+          tar xvzf nyc-output-win32_unit-m50xc_n12_node_runtime_worker_thread.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-m50xe_n12_node_runtime_worker_thread.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-m50xe_n12_node_runtime_worker_thread.tgz
+        local_file: src/nyc-output-win32_unit-m50xe_n12_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m50xe_n12_node_runtime_worker_thread.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -4011,13 +4011,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-m50xe_n12_node_runtime_worker_thread.tgz
+          tar xvzf nyc-output-win32_unit-m50xe_n12_node_runtime_worker_thread.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-mlatest_n12_node_runtime_worker_thread.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-mlatest_n12_node_runtime_worker_thread.tgz
+        local_file: src/nyc-output-win32_unit-mlatest_n12_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-mlatest_n12_node_runtime_worker_thread.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -4025,13 +4025,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-mlatest_n12_node_runtime_worker_thread.tgz
+          tar xvzf nyc-output-win32_unit-mlatest_n12_node_runtime_worker_thread.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-m40xc_n14_node_runtime_worker_thread.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-m40xc_n14_node_runtime_worker_thread.tgz
+        local_file: src/nyc-output-win32_unit-m40xc_n14_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m40xc_n14_node_runtime_worker_thread.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -4039,13 +4039,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-m40xc_n14_node_runtime_worker_thread.tgz
+          tar xvzf nyc-output-win32_unit-m40xc_n14_node_runtime_worker_thread.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-m40xe_n14_node_runtime_worker_thread.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-m40xe_n14_node_runtime_worker_thread.tgz
+        local_file: src/nyc-output-win32_unit-m40xe_n14_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m40xe_n14_node_runtime_worker_thread.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -4053,13 +4053,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-m40xe_n14_node_runtime_worker_thread.tgz
+          tar xvzf nyc-output-win32_unit-m40xe_n14_node_runtime_worker_thread.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-m42xc_n14_node_runtime_worker_thread.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-m42xc_n14_node_runtime_worker_thread.tgz
+        local_file: src/nyc-output-win32_unit-m42xc_n14_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m42xc_n14_node_runtime_worker_thread.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -4067,13 +4067,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-m42xc_n14_node_runtime_worker_thread.tgz
+          tar xvzf nyc-output-win32_unit-m42xc_n14_node_runtime_worker_thread.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-m42xe_n14_node_runtime_worker_thread.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-m42xe_n14_node_runtime_worker_thread.tgz
+        local_file: src/nyc-output-win32_unit-m42xe_n14_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m42xe_n14_node_runtime_worker_thread.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -4081,13 +4081,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-m42xe_n14_node_runtime_worker_thread.tgz
+          tar xvzf nyc-output-win32_unit-m42xe_n14_node_runtime_worker_thread.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-m44xc_n14_node_runtime_worker_thread.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-m44xc_n14_node_runtime_worker_thread.tgz
+        local_file: src/nyc-output-win32_unit-m44xc_n14_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m44xc_n14_node_runtime_worker_thread.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -4095,13 +4095,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-m44xc_n14_node_runtime_worker_thread.tgz
+          tar xvzf nyc-output-win32_unit-m44xc_n14_node_runtime_worker_thread.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-m44xe_n14_node_runtime_worker_thread.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-m44xe_n14_node_runtime_worker_thread.tgz
+        local_file: src/nyc-output-win32_unit-m44xe_n14_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m44xe_n14_node_runtime_worker_thread.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -4109,13 +4109,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-m44xe_n14_node_runtime_worker_thread.tgz
+          tar xvzf nyc-output-win32_unit-m44xe_n14_node_runtime_worker_thread.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-m50xc_n14_node_runtime_worker_thread.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-m50xc_n14_node_runtime_worker_thread.tgz
+        local_file: src/nyc-output-win32_unit-m50xc_n14_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m50xc_n14_node_runtime_worker_thread.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -4123,13 +4123,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-m50xc_n14_node_runtime_worker_thread.tgz
+          tar xvzf nyc-output-win32_unit-m50xc_n14_node_runtime_worker_thread.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-m50xe_n14_node_runtime_worker_thread.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-m50xe_n14_node_runtime_worker_thread.tgz
+        local_file: src/nyc-output-win32_unit-m50xe_n14_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m50xe_n14_node_runtime_worker_thread.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -4137,13 +4137,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-m50xe_n14_node_runtime_worker_thread.tgz
+          tar xvzf nyc-output-win32_unit-m50xe_n14_node_runtime_worker_thread.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-mlatest_n14_node_runtime_worker_thread.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-mlatest_n14_node_runtime_worker_thread.tgz
+        local_file: src/nyc-output-win32_unit-mlatest_n14_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-mlatest_n14_node_runtime_worker_thread.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -4151,13 +4151,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-mlatest_n14_node_runtime_worker_thread.tgz
+          tar xvzf nyc-output-win32_unit-mlatest_n14_node_runtime_worker_thread.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-n12_service_provider_core.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-n12_service_provider_core.tgz
+        local_file: src/nyc-output-win32_unit-n12_service_provider_core.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-n12_service_provider_core.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -4165,13 +4165,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-n12_service_provider_core.tgz
+          tar xvzf nyc-output-win32_unit-n12_service_provider_core.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-n14_service_provider_core.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-n14_service_provider_core.tgz
+        local_file: src/nyc-output-win32_unit-n14_service_provider_core.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-n14_service_provider_core.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -4179,13 +4179,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-n14_service_provider_core.tgz
+          tar xvzf nyc-output-win32_unit-n14_service_provider_core.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-m40xc_n12_service_provider_server.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-m40xc_n12_service_provider_server.tgz
+        local_file: src/nyc-output-win32_unit-m40xc_n12_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m40xc_n12_service_provider_server.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -4193,13 +4193,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-m40xc_n12_service_provider_server.tgz
+          tar xvzf nyc-output-win32_unit-m40xc_n12_service_provider_server.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-m40xe_n12_service_provider_server.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-m40xe_n12_service_provider_server.tgz
+        local_file: src/nyc-output-win32_unit-m40xe_n12_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m40xe_n12_service_provider_server.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -4207,13 +4207,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-m40xe_n12_service_provider_server.tgz
+          tar xvzf nyc-output-win32_unit-m40xe_n12_service_provider_server.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-m42xc_n12_service_provider_server.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-m42xc_n12_service_provider_server.tgz
+        local_file: src/nyc-output-win32_unit-m42xc_n12_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m42xc_n12_service_provider_server.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -4221,13 +4221,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-m42xc_n12_service_provider_server.tgz
+          tar xvzf nyc-output-win32_unit-m42xc_n12_service_provider_server.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-m42xe_n12_service_provider_server.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-m42xe_n12_service_provider_server.tgz
+        local_file: src/nyc-output-win32_unit-m42xe_n12_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m42xe_n12_service_provider_server.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -4235,13 +4235,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-m42xe_n12_service_provider_server.tgz
+          tar xvzf nyc-output-win32_unit-m42xe_n12_service_provider_server.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-m44xc_n12_service_provider_server.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-m44xc_n12_service_provider_server.tgz
+        local_file: src/nyc-output-win32_unit-m44xc_n12_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m44xc_n12_service_provider_server.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -4249,13 +4249,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-m44xc_n12_service_provider_server.tgz
+          tar xvzf nyc-output-win32_unit-m44xc_n12_service_provider_server.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-m44xe_n12_service_provider_server.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-m44xe_n12_service_provider_server.tgz
+        local_file: src/nyc-output-win32_unit-m44xe_n12_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m44xe_n12_service_provider_server.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -4263,13 +4263,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-m44xe_n12_service_provider_server.tgz
+          tar xvzf nyc-output-win32_unit-m44xe_n12_service_provider_server.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-m50xc_n12_service_provider_server.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-m50xc_n12_service_provider_server.tgz
+        local_file: src/nyc-output-win32_unit-m50xc_n12_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m50xc_n12_service_provider_server.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -4277,13 +4277,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-m50xc_n12_service_provider_server.tgz
+          tar xvzf nyc-output-win32_unit-m50xc_n12_service_provider_server.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-m50xe_n12_service_provider_server.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-m50xe_n12_service_provider_server.tgz
+        local_file: src/nyc-output-win32_unit-m50xe_n12_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m50xe_n12_service_provider_server.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -4291,13 +4291,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-m50xe_n12_service_provider_server.tgz
+          tar xvzf nyc-output-win32_unit-m50xe_n12_service_provider_server.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-mlatest_n12_service_provider_server.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-mlatest_n12_service_provider_server.tgz
+        local_file: src/nyc-output-win32_unit-mlatest_n12_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-mlatest_n12_service_provider_server.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -4305,13 +4305,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-mlatest_n12_service_provider_server.tgz
+          tar xvzf nyc-output-win32_unit-mlatest_n12_service_provider_server.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-m40xc_n14_service_provider_server.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-m40xc_n14_service_provider_server.tgz
+        local_file: src/nyc-output-win32_unit-m40xc_n14_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m40xc_n14_service_provider_server.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -4319,13 +4319,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-m40xc_n14_service_provider_server.tgz
+          tar xvzf nyc-output-win32_unit-m40xc_n14_service_provider_server.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-m40xe_n14_service_provider_server.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-m40xe_n14_service_provider_server.tgz
+        local_file: src/nyc-output-win32_unit-m40xe_n14_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m40xe_n14_service_provider_server.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -4333,13 +4333,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-m40xe_n14_service_provider_server.tgz
+          tar xvzf nyc-output-win32_unit-m40xe_n14_service_provider_server.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-m42xc_n14_service_provider_server.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-m42xc_n14_service_provider_server.tgz
+        local_file: src/nyc-output-win32_unit-m42xc_n14_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m42xc_n14_service_provider_server.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -4347,13 +4347,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-m42xc_n14_service_provider_server.tgz
+          tar xvzf nyc-output-win32_unit-m42xc_n14_service_provider_server.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-m42xe_n14_service_provider_server.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-m42xe_n14_service_provider_server.tgz
+        local_file: src/nyc-output-win32_unit-m42xe_n14_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m42xe_n14_service_provider_server.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -4361,13 +4361,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-m42xe_n14_service_provider_server.tgz
+          tar xvzf nyc-output-win32_unit-m42xe_n14_service_provider_server.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-m44xc_n14_service_provider_server.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-m44xc_n14_service_provider_server.tgz
+        local_file: src/nyc-output-win32_unit-m44xc_n14_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m44xc_n14_service_provider_server.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -4375,13 +4375,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-m44xc_n14_service_provider_server.tgz
+          tar xvzf nyc-output-win32_unit-m44xc_n14_service_provider_server.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-m44xe_n14_service_provider_server.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-m44xe_n14_service_provider_server.tgz
+        local_file: src/nyc-output-win32_unit-m44xe_n14_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m44xe_n14_service_provider_server.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -4389,13 +4389,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-m44xe_n14_service_provider_server.tgz
+          tar xvzf nyc-output-win32_unit-m44xe_n14_service_provider_server.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-m50xc_n14_service_provider_server.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-m50xc_n14_service_provider_server.tgz
+        local_file: src/nyc-output-win32_unit-m50xc_n14_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m50xc_n14_service_provider_server.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -4403,13 +4403,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-m50xc_n14_service_provider_server.tgz
+          tar xvzf nyc-output-win32_unit-m50xc_n14_service_provider_server.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-m50xe_n14_service_provider_server.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-m50xe_n14_service_provider_server.tgz
+        local_file: src/nyc-output-win32_unit-m50xe_n14_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m50xe_n14_service_provider_server.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -4417,13 +4417,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-m50xe_n14_service_provider_server.tgz
+          tar xvzf nyc-output-win32_unit-m50xe_n14_service_provider_server.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-mlatest_n14_service_provider_server.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-mlatest_n14_service_provider_server.tgz
+        local_file: src/nyc-output-win32_unit-mlatest_n14_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-mlatest_n14_service_provider_server.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -4431,13 +4431,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-mlatest_n14_service_provider_server.tgz
+          tar xvzf nyc-output-win32_unit-mlatest_n14_service_provider_server.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-m40xc_n12_shell_api.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-m40xc_n12_shell_api.tgz
+        local_file: src/nyc-output-win32_unit-m40xc_n12_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m40xc_n12_shell_api.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -4445,13 +4445,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-m40xc_n12_shell_api.tgz
+          tar xvzf nyc-output-win32_unit-m40xc_n12_shell_api.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-m40xe_n12_shell_api.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-m40xe_n12_shell_api.tgz
+        local_file: src/nyc-output-win32_unit-m40xe_n12_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m40xe_n12_shell_api.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -4459,13 +4459,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-m40xe_n12_shell_api.tgz
+          tar xvzf nyc-output-win32_unit-m40xe_n12_shell_api.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-m42xc_n12_shell_api.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-m42xc_n12_shell_api.tgz
+        local_file: src/nyc-output-win32_unit-m42xc_n12_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m42xc_n12_shell_api.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -4473,13 +4473,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-m42xc_n12_shell_api.tgz
+          tar xvzf nyc-output-win32_unit-m42xc_n12_shell_api.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-m42xe_n12_shell_api.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-m42xe_n12_shell_api.tgz
+        local_file: src/nyc-output-win32_unit-m42xe_n12_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m42xe_n12_shell_api.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -4487,13 +4487,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-m42xe_n12_shell_api.tgz
+          tar xvzf nyc-output-win32_unit-m42xe_n12_shell_api.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-m44xc_n12_shell_api.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-m44xc_n12_shell_api.tgz
+        local_file: src/nyc-output-win32_unit-m44xc_n12_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m44xc_n12_shell_api.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -4501,13 +4501,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-m44xc_n12_shell_api.tgz
+          tar xvzf nyc-output-win32_unit-m44xc_n12_shell_api.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-m44xe_n12_shell_api.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-m44xe_n12_shell_api.tgz
+        local_file: src/nyc-output-win32_unit-m44xe_n12_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m44xe_n12_shell_api.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -4515,13 +4515,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-m44xe_n12_shell_api.tgz
+          tar xvzf nyc-output-win32_unit-m44xe_n12_shell_api.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-m50xc_n12_shell_api.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-m50xc_n12_shell_api.tgz
+        local_file: src/nyc-output-win32_unit-m50xc_n12_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m50xc_n12_shell_api.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -4529,13 +4529,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-m50xc_n12_shell_api.tgz
+          tar xvzf nyc-output-win32_unit-m50xc_n12_shell_api.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-m50xe_n12_shell_api.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-m50xe_n12_shell_api.tgz
+        local_file: src/nyc-output-win32_unit-m50xe_n12_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m50xe_n12_shell_api.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -4543,13 +4543,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-m50xe_n12_shell_api.tgz
+          tar xvzf nyc-output-win32_unit-m50xe_n12_shell_api.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-mlatest_n12_shell_api.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-mlatest_n12_shell_api.tgz
+        local_file: src/nyc-output-win32_unit-mlatest_n12_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-mlatest_n12_shell_api.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -4557,13 +4557,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-mlatest_n12_shell_api.tgz
+          tar xvzf nyc-output-win32_unit-mlatest_n12_shell_api.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-m40xc_n14_shell_api.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-m40xc_n14_shell_api.tgz
+        local_file: src/nyc-output-win32_unit-m40xc_n14_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m40xc_n14_shell_api.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -4571,13 +4571,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-m40xc_n14_shell_api.tgz
+          tar xvzf nyc-output-win32_unit-m40xc_n14_shell_api.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-m40xe_n14_shell_api.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-m40xe_n14_shell_api.tgz
+        local_file: src/nyc-output-win32_unit-m40xe_n14_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m40xe_n14_shell_api.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -4585,13 +4585,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-m40xe_n14_shell_api.tgz
+          tar xvzf nyc-output-win32_unit-m40xe_n14_shell_api.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-m42xc_n14_shell_api.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-m42xc_n14_shell_api.tgz
+        local_file: src/nyc-output-win32_unit-m42xc_n14_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m42xc_n14_shell_api.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -4599,13 +4599,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-m42xc_n14_shell_api.tgz
+          tar xvzf nyc-output-win32_unit-m42xc_n14_shell_api.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-m42xe_n14_shell_api.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-m42xe_n14_shell_api.tgz
+        local_file: src/nyc-output-win32_unit-m42xe_n14_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m42xe_n14_shell_api.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -4613,13 +4613,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-m42xe_n14_shell_api.tgz
+          tar xvzf nyc-output-win32_unit-m42xe_n14_shell_api.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-m44xc_n14_shell_api.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-m44xc_n14_shell_api.tgz
+        local_file: src/nyc-output-win32_unit-m44xc_n14_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m44xc_n14_shell_api.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -4627,13 +4627,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-m44xc_n14_shell_api.tgz
+          tar xvzf nyc-output-win32_unit-m44xc_n14_shell_api.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-m44xe_n14_shell_api.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-m44xe_n14_shell_api.tgz
+        local_file: src/nyc-output-win32_unit-m44xe_n14_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m44xe_n14_shell_api.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -4641,13 +4641,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-m44xe_n14_shell_api.tgz
+          tar xvzf nyc-output-win32_unit-m44xe_n14_shell_api.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-m50xc_n14_shell_api.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-m50xc_n14_shell_api.tgz
+        local_file: src/nyc-output-win32_unit-m50xc_n14_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m50xc_n14_shell_api.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -4655,13 +4655,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-m50xc_n14_shell_api.tgz
+          tar xvzf nyc-output-win32_unit-m50xc_n14_shell_api.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-m50xe_n14_shell_api.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-m50xe_n14_shell_api.tgz
+        local_file: src/nyc-output-win32_unit-m50xe_n14_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m50xe_n14_shell_api.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -4669,13 +4669,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-m50xe_n14_shell_api.tgz
+          tar xvzf nyc-output-win32_unit-m50xe_n14_shell_api.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-mlatest_n14_shell_api.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-mlatest_n14_shell_api.tgz
+        local_file: src/nyc-output-win32_unit-mlatest_n14_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-mlatest_n14_shell_api.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -4683,13 +4683,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-mlatest_n14_shell_api.tgz
+          tar xvzf nyc-output-win32_unit-mlatest_n14_shell_api.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-n12_shell_evaluator.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-n12_shell_evaluator.tgz
+        local_file: src/nyc-output-win32_unit-n12_shell_evaluator.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-n12_shell_evaluator.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -4697,13 +4697,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-n12_shell_evaluator.tgz
+          tar xvzf nyc-output-win32_unit-n12_shell_evaluator.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-n14_shell_evaluator.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-n14_shell_evaluator.tgz
+        local_file: src/nyc-output-win32_unit-n14_shell_evaluator.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-n14_shell_evaluator.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -4711,13 +4711,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-n14_shell_evaluator.tgz
+          tar xvzf nyc-output-win32_unit-n14_shell_evaluator.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-n12_snippet_manager.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-n12_snippet_manager.tgz
+        local_file: src/nyc-output-win32_unit-n12_snippet_manager.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-n12_snippet_manager.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -4725,13 +4725,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-n12_snippet_manager.tgz
+          tar xvzf nyc-output-win32_unit-n12_snippet_manager.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-n14_snippet_manager.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-n14_snippet_manager.tgz
+        local_file: src/nyc-output-win32_unit-n14_snippet_manager.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-n14_snippet_manager.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -4739,13 +4739,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-n14_snippet_manager.tgz
+          tar xvzf nyc-output-win32_unit-n14_snippet_manager.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-n12_types.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-n12_types.tgz
+        local_file: src/nyc-output-win32_unit-n12_types.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-n12_types.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -4753,13 +4753,13 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-n12_types.tgz
+          tar xvzf nyc-output-win32_unit-n12_types.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-win32-n14_types.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32-n14_types.tgz
+        local_file: src/nyc-output-win32_unit-n14_types.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-n14_types.tgz
         bucket: mciuploads
     - command: shell.exec
       params:
@@ -4767,7 +4767,7 @@ functions:
         shell: bash
         script: |
           set -e
-          tar xvzf nyc-output-win32-n14_types.tgz
+          tar xvzf nyc-output-win32_unit-n14_types.tgz
     - command: shell.exec
       params:
         working_dir: src

--- a/.evergreen/evergreen.yml.in
+++ b/.evergreen/evergreen.yml.in
@@ -52,7 +52,7 @@ for (const packageInfo of MONGOSH_PACKAGES) {
   }
 }
 
-const ALL_UNIT_TEST_BUILD_VARIANTS = ['darwin', 'linux', 'win32'];
+const ALL_UNIT_TEST_BUILD_VARIANTS = ['darwin_unit', 'linux_unit', 'win32_unit'];
 
 const EXECUTABLE_PKG_INFO = [
   {
@@ -241,7 +241,7 @@ functions:
 
   check_coverage:
     <% for (let buildVariant of ALL_UNIT_TEST_BUILD_VARIANTS) {
-        for (let unitTest of ALL_UNIT_TESTS.filter(t => !t.variants || t.variants.includes(buildVariant))) { %>
+        for (let unitTest of ALL_UNIT_TESTS.filter(t => !t.variants || t.variants.includes(buildVariant.replace(/_unit$/, '')))) { %>
     - command: s3.get
       params:
         aws_key: ${aws_key}

--- a/.evergreen/evergreen.yml.in
+++ b/.evergreen/evergreen.yml.in
@@ -74,38 +74,38 @@ const EXECUTABLE_PKG_INFO = [
     executableOsId: 'linux-x64',
     compileBuildVariant: 'linux_x64_build',
     distributionBuildVariants: [
-      { name: 'linux-x64', packageOn: 'linux', smokeTestKind: 'none' },
-      { name: 'debian-x64', packageOn: 'linux', smokeTestKind: 'docker', smokeTestDockerfiles: ['ubuntu18.04-deb', 'ubuntu20.04-deb', 'debian9-deb', 'debian10-deb'] },
-      { name: 'rhel7-x64', packageOn: 'linux', smokeTestKind: 'docker', smokeTestDockerfiles: ['centos7-rpm', 'amazonlinux2-rpm'] },
-      { name: 'rhel8-x64', packageOn: 'linux', smokeTestKind: 'docker', smokeTestDockerfiles: ['rocky8-rpm', 'fedora34-rpm'] },
-      { name: 'suse-x64', packageOn: 'linux', smokeTestKind: 'docker', smokeTestDockerfiles: ['suse12-rpm', 'suse15-rpm'] },
-      { name: 'amzn1-x64', packageOn: 'linux', smokeTestKind: 'docker', smokeTestDockerfiles: ['amazonlinux1-rpm'] }
+      { name: 'linux-x64', packageOn: 'linux_package', smokeTestKind: 'none' },
+      { name: 'debian-x64', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['ubuntu18.04-deb', 'ubuntu20.04-deb', 'debian9-deb', 'debian10-deb'] },
+      { name: 'rhel7-x64', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['centos7-rpm', 'amazonlinux2-rpm'] },
+      { name: 'rhel8-x64', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['rocky8-rpm', 'fedora34-rpm'] },
+      { name: 'suse-x64', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['suse12-rpm', 'suse15-rpm'] },
+      { name: 'amzn1-x64', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['amazonlinux1-rpm'] }
     ]
   },
   {
     executableOsId: 'linux-arm64',
     compileBuildVariant: 'linux_arm64_build',
     distributionBuildVariants: [
-      { name: 'linux-arm64', packageOn: 'linux', smokeTestKind: 'none' },
-      { name: 'debian-arm64', packageOn: 'linux', smokeTestKind: 'debextract' },
-      { name: 'rhel8-arm64', packageOn: 'linux', smokeTestKind: 'rpmextract' },
-      { name: 'amzn2-arm64', packageOn: 'linux', smokeTestKind: 'rpmextract' }
+      { name: 'linux-arm64', packageOn: 'linux_package', smokeTestKind: 'none' },
+      { name: 'debian-arm64', packageOn: 'linux_package', smokeTestKind: 'debextract' },
+      { name: 'rhel8-arm64', packageOn: 'linux_package', smokeTestKind: 'rpmextract' },
+      { name: 'amzn2-arm64', packageOn: 'linux_package', smokeTestKind: 'rpmextract' }
     ]
   },
   {
     executableOsId: 'linux-ppc64le',
     compileBuildVariant: 'linux_ppc64le_build',
     distributionBuildVariants: [
-      { name: 'linux-ppc64le', packageOn: 'linux', smokeTestKind: 'none' },
-      { name: 'rhel8-ppc64le', packageOn: 'linux', smokeTestKind: 'rpmextract' }
+      { name: 'linux-ppc64le', packageOn: 'linux_package', smokeTestKind: 'none' },
+      { name: 'rhel8-ppc64le', packageOn: 'linux_package', smokeTestKind: 'rpmextract' }
     ]
   },
   {
     executableOsId: 'linux-s390x',
     compileBuildVariant: 'linux_s390x_build',
     distributionBuildVariants: [
-      { name: 'linux-s390x', packageOn: 'linux', smokeTestKind: 'none' },
-      { name: 'rhel7-s390x', packageOn: 'linux', smokeTestKind: 'rpmextract' }
+      { name: 'linux-s390x', packageOn: 'linux_package', smokeTestKind: 'none' },
+      { name: 'rhel7-s390x', packageOn: 'linux_package', smokeTestKind: 'rpmextract' }
     ]
   },
   {
@@ -619,7 +619,7 @@ tasks:
   - name: check
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -651,7 +651,7 @@ tasks:
     tags: <% out(["unit-test", ...(mShort === 'latest' ? ["mlatest"] : [])]) %>
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -673,7 +673,7 @@ tasks:
     tags: ["extra-integration-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -686,7 +686,7 @@ tasks:
     tags: ["extra-integration-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -697,7 +697,7 @@ tasks:
     tags: ["extra-integration-test"]
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -711,7 +711,7 @@ tasks:
   - name: compile_artifact
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -839,7 +839,7 @@ tasks:
     exec_timeout_secs: 86400
     depends_on:
       - name: compile_ts
-        variant: linux
+        variant: linux_unit
     commands:
       - func: checkout
       - func: install
@@ -851,8 +851,8 @@ tasks:
 
 # Need to run builds for every possible build variant.
 buildvariants:
-  - name: darwin
-    display_name: "MacOS Mojave"
+  - name: darwin_unit
+    display_name: "MacOS Mojave (Unit tests)"
     run_on: macos-1014
     expansions:
       executable_os_id: darwin-x64
@@ -861,10 +861,23 @@ buildvariants:
       <% for (const test of ALL_UNIT_TESTS.filter(t => !t.variants || t.variants.includes('darwin'))) { %>
       - name: test_<% out(test.id) %>
       <% } %>
+  - name: darwin
+    display_name: "MacOS Mojave"
+    run_on: macos-1014
+    expansions:
+      executable_os_id: darwin-x64
+    tasks:
       - name: compile_artifact
       - name: e2e_tests_darwin_x64
       - name: package_and_upload_artifact_darwin_x64
       - name: package_and_upload_artifact_darwin_arm64
+  - name: darwin_1100
+    display_name: "MacOS Big Sur"
+    run_on: macos-1100
+    expansions:
+      executable_os_id: darwin-x64
+    tasks:
+      - name: e2e_tests_darwin_x64
   - name: darwin_arm64
     display_name: "MacOS Big Sur (arm64)"
     run_on: macos-1100-arm64
@@ -875,19 +888,27 @@ buildvariants:
       # - name: e2e_tests_darwin_arm64
       # No E2E test for now because there are no server releases to run them against
 
-  - name: linux
-    display_name: "Ubuntu 18.04 x64"
+  - name: linux_unit
+    display_name: "Ubuntu 18.04 x64 (Unit tests)"
     run_on: ubuntu1804-small
     tasks:
       - name: compile_ts
       - name: check
-      - name: check_coverage
       <% for (const test of ALL_UNIT_TESTS.filter(t => !t.variants || t.variants.includes('linux'))) { %>
       - name: test_<% out(test.id) %>
       <% } %>
       - name: test_vscode
       - name: test_connectivity
       - name: test_apistrict
+  - name: linux_coverage
+    display_name: "Coverage Check"
+    run_on: ubuntu1804-small
+    tasks:
+      - name: check_coverage
+  - name: linux_package
+    display_name: "Ubuntu 18.04 x64 (Packaging)"
+    run_on: ubuntu1804-small
+    tasks:
       - name: package_and_upload_artifact_linux_x64
       - name: package_and_upload_artifact_debian_x64
       - name: package_and_upload_artifact_rhel7_x64
@@ -1024,8 +1045,8 @@ buildvariants:
 #    tasks:
 #      - name: e2e_tests_linux_s390x
 
-  - name: win32
-    display_name: "Windows VS 2019"
+  - name: win32_unit
+    display_name: "Windows VS 2019 (Unit tests)"
     run_on: windows-64-vs2019-small
     expansions:
       executable_os_id: win32
@@ -1034,6 +1055,12 @@ buildvariants:
       <% for (const test of ALL_UNIT_TESTS.filter(t => !t.variants || t.variants.includes('win32'))) { %>
       - name: test_<% out(test.id) %>
       <% } %>
+  - name: win32
+    display_name: "Windows VS 2019"
+    run_on: windows-64-vs2019-small
+    expansions:
+      executable_os_id: win32
+    tasks:
       - name: e2e_tests_win32
       - name: package_and_upload_artifact_win32_x64
       - name: package_and_upload_artifact_win32msi_x64
@@ -1066,9 +1093,14 @@ buildvariants:
     tasks:
       - name: pkg_test_ssh_win32_x64
       - name: pkg_test_ssh_win32msi_x64
-  - name: pkg_smoke_tests_macos_x64
-    display_name: "package smoke tests (macos x64)"
+  - name: pkg_smoke_tests_macos_1014_x64
+    display_name: "package smoke tests (macos 10.14 x64)"
     run_on: macos-1014
+    tasks:
+      - name: pkg_test_macos_darwin_x64
+  - name: pkg_smoke_tests_macos_1100_x64
+    display_name: "package smoke tests (macos 11.00 x64)"
+    run_on: macos-1100
     tasks:
       - name: pkg_test_macos_darwin_x64
   - name: pkg_smoke_tests_macos_arm64

--- a/packages/cli-repl/test/e2e-auth.spec.ts
+++ b/packages/cli-repl/test/e2e-auth.spec.ts
@@ -906,6 +906,7 @@ describe('Auth e2e', function() {
           'Received authentication for mechanism GSSAPI which is not enabled',
           'Received authentication for mechanism GSSAPI which is unknown or not enabled',
           'Miscellaneous failure (see text): Unable to find realm of host localhost',
+          'Miscellaneous failure (see text): no credential for',
           "Unsupported mechanism 'GSSAPI' on authentication database '$external'"
         ];
         expect(messages.some(msg => shell.output.includes(msg)))


### PR DESCRIPTION
In particular, split out Linux unit tests so that we can
make merging dependent on them, and add macos 11 x64
test tasks (MONGOSH-1107).