### PR TITLE
fix(shell-api): make .getKeyVault() create index over keyAltNames

### DIFF
--- a/packages/shell-api/src/field-level-encryption.spec.ts
+++ b/packages/shell-api/src/field-level-encryption.spec.ts
@@ -732,7 +732,7 @@ srDVjIT3LsvTqw==`
       await mongo.getKeyVault();
       expect(printedOutput).to.have.lengthOf(1);
       expect(printedOutput[0].printable).to.match(new RegExp(
-        String.raw `^Warning: Creating 'keyAltNames' index on '${dbname}\.__keyVault' failed: Index build failed`));
+        String.raw `^Warning: Creating 'keyAltNames' index on '${dbname}\.__keyVault' failed:`));
     });
   });
 });

--- a/packages/shell-api/src/mongo.ts
+++ b/packages/shell-api/src/mongo.ts
@@ -584,8 +584,12 @@ export default class Mongo extends ShellApiClass {
   @platforms([ReplPlatform.CLI])
   @serverVersions(['4.2.0', ServerVersions.latest])
   @returnType('KeyVault')
-  getKeyVault(): KeyVault {
-    this._keyVault = new KeyVault(this.getClientEncryption());
+  @returnsPromise
+  async getKeyVault(): Promise<KeyVault> {
+    if (!this._keyVault) {
+      this._keyVault = new KeyVault(this.getClientEncryption());
+      await this._keyVault._init();
+    }
     return this._keyVault;
   }
 }


### PR DESCRIPTION
MONGOSH-1191

This was missed when porting `KeyVault` over from the legacy shell.
Instead of erroring out if the index could not be created (as the
legacy shell would have done), print a warning instead.

Other fixes here:
- Fix the namespace parsing in the `KeyVault` constructor
- Ensure that the `KeyVault` object is only instantiated
  once per `Mongo` object.
- Use `$addToSet` instead of `$push` for adding keyAltName entries to avoid duplicates inside the array
- Fix empty array removal in `removeKeyAlternateName()`
- Account for the broken empty array removal before creating the `keyAltNames` index