### PR TITLE
numeral rather than pretty bytes MONGOSH-1124

### DIFF
--- a/packages/browser-repl/package-lock.json
+++ b/packages/browser-repl/package-lock.json
@@ -10,7 +10,7 @@
 			"license": "Apache-2.0",
 			"dependencies": {
 				"karma": "^6.3.9",
-				"pretty-bytes": "^5.3.0",
+				"numeral": "^2.0.6",
 				"text-table": "^0.2.0"
 			},
 			"devDependencies": {
@@ -27,6 +27,7 @@
 				"@storybook/react": "^5.3.1",
 				"@types/classnames": "^2.2.11",
 				"@types/enzyme-adapter-react-16": "^1.0.5",
+				"@types/numeral": "^2.0.2",
 				"@types/react": "^16.9.17",
 				"@types/sinon": "^7.5.1",
 				"@types/sinon-chai": "^3.2.3",
@@ -3354,6 +3355,12 @@
 			"version": "4.1.4",
 			"resolved": "https://registry.npmjs.org/@types/npmlog/-/npmlog-4.1.4.tgz",
 			"integrity": "sha512-WKG4gTr8przEZBiJ5r3s8ZIAoMXNbOgQ+j/d5O4X3x6kZJRLNvyUJuUK/KoG3+8BaOHPhp2m7WC6JKKeovDSzQ==",
+			"dev": true
+		},
+		"node_modules/@types/numeral": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@types/numeral/-/numeral-2.0.2.tgz",
+			"integrity": "sha512-A8F30k2gYJ/6e07spSCPpkuZu79LCnkPTvqmIWQzNGcrzwFKpVOydG41lNt5wZXjSI149qjyzC2L1+F2PD/NUA==",
 			"dev": true
 		},
 		"node_modules/@types/parse-json": {
@@ -12661,6 +12668,14 @@
 				"node": ">=0.10.0"
 			}
 		},
+		"node_modules/numeral": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/numeral/-/numeral-2.0.6.tgz",
+			"integrity": "sha1-StCAk21EPCVhrtnyGX7//iX05QY=",
+			"engines": {
+				"node": "*"
+			}
+		},
 		"node_modules/object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -13612,17 +13627,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">=0.10.0"
-			}
-		},
-		"node_modules/pretty-bytes": {
-			"version": "5.6.0",
-			"resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
-			"integrity": "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==",
-			"engines": {
-				"node": ">=6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/pretty-error": {
@@ -20954,8 +20958,8 @@
 				"polished": "^3.3.1",
 				"prop-types": "^15.7.2",
 				"qs": "^6.6.0",
-				"react": "^16.8.3",
-				"react-dom": "^16.8.3",
+				"react": "^16.14.0",
+				"react-dom": "^16.14.0",
 				"react-draggable": "^4.0.3",
 				"react-helmet-async": "^1.0.2",
 				"react-hotkeys": "2.0.0",
@@ -21199,6 +21203,12 @@
 			"version": "4.1.4",
 			"resolved": "https://registry.npmjs.org/@types/npmlog/-/npmlog-4.1.4.tgz",
 			"integrity": "sha512-WKG4gTr8przEZBiJ5r3s8ZIAoMXNbOgQ+j/d5O4X3x6kZJRLNvyUJuUK/KoG3+8BaOHPhp2m7WC6JKKeovDSzQ==",
+			"dev": true
+		},
+		"@types/numeral": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@types/numeral/-/numeral-2.0.2.tgz",
+			"integrity": "sha512-A8F30k2gYJ/6e07spSCPpkuZu79LCnkPTvqmIWQzNGcrzwFKpVOydG41lNt5wZXjSI149qjyzC2L1+F2PD/NUA==",
 			"dev": true
 		},
 		"@types/parse-json": {
@@ -28743,6 +28753,11 @@
 			"integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
 			"dev": true
 		},
+		"numeral": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/numeral/-/numeral-2.0.6.tgz",
+			"integrity": "sha1-StCAk21EPCVhrtnyGX7//iX05QY="
+		},
 		"object-assign": {
 			"version": "4.1.1",
 			"resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -29489,11 +29504,6 @@
 			"resolved": "https://registry.npmjs.org/prepend-http/-/prepend-http-1.0.4.tgz",
 			"integrity": "sha1-1PRWKwzjaW5BrFLQ4ALlemNdxtw=",
 			"dev": true
-		},
-		"pretty-bytes": {
-			"version": "5.6.0",
-			"resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
-			"integrity": "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg=="
 		},
 		"pretty-error": {
 			"version": "2.1.2",

--- a/packages/browser-repl/package.json
+++ b/packages/browser-repl/package.json
@@ -45,7 +45,7 @@
     "@mongosh/node-runtime-worker-thread": "0.0.0-dev.0",
     "@mongosh/service-provider-core": "0.0.0-dev.0",
     "karma": "^6.3.9",
-    "pretty-bytes": "^5.3.0",
+    "numeral": "^2.0.6",
     "text-table": "^0.2.0"
   },
   "devDependencies": {
@@ -62,6 +62,7 @@
     "@storybook/react": "^5.3.1",
     "@types/classnames": "^2.2.11",
     "@types/enzyme-adapter-react-16": "^1.0.5",
+    "@types/numeral": "^2.0.2",
     "@types/react": "^16.9.17",
     "@types/sinon": "^7.5.1",
     "@types/sinon-chai": "^3.2.3",

--- a/packages/browser-repl/src/components/shell-output-line.spec.tsx
+++ b/packages/browser-repl/src/components/shell-output-line.spec.tsx
@@ -132,7 +132,7 @@ describe('<ShellOutputLine />', () => {
       ]
     }} />);
 
-    expect(wrapper.text()).to.contain('admin     45.1 kB\ndxl       8.19 kB\nsupplies  2.24 MB\ntest      5.66 MB\ntest       600 GB');
+    expect(wrapper.text()).to.contain('admin      45.1KB\ndxl         8.2KB\nsupplies    2.2MB\ntest        5.7MB\ntest      600.0GB');
   });
 
   it('renders StatsResult', () => {

--- a/packages/browser-repl/src/components/shell-output-line.spec.tsx
+++ b/packages/browser-repl/src/components/shell-output-line.spec.tsx
@@ -132,7 +132,13 @@ describe('<ShellOutputLine />', () => {
       ]
     }} />);
 
-    expect(wrapper.text()).to.contain('admin      45.1KB\ndxl         8.2KB\nsupplies    2.2MB\ntest        5.7MB\ntest      600.0GB');
+    expect(wrapper.text()).to.equal(`
+admin      44.00 KiB
+dxl         8.00 KiB
+supplies    2.13 MiB
+test        5.40 MiB
+test      558.79 GiB
+`.trim());
   });
 
   it('renders StatsResult', () => {

--- a/packages/browser-repl/src/components/types/show-dbs-output.spec.tsx
+++ b/packages/browser-repl/src/components/types/show-dbs-output.spec.tsx
@@ -20,6 +20,12 @@ describe('ShowDbsOutput', () => {
       { name: 'test', sizeOnDisk: 599999768000, empty: false }
     ]} />);
 
-    expect(wrapper.text()).to.contain('admin      45.1KB\ndxl         8.2KB\nsupplies    2.2MB\ntest        5.7MB\ntest      600.0GB');
+    expect(wrapper.text()).to.equal(`
+admin      44.00 KiB
+dxl         8.00 KiB
+supplies    2.13 MiB
+test        5.40 MiB
+test      558.79 GiB
+`.trim());
   });
 });

--- a/packages/browser-repl/src/components/types/show-dbs-output.spec.tsx
+++ b/packages/browser-repl/src/components/types/show-dbs-output.spec.tsx
@@ -20,6 +20,6 @@ describe('ShowDbsOutput', () => {
       { name: 'test', sizeOnDisk: 599999768000, empty: false }
     ]} />);
 
-    expect(wrapper.text()).to.contain('admin     45.1 kB\ndxl       8.19 kB\nsupplies  2.24 MB\ntest      5.66 MB\ntest       600 GB');
+    expect(wrapper.text()).to.contain('admin      45.1KB\ndxl         8.2KB\nsupplies    2.2MB\ntest        5.7MB\ntest      600.0GB');
   });
 });

--- a/packages/browser-repl/src/components/types/show-dbs-output.tsx
+++ b/packages/browser-repl/src/components/types/show-dbs-output.tsx
@@ -13,8 +13,8 @@ type DatabaseObject = {
 };
 
 function formatBytes(value: number): string {
-  const precision = value <= 1000 ? '0' : '0.0';
-  return numeral(value).format(precision + 'b');
+  const precision = value <= 1000 ? '0' : '0.00';
+  return numeral(value).format(precision + ' ib');
 }
 
 export class ShowDbsOutput extends Component<ShowDbsOutputProps> {

--- a/packages/browser-repl/src/components/types/show-dbs-output.tsx
+++ b/packages/browser-repl/src/components/types/show-dbs-output.tsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import prettyBytes from 'pretty-bytes';
+import numeral from 'numeral';
 import PropTypes from 'prop-types';
 import textTable from 'text-table';
 
@@ -12,6 +12,11 @@ type DatabaseObject = {
   map: any;
 };
 
+function formatBytes(value: number): string {
+  const precision = value <= 1000 ? '0' : '0.0';
+  return numeral(value).format(precision + 'b');
+}
+
 export class ShowDbsOutput extends Component<ShowDbsOutputProps> {
   static propTypes = {
     value: PropTypes.any
@@ -19,7 +24,7 @@ export class ShowDbsOutput extends Component<ShowDbsOutputProps> {
 
   renderTable = (value: DatabaseObject): string => {
     const tableEntries = value.map(
-      (db: any) => [db.name, prettyBytes(db.sizeOnDisk)]
+      (db: any) => [db.name, formatBytes(db.sizeOnDisk)]
     );
 
     return textTable(tableEntries, { align: ['l', 'r'] });

--- a/packages/cli-repl/package-lock.json
+++ b/packages/cli-repl/package-lock.json
@@ -18,7 +18,7 @@
 				"mongodb-connection-string-url": "^2.5.2",
 				"mongodb-log-writer": "^1.1.3",
 				"nanobus": "^4.4.0",
-				"pretty-bytes": "^5.3.0",
+				"numeral": "^2.0.6",
 				"pretty-repl": "^3.1.1",
 				"semver": "^7.1.2",
 				"strip-ansi": "^6.0.0",
@@ -34,6 +34,7 @@
 				"@types/chai-as-promised": "^7.1.3",
 				"@types/js-yaml": "^4.0.5",
 				"@types/node": "^14.14.5",
+				"@types/numeral": "^2.0.2",
 				"@types/text-table": "^0.2.1",
 				"@types/yargs-parser": "^15.0.0",
 				"chai-as-promised": "^7.1.1",
@@ -106,6 +107,12 @@
 			"version": "14.18.12",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.12.tgz",
 			"integrity": "sha512-q4jlIR71hUpWTnGhXWcakgkZeHa3CCjcQcnuzU8M891BAWA2jHiziiWEPEkdS5pFsz7H9HJiy8BrK7tBRNrY7A=="
+		},
+		"node_modules/@types/numeral": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@types/numeral/-/numeral-2.0.2.tgz",
+			"integrity": "sha512-A8F30k2gYJ/6e07spSCPpkuZu79LCnkPTvqmIWQzNGcrzwFKpVOydG41lNt5wZXjSI149qjyzC2L1+F2PD/NUA==",
+			"dev": true
 		},
 		"node_modules/@types/text-table": {
 			"version": "0.2.2",
@@ -812,6 +819,14 @@
 				"node": ">= 6.13.0"
 			}
 		},
+		"node_modules/numeral": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/numeral/-/numeral-2.0.6.tgz",
+			"integrity": "sha1-StCAk21EPCVhrtnyGX7//iX05QY=",
+			"engines": {
+				"node": "*"
+			}
+		},
 		"node_modules/pathval": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
@@ -820,17 +835,6 @@
 			"peer": true,
 			"engines": {
 				"node": "*"
-			}
-		},
-		"node_modules/pretty-bytes": {
-			"version": "5.6.0",
-			"resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
-			"integrity": "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg==",
-			"engines": {
-				"node": ">=6"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
 			}
 		},
 		"node_modules/pretty-repl": {
@@ -1045,6 +1049,12 @@
 			"version": "14.18.12",
 			"resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.12.tgz",
 			"integrity": "sha512-q4jlIR71hUpWTnGhXWcakgkZeHa3CCjcQcnuzU8M891BAWA2jHiziiWEPEkdS5pFsz7H9HJiy8BrK7tBRNrY7A=="
+		},
+		"@types/numeral": {
+			"version": "2.0.2",
+			"resolved": "https://registry.npmjs.org/@types/numeral/-/numeral-2.0.2.tgz",
+			"integrity": "sha512-A8F30k2gYJ/6e07spSCPpkuZu79LCnkPTvqmIWQzNGcrzwFKpVOydG41lNt5wZXjSI149qjyzC2L1+F2PD/NUA==",
+			"dev": true
 		},
 		"@types/text-table": {
 			"version": "0.2.2",
@@ -1561,17 +1571,17 @@
 			"integrity": "sha512-dPEtOeMvF9VMcYV/1Wb8CPoVAXtp6MKMlcbAt4ddqmGqUJ6fQZFXkNZNkNlfevtNkGtaSoXf/vNNNSvgrdXwtA==",
 			"optional": true
 		},
+		"numeral": {
+			"version": "2.0.6",
+			"resolved": "https://registry.npmjs.org/numeral/-/numeral-2.0.6.tgz",
+			"integrity": "sha1-StCAk21EPCVhrtnyGX7//iX05QY="
+		},
 		"pathval": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/pathval/-/pathval-1.1.1.tgz",
 			"integrity": "sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==",
 			"dev": true,
 			"peer": true
-		},
-		"pretty-bytes": {
-			"version": "5.6.0",
-			"resolved": "https://registry.npmjs.org/pretty-bytes/-/pretty-bytes-5.6.0.tgz",
-			"integrity": "sha512-FFw039TmrBqFK8ma/7OL3sDz/VytdtJr044/QUJtH0wK9lb9jLq9tJyIxUwtQJHwar2BqtiA4iCWSwo9JLkzFg=="
 		},
 		"pretty-repl": {
 			"version": "3.1.1",

--- a/packages/cli-repl/package.json
+++ b/packages/cli-repl/package.json
@@ -40,9 +40,15 @@
   },
   "mongosh": {
     "ciRequiredOptionalDependencies": {
-      "macos-export-certificate-and-key": ["darwin"],
-      "win-export-certificate-and-key": ["win32"],
-      "get-console-process-list": ["win32"]
+      "macos-export-certificate-and-key": [
+        "darwin"
+      ],
+      "win-export-certificate-and-key": [
+        "win32"
+      ],
+      "get-console-process-list": [
+        "win32"
+      ]
     }
   },
   "dependencies": {
@@ -69,7 +75,7 @@
     "mongodb-connection-string-url": "^2.5.2",
     "mongodb-log-writer": "^1.1.3",
     "nanobus": "^4.4.0",
-    "pretty-bytes": "^5.3.0",
+    "numeral": "^2.0.6",
     "pretty-repl": "^3.1.1",
     "semver": "^7.1.2",
     "strip-ansi": "^6.0.0",
@@ -82,6 +88,7 @@
     "@types/chai-as-promised": "^7.1.3",
     "@types/js-yaml": "^4.0.5",
     "@types/node": "^14.14.5",
+    "@types/numeral": "^2.0.2",
     "@types/text-table": "^0.2.1",
     "@types/yargs-parser": "^15.0.0",
     "chai-as-promised": "^7.1.1",
@@ -89,8 +96,8 @@
     "moment": "^2.29.1"
   },
   "optionalDependencies": {
+    "get-console-process-list": "^1.0.4",
     "macos-export-certificate-and-key": "^1.1.1",
-    "win-export-certificate-and-key": "^1.1.1",
-    "get-console-process-list": "^1.0.4"
+    "win-export-certificate-and-key": "^1.1.1"
   }
 }

--- a/packages/cli-repl/src/format-output.spec.ts
+++ b/packages/cli-repl/src/format-output.spec.ts
@@ -155,7 +155,7 @@ for (const colors of [ false, true ]) {
           type: 'ShowDatabasesResult'
         }));
 
-        expect(output).to.contain('admin     45.1 kB\ndxl       8.19 kB\nsupplies  2.24 MB\ntest      5.66 MB\ntest       600 GB');
+        expect(output).to.contain('admin      45.1KB\ndxl         8.2KB\nsupplies    2.2MB\ntest        5.7MB\ntest      600.0GB');
       });
     });
 

--- a/packages/cli-repl/src/format-output.spec.ts
+++ b/packages/cli-repl/src/format-output.spec.ts
@@ -155,7 +155,13 @@ for (const colors of [ false, true ]) {
           type: 'ShowDatabasesResult'
         }));
 
-        expect(output).to.contain('admin      45.1KB\ndxl         8.2KB\nsupplies    2.2MB\ntest        5.7MB\ntest      600.0GB');
+        expect(output).to.equal(`
+admin      44.00 KiB
+dxl         8.00 KiB
+supplies    2.13 MiB
+test        5.40 MiB
+test      558.79 GiB
+`.trim());
       });
     });
 
@@ -172,7 +178,7 @@ for (const colors of [ false, true ]) {
           type: 'ShowCollectionsResult'
         }));
 
-        expect(output).to.contain('nested_documents\ndecimal128\ncoll\npeople_imported   [view]\ncats              [time-series]');
+        expect(output).to.equal('nested_documents\ndecimal128\ncoll\npeople_imported   [view]\ncats              [time-series]');
       });
     });
 

--- a/packages/cli-repl/src/format-output.ts
+++ b/packages/cli-repl/src/format-output.ts
@@ -23,8 +23,8 @@ type FormatOptions = {
 };
 
 function formatBytes(value: number): string {
-  const precision = value <= 1000 ? '0' : '0.0';
-  return numeral(value).format(precision + 'b');
+  const precision = value <= 1000 ? '0' : '0.00';
+  return numeral(value).format(precision + ' ib');
 }
 
 /**

--- a/packages/cli-repl/src/format-output.ts
+++ b/packages/cli-repl/src/format-output.ts
@@ -1,4 +1,4 @@
-import prettyBytes from 'pretty-bytes';
+import numeral from 'numeral';
 import textTable from 'text-table';
 import i18n from '@mongosh/i18n';
 import util from 'util';
@@ -21,6 +21,11 @@ type FormatOptions = {
   showStackTraces?: boolean;
   bugReportErrorMessageInfo?: string;
 };
+
+function formatBytes(value: number): string {
+  const precision = value <= 1000 ? '0' : '0.0';
+  return numeral(value).format(precision + 'b');
+}
 
 /**
  * Return the pretty string for the output.
@@ -144,7 +149,7 @@ function formatCollections(output: CollectionNamesWithTypes[], options: FormatOp
 
 function formatDatabases(output: any[], options: FormatOptions): string {
   const tableEntries = output.map(
-    (db) => [clr(db.name, 'bold', options), prettyBytes(db.sizeOnDisk)]
+    (db) => [clr(db.name, 'bold', options), formatBytes(db.sizeOnDisk)]
   );
 
   return textTable(tableEntries, { align: ['l', 'r'] });


### PR DESCRIPTION
This treats 1KB as 1024 bytes, has no space between the number and unit and uses KB, MB, etc all just like legacy shell. BUT I don't know about all the nuances of 0.1GB vs 100MB, for example. How much do we care about matching that level of detail? Also unclear about things like rounding up and down.