### PR TITLE
feat(JMongosh): allow setting MongoClient after MongoShell was created

### DIFF
--- a/packages/java-shell/build.gradle
+++ b/packages/java-shell/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk8"
     testImplementation group: 'junit', name: 'junit', version: '4.12'
     implementation group: 'org.graalvm.js', name: 'js', version: '22.0.0.2'
-    implementation group: 'org.mongodb', name: 'mongodb-driver-sync', version: '4.4.0'
+    implementation group: 'org.mongodb', name: 'mongodb-driver-sync', version: '4.5.1'
     implementation group: 'org.apache.commons', name: 'commons-text', version: '1.8'
 }
 

--- a/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/MongoShell.kt
+++ b/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/MongoShell.kt
@@ -5,12 +5,14 @@ import com.mongodb.mongosh.result.ArrayResult
 import com.mongodb.mongosh.result.MongoShellResult
 import org.intellij.lang.annotations.Language
 
-class MongoShell(client: MongoClient) {
+class MongoShell(client: MongoClient? = null) {
     private val context = MongoShellContext()
     private val wrapper = ValueWrapper(context)
     private val converter = MongoShellConverter(context, wrapper)
     private val evaluator = MongoShellEvaluator(client, context, converter, wrapper)
     private val consoleLog = ConsoleLogSupport(context, converter)
+
+    fun setClient(client: MongoClient): Unit = evaluator.setClient(client)
 
     fun eval(@Language("js") script: String): MongoShellResult<*> {
         val printedValues = mutableListOf<List<Any?>>()

--- a/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/MongoShellEvaluator.kt
+++ b/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/MongoShellEvaluator.kt
@@ -15,7 +15,7 @@ import java.time.temporal.TemporalField
 import java.time.temporal.UnsupportedTemporalTypeException
 import java.util.*
 
-internal class MongoShellEvaluator(client: MongoClient, private val context: MongoShellContext, private val converter: MongoShellConverter, wrapper: ValueWrapper) {
+internal class MongoShellEvaluator(client: MongoClient?, private val context: MongoShellContext, private val converter: MongoShellConverter, wrapper: ValueWrapper) {
     private val serviceProvider = JavaServiceProvider(client, converter, wrapper)
     private val shellEvaluator: Value
     private val shellInstanceState: Value
@@ -136,6 +136,8 @@ internal class MongoShellEvaluator(client: MongoClient, private val context: Mon
     fun close() {
         context.close()
     }
+
+    fun setClient(client: MongoClient): Unit = serviceProvider.setClient(client)
 }
 
 private val COLON = DateTimeFormatterBuilder().appendLiteral(":").toFormatter()


### PR DESCRIPTION
This is needed to improve JDBC driver performance - we'll create MongoShell instances beforehand