### PR TITLE
fix(shell-api): pass through collection.drop() options MONGOSH-1199

### DIFF
--- a/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/service/JavaServiceProvider.kt
+++ b/packages/java-shell/src/main/kotlin/com/mongodb/mongosh/service/JavaServiceProvider.kt
@@ -555,6 +555,7 @@ internal class JavaServiceProvider(private var client: MongoClient?,
     override fun dropCollection(database: String, collection: String, options: Value?): Value = promise {
         val options = toDocument(options, "options")
         val dbOptions = options?.filterKeys { dbConverters.containsKey(it) }
+        // TODO: pass through options once the java driver supports it
         getDatabase(database, dbOptions).map { db ->
             db.getCollection(collection).drop()
         }

--- a/packages/service-provider-server/src/cli-service-provider.ts
+++ b/packages/service-provider-server/src/cli-service-provider.ts
@@ -1009,7 +1009,7 @@ class CliServiceProvider extends ServiceProviderCore implements ServiceProvider 
   ): Promise<boolean> {
     return this.db(database, dbOptions)
       .collection(collection)
-      .drop({ ...this.baseCmdOptions, ...options } as DropCollectionOptions);
+      .drop({ ...this.baseCmdOptions, ...options });
   }
 
   /**

--- a/packages/shell-api/src/collection.spec.ts
+++ b/packages/shell-api/src/collection.spec.ts
@@ -1241,6 +1241,13 @@ describe('Collection', () => {
         serviceProvider.dropCollection.rejects(error);
         expect(await (collection.drop().catch((e) => e))).to.equal(error);
       });
+
+      it('passes through options', async() => {
+        serviceProvider.dropCollection.resolves();
+        await collection.drop({ promoteValues: false });
+        expect(serviceProvider.dropCollection).to.have.been.calledWith(
+          'db1', 'coll1', { promoteValues: false });
+      });
     });
 
     describe('getFullName', () => {

--- a/packages/shell-api/src/collection.ts
+++ b/packages/shell-api/src/collection.ts
@@ -53,6 +53,7 @@ import {
   ReplaceOptions,
   RunCommandOptions,
   UpdateOptions,
+  DropCollectionOptions
 } from '@mongosh/service-provider-core';
 import {
   AggregationCursor,
@@ -1336,14 +1337,14 @@ export default class Collection extends ShellApiWithMongoClass {
    */
   @returnsPromise
   @apiVersions([1])
-  async drop(): Promise<boolean> {
+  async drop(options: DropCollectionOptions = {}): Promise<boolean> {
     this._emitCollectionApiCall('drop');
 
     try {
       return await this._mongo._serviceProvider.dropCollection(
         this._database._name,
         this._name,
-        await this._database._baseOptions()
+        { ...await this._database._baseOptions(), ...options }
       );
     } catch (error: any) {
       if (error?.codeName === 'NamespaceNotFound') {


### PR DESCRIPTION
Passing through options is a) documented and b) something we also do for other methods.