### PR TITLE
 chore(service-provider-server): add clustered collection index tests MONGOSH-1172

### DIFF
--- a/packages/service-provider-server/src/cli-service-provider.integration.spec.ts
+++ b/packages/service-provider-server/src/cli-service-provider.integration.spec.ts
@@ -668,7 +668,9 @@ describe('CliServiceProvider [integration]', function() {
       it('allows clustered indexes on collections', async() => {
         await db.createCollection(
           'coll1',
-          { clusteredIndex: { key: { _id: 1 } }, unique: true }
+          // TODO: Remove `any` usage once there is driver type support
+          // for clustered collection indexes. NODE-4189
+          { clusteredIndex: { key: { _id: 1 } }, unique: true } as any
         );
 
         const collections = await serviceProvider.listCollections(dbName, {}, { nameOnly: true });

--- a/packages/service-provider-server/src/cli-service-provider.integration.spec.ts
+++ b/packages/service-provider-server/src/cli-service-provider.integration.spec.ts
@@ -670,16 +670,27 @@ describe('CliServiceProvider [integration]', function() {
           'coll1',
           // TODO: Remove `any` usage once there is driver type support
           // for clustered collection indexes. NODE-4189
-          { clusteredIndex: { key: { _id: 1 }, unique: true } } as any
+          {
+            clusteredIndex: {
+              key: { _id: 1 },
+              unique: true
+            }
+          } as any
         );
 
-        const collections = await serviceProvider.listCollections(dbName, {}, { nameOnly: true });
+        const collections = await serviceProvider.listCollections(dbName, {}, {});
 
+        const matchingCollection = collections.find(collection => collection.name === 'coll1');
+        expect(matchingCollection).to.not.be.undefined;
         expect(
-          collections
+          matchingCollection.options
         ).to.deep.contain({
-          name: 'coll1',
-          options: { clusteredIndex: { key: { _id: 1 } } }
+          clusteredIndex: {
+            v: 2,
+            key: { _id: 1 },
+            name: '_id_',
+            unique: true
+          }
         });
 
         const indexes = await serviceProvider.getIndexes(dbName, 'coll1');

--- a/packages/service-provider-server/src/cli-service-provider.integration.spec.ts
+++ b/packages/service-provider-server/src/cli-service-provider.integration.spec.ts
@@ -690,7 +690,7 @@ describe('CliServiceProvider [integration]', function() {
           key: {
             _id: 1
           },
-          name: '_id_1',
+          name: '_id_',
           v: 2,
           clustered: true,
           unique: true

--- a/packages/service-provider-server/src/cli-service-provider.integration.spec.ts
+++ b/packages/service-provider-server/src/cli-service-provider.integration.spec.ts
@@ -2,6 +2,7 @@ import CliServiceProvider from './cli-service-provider';
 import { expect } from 'chai';
 import { EventEmitter } from 'events';
 import { MongoClient } from 'mongodb';
+import type { Db } from 'mongodb';
 import { startTestServer, skipIfServerVersion } from '../../../testing/integration-testing-hooks';
 import { DbOptions, MongoClientOptions } from '@mongosh/service-provider-core';
 import ConnectionString from 'mongodb-connection-string-url';
@@ -12,7 +13,7 @@ describe('CliServiceProvider [integration]', function() {
   let serviceProvider: CliServiceProvider;
   let client: MongoClient;
   let dbName: string;
-  let db;
+  let db: Db;
   let connectionString: string;
   let bus: EventEmitter;
 
@@ -657,6 +658,40 @@ describe('CliServiceProvider [integration]', function() {
         ).to.deep.contain({
           name: 'system.views',
           type: 'collection'
+        });
+      });
+    });
+
+    context('post-5.3', () => {
+      skipIfServerVersion(testServer, '< 5.3');
+
+      it('allows clustered indexes on collections', async() => {
+        await db.createCollection(
+          'coll1',
+          { clusteredIndex: { key: { _id: 1 } }, unique: true }
+        );
+
+        const collections = await serviceProvider.listCollections(dbName, {}, { nameOnly: true });
+
+        expect(
+          collections
+        ).to.deep.contain({
+          name: 'coll1',
+          options: { clusteredIndex: { key: { _id: 1 } } }
+        });
+
+        const indexes = await serviceProvider.getIndexes(dbName, 'coll1');
+
+        expect(
+          indexes
+        ).to.deep.contain({
+          key: {
+            _id: 1
+          },
+          name: '_id_1',
+          v: 2,
+          clustered: true,
+          unique: true
         });
       });
     });

--- a/packages/service-provider-server/src/cli-service-provider.integration.spec.ts
+++ b/packages/service-provider-server/src/cli-service-provider.integration.spec.ts
@@ -670,7 +670,7 @@ describe('CliServiceProvider [integration]', function() {
           'coll1',
           // TODO: Remove `any` usage once there is driver type support
           // for clustered collection indexes. NODE-4189
-          { clusteredIndex: { key: { _id: 1 } }, unique: true } as any
+          { clusteredIndex: { key: { _id: 1 }, unique: true } } as any
         );
 
         const collections = await serviceProvider.listCollections(dbName, {}, { nameOnly: true });

--- a/packages/shell-api/src/integration.spec.ts
+++ b/packages/shell-api/src/integration.spec.ts
@@ -490,12 +490,14 @@ describe('Shell API (integration)', function() {
           await serviceProvider.createCollection(
             dbName,
             collectionName,
+            // TODO: Remove `any` usage once there is driver type support
+            // for clustered collection indexes. NODE-4189
             {
               clusteredIndex: {
                 key: { _id: 1 },
                 unique: true
               },
-            }
+            } as any
           );
         });
 

--- a/packages/shell-api/src/integration.spec.ts
+++ b/packages/shell-api/src/integration.spec.ts
@@ -504,15 +504,8 @@ describe('Shell API (integration)', function() {
         it('returns clustered indexes for the collection', async() => {
           const indexes = await collection.getIndexes();
 
-          expect(indexes.length).to.equal(2);
+          expect(indexes.length).to.equal(1);
           expect(indexes[0]).to.deep.include({
-            key: {
-              _id: 1
-            },
-            name: '_id_',
-            v: 2
-          });
-          expect(indexes[1]).to.deep.include({
             key: {
               _id: 1
             },

--- a/packages/shell-api/src/integration.spec.ts
+++ b/packages/shell-api/src/integration.spec.ts
@@ -509,7 +509,7 @@ describe('Shell API (integration)', function() {
             key: {
               _id: 1
             },
-            name: '_id_1',
+            name: '_id_',
             v: 2,
             clustered: true,
             unique: true


### PR DESCRIPTION
MONGOSH-1172

Adds a few tests for clustered indexes on collections. Checking CI before opening.