### PR TITLE
feat(shell-api): Mark `collection.reIndex()` deprecated MONGOSH-1182

### DIFF
--- a/packages/shell-api/src/collection.ts
+++ b/packages/shell-api/src/collection.ts
@@ -1265,6 +1265,7 @@ export default class Collection extends ShellApiWithMongoClass {
    * @return {Promise}
    */
   @returnsPromise
+  @deprecated
   @topologies([Topologies.Standalone])
   @apiVersions([])
   async reIndex(): Promise<Document> {


### PR DESCRIPTION
MONGOSH-1182

This PR marks the collection `reIndex` function as deprecated.

## Open questions
Should we print a deprecation warning? 
```ts
await this._instanceState.printDeprecationWarning(
  'Collection.reIndex() is deprecated and not recommended for use.'
);
```