### PR TITLE
fix(shell-api): clone public bson ctors and prototypes MONGOSH-1097

### DIFF
--- a/packages/shell-api/src/shell-bson.spec.ts
+++ b/packages/shell-api/src/shell-bson.spec.ts
@@ -21,6 +21,15 @@ describe('Shell BSON', () => {
     shellBson = constructShellBson(bson, printWarning);
   });
 
+  describe('BSON object construction', () => {
+    it('clones methods and their prototypes', () => {
+      expect(shellBson.ObjectId).to.not.equal(bson.ObjectId);
+      expect(shellBson.ObjectId.prototype).to.not.equal(bson.ObjectId.prototype);
+      expect(shellBson.Binary).to.not.equal(bson.Binary);
+      expect(shellBson.Binary.prototype).to.not.equal(bson.Binary.prototype);
+    });
+  });
+
   describe('DBRef', () => {
     it('without new', () => {
       const s = shellBson.DBRef('namespace', 'oid');


### PR DESCRIPTION
Clone the properties and prototypes of publicly exposed BSON
constructors before adding them to the shell API.

This ensures that changes to these methods from user code will not
affect mongosh internals.

Unfortunately, it is not easily possible to add a regression test
for the original ticket here, since it depends specifically on
the way in which homebrew (or npx) install mongosh, where dependencies
of the different packages in the monorepo are deduplicated during
installation (which makes `service-provider-server` and
`service-provider-core` share a `bson` dependency rather than
using separate ones).