### PR TITLE
chore(shell-api): Remove `any` usage in create collection test 

### DIFF
--- a/packages/service-provider-server/src/cli-service-provider.integration.spec.ts
+++ b/packages/service-provider-server/src/cli-service-provider.integration.spec.ts
@@ -668,14 +668,12 @@ describe('CliServiceProvider [integration]', function() {
       it('allows clustered indexes on collections', async() => {
         await db.createCollection(
           'coll1',
-          // TODO: Remove `any` usage once there is driver type support
-          // for clustered collection indexes. NODE-4189
           {
             clusteredIndex: {
               key: { _id: 1 },
               unique: true
             }
-          } as any
+          }
         );
 
         const collections = await serviceProvider.listCollections(dbName, {}, {});

--- a/packages/shell-api/src/integration.spec.ts
+++ b/packages/shell-api/src/integration.spec.ts
@@ -490,14 +490,12 @@ describe('Shell API (integration)', function() {
           await serviceProvider.createCollection(
             dbName,
             collectionName,
-            // TODO: Remove `any` usage once there is driver type support
-            // for clustered collection indexes. NODE-4189
             {
               clusteredIndex: {
                 key: { _id: 1 },
                 unique: true
-              },
-            } as any
+              }
+            }
           );
         });
 


### PR DESCRIPTION
Since we've updated the driver we can now remove this `any` usage in the creation of clustered collections in tests. https://jira.mongodb.org/browse/NODE-4189