### PR TITLE
fix: explicitly call ObjectId.toHexString() in internals MONGOSH-1097

### DIFF
--- a/packages/cli-repl/src/cli-repl.ts
+++ b/packages/cli-repl/src/cli-repl.ts
@@ -106,7 +106,7 @@ class CliRepl implements MongoshIOProvider {
     this.analyticsOptions = options.analyticsOptions;
     this.onExit = options.onExit;
 
-    const id = new bson.ObjectId().toString();
+    const id = new bson.ObjectId().toHexString();
     this.config = {
       userId: id,
       telemetryAnonymousId: id,

--- a/packages/editor/src/editor.ts
+++ b/packages/editor/src/editor.ts
@@ -106,7 +106,7 @@ export class Editor {
   }
 
   async _createTempFile({ content, ext }: { content: string; ext: string }): Promise<string> {
-    const tmpDoc = path.join(this._tmpDir, `edit-${new bson.ObjectId()}.${ext}`);
+    const tmpDoc = path.join(this._tmpDir, `edit-${new bson.ObjectId().toHexString()}.${ext}`);
 
     // Create a temp file to store a content that is being edited.
     await fs.mkdir(path.dirname(tmpDoc), { recursive: true, mode: 0o700 });


### PR DESCRIPTION
Call `.toHexString()` when we convert an `ObjectId` to a string
for internal usage.

This ensures that changes to `ObjectId.prototyp.toString()` from
user code will not affect mongosh internals.

Unfortunately, it is not easily possible to add a regression test
for the original ticket here, since it depends specifically on
the way in which homebrew (or npx) install mongosh, where dependencies
of the different packages in the monorepo are deduplicated during
installation (which makes `service-provider-server` and
`service-provider-core` share a `bson` dependency rather than
using separate ones).