### PR TITLE
feat(java-shell): return inserted ids from insert operations

### DIFF
--- a/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/result/MongoShellResult.kt
+++ b/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/result/MongoShellResult.kt
@@ -95,8 +95,8 @@ class PatternResult(override val value: Pattern) : MongoShellResult<Pattern>()
 
 class MongoShellUpdateResult(override val value: UpdateResult) : MongoShellResult<UpdateResult>()
 
-class InsertOneResult(val acknowledged: Boolean, val insertedId: String) : MongoShellResult<Map<String, Any>>() {
-    override val value: Map<String, Any>
+class InsertOneResult(val acknowledged: Boolean, val insertedId: Any?) : MongoShellResult<Map<String, Any?>>() {
+    override val value: Map<String, Any?>
         get() = mapOf("acknowledged" to acknowledged, "insertedId" to insertedId)
 }
 
@@ -112,6 +112,7 @@ class DeleteResult(val acknowledged: Boolean, val deletedCount: Long) : MongoShe
 
 class BulkWriteResult(val acknowledged: Boolean,
                       val insertedCount: Int,
+                      val insertedIds: Map<String, Any?>,
                       val matchedCount: Int,
                       val modifiedCount: Int,
                       val deletedCount: Int,
@@ -120,6 +121,7 @@ class BulkWriteResult(val acknowledged: Boolean,
     override val value: Map<String, Any>
         get() = mapOf("acknowledged" to acknowledged,
                 "insertedCount" to insertedCount,
+                "insertedIds" to insertedIds,
                 "matchedCount" to matchedCount,
                 "modifiedCount" to modifiedCount,
                 "deletedCount" to deletedCount,

--- a/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/service/JavaServiceProvider.kt
+++ b/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/service/JavaServiceProvider.kt
@@ -8,7 +8,6 @@ import com.mongodb.client.result.UpdateResult
 import com.mongodb.mongosh.MongoShellConverter
 import com.mongodb.mongosh.ValueWrapper
 import com.mongodb.mongosh.result.ArrayResult
-import com.mongodb.mongosh.result.CommandException
 import com.mongodb.mongosh.result.DocumentResult
 import org.bson.Document
 import org.graalvm.polyglot.HostAccess
@@ -61,8 +60,8 @@ internal class JavaServiceProvider(private var client: MongoClient?,
         val options = toDocument(options, "options")
         val dbOptions = options?.filterKeys { dbConverters.containsKey(it) }
         getDatabase(database, dbOptions).map { db ->
-            db.getCollection(collection).insertOne(document)
-            mapOf("acknowledged" to true, "insertedId" to "UNKNOWN")
+            val result = db.getCollection(collection).insertOne(document)
+            mapOf("acknowledged" to result.wasAcknowledged(), "insertedId" to result.insertedId)
         }
     }
 
@@ -168,7 +167,7 @@ internal class JavaServiceProvider(private var client: MongoClient?,
                     mapOf(
                             "ok" to result.wasAcknowledged(),
                             "insertedCount" to result.insertedCount,
-                            "insertedIds" to "UNKNOWN",
+                            "insertedIds" to result.inserts.associate { Pair(it.index.toString(), it.id) },
                             "matchedCount" to result.matchedCount,
                             "modifiedCount" to result.modifiedCount,
                             "deletedCount" to result.deletedCount,

--- a/packages/java-shell/src/test/resources/collection/bulkWrite.expected.txt
+++ b/packages/java-shell/src/test/resources/collection/bulkWrite.expected.txt
@@ -1,2 +1,2 @@
-{ "acknowledged": true, "insertedCount": 2, "matchedCount": 3, "modifiedCount": 3, "deletedCount": 2, "upsertedCount": 1, "upsertedIds": [ { } ] }
+{ "acknowledged": true, "insertedCount": 2, "insertedIds": { "0": <ObjectID>, "1": <ObjectID> }, "matchedCount": 3, "modifiedCount": 3, "deletedCount": 2, "upsertedCount": 1, "upsertedIds": [ <ObjectID> ] }
 [ { "_id": <ObjectID>, "v": "after update" }, { "_id": <ObjectID>, "v": "after update many" }, { "_id": <ObjectID>, "v": "after update many" }, { "_id": <ObjectID>, "a": 1 }, { "_id": <ObjectID>, "a": 1 }, { "_id": <ObjectID>, "v2": "after replace" } ]

--- a/packages/java-shell/src/test/resources/collection/insertOne.expected.txt
+++ b/packages/java-shell/src/test/resources/collection/insertOne.expected.txt
@@ -1,3 +1,12 @@
-{ "acknowledged": true, "insertedId": "UNKNOWN" }
+{ "acknowledged": true, "insertedId": <ObjectID> }
 true
 [ { "_id": <ObjectID>, "a": 1, "objectId": <ObjectID>, "maxKey": {"$maxKey": 1}, "minKey": {"$minKey": 1}, "binData": {"$binary": {"base64": "MTIzNA==", "subType": "10"}}, "date": {"$date": {"$numberLong": "1355875200000"}}, "isoDate": {"$date": {"$numberLong": "1355875200000"}}, "numberInt": 24, "timestamp": Timestamp{value=429496729600, seconds=100, inc=0}, "undefined": null, "null": null, "uuid": <UUID> } ]
+{ "acknowledged": true, "insertedId": null }
+{ "acknowledged": true, "insertedId": {"$date": {"$numberLong": "1355875200000"}} }
+{ "acknowledged": true, "insertedId": {"$binary": {"base64": "ASNFZ4mrze8BI0VniavN7w==", "subType": "04"}} }
+{ "acknowledged": true, "insertedId": {"$maxKey": 1} }
+{ "acknowledged": true, "insertedId": 24 }
+{ "acknowledged": true, "insertedId": true }
+{ "acknowledged": true, "insertedId": "string key" }
+{ "acknowledged": true, "insertedId": {"$binary": {"base64": "MTIzNA==", "subType": "10"}} }
+{ "acknowledged": true, "insertedId": { "document": "key" } }

--- a/packages/java-shell/src/test/resources/collection/insertOne.js
+++ b/packages/java-shell/src/test/resources/collection/insertOne.js
@@ -21,5 +21,23 @@ res
 res.acknowledged
 // command
 db.coll.find();
+// command
+db.coll.insertOne({_id: null});
+// command
+db.coll.insertOne({_id: new ISODate("2012-12-19")});
+// command
+db.coll.insertOne({_id: new UUID('01234567-89ab-cdef-0123-456789abcdef')});
+// command
+db.coll.insertOne({_id: new MaxKey()});
+// command
+db.coll.insertOne({_id: new NumberInt("24")});
+// command
+db.coll.insertOne({_id: true});
+// command
+db.coll.insertOne({_id: "string key"});
+// command
+db.coll.insertOne({_id: new BinData(16, 'MTIzNA==')});
+// command
+db.coll.insertOne({_id: {"document": "key"}});
 // clear
 db.coll.drop();

--- a/packages/java-shell/src/test/resources/collection/insertOneWriteConcern.expected.txt
+++ b/packages/java-shell/src/test/resources/collection/insertOneWriteConcern.expected.txt
@@ -1,2 +1,2 @@
-{ "acknowledged": true, "insertedId": "UNKNOWN" }
+{ "acknowledged": true, "insertedId": <ObjectID> }
 [ { "_id": <ObjectID>, "a": 1 } ]

--- a/packages/java-shell/src/test/resources/db/createCollectionWithTimeseries.expected.1.txt
+++ b/packages/java-shell/src/test/resources/db/createCollectionWithTimeseries.expected.1.txt
@@ -1,3 +1,3 @@
 com.mongodb.MongoCommandException: Command failed with error 40415 (Location40415): 'BSON field 'create.expireAfterSeconds' is an unknown field.' on server %mongohostport%. The full response is {"ok": 0.0, "errmsg": "BSON field 'create.expireAfterSeconds' is an unknown field.", "code": 40415, "codeName": "Location40415"}
-{ "acknowledged": true, "insertedId": "UNKNOWN" }
+{ "acknowledged": true, "insertedId": <ObjectID> }
 { "timestamp": {"$date": {"$numberLong": "1621296000000"}} }

--- a/packages/java-shell/src/test/resources/db/createCollectionWithTimeseries.expected.2.txt
+++ b/packages/java-shell/src/test/resources/db/createCollectionWithTimeseries.expected.2.txt
@@ -1,3 +1,3 @@
 com.mongodb.MongoCommandException: Command failed with error 72 (InvalidOptions): 'The field 'expireAfterSeconds' is not a valid collection option. Options: { capped: false, expireAfterSeconds: 86400, timeseries: { timeField: "timestamp", metaField: "metadata", granularity: "minutes" } }' on server %mongohostport%. The full response is {"ok": 0.0, "errmsg": "The field 'expireAfterSeconds' is not a valid collection option. Options: { capped: false, expireAfterSeconds: 86400, timeseries: { timeField: \"timestamp\", metaField: \"metadata\", granularity: \"minutes\" } }", "code": 72, "codeName": "InvalidOptions"}
-{ "acknowledged": true, "insertedId": "UNKNOWN" }
+{ "acknowledged": true, "insertedId": <ObjectID> }
 { "timestamp": {"$date": {"$numberLong": "1621296000000"}} }

--- a/packages/java-shell/src/test/resources/db/createCollectionWithTimeseries.expected.txt
+++ b/packages/java-shell/src/test/resources/db/createCollectionWithTimeseries.expected.txt
@@ -1,2 +1,2 @@
-{ "acknowledged": true, "insertedId": "UNKNOWN" }
+{ "acknowledged": true, "insertedId": <ObjectID> }
 { "timestamp": {"$date": {"$numberLong": "1621296000000"}} }

--- a/packages/java-shell/src/test/resources/db/showCollections.expected.txt
+++ b/packages/java-shell/src/test/resources/db/showCollections.expected.txt
@@ -1,2 +1,2 @@
-{ "acknowledged": true, "insertedId": "UNKNOWN" }
+{ "acknowledged": true, "insertedId": <ObjectID> }
 [ { "name": "coll", "badge": "" } ]


### PR DESCRIPTION
[DBE-15167](https://youtrack.jetbrains.com/issue/DBE-15167/MongoDB-%60returnedId%60-is-always-UNKNOWN) MongoDB `returnedId` is always UNKNOWN