### PR TITLE
fix(ci): use auth token in dry-run-publish step

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -5114,6 +5114,7 @@ functions:
         script: |
           set -e
           {
+          echo "//registry.npmjs.org/:_authToken=${devtoolsbot_npm_token}" > .npmrc
           export NODE_JS_VERSION=${node_js_version}
           source .evergreen/setup-env.sh
           export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD="true"

--- a/.evergreen/evergreen.yml.in
+++ b/.evergreen/evergreen.yml.in
@@ -631,6 +631,7 @@ functions:
         script: |
           set -e
           {
+          echo "//registry.npmjs.org/:_authToken=${devtoolsbot_npm_token}" > .npmrc
           export NODE_JS_VERSION=${node_js_version}
           source .evergreen/setup-env.sh
           export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD="true"


### PR DESCRIPTION
I was assuming that it would not be necessary to include it here,
but it seems like it is in order for lerna to be able to check
whether the current user has publish access to the packages.
(That also seems like a good thing to check in the dry-run step,
since we’ve had issues before with adding new packages to which
the automation bot did not have access yet.)