### PR TITLE
fix(shell-api): Remove removed collection save command instead of deprecating MONGOSH-1195

### DIFF
--- a/packages/i18n/src/locales/en_US.ts
+++ b/packages/i18n/src/locales/en_US.ts
@@ -498,11 +498,6 @@ const translations: Catalog = {
               description: 'Removes documents from a collection.',
               example: 'db.collection.remove(query, options)'
             },
-            save: {
-              link: 'https://docs.mongodb.com/manual/reference/method/db.collection.save',
-              description: 'Updates an existing document or inserts a new document, depending on its document parameter.',
-              example: 'db.collection.save(document, options)'
-            },
             stats: {
               link: 'https://docs.mongodb.com/manual/reference/method/db.collection.stats',
               description: 'Returns statistics about the collection.',

--- a/packages/shell-api/src/collection.spec.ts
+++ b/packages/shell-api/src/collection.spec.ts
@@ -1921,7 +1921,7 @@ describe('Collection', () => {
       watch: { i: 1 }
     };
     const ignore: (keyof (typeof Collection)['prototype'])[] = [
-      'getShardDistribution', 'stats', 'isCapped', 'save'
+      'getShardDistribution', 'stats', 'isCapped'
     ];
     const args = [ { query: {} }, {}, { out: 'coll' } ];
     beforeEach(() => {

--- a/packages/shell-api/src/collection.ts
+++ b/packages/shell-api/src/collection.ts
@@ -801,13 +801,6 @@ export default class Collection extends ShellApiWithMongoClass {
     );
   }
 
-  @deprecated
-  save(): never {
-    throw new MongoshInvalidInputError(
-      'Collection.save() is deprecated. Use insertOne, insertMany, updateOne, or updateMany.'
-    );
-  }
-
   /**
    * Replace a document with another.
    *


### PR DESCRIPTION
MONGOSH-1195

Currently the collection `.save()` command errors with a `MongoshInvalidInputError` error. As this command has been removed in the driver as of 4.0 I'm thinking we should be able to drop it entirely. If folks feel it's better to keep a message being displayed that's cool also.
Currently we are printing a message with the error that states the command is deprecated. If we don't remove I think we should update the message to be explicit that the command has been removed.