### PR TITLE
chore: bump mongodb-client-encryption, add ts-expect-error MONGOSH-1196

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -8246,7 +8246,8 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "14.18.3"
+          node_js_version: "14.19.1"
+          npm_deps_mode: cli_build
       - func: test_artifact_docker
         vars:
           dockerfile: ubuntu18.04-deb
@@ -8263,7 +8264,8 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "14.18.3"
+          node_js_version: "14.19.1"
+          npm_deps_mode: cli_build
       - func: test_artifact_docker
         vars:
           dockerfile: ubuntu20.04-deb
@@ -8280,7 +8282,8 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "14.18.3"
+          node_js_version: "14.19.1"
+          npm_deps_mode: cli_build
       - func: test_artifact_docker
         vars:
           dockerfile: debian9-deb
@@ -8297,7 +8300,8 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "14.18.3"
+          node_js_version: "14.19.1"
+          npm_deps_mode: cli_build
       - func: test_artifact_docker
         vars:
           dockerfile: debian10-deb
@@ -8314,7 +8318,8 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "14.18.3"
+          node_js_version: "14.19.1"
+          npm_deps_mode: cli_build
       - func: test_artifact_docker
         vars:
           dockerfile: centos7-rpm
@@ -8331,7 +8336,8 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "14.18.3"
+          node_js_version: "14.19.1"
+          npm_deps_mode: cli_build
       - func: test_artifact_docker
         vars:
           dockerfile: amazonlinux2-rpm
@@ -8348,7 +8354,8 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "14.18.3"
+          node_js_version: "14.19.1"
+          npm_deps_mode: cli_build
       - func: test_artifact_docker
         vars:
           dockerfile: rocky8-rpm
@@ -8365,7 +8372,8 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "14.18.3"
+          node_js_version: "14.19.1"
+          npm_deps_mode: cli_build
       - func: test_artifact_docker
         vars:
           dockerfile: fedora34-rpm
@@ -8382,7 +8390,8 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "14.18.3"
+          node_js_version: "14.19.1"
+          npm_deps_mode: cli_build
       - func: test_artifact_docker
         vars:
           dockerfile: suse12-rpm
@@ -8399,7 +8408,8 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "14.18.3"
+          node_js_version: "14.19.1"
+          npm_deps_mode: cli_build
       - func: test_artifact_docker
         vars:
           dockerfile: suse15-rpm
@@ -8416,7 +8426,8 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "14.18.3"
+          node_js_version: "14.19.1"
+          npm_deps_mode: cli_build
       - func: test_artifact_docker
         vars:
           dockerfile: amazonlinux1-rpm

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -5033,6 +5033,7 @@ functions:
           set -e
           set -x
           {
+          export NODE_JS_VERSION=${node_js_version}
           . .evergreen/setup-env.sh
           . preload.sh
           ./scripts/docker/build.sh ${dockerfile}
@@ -8251,6 +8252,7 @@ tasks:
           npm_deps_mode: cli_build
       - func: test_artifact_docker
         vars:
+          node_js_version: "14.19.1"
           dockerfile: ubuntu18.04-deb
   - name: pkg_test_docker_ubuntu20_04_deb
     tags: ["smoke-test"]
@@ -8269,6 +8271,7 @@ tasks:
           npm_deps_mode: cli_build
       - func: test_artifact_docker
         vars:
+          node_js_version: "14.19.1"
           dockerfile: ubuntu20.04-deb
   - name: pkg_test_docker_debian9_deb
     tags: ["smoke-test"]
@@ -8287,6 +8290,7 @@ tasks:
           npm_deps_mode: cli_build
       - func: test_artifact_docker
         vars:
+          node_js_version: "14.19.1"
           dockerfile: debian9-deb
   - name: pkg_test_docker_debian10_deb
     tags: ["smoke-test"]
@@ -8305,6 +8309,7 @@ tasks:
           npm_deps_mode: cli_build
       - func: test_artifact_docker
         vars:
+          node_js_version: "14.19.1"
           dockerfile: debian10-deb
   - name: pkg_test_docker_centos7_rpm
     tags: ["smoke-test"]
@@ -8323,6 +8328,7 @@ tasks:
           npm_deps_mode: cli_build
       - func: test_artifact_docker
         vars:
+          node_js_version: "14.19.1"
           dockerfile: centos7-rpm
   - name: pkg_test_docker_amazonlinux2_rpm
     tags: ["smoke-test"]
@@ -8341,6 +8347,7 @@ tasks:
           npm_deps_mode: cli_build
       - func: test_artifact_docker
         vars:
+          node_js_version: "14.19.1"
           dockerfile: amazonlinux2-rpm
   - name: pkg_test_docker_rocky8_rpm
     tags: ["smoke-test"]
@@ -8359,6 +8366,7 @@ tasks:
           npm_deps_mode: cli_build
       - func: test_artifact_docker
         vars:
+          node_js_version: "14.19.1"
           dockerfile: rocky8-rpm
   - name: pkg_test_docker_fedora34_rpm
     tags: ["smoke-test"]
@@ -8377,6 +8385,7 @@ tasks:
           npm_deps_mode: cli_build
       - func: test_artifact_docker
         vars:
+          node_js_version: "14.19.1"
           dockerfile: fedora34-rpm
   - name: pkg_test_docker_suse12_rpm
     tags: ["smoke-test"]
@@ -8395,6 +8404,7 @@ tasks:
           npm_deps_mode: cli_build
       - func: test_artifact_docker
         vars:
+          node_js_version: "14.19.1"
           dockerfile: suse12-rpm
   - name: pkg_test_docker_suse15_rpm
     tags: ["smoke-test"]
@@ -8413,6 +8423,7 @@ tasks:
           npm_deps_mode: cli_build
       - func: test_artifact_docker
         vars:
+          node_js_version: "14.19.1"
           dockerfile: suse15-rpm
   - name: pkg_test_docker_amazonlinux1_rpm
     tags: ["smoke-test"]
@@ -8431,6 +8442,7 @@ tasks:
           npm_deps_mode: cli_build
       - func: test_artifact_docker
         vars:
+          node_js_version: "14.19.1"
           dockerfile: amazonlinux1-rpm
   - name: pkg_test_debextract_debian_arm64
     tags: ["smoke-test"]

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -5033,6 +5033,7 @@ functions:
           set -e
           set -x
           {
+          . .evergreen/setup-env.sh
           . preload.sh
           ./scripts/docker/build.sh ${dockerfile}
           ./scripts/docker/run.sh ${dockerfile} --smokeTests

--- a/.evergreen/evergreen.yml.in
+++ b/.evergreen/evergreen.yml.in
@@ -820,6 +820,7 @@ tasks:
       - func: install
         vars:
           node_js_version: "<% out(NODE_JS_VERSION_14) %>"
+          npm_deps_mode: cli_build
       - func: test_artifact_docker
         vars:
           dockerfile: <% out(dockerfile) %>

--- a/.evergreen/evergreen.yml.in
+++ b/.evergreen/evergreen.yml.in
@@ -522,6 +522,7 @@ functions:
           set -e
           set -x
           {
+          . .evergreen/setup-env.sh
           . preload.sh
           ./scripts/docker/build.sh ${dockerfile}
           ./scripts/docker/run.sh ${dockerfile} --smokeTests

--- a/.evergreen/evergreen.yml.in
+++ b/.evergreen/evergreen.yml.in
@@ -522,6 +522,7 @@ functions:
           set -e
           set -x
           {
+          export NODE_JS_VERSION=${node_js_version}
           . .evergreen/setup-env.sh
           . preload.sh
           ./scripts/docker/build.sh ${dockerfile}
@@ -824,6 +825,7 @@ tasks:
           npm_deps_mode: cli_build
       - func: test_artifact_docker
         vars:
+          node_js_version: "<% out(NODE_JS_VERSION_14) %>"
           dockerfile: <% out(dockerfile) %>
     <% }; break;
     // We don't have docker for platforms other than x64, so for those we just

--- a/packages/arg-parser/src/arg-mapper.ts
+++ b/packages/arg-parser/src/arg-mapper.ts
@@ -105,6 +105,7 @@ const MAPPINGS: {
   awsSecretAccessKey: (i, v) => setAWSKMS(i, 'secretAccessKey', v),
   awsSessionToken: (i, v) => setAWSKMS(i, 'sessionToken', v),
   awsIamSessionToken: (i, v) => setAuthMechProp(i, 'AWS_SESSION_TOKEN', v),
+  // @ts-expect-error waiting for driver release
   csfleLibraryPath: (i, v) => setAutoEncryptExtra(i, 'csflePath', v),
   gssapiServiceName: (i, v) => setAuthMechProp(i, 'SERVICE_NAME', v),
   sspiRealmOverride: (i, v) => setAuthMechProp(i, 'SERVICE_REALM', v),

--- a/packages/build/src/download-mongodb.ts
+++ b/packages/build/src/download-mongodb.ts
@@ -64,19 +64,35 @@ async function doDownload(
     const url = await lookupDownloadUrl();
     console.info('Downloading...', url);
 
-    if (url.match(/\.tgz$|\.tar(\.[^.]+)?$/)) {
-      // the server's tarballs can contain hard links, which the (unmaintained?)
-      // `download` package is unable to handle (https://github.com/kevva/decompress/issues/93)
-      const response = await fetch(url);
-      await promisify(pipeline)(
-        response.body,
-        tar.x({ cwd: downloadTarget, strip: isCsfle ? 0 : 1 })
-      );
-    } else {
-      await download(url, downloadTarget, { extract: true, strip: 1 });
+    async function downloadAndExtract(withExtraStripDepth = 0): Promise<void> {
+      if (url.match(/\.tgz$|\.tar(\.[^.]+)?$/)) {
+        // the server's tarballs can contain hard links, which the (unmaintained?)
+        // `download` package is unable to handle (https://github.com/kevva/decompress/issues/93)
+        const response = await fetch(url);
+        await promisify(pipeline)(
+          response.body,
+          tar.x({ cwd: downloadTarget, strip: isCsfle ? 0 : 1 })
+        );
+      } else {
+        await download(url, downloadTarget, { extract: true, strip: isCsfle ? 0 : 1 });
+      }
+
+      try {
+        await fs.stat(bindir); // Make sure it exists.
+      } catch (err) {
+        if (withExtraStripDepth === 0 && url.includes('macos')) {
+          // The server team changed how macos release artifacts are packed
+          // and added a `./` prefix to paths in the tarball,
+          // which seems like it shouldn't change anything but does
+          // in fact require an increased path strip depth.
+          console.info('Retry due to miscalculated --strip-components depth');
+          return await downloadAndExtract(1);
+        }
+        throw err;
+      }
     }
 
-    await fs.stat(bindir); // Make sure it exists.
+    await downloadAndExtract();
     return bindir;
   })();
 }

--- a/packages/build/src/download-mongodb.ts
+++ b/packages/build/src/download-mongodb.ts
@@ -51,7 +51,9 @@ async function doDownload(
     `mongodb-${process.platform}-${process.env.DISTRO_ID || 'none'}-${process.arch}-${version}`
       .replace(/[^a-zA-Z0-9_-]/g, ''));
   return downloadPromises[downloadTarget] ??= (async() => {
-    const bindir = path.resolve(downloadTarget, isCsfle ? 'lib' : 'bin');
+    const bindir = path.resolve(
+      downloadTarget,
+      isCsfle && process.platform !== 'win32' ? 'lib' : 'bin');
     try {
       await fs.stat(bindir);
       console.info(`Skipping download because ${downloadTarget} exists`);

--- a/packages/build/src/packaging/download-csfle-library.ts
+++ b/packages/build/src/packaging/download-csfle-library.ts
@@ -26,14 +26,10 @@ export async function downloadCsfleLibrary(variant: BuildVariant | 'host'): Prom
     }
   }
   if (!libdir) throw error;
-  let csfleLibrary = path.join(libdir, 'mongo_csfle_v1');
-  if (opts.distro === 'win32') {
-    csfleLibrary += '.dll';
-  } else if (opts.distro === 'darwin') {
-    csfleLibrary += '.dylib';
-  } else {
-    csfleLibrary += '.so';
-  }
+  const csfleLibrary = path.join(
+    libdir,
+    (await fs.readdir(libdir)).find(filename => filename.match(/^mongo_csfle_v1\.(so|dylib|dll)$/)) as string
+  );
   // Make sure that the binary exists and is readable.
   await fs.access(csfleLibrary, fsConstants.R_OK);
   console.info('mongosh: downloaded', csfleLibrary);

--- a/packages/build/src/packaging/run-package.ts
+++ b/packages/build/src/packaging/run-package.ts
@@ -13,14 +13,10 @@ export async function runPackage(
   validateBuildVariant(distributionBuildVariant);
 
   await fs.mkdir(path.dirname(config.csfleLibraryPath), { recursive: true });
-  // TODO: add csfle and E2E tests for darwin-arm64 once server builds
-  // are available for that platform.
-  if (distributionBuildVariant !== 'darwin-arm64') {
-    await fs.copyFile(
-      await downloadCsfleLibrary(distributionBuildVariant),
-      config.csfleLibraryPath,
-      fsConstants.COPYFILE_FICLONE);
-  }
+  await fs.copyFile(
+    await downloadCsfleLibrary(distributionBuildVariant),
+    config.csfleLibraryPath,
+    fsConstants.COPYFILE_FICLONE);
 
   const { manpage } = config;
   if (manpage) {

--- a/packages/cli-repl/package-lock.json
+++ b/packages/cli-repl/package-lock.json
@@ -38,7 +38,8 @@
 				"@types/yargs-parser": "^15.0.0",
 				"chai-as-promised": "^7.1.1",
 				"lodash": "^4.17.21",
-				"moment": "^2.29.1"
+				"moment": "^2.29.1",
+				"mongodb-csfle-library-dummy": "^1.0.1"
 			},
 			"engines": {
 				"node": ">=14.15.0"
@@ -46,6 +47,7 @@
 			"optionalDependencies": {
 				"get-console-process-list": "^1.0.4",
 				"macos-export-certificate-and-key": "^1.1.1",
+				"mongodb-csfle-library-version": "^1.0.2",
 				"win-export-certificate-and-key": "^1.1.1"
 			}
 		},
@@ -750,6 +752,27 @@
 			"dependencies": {
 				"@types/whatwg-url": "^8.2.1",
 				"whatwg-url": "^11.0.0"
+			}
+		},
+		"node_modules/mongodb-csfle-library-dummy": {
+			"version": "1.0.1",
+			"resolved": "https://registry.npmjs.org/mongodb-csfle-library-dummy/-/mongodb-csfle-library-dummy-1.0.1.tgz",
+			"integrity": "sha512-HrNXwbXcgyO93EqCuNpeUborAmO5Vmr8ZCswxk7MdAke1dO8gmNo02NlabE47PwiCGzf3TPzmX5cf4K7TXIt3Q==",
+			"dev": true,
+			"hasInstallScript": true
+		},
+		"node_modules/mongodb-csfle-library-version": {
+			"version": "1.0.2",
+			"resolved": "https://registry.npmjs.org/mongodb-csfle-library-version/-/mongodb-csfle-library-version-1.0.2.tgz",
+			"integrity": "sha512-DzO4BDGh8nQUEjr7HcB9w1K1CZlfWQRA1Rkq1ROk8aJoaaEK2m++cyVHVUNzHGrYu7X1r5yqHlGxfPw5bSEU0w==",
+			"hasInstallScript": true,
+			"optional": true,
+			"dependencies": {
+				"bindings": "^1.5.0",
+				"node-addon-api": "^4.3.0"
+			},
+			"bin": {
+				"mongodb-csfle-library-version": "bin/mongodb-csfle-library-version.js"
 			}
 		},
 		"node_modules/mongodb-log-writer": {

--- a/packages/cli-repl/src/cli-repl.ts
+++ b/packages/cli-repl/src/cli-repl.ts
@@ -233,10 +233,12 @@ class CliRepl implements MongoshIOProvider {
 
     if (driverOptions.autoEncryption) {
       const origExtraOptions = driverOptions.autoEncryption.extraOptions ?? {};
+      // @ts-expect-error waiting for driver release
       if (origExtraOptions.csflePath) {
         // If a CSFLE path has been specified through 'driverOptions', save it
         // for later use.
         this.cachedCSFLELibraryPath = Promise.resolve({
+          // @ts-expect-error waiting for driver release
           csflePath: origExtraOptions.csflePath
         });
       }
@@ -654,6 +656,7 @@ class CliRepl implements MongoshIOProvider {
     if (!this.getCSFLELibraryPaths) {
       throw new MongoshInternalError('This instance of mongosh is not configured for CSFLE');
     }
+    // @ts-expect-error waiting for driver release
     return (this.cachedCSFLELibraryPath ??= this.getCSFLELibraryPaths(this.bus));
   }
 

--- a/packages/cli-repl/src/csfle-library-paths.spec.ts
+++ b/packages/cli-repl/src/csfle-library-paths.spec.ts
@@ -34,7 +34,7 @@ describe('getCSFLELibraryPaths', () => {
       csflePath,
       expectedVersion
     });
-    expect(events).to.deep.equal([
+    expect(events.slice(1)).to.deep.equal([
       [ 'mongosh:csfle-load-found', { csflePath, expectedVersion } ]
     ]);
   });
@@ -60,7 +60,7 @@ describe('getCSFLELibraryPaths', () => {
     });
     expect(events[0][0]).to.equal('mongosh:csfle-load-skip');
     expect(events[0][1].reason).to.match(/ENOENT|LoadLibraryW failed/);
-    expect(events.slice(1)).to.deep.equal([
+    expect(events.slice(2)).to.deep.equal([
       [ 'mongosh:csfle-load-found', { csflePath, expectedVersion } ]
     ]);
   });
@@ -73,8 +73,8 @@ describe('getCSFLELibraryPaths', () => {
     await fs.copyFile(csfleLibraryDummy, csflePath);
     await fs.chmod(csflePath, 0o000);
     expect(await getCSFLELibraryPaths(bus, fakeMongoshExecPath)).to.deep.equal({});
-    expect(events[0][0]).to.equal('mongosh:csfle-load-skip');
-    expect(events[0][1].reason).to.include('EACCES');
+    expect(events[1][0]).to.equal('mongosh:csfle-load-skip');
+    expect(events[1][1].reason).to.include('EACCES');
   });
 
   it('will reject a shared library if its permissions are world-writable', async function() {
@@ -85,7 +85,7 @@ describe('getCSFLELibraryPaths', () => {
     await fs.copyFile(csfleLibraryDummy, csflePath);
     await fs.chmod(csflePath, 0o777);
     expect(await getCSFLELibraryPaths(bus, fakeMongoshExecPath)).to.deep.equal({});
-    expect(events[0][0]).to.equal('mongosh:csfle-load-skip');
-    expect(events[0][1].reason).to.include('permissions mismatch');
+    expect(events[1][0]).to.equal('mongosh:csfle-load-skip');
+    expect(events[1][1].reason).to.include('permissions mismatch');
   });
 });

--- a/packages/cli-repl/src/csfle-library-paths.spec.ts
+++ b/packages/cli-repl/src/csfle-library-paths.spec.ts
@@ -23,11 +23,24 @@ describe('getCSFLELibraryPaths', () => {
     fakeMongoshExecPath = path.join(tmpdir.path, 'bin', 'mongosh');
     await fs.mkdir(path.join(tmpdir.path, 'bin'), { recursive: true });
     await fs.mkdir(path.join(tmpdir.path, 'lib'), { recursive: true });
+    await fs.mkdir(path.join(tmpdir.path, 'lib64'), { recursive: true });
     await fs.writeFile(fakeMongoshExecPath, '# dummy', { mode: 0o755 });
   });
 
   it('will look up a shared library located in <bindir>/../lib/', async function() {
     const csflePath = path.join(tmpdir.path, 'lib', csfleFilename);
+    await fs.copyFile(csfleLibraryDummy, csflePath);
+    expect(await getCSFLELibraryPaths(bus, fakeMongoshExecPath)).to.deep.equal({
+      csflePath,
+      expectedVersion
+    });
+    expect(events).to.deep.equal([
+      [ 'mongosh:csfle-load-found', { csflePath, expectedVersion } ]
+    ]);
+  });
+
+  it('will look up a shared library located in <bindir>/../lib64/', async function() {
+    const csflePath = path.join(tmpdir.path, 'lib64', csfleFilename);
     await fs.copyFile(csfleLibraryDummy, csflePath);
     expect(await getCSFLELibraryPaths(bus, fakeMongoshExecPath)).to.deep.equal({
       csflePath,
@@ -46,7 +59,7 @@ describe('getCSFLELibraryPaths', () => {
       expectedVersion
     });
     expect(events[0][0]).to.equal('mongosh:csfle-load-skip');
-    expect(events[0][1].reason).to.include('ENOENT');
+    expect(events[0][1].reason).to.match(/ENOENT|LoadLibraryW failed/);
     expect(events.slice(1)).to.deep.equal([
       [ 'mongosh:csfle-load-found', { csflePath, expectedVersion } ]
     ]);

--- a/packages/cli-repl/src/csfle-library-paths.ts
+++ b/packages/cli-repl/src/csfle-library-paths.ts
@@ -32,7 +32,8 @@ export async function getCSFLELibraryPaths(
     const bindir = path.dirname(execPath);
     const execPathStat = await fs.stat(execPath);
     for await (const libraryCandidate of [
-      // Location of the shared library in the deb and rpm packages
+      // Locations of the shared library in the deb and rpm packages
+      path.resolve(bindir, '..', 'lib64', `mongosh_csfle_v1.${SHARED_LIBRARY_SUFFIX}`),
       path.resolve(bindir, '..', 'lib', `mongosh_csfle_v1.${SHARED_LIBRARY_SUFFIX}`),
       // Location of the shared library in the zip and tgz packages
       path.resolve(bindir, `mongosh_csfle_v1.${SHARED_LIBRARY_SUFFIX}`)

--- a/packages/node-runtime-worker-thread/src/child-process-evaluation-listener.ts
+++ b/packages/node-runtime-worker-thread/src/child-process-evaluation-listener.ts
@@ -4,7 +4,7 @@ import type { WorkerRuntime } from './index';
 import { RuntimeEvaluationListener } from '@mongosh/browser-runtime-core';
 
 export class ChildProcessEvaluationListener {
-  exposedListener: Exposed<Required<Omit<RuntimeEvaluationListener, 'onLoad' | 'startMongocryptd'>>>;
+  exposedListener: Exposed<Required<Omit<RuntimeEvaluationListener, 'onLoad' | 'getCSFLELibraryOptions'>>>;
 
   constructor(workerRuntime: WorkerRuntime, childProcess: ChildProcess) {
     this.exposedListener = exposeAll(

--- a/packages/service-provider-core/package-lock.json
+++ b/packages/service-provider-core/package-lock.json
@@ -17,7 +17,7 @@
 				"node": ">=12.4.0"
 			},
 			"optionalDependencies": {
-				"mongodb-client-encryption": "^2.0.0"
+				"mongodb-client-encryption": "^2.1.0"
 			}
 		},
 		"node_modules/@types/node": {
@@ -405,9 +405,9 @@
 			}
 		},
 		"node_modules/mongodb-client-encryption": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-2.0.0.tgz",
-			"integrity": "sha512-NMawTgf4h5E/yLqse5MUj7fjLYFnBnPcP0ohsDc8qaK3Wpi2A27sjkJmclm0LJ7X8duaZrpuQChTLk1M8wtqxQ==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-2.1.0.tgz",
+			"integrity": "sha512-9HlH2HlvF091SBj4aTV4duPgJzSPPpLc82CFvuMCCp15dP3HKvjMQec/lj1IzTfIH3ydgzteBw3z6PkKuIFujg==",
 			"hasInstallScript": true,
 			"optional": true,
 			"dependencies": {
@@ -1153,9 +1153,9 @@
 			}
 		},
 		"mongodb-client-encryption": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-2.0.0.tgz",
-			"integrity": "sha512-NMawTgf4h5E/yLqse5MUj7fjLYFnBnPcP0ohsDc8qaK3Wpi2A27sjkJmclm0LJ7X8duaZrpuQChTLk1M8wtqxQ==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-2.1.0.tgz",
+			"integrity": "sha512-9HlH2HlvF091SBj4aTV4duPgJzSPPpLc82CFvuMCCp15dP3HKvjMQec/lj1IzTfIH3ydgzteBw3z6PkKuIFujg==",
 			"optional": true,
 			"requires": {
 				"bindings": "^1.5.0",

--- a/packages/service-provider-core/package.json
+++ b/packages/service-provider-core/package.json
@@ -39,7 +39,7 @@
     "mongodb-build-info": "^1.2.0"
   },
   "optionalDependencies": {
-    "mongodb-client-encryption": "^2.0.0"
+    "mongodb-client-encryption": "^2.1.0"
   },
   "dependency-check": {
     "entries": [

--- a/packages/service-provider-server/package-lock.json
+++ b/packages/service-provider-server/package-lock.json
@@ -21,7 +21,7 @@
 			},
 			"optionalDependencies": {
 				"kerberos": "^2.0.0",
-				"mongodb-client-encryption": "^2.0.0"
+				"mongodb-client-encryption": "^2.1.0"
 			}
 		},
 		"node_modules/@mongodb-js/devtools-connect": {
@@ -506,9 +506,9 @@
 			}
 		},
 		"node_modules/mongodb-client-encryption": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-2.0.0.tgz",
-			"integrity": "sha512-NMawTgf4h5E/yLqse5MUj7fjLYFnBnPcP0ohsDc8qaK3Wpi2A27sjkJmclm0LJ7X8duaZrpuQChTLk1M8wtqxQ==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-2.1.0.tgz",
+			"integrity": "sha512-9HlH2HlvF091SBj4aTV4duPgJzSPPpLc82CFvuMCCp15dP3HKvjMQec/lj1IzTfIH3ydgzteBw3z6PkKuIFujg==",
 			"hasInstallScript": true,
 			"optional": true,
 			"dependencies": {
@@ -1435,9 +1435,9 @@
 			}
 		},
 		"mongodb-client-encryption": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-2.0.0.tgz",
-			"integrity": "sha512-NMawTgf4h5E/yLqse5MUj7fjLYFnBnPcP0ohsDc8qaK3Wpi2A27sjkJmclm0LJ7X8duaZrpuQChTLk1M8wtqxQ==",
+			"version": "2.1.0",
+			"resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-2.1.0.tgz",
+			"integrity": "sha512-9HlH2HlvF091SBj4aTV4duPgJzSPPpLc82CFvuMCCp15dP3HKvjMQec/lj1IzTfIH3ydgzteBw3z6PkKuIFujg==",
 			"optional": true,
 			"requires": {
 				"bindings": "^1.5.0",

--- a/packages/service-provider-server/package.json
+++ b/packages/service-provider-server/package.json
@@ -55,7 +55,7 @@
     "saslprep": "mongodb-js/saslprep#v1.0.4"
   },
   "optionalDependencies": {
-    "mongodb-client-encryption": "^2.0.0",
+    "mongodb-client-encryption": "^2.1.0",
     "kerberos": "^2.0.0"
   }
 }


### PR DESCRIPTION
This should be sufficient for bringing the CSFLE shared library work
into a mergeable state.

The ts-expect-error comments can likely be removed pretty soon as well,
with the next driver bump.