### PR TITLE
fix(node-runtime-worker-thread): pass through CSFLE schema options COMPASS-5647

### DIFF
--- a/packages/node-runtime-worker-thread/src/index.ts
+++ b/packages/node-runtime-worker-thread/src/index.ts
@@ -14,7 +14,7 @@ import { kill } from './spawn-child-from-source';
 import { Caller, createCaller, cancel } from './rpc';
 import { ChildProcessEvaluationListener } from './child-process-evaluation-listener';
 import type { WorkerRuntime as WorkerThreadWorkerRuntime } from './worker-runtime';
-import { deserializeEvaluationResult } from './serializer';
+import { deserializeEvaluationResult, serializeConnectOptions } from './serializer';
 import { ChildProcessMongoshBus } from './child-process-mongosh-bus';
 import type { CompassServiceProvider } from '@mongosh/service-provider-server';
 
@@ -159,7 +159,7 @@ class WorkerRuntime implements Runtime {
       this.childProcess
     );
 
-    await this.childProcessRuntime.init(uri, driverOptions, cliOptions);
+    await this.childProcessRuntime.init(uri, serializeConnectOptions(driverOptions), cliOptions);
   }
 
   async evaluate(code: string): Promise<RuntimeEvaluationResult> {

--- a/packages/node-runtime-worker-thread/src/worker-runtime.ts
+++ b/packages/node-runtime-worker-thread/src/worker-runtime.ts
@@ -13,7 +13,7 @@ import {
   CompassServiceProvider
 } from '@mongosh/service-provider-server';
 import { exposeAll, createCaller } from './rpc';
-import { serializeEvaluationResult } from './serializer';
+import { serializeEvaluationResult, deserializeConnectOptions } from './serializer';
 import type { MongoshBus } from '@mongosh/types';
 import { Lock, UNLOCKED } from './lock';
 import { runInterruptible, InterruptHandle } from 'interruptor';
@@ -97,7 +97,7 @@ const workerRuntime: WorkerRuntime = {
     // will have to do for now.
     provider = await (CompassServiceProvider as any).connect(
       uri,
-      driverOptions,
+      deserializeConnectOptions(driverOptions),
       cliOptions,
       messageBus
     );


### PR DESCRIPTION
`schemaMap` and the soon-to-be-introduced `encryptedFieldConfigMap`
(or similar) typically contain bson values that are not serialized
properly right now.

We add EJSON serialization for transferring them to the worker runtime.