### PR TITLE
feat: drop collection using encrypted fields from collection list MONGOSH-1208

### DIFF
--- a/packages/cli-repl/test/e2e-fle.spec.ts
+++ b/packages/cli-repl/test/e2e-fle.spec.ts
@@ -284,6 +284,11 @@ describe('FLE tests', () => {
       expect(autoMongoResult).to.include("phoneNumber: '+12874627836445'");
 
       await shell.executeLine(`plainMongo = Mongo(${uri});`);
+
+      const plainMongoResult = await shell.executeLine(`plainMongo.getDB('${dbname}').collfle2.find()`);
+      expect(plainMongoResult).to.include('phoneNumber: Binary(Buffer.from');
+      expect(plainMongoResult).to.not.include("phoneNumber: '+12874627836445'");
+
       let collections = await shell.executeLine(`plainMongo.getDB('${dbname}').getCollectionNames()`);
 
       expect(collections).to.include('enxcol_.collfle2.ecc');

--- a/packages/cli-repl/test/e2e-fle.spec.ts
+++ b/packages/cli-repl/test/e2e-fle.spec.ts
@@ -239,7 +239,7 @@ describe('FLE tests', () => {
   context('6.0+', () => {
     skipIfServerVersion(testServer, '< 6.0'); // FLE2 only available on 6.0+
 
-    it('drops fle2 collection with all helper collections when encryptedFields in collections listd', async() => {
+    it('drops fle2 collection with all helper collections when encryptedFields options are in listCollections', async() => {
       const shell = TestShell.start({
         args: ['--nodb'],
         env: {

--- a/packages/shell-api/src/collection.ts
+++ b/packages/shell-api/src/collection.ts
@@ -1346,6 +1346,7 @@ export default class Collection extends ShellApiWithMongoClass {
     const encryptedFieldsMap = this._mongo._fleOptions?.encryptedFieldsMap;
     const encryptedFields: Document | undefined = encryptedFieldsMap?.[`${this._database._name}.${ this._name}`];
 
+    // @ts-expect-error waiting for driver release
     if (!encryptedFields && !options.encryptedFields) {
       const collectionInfos = await this._mongo._serviceProvider.listCollections(
         this._database._name,


### PR DESCRIPTION
If a collection was not listed in the Mongo() `encryptedFieldsMap` and no explicit `encryptedFields` option was passed to `collection.drop(options)`, we always look up the `encryptedFields` from `listCollections` and pass that instead.