### PR TITLE
feat(cli-repl): add support for the --tlsFIPSMode flag MONGOSH-1221

### DIFF
--- a/packages/cli-repl/src/arg-parser.spec.ts
+++ b/packages/cli-repl/src/arg-parser.spec.ts
@@ -322,12 +322,12 @@ describe('arg-parser', () => {
         context('when providing --gssapiHostName', () => {
           const argv = [ ...baseArgv, uri, '--gssapiHostName', 'example.com' ];
 
-          it('throws an error since it is not yet supported', () => {
+          it('throws an error since it is not supported', () => {
             try {
               parseCliArgs(argv);
             } catch (e: any) {
               expect(e).to.be.instanceOf(MongoshUnimplementedError);
-              expect(e.message).to.include('Argument --gssapiHostName is not yet supported in mongosh');
+              expect(e.message).to.include('Argument --gssapiHostName is not supported in mongosh');
               return;
             }
             expect.fail('Expected error');
@@ -488,15 +488,15 @@ describe('arg-parser', () => {
           });
         });
 
-        context('when providing --tlsFIPSMode', () => {
-          const argv = [ ...baseArgv, uri, '--tlsFIPSMode' ];
+        context('when providing --sslFIPSMode', () => {
+          const argv = [ ...baseArgv, uri, '--sslFIPSMode' ];
 
-          it('throws an error since it is not yet supported', () => {
+          it('throws an error since it is not supported', () => {
             try {
               parseCliArgs(argv);
             } catch (e: any) {
               expect(e).to.be.instanceOf(MongoshUnimplementedError);
-              expect(e.message).to.include('Argument --tlsFIPSMode is not yet supported in mongosh');
+              expect(e.message).to.include('Argument --sslFIPSMode is not supported in mongosh');
               return;
             }
             expect.fail('Expected error');

--- a/packages/cli-repl/src/arg-parser.ts
+++ b/packages/cli-repl/src/arg-parser.ts
@@ -115,7 +115,6 @@ const DEPRECATED_ARGS_WITH_REPLACEMENT: Record<string, keyof CliOptions> = {
  */
 const UNSUPPORTED_ARGS: Readonly<string[]> = [
   'sslFIPSMode',
-  'tlsFIPSMode',
   'gssapiHostName'
 ];
 
@@ -188,7 +187,7 @@ export function verifyCliArguments(args: any /* CliOptions */): string[] {
   for (const unsupported of UNSUPPORTED_ARGS) {
     if (unsupported in args) {
       throw new MongoshUnimplementedError(
-        `Argument --${unsupported} is not yet supported in mongosh`,
+        `Argument --${unsupported} is not supported in mongosh`,
         CommonErrors.InvalidArgument
       );
     }

--- a/packages/cli-repl/test/e2e.spec.ts
+++ b/packages/cli-repl/test/e2e.spec.ts
@@ -156,6 +156,20 @@ describe('e2e', function() {
         shell.assertContainsOutput('233');
       });
     });
+    it('accepts a --tlsFIPSMode argument', async() => {
+      shell = TestShell.start({
+        args: [ '--nodb', '--tlsFIPSMode' ]
+      });
+      const result = await shell.waitForPromptOrExit();
+      // Whether this worked depends on the environment the test is running in.
+      // We check both possibilities.
+      if (result.state === 'exit') {
+        shell.assertContainsOutput('Could not enable FIPS mode');
+        expect(result.exitCode).to.equal(1);
+      } else {
+        expect(await shell.executeLine('[crypto.getFips()]')).to.include('[1]');
+      }
+    });
   });
 
   describe('set db', () => {


### PR DESCRIPTION
Proper testing of the functionality is left to MONGOSH-1222.

This does not add support for `--sslFIPSMode` or spelling variants
of `--tlsFIPSMode` that would be recognized by yargs, in order to
keep the setup code as straightforward as possible.