### PR TITLE
feat(build): add shared-openssl packages to releases MONGOSH-1231

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -4926,11 +4926,11 @@ functions:
   #
   # package_and_upload_artifact expects the following arguments:
   # - distro_id
-  # - distribution_build_variant
+  # - package_variant
   # - executable_os_id
   #
   # get_artifact_url expects the following arguments:
-  # - distribution_build_variant
+  # - package_variant
   ###
   package_and_upload_artifact:
     - command: expansions.write
@@ -4952,7 +4952,7 @@ functions:
         env:
           NODE_JS_VERSION: ${node_js_version}
           DISTRO_ID_OVERRIDE: ${distro_id}
-          DISTRIBUTION_BUILD_VARIANT: ${distribution_build_variant}
+          PACKAGE_VARIANT: ${package_variant}
           MACOS_NOTARY_KEY: ${macos_notary_key}
           MACOS_NOTARY_SECRET: ${macos_notary_secret}
     - command: s3.put
@@ -4960,7 +4960,7 @@ functions:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
         local_file: src/artifact-url.txt
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/artifact-url-${distribution_build_variant}.txt
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/artifact-url-${package_variant}.txt
         bucket: mciuploads
         permissions: public-read
         content_type: application/x-gzip
@@ -4970,7 +4970,7 @@ functions:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
         local_file: artifact-url.txt
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/artifact-url-${source_distribution_build_variant}.txt
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/artifact-url-${source_package_variant}.txt
         bucket: mciuploads
 
   write_preload_script:
@@ -8228,7 +8228,7 @@ tasks:
       - func: package_and_upload_artifact
         vars:
           node_js_version: "16.15.0"
-          distribution_build_variant: darwin-x64
+          package_variant: darwin-x64
           executable_os_id: darwin-x64
   - name: package_and_upload_artifact_darwin_arm64
     depends_on:
@@ -8243,7 +8243,7 @@ tasks:
       - func: package_and_upload_artifact
         vars:
           node_js_version: "16.15.0"
-          distribution_build_variant: darwin-arm64
+          package_variant: darwin-arm64
           executable_os_id: darwin-arm64
   - name: package_and_upload_artifact_linux_x64
     depends_on:
@@ -8258,9 +8258,9 @@ tasks:
       - func: package_and_upload_artifact
         vars:
           node_js_version: "16.15.0"
-          distribution_build_variant: linux-x64
+          package_variant: linux-x64
           executable_os_id: linux-x64
-  - name: package_and_upload_artifact_debian_x64
+  - name: package_and_upload_artifact_deb_x64
     depends_on:
       - name: compile_artifact
         variant: linux_x64_build
@@ -8273,9 +8273,9 @@ tasks:
       - func: package_and_upload_artifact
         vars:
           node_js_version: "16.15.0"
-          distribution_build_variant: debian-x64
+          package_variant: deb-x64
           executable_os_id: linux-x64
-  - name: package_and_upload_artifact_rhel7_x64
+  - name: package_and_upload_artifact_rpm_x64
     depends_on:
       - name: compile_artifact
         variant: linux_x64_build
@@ -8288,52 +8288,7 @@ tasks:
       - func: package_and_upload_artifact
         vars:
           node_js_version: "16.15.0"
-          distribution_build_variant: rhel7-x64
-          executable_os_id: linux-x64
-  - name: package_and_upload_artifact_rhel8_x64
-    depends_on:
-      - name: compile_artifact
-        variant: linux_x64_build
-    commands:
-      - func: checkout
-      - func: install
-        vars:
-          npm_deps_mode: cli_build
-          node_js_version: "16.15.0"
-      - func: package_and_upload_artifact
-        vars:
-          node_js_version: "16.15.0"
-          distribution_build_variant: rhel8-x64
-          executable_os_id: linux-x64
-  - name: package_and_upload_artifact_suse_x64
-    depends_on:
-      - name: compile_artifact
-        variant: linux_x64_build
-    commands:
-      - func: checkout
-      - func: install
-        vars:
-          npm_deps_mode: cli_build
-          node_js_version: "16.15.0"
-      - func: package_and_upload_artifact
-        vars:
-          node_js_version: "16.15.0"
-          distribution_build_variant: suse-x64
-          executable_os_id: linux-x64
-  - name: package_and_upload_artifact_amzn1_x64
-    depends_on:
-      - name: compile_artifact
-        variant: linux_x64_build
-    commands:
-      - func: checkout
-      - func: install
-        vars:
-          npm_deps_mode: cli_build
-          node_js_version: "16.15.0"
-      - func: package_and_upload_artifact
-        vars:
-          node_js_version: "16.15.0"
-          distribution_build_variant: amzn1-x64
+          package_variant: rpm-x64
           executable_os_id: linux-x64
   - name: package_and_upload_artifact_linux_x64_openssl11
     depends_on:
@@ -8348,9 +8303,9 @@ tasks:
       - func: package_and_upload_artifact
         vars:
           node_js_version: "16.15.0"
-          distribution_build_variant: linux-x64-openssl11
+          package_variant: linux-x64-openssl11
           executable_os_id: linux-x64-openssl11
-  - name: package_and_upload_artifact_debian_x64_openssl11
+  - name: package_and_upload_artifact_deb_x64_openssl11
     depends_on:
       - name: compile_artifact
         variant: linux_x64_build_openssl11
@@ -8363,9 +8318,9 @@ tasks:
       - func: package_and_upload_artifact
         vars:
           node_js_version: "16.15.0"
-          distribution_build_variant: debian-x64-openssl11
+          package_variant: deb-x64-openssl11
           executable_os_id: linux-x64-openssl11
-  - name: package_and_upload_artifact_rhel7_x64_openssl11
+  - name: package_and_upload_artifact_rpm_x64_openssl11
     depends_on:
       - name: compile_artifact
         variant: linux_x64_build_openssl11
@@ -8378,22 +8333,7 @@ tasks:
       - func: package_and_upload_artifact
         vars:
           node_js_version: "16.15.0"
-          distribution_build_variant: rhel7-x64-openssl11
-          executable_os_id: linux-x64-openssl11
-  - name: package_and_upload_artifact_rhel8_x64_openssl11
-    depends_on:
-      - name: compile_artifact
-        variant: linux_x64_build_openssl11
-    commands:
-      - func: checkout
-      - func: install
-        vars:
-          npm_deps_mode: cli_build
-          node_js_version: "16.15.0"
-      - func: package_and_upload_artifact
-        vars:
-          node_js_version: "16.15.0"
-          distribution_build_variant: rhel8-x64-openssl11
+          package_variant: rpm-x64-openssl11
           executable_os_id: linux-x64-openssl11
   - name: package_and_upload_artifact_linux_x64_openssl3
     depends_on:
@@ -8408,9 +8348,9 @@ tasks:
       - func: package_and_upload_artifact
         vars:
           node_js_version: "16.15.0"
-          distribution_build_variant: linux-x64-openssl3
+          package_variant: linux-x64-openssl3
           executable_os_id: linux-x64-openssl3
-  - name: package_and_upload_artifact_debian_x64_openssl3
+  - name: package_and_upload_artifact_deb_x64_openssl3
     depends_on:
       - name: compile_artifact
         variant: linux_x64_build_openssl3
@@ -8423,9 +8363,9 @@ tasks:
       - func: package_and_upload_artifact
         vars:
           node_js_version: "16.15.0"
-          distribution_build_variant: debian-x64-openssl3
+          package_variant: deb-x64-openssl3
           executable_os_id: linux-x64-openssl3
-  - name: package_and_upload_artifact_rhel8_x64_openssl3
+  - name: package_and_upload_artifact_rpm_x64_openssl3
     depends_on:
       - name: compile_artifact
         variant: linux_x64_build_openssl3
@@ -8438,7 +8378,7 @@ tasks:
       - func: package_and_upload_artifact
         vars:
           node_js_version: "16.15.0"
-          distribution_build_variant: rhel8-x64-openssl3
+          package_variant: rpm-x64-openssl3
           executable_os_id: linux-x64-openssl3
   - name: package_and_upload_artifact_linux_arm64
     depends_on:
@@ -8453,9 +8393,9 @@ tasks:
       - func: package_and_upload_artifact
         vars:
           node_js_version: "16.15.0"
-          distribution_build_variant: linux-arm64
+          package_variant: linux-arm64
           executable_os_id: linux-arm64
-  - name: package_and_upload_artifact_debian_arm64
+  - name: package_and_upload_artifact_deb_arm64
     depends_on:
       - name: compile_artifact
         variant: linux_arm64_build
@@ -8468,9 +8408,9 @@ tasks:
       - func: package_and_upload_artifact
         vars:
           node_js_version: "16.15.0"
-          distribution_build_variant: debian-arm64
+          package_variant: deb-arm64
           executable_os_id: linux-arm64
-  - name: package_and_upload_artifact_rhel8_arm64
+  - name: package_and_upload_artifact_rpm_arm64
     depends_on:
       - name: compile_artifact
         variant: linux_arm64_build
@@ -8483,22 +8423,7 @@ tasks:
       - func: package_and_upload_artifact
         vars:
           node_js_version: "16.15.0"
-          distribution_build_variant: rhel8-arm64
-          executable_os_id: linux-arm64
-  - name: package_and_upload_artifact_amzn2_arm64
-    depends_on:
-      - name: compile_artifact
-        variant: linux_arm64_build
-    commands:
-      - func: checkout
-      - func: install
-        vars:
-          npm_deps_mode: cli_build
-          node_js_version: "16.15.0"
-      - func: package_and_upload_artifact
-        vars:
-          node_js_version: "16.15.0"
-          distribution_build_variant: amzn2-arm64
+          package_variant: rpm-arm64
           executable_os_id: linux-arm64
   - name: package_and_upload_artifact_linux_arm64_openssl11
     depends_on:
@@ -8513,9 +8438,9 @@ tasks:
       - func: package_and_upload_artifact
         vars:
           node_js_version: "16.15.0"
-          distribution_build_variant: linux-arm64-openssl11
+          package_variant: linux-arm64-openssl11
           executable_os_id: linux-arm64-openssl11
-  - name: package_and_upload_artifact_debian_arm64_openssl11
+  - name: package_and_upload_artifact_deb_arm64_openssl11
     depends_on:
       - name: compile_artifact
         variant: linux_arm64_build_openssl11
@@ -8528,9 +8453,9 @@ tasks:
       - func: package_and_upload_artifact
         vars:
           node_js_version: "16.15.0"
-          distribution_build_variant: debian-arm64-openssl11
+          package_variant: deb-arm64-openssl11
           executable_os_id: linux-arm64-openssl11
-  - name: package_and_upload_artifact_rhel8_arm64_openssl11
+  - name: package_and_upload_artifact_rpm_arm64_openssl11
     depends_on:
       - name: compile_artifact
         variant: linux_arm64_build_openssl11
@@ -8543,22 +8468,7 @@ tasks:
       - func: package_and_upload_artifact
         vars:
           node_js_version: "16.15.0"
-          distribution_build_variant: rhel8-arm64-openssl11
-          executable_os_id: linux-arm64-openssl11
-  - name: package_and_upload_artifact_amzn2_arm64_openssl11
-    depends_on:
-      - name: compile_artifact
-        variant: linux_arm64_build_openssl11
-    commands:
-      - func: checkout
-      - func: install
-        vars:
-          npm_deps_mode: cli_build
-          node_js_version: "16.15.0"
-      - func: package_and_upload_artifact
-        vars:
-          node_js_version: "16.15.0"
-          distribution_build_variant: amzn2-arm64-openssl11
+          package_variant: rpm-arm64-openssl11
           executable_os_id: linux-arm64-openssl11
   - name: package_and_upload_artifact_linux_ppc64le
     depends_on:
@@ -8573,9 +8483,9 @@ tasks:
       - func: package_and_upload_artifact
         vars:
           node_js_version: "16.15.0"
-          distribution_build_variant: linux-ppc64le
+          package_variant: linux-ppc64le
           executable_os_id: linux-ppc64le
-  - name: package_and_upload_artifact_rhel8_ppc64le
+  - name: package_and_upload_artifact_rpm_ppc64le
     depends_on:
       - name: compile_artifact
         variant: linux_ppc64le_build
@@ -8588,7 +8498,7 @@ tasks:
       - func: package_and_upload_artifact
         vars:
           node_js_version: "16.15.0"
-          distribution_build_variant: rhel8-ppc64le
+          package_variant: rpm-ppc64le
           executable_os_id: linux-ppc64le
   - name: package_and_upload_artifact_linux_s390x
     depends_on:
@@ -8603,9 +8513,9 @@ tasks:
       - func: package_and_upload_artifact
         vars:
           node_js_version: "16.15.0"
-          distribution_build_variant: linux-s390x
+          package_variant: linux-s390x
           executable_os_id: linux-s390x
-  - name: package_and_upload_artifact_rhel7_s390x
+  - name: package_and_upload_artifact_rpm_s390x
     depends_on:
       - name: compile_artifact
         variant: linux_s390x_build
@@ -8618,7 +8528,7 @@ tasks:
       - func: package_and_upload_artifact
         vars:
           node_js_version: "16.15.0"
-          distribution_build_variant: rhel7-s390x
+          package_variant: rpm-s390x
           executable_os_id: linux-s390x
   - name: package_and_upload_artifact_win32_x64
     depends_on:
@@ -8633,7 +8543,7 @@ tasks:
       - func: package_and_upload_artifact
         vars:
           node_js_version: "16.15.0"
-          distribution_build_variant: win32-x64
+          package_variant: win32-x64
           executable_os_id: win32
   - name: package_and_upload_artifact_win32msi_x64
     depends_on:
@@ -8648,7 +8558,7 @@ tasks:
       - func: package_and_upload_artifact
         vars:
           node_js_version: "16.15.0"
-          distribution_build_variant: win32msi-x64
+          package_variant: win32msi-x64
           executable_os_id: win32
 
   ###
@@ -8663,7 +8573,7 @@ tasks:
       - func: checkout
       - func: get_artifact_url
         vars:
-          source_distribution_build_variant: darwin-x64
+          source_package_variant: darwin-x64
       - func: write_preload_script
       - func: test_artifact_macos
   - name: pkg_test_macos_darwin_arm64
@@ -8675,7 +8585,7 @@ tasks:
       - func: checkout
       - func: get_artifact_url
         vars:
-          source_distribution_build_variant: darwin-arm64
+          source_package_variant: darwin-arm64
       - func: write_preload_script
       - func: test_artifact_macos
   - name: pkg_test_docker_linux_x64_ubuntu20_04_tgz
@@ -8687,7 +8597,7 @@ tasks:
       - func: checkout
       - func: get_artifact_url
         vars:
-          source_distribution_build_variant: linux-x64
+          source_package_variant: linux-x64
       - func: write_preload_script
       - func: install
         vars:
@@ -8697,16 +8607,16 @@ tasks:
         vars:
           node_js_version: "16.15.0"
           dockerfile: ubuntu20.04-tgz
-  - name: pkg_test_docker_debian_x64_ubuntu18_04_deb
+  - name: pkg_test_docker_deb_x64_ubuntu18_04_deb
     tags: ["smoke-test"]
     depends_on:
-      - name: package_and_upload_artifact_debian_x64
+      - name: package_and_upload_artifact_deb_x64
         variant: linux_package
     commands:
       - func: checkout
       - func: get_artifact_url
         vars:
-          source_distribution_build_variant: debian-x64
+          source_package_variant: deb-x64
       - func: write_preload_script
       - func: install
         vars:
@@ -8716,16 +8626,16 @@ tasks:
         vars:
           node_js_version: "16.15.0"
           dockerfile: ubuntu18.04-deb
-  - name: pkg_test_docker_debian_x64_ubuntu20_04_deb
+  - name: pkg_test_docker_deb_x64_ubuntu20_04_deb
     tags: ["smoke-test"]
     depends_on:
-      - name: package_and_upload_artifact_debian_x64
+      - name: package_and_upload_artifact_deb_x64
         variant: linux_package
     commands:
       - func: checkout
       - func: get_artifact_url
         vars:
-          source_distribution_build_variant: debian-x64
+          source_package_variant: deb-x64
       - func: write_preload_script
       - func: install
         vars:
@@ -8735,16 +8645,16 @@ tasks:
         vars:
           node_js_version: "16.15.0"
           dockerfile: ubuntu20.04-deb
-  - name: pkg_test_docker_debian_x64_ubuntu22_04_deb
+  - name: pkg_test_docker_deb_x64_ubuntu22_04_deb
     tags: ["smoke-test"]
     depends_on:
-      - name: package_and_upload_artifact_debian_x64
+      - name: package_and_upload_artifact_deb_x64
         variant: linux_package
     commands:
       - func: checkout
       - func: get_artifact_url
         vars:
-          source_distribution_build_variant: debian-x64
+          source_package_variant: deb-x64
       - func: write_preload_script
       - func: install
         vars:
@@ -8754,16 +8664,16 @@ tasks:
         vars:
           node_js_version: "16.15.0"
           dockerfile: ubuntu22.04-deb
-  - name: pkg_test_docker_debian_x64_debian9_deb
+  - name: pkg_test_docker_deb_x64_debian9_deb
     tags: ["smoke-test"]
     depends_on:
-      - name: package_and_upload_artifact_debian_x64
+      - name: package_and_upload_artifact_deb_x64
         variant: linux_package
     commands:
       - func: checkout
       - func: get_artifact_url
         vars:
-          source_distribution_build_variant: debian-x64
+          source_package_variant: deb-x64
       - func: write_preload_script
       - func: install
         vars:
@@ -8773,16 +8683,16 @@ tasks:
         vars:
           node_js_version: "16.15.0"
           dockerfile: debian9-deb
-  - name: pkg_test_docker_debian_x64_debian10_deb
+  - name: pkg_test_docker_deb_x64_debian10_deb
     tags: ["smoke-test"]
     depends_on:
-      - name: package_and_upload_artifact_debian_x64
+      - name: package_and_upload_artifact_deb_x64
         variant: linux_package
     commands:
       - func: checkout
       - func: get_artifact_url
         vars:
-          source_distribution_build_variant: debian-x64
+          source_package_variant: deb-x64
       - func: write_preload_script
       - func: install
         vars:
@@ -8792,16 +8702,16 @@ tasks:
         vars:
           node_js_version: "16.15.0"
           dockerfile: debian10-deb
-  - name: pkg_test_docker_debian_x64_debian11_deb
+  - name: pkg_test_docker_deb_x64_debian11_deb
     tags: ["smoke-test"]
     depends_on:
-      - name: package_and_upload_artifact_debian_x64
+      - name: package_and_upload_artifact_deb_x64
         variant: linux_package
     commands:
       - func: checkout
       - func: get_artifact_url
         vars:
-          source_distribution_build_variant: debian-x64
+          source_package_variant: deb-x64
       - func: write_preload_script
       - func: install
         vars:
@@ -8811,16 +8721,16 @@ tasks:
         vars:
           node_js_version: "16.15.0"
           dockerfile: debian11-deb
-  - name: pkg_test_docker_rhel7_x64_centos7_rpm
+  - name: pkg_test_docker_rpm_x64_centos7_rpm
     tags: ["smoke-test"]
     depends_on:
-      - name: package_and_upload_artifact_rhel7_x64
+      - name: package_and_upload_artifact_rpm_x64
         variant: linux_package
     commands:
       - func: checkout
       - func: get_artifact_url
         vars:
-          source_distribution_build_variant: rhel7-x64
+          source_package_variant: rpm-x64
       - func: write_preload_script
       - func: install
         vars:
@@ -8830,16 +8740,16 @@ tasks:
         vars:
           node_js_version: "16.15.0"
           dockerfile: centos7-rpm
-  - name: pkg_test_docker_rhel7_x64_amazonlinux2_rpm
+  - name: pkg_test_docker_rpm_x64_amazonlinux2_rpm
     tags: ["smoke-test"]
     depends_on:
-      - name: package_and_upload_artifact_rhel7_x64
+      - name: package_and_upload_artifact_rpm_x64
         variant: linux_package
     commands:
       - func: checkout
       - func: get_artifact_url
         vars:
-          source_distribution_build_variant: rhel7-x64
+          source_package_variant: rpm-x64
       - func: write_preload_script
       - func: install
         vars:
@@ -8849,16 +8759,16 @@ tasks:
         vars:
           node_js_version: "16.15.0"
           dockerfile: amazonlinux2-rpm
-  - name: pkg_test_docker_rhel8_x64_rocky8_rpm
+  - name: pkg_test_docker_rpm_x64_rocky8_rpm
     tags: ["smoke-test"]
     depends_on:
-      - name: package_and_upload_artifact_rhel8_x64
+      - name: package_and_upload_artifact_rpm_x64
         variant: linux_package
     commands:
       - func: checkout
       - func: get_artifact_url
         vars:
-          source_distribution_build_variant: rhel8-x64
+          source_package_variant: rpm-x64
       - func: write_preload_script
       - func: install
         vars:
@@ -8868,16 +8778,16 @@ tasks:
         vars:
           node_js_version: "16.15.0"
           dockerfile: rocky8-rpm
-  - name: pkg_test_docker_rhel8_x64_fedora34_rpm
+  - name: pkg_test_docker_rpm_x64_fedora34_rpm
     tags: ["smoke-test"]
     depends_on:
-      - name: package_and_upload_artifact_rhel8_x64
+      - name: package_and_upload_artifact_rpm_x64
         variant: linux_package
     commands:
       - func: checkout
       - func: get_artifact_url
         vars:
-          source_distribution_build_variant: rhel8-x64
+          source_package_variant: rpm-x64
       - func: write_preload_script
       - func: install
         vars:
@@ -8887,16 +8797,16 @@ tasks:
         vars:
           node_js_version: "16.15.0"
           dockerfile: fedora34-rpm
-  - name: pkg_test_docker_suse_x64_suse12_rpm
+  - name: pkg_test_docker_rpm_x64_suse12_rpm
     tags: ["smoke-test"]
     depends_on:
-      - name: package_and_upload_artifact_suse_x64
+      - name: package_and_upload_artifact_rpm_x64
         variant: linux_package
     commands:
       - func: checkout
       - func: get_artifact_url
         vars:
-          source_distribution_build_variant: suse-x64
+          source_package_variant: rpm-x64
       - func: write_preload_script
       - func: install
         vars:
@@ -8906,16 +8816,16 @@ tasks:
         vars:
           node_js_version: "16.15.0"
           dockerfile: suse12-rpm
-  - name: pkg_test_docker_suse_x64_suse15_rpm
+  - name: pkg_test_docker_rpm_x64_suse15_rpm
     tags: ["smoke-test"]
     depends_on:
-      - name: package_and_upload_artifact_suse_x64
+      - name: package_and_upload_artifact_rpm_x64
         variant: linux_package
     commands:
       - func: checkout
       - func: get_artifact_url
         vars:
-          source_distribution_build_variant: suse-x64
+          source_package_variant: rpm-x64
       - func: write_preload_script
       - func: install
         vars:
@@ -8925,16 +8835,16 @@ tasks:
         vars:
           node_js_version: "16.15.0"
           dockerfile: suse15-rpm
-  - name: pkg_test_docker_amzn1_x64_amazonlinux1_rpm
+  - name: pkg_test_docker_rpm_x64_amazonlinux1_rpm
     tags: ["smoke-test"]
     depends_on:
-      - name: package_and_upload_artifact_amzn1_x64
+      - name: package_and_upload_artifact_rpm_x64
         variant: linux_package
     commands:
       - func: checkout
       - func: get_artifact_url
         vars:
-          source_distribution_build_variant: amzn1-x64
+          source_package_variant: rpm-x64
       - func: write_preload_script
       - func: install
         vars:
@@ -8944,16 +8854,16 @@ tasks:
         vars:
           node_js_version: "16.15.0"
           dockerfile: amazonlinux1-rpm
-  - name: pkg_test_docker_debian_x64_openssl11_ubuntu20_04_deb
+  - name: pkg_test_docker_deb_x64_openssl11_ubuntu20_04_deb
     tags: ["smoke-test"]
     depends_on:
-      - name: package_and_upload_artifact_debian_x64_openssl11
+      - name: package_and_upload_artifact_deb_x64_openssl11
         variant: linux_package
     commands:
       - func: checkout
       - func: get_artifact_url
         vars:
-          source_distribution_build_variant: debian-x64-openssl11
+          source_package_variant: deb-x64-openssl11
       - func: write_preload_script
       - func: install
         vars:
@@ -8963,16 +8873,16 @@ tasks:
         vars:
           node_js_version: "16.15.0"
           dockerfile: ubuntu20.04-deb
-  - name: pkg_test_docker_debian_x64_openssl11_debian10_deb
+  - name: pkg_test_docker_deb_x64_openssl11_debian10_deb
     tags: ["smoke-test"]
     depends_on:
-      - name: package_and_upload_artifact_debian_x64_openssl11
+      - name: package_and_upload_artifact_deb_x64_openssl11
         variant: linux_package
     commands:
       - func: checkout
       - func: get_artifact_url
         vars:
-          source_distribution_build_variant: debian-x64-openssl11
+          source_package_variant: deb-x64-openssl11
       - func: write_preload_script
       - func: install
         vars:
@@ -8982,16 +8892,16 @@ tasks:
         vars:
           node_js_version: "16.15.0"
           dockerfile: debian10-deb
-  - name: pkg_test_docker_debian_x64_openssl11_debian11_deb
+  - name: pkg_test_docker_deb_x64_openssl11_debian11_deb
     tags: ["smoke-test"]
     depends_on:
-      - name: package_and_upload_artifact_debian_x64_openssl11
+      - name: package_and_upload_artifact_deb_x64_openssl11
         variant: linux_package
     commands:
       - func: checkout
       - func: get_artifact_url
         vars:
-          source_distribution_build_variant: debian-x64-openssl11
+          source_package_variant: deb-x64-openssl11
       - func: write_preload_script
       - func: install
         vars:
@@ -9001,16 +8911,16 @@ tasks:
         vars:
           node_js_version: "16.15.0"
           dockerfile: debian11-deb
-  - name: pkg_test_docker_rhel7_x64_openssl11_centos7_epel_rpm
+  - name: pkg_test_docker_rpm_x64_openssl11_centos7_epel_rpm
     tags: ["smoke-test"]
     depends_on:
-      - name: package_and_upload_artifact_rhel7_x64_openssl11
+      - name: package_and_upload_artifact_rpm_x64_openssl11
         variant: linux_package
     commands:
       - func: checkout
       - func: get_artifact_url
         vars:
-          source_distribution_build_variant: rhel7-x64-openssl11
+          source_package_variant: rpm-x64-openssl11
       - func: write_preload_script
       - func: install
         vars:
@@ -9020,16 +8930,16 @@ tasks:
         vars:
           node_js_version: "16.15.0"
           dockerfile: centos7-epel-rpm
-  - name: pkg_test_docker_rhel7_x64_openssl11_amazonlinux2_rpm
+  - name: pkg_test_docker_rpm_x64_openssl11_amazonlinux2_rpm
     tags: ["smoke-test"]
     depends_on:
-      - name: package_and_upload_artifact_rhel7_x64_openssl11
+      - name: package_and_upload_artifact_rpm_x64_openssl11
         variant: linux_package
     commands:
       - func: checkout
       - func: get_artifact_url
         vars:
-          source_distribution_build_variant: rhel7-x64-openssl11
+          source_package_variant: rpm-x64-openssl11
       - func: write_preload_script
       - func: install
         vars:
@@ -9039,16 +8949,16 @@ tasks:
         vars:
           node_js_version: "16.15.0"
           dockerfile: amazonlinux2-rpm
-  - name: pkg_test_docker_rhel8_x64_openssl11_rocky8_rpm
+  - name: pkg_test_docker_rpm_x64_openssl11_rocky8_rpm
     tags: ["smoke-test"]
     depends_on:
-      - name: package_and_upload_artifact_rhel8_x64_openssl11
+      - name: package_and_upload_artifact_rpm_x64_openssl11
         variant: linux_package
     commands:
       - func: checkout
       - func: get_artifact_url
         vars:
-          source_distribution_build_variant: rhel8-x64-openssl11
+          source_package_variant: rpm-x64-openssl11
       - func: write_preload_script
       - func: install
         vars:
@@ -9058,16 +8968,16 @@ tasks:
         vars:
           node_js_version: "16.15.0"
           dockerfile: rocky8-rpm
-  - name: pkg_test_docker_rhel8_x64_openssl11_fedora34_rpm
+  - name: pkg_test_docker_rpm_x64_openssl11_fedora34_rpm
     tags: ["smoke-test"]
     depends_on:
-      - name: package_and_upload_artifact_rhel8_x64_openssl11
+      - name: package_and_upload_artifact_rpm_x64_openssl11
         variant: linux_package
     commands:
       - func: checkout
       - func: get_artifact_url
         vars:
-          source_distribution_build_variant: rhel8-x64-openssl11
+          source_package_variant: rpm-x64-openssl11
       - func: write_preload_script
       - func: install
         vars:
@@ -9077,16 +8987,16 @@ tasks:
         vars:
           node_js_version: "16.15.0"
           dockerfile: fedora34-rpm
-  - name: pkg_test_docker_debian_x64_openssl3_ubuntu22_04_deb
+  - name: pkg_test_docker_deb_x64_openssl3_ubuntu22_04_deb
     tags: ["smoke-test"]
     depends_on:
-      - name: package_and_upload_artifact_debian_x64_openssl3
+      - name: package_and_upload_artifact_deb_x64_openssl3
         variant: linux_package
     commands:
       - func: checkout
       - func: get_artifact_url
         vars:
-          source_distribution_build_variant: debian-x64-openssl3
+          source_package_variant: deb-x64-openssl3
       - func: write_preload_script
       - func: install
         vars:
@@ -9096,16 +9006,16 @@ tasks:
         vars:
           node_js_version: "16.15.0"
           dockerfile: ubuntu22.04-deb
-  - name: pkg_test_docker_rhel8_x64_openssl3_rocky8_epel_rpm
+  - name: pkg_test_docker_rpm_x64_openssl3_rocky8_epel_rpm
     tags: ["smoke-test"]
     depends_on:
-      - name: package_and_upload_artifact_rhel8_x64_openssl3
+      - name: package_and_upload_artifact_rpm_x64_openssl3
         variant: linux_package
     commands:
       - func: checkout
       - func: get_artifact_url
         vars:
-          source_distribution_build_variant: rhel8-x64-openssl3
+          source_package_variant: rpm-x64-openssl3
       - func: write_preload_script
       - func: install
         vars:
@@ -9124,7 +9034,7 @@ tasks:
       - func: checkout
       - func: get_artifact_url
         vars:
-          source_distribution_build_variant: linux-arm64
+          source_package_variant: linux-arm64
       - func: write_preload_script
       - func: install
         vars:
@@ -9134,16 +9044,16 @@ tasks:
         vars:
           node_js_version: "16.15.0"
           dockerfile: ubuntu20.04-tgz
-  - name: pkg_test_docker_debian_arm64_ubuntu18_04_deb
+  - name: pkg_test_docker_deb_arm64_ubuntu18_04_deb
     tags: ["smoke-test"]
     depends_on:
-      - name: package_and_upload_artifact_debian_arm64
+      - name: package_and_upload_artifact_deb_arm64
         variant: linux_package
     commands:
       - func: checkout
       - func: get_artifact_url
         vars:
-          source_distribution_build_variant: debian-arm64
+          source_package_variant: deb-arm64
       - func: write_preload_script
       - func: install
         vars:
@@ -9153,16 +9063,16 @@ tasks:
         vars:
           node_js_version: "16.15.0"
           dockerfile: ubuntu18.04-deb
-  - name: pkg_test_docker_debian_arm64_ubuntu20_04_deb
+  - name: pkg_test_docker_deb_arm64_ubuntu20_04_deb
     tags: ["smoke-test"]
     depends_on:
-      - name: package_and_upload_artifact_debian_arm64
+      - name: package_and_upload_artifact_deb_arm64
         variant: linux_package
     commands:
       - func: checkout
       - func: get_artifact_url
         vars:
-          source_distribution_build_variant: debian-arm64
+          source_package_variant: deb-arm64
       - func: write_preload_script
       - func: install
         vars:
@@ -9172,16 +9082,16 @@ tasks:
         vars:
           node_js_version: "16.15.0"
           dockerfile: ubuntu20.04-deb
-  - name: pkg_test_docker_debian_arm64_ubuntu22_04_deb
+  - name: pkg_test_docker_deb_arm64_ubuntu22_04_deb
     tags: ["smoke-test"]
     depends_on:
-      - name: package_and_upload_artifact_debian_arm64
+      - name: package_and_upload_artifact_deb_arm64
         variant: linux_package
     commands:
       - func: checkout
       - func: get_artifact_url
         vars:
-          source_distribution_build_variant: debian-arm64
+          source_package_variant: deb-arm64
       - func: write_preload_script
       - func: install
         vars:
@@ -9191,16 +9101,16 @@ tasks:
         vars:
           node_js_version: "16.15.0"
           dockerfile: ubuntu22.04-deb
-  - name: pkg_test_docker_debian_arm64_debian10_deb
+  - name: pkg_test_docker_deb_arm64_debian10_deb
     tags: ["smoke-test"]
     depends_on:
-      - name: package_and_upload_artifact_debian_arm64
+      - name: package_and_upload_artifact_deb_arm64
         variant: linux_package
     commands:
       - func: checkout
       - func: get_artifact_url
         vars:
-          source_distribution_build_variant: debian-arm64
+          source_package_variant: deb-arm64
       - func: write_preload_script
       - func: install
         vars:
@@ -9210,16 +9120,16 @@ tasks:
         vars:
           node_js_version: "16.15.0"
           dockerfile: debian10-deb
-  - name: pkg_test_docker_debian_arm64_debian11_deb
+  - name: pkg_test_docker_deb_arm64_debian11_deb
     tags: ["smoke-test"]
     depends_on:
-      - name: package_and_upload_artifact_debian_arm64
+      - name: package_and_upload_artifact_deb_arm64
         variant: linux_package
     commands:
       - func: checkout
       - func: get_artifact_url
         vars:
-          source_distribution_build_variant: debian-arm64
+          source_package_variant: deb-arm64
       - func: write_preload_script
       - func: install
         vars:
@@ -9229,16 +9139,16 @@ tasks:
         vars:
           node_js_version: "16.15.0"
           dockerfile: debian11-deb
-  - name: pkg_test_docker_rhel8_arm64_rocky8_rpm
+  - name: pkg_test_docker_rpm_arm64_rocky8_rpm
     tags: ["smoke-test"]
     depends_on:
-      - name: package_and_upload_artifact_rhel8_arm64
+      - name: package_and_upload_artifact_rpm_arm64
         variant: linux_package
     commands:
       - func: checkout
       - func: get_artifact_url
         vars:
-          source_distribution_build_variant: rhel8-arm64
+          source_package_variant: rpm-arm64
       - func: write_preload_script
       - func: install
         vars:
@@ -9248,16 +9158,16 @@ tasks:
         vars:
           node_js_version: "16.15.0"
           dockerfile: rocky8-rpm
-  - name: pkg_test_docker_rhel8_arm64_fedora34_rpm
+  - name: pkg_test_docker_rpm_arm64_fedora34_rpm
     tags: ["smoke-test"]
     depends_on:
-      - name: package_and_upload_artifact_rhel8_arm64
+      - name: package_and_upload_artifact_rpm_arm64
         variant: linux_package
     commands:
       - func: checkout
       - func: get_artifact_url
         vars:
-          source_distribution_build_variant: rhel8-arm64
+          source_package_variant: rpm-arm64
       - func: write_preload_script
       - func: install
         vars:
@@ -9267,16 +9177,16 @@ tasks:
         vars:
           node_js_version: "16.15.0"
           dockerfile: fedora34-rpm
-  - name: pkg_test_docker_amzn2_arm64_amazonlinux2_rpm
+  - name: pkg_test_docker_rpm_arm64_amazonlinux2_rpm
     tags: ["smoke-test"]
     depends_on:
-      - name: package_and_upload_artifact_amzn2_arm64
+      - name: package_and_upload_artifact_rpm_arm64
         variant: linux_package
     commands:
       - func: checkout
       - func: get_artifact_url
         vars:
-          source_distribution_build_variant: amzn2-arm64
+          source_package_variant: rpm-arm64
       - func: write_preload_script
       - func: install
         vars:
@@ -9286,16 +9196,16 @@ tasks:
         vars:
           node_js_version: "16.15.0"
           dockerfile: amazonlinux2-rpm
-  - name: pkg_test_docker_debian_arm64_openssl11_ubuntu20_04_deb
+  - name: pkg_test_docker_deb_arm64_openssl11_ubuntu20_04_deb
     tags: ["smoke-test"]
     depends_on:
-      - name: package_and_upload_artifact_debian_arm64_openssl11
+      - name: package_and_upload_artifact_deb_arm64_openssl11
         variant: linux_package
     commands:
       - func: checkout
       - func: get_artifact_url
         vars:
-          source_distribution_build_variant: debian-arm64-openssl11
+          source_package_variant: deb-arm64-openssl11
       - func: write_preload_script
       - func: install
         vars:
@@ -9305,16 +9215,16 @@ tasks:
         vars:
           node_js_version: "16.15.0"
           dockerfile: ubuntu20.04-deb
-  - name: pkg_test_docker_debian_arm64_openssl11_debian10_deb
+  - name: pkg_test_docker_deb_arm64_openssl11_debian10_deb
     tags: ["smoke-test"]
     depends_on:
-      - name: package_and_upload_artifact_debian_arm64_openssl11
+      - name: package_and_upload_artifact_deb_arm64_openssl11
         variant: linux_package
     commands:
       - func: checkout
       - func: get_artifact_url
         vars:
-          source_distribution_build_variant: debian-arm64-openssl11
+          source_package_variant: deb-arm64-openssl11
       - func: write_preload_script
       - func: install
         vars:
@@ -9324,16 +9234,16 @@ tasks:
         vars:
           node_js_version: "16.15.0"
           dockerfile: debian10-deb
-  - name: pkg_test_docker_debian_arm64_openssl11_debian11_deb
+  - name: pkg_test_docker_deb_arm64_openssl11_debian11_deb
     tags: ["smoke-test"]
     depends_on:
-      - name: package_and_upload_artifact_debian_arm64_openssl11
+      - name: package_and_upload_artifact_deb_arm64_openssl11
         variant: linux_package
     commands:
       - func: checkout
       - func: get_artifact_url
         vars:
-          source_distribution_build_variant: debian-arm64-openssl11
+          source_package_variant: deb-arm64-openssl11
       - func: write_preload_script
       - func: install
         vars:
@@ -9343,16 +9253,16 @@ tasks:
         vars:
           node_js_version: "16.15.0"
           dockerfile: debian11-deb
-  - name: pkg_test_docker_rhel8_arm64_openssl11_rocky8_rpm
+  - name: pkg_test_docker_rpm_arm64_openssl11_rocky8_rpm
     tags: ["smoke-test"]
     depends_on:
-      - name: package_and_upload_artifact_rhel8_arm64_openssl11
+      - name: package_and_upload_artifact_rpm_arm64_openssl11
         variant: linux_package
     commands:
       - func: checkout
       - func: get_artifact_url
         vars:
-          source_distribution_build_variant: rhel8-arm64-openssl11
+          source_package_variant: rpm-arm64-openssl11
       - func: write_preload_script
       - func: install
         vars:
@@ -9362,16 +9272,16 @@ tasks:
         vars:
           node_js_version: "16.15.0"
           dockerfile: rocky8-rpm
-  - name: pkg_test_docker_rhel8_arm64_openssl11_fedora34_rpm
+  - name: pkg_test_docker_rpm_arm64_openssl11_fedora34_rpm
     tags: ["smoke-test"]
     depends_on:
-      - name: package_and_upload_artifact_rhel8_arm64_openssl11
+      - name: package_and_upload_artifact_rpm_arm64_openssl11
         variant: linux_package
     commands:
       - func: checkout
       - func: get_artifact_url
         vars:
-          source_distribution_build_variant: rhel8-arm64-openssl11
+          source_package_variant: rpm-arm64-openssl11
       - func: write_preload_script
       - func: install
         vars:
@@ -9381,16 +9291,16 @@ tasks:
         vars:
           node_js_version: "16.15.0"
           dockerfile: fedora34-rpm
-  - name: pkg_test_docker_amzn2_arm64_openssl11_amazonlinux2_rpm
+  - name: pkg_test_docker_rpm_arm64_openssl11_amazonlinux2_rpm
     tags: ["smoke-test"]
     depends_on:
-      - name: package_and_upload_artifact_amzn2_arm64_openssl11
+      - name: package_and_upload_artifact_rpm_arm64_openssl11
         variant: linux_package
     commands:
       - func: checkout
       - func: get_artifact_url
         vars:
-          source_distribution_build_variant: amzn2-arm64-openssl11
+          source_package_variant: rpm-arm64-openssl11
       - func: write_preload_script
       - func: install
         vars:
@@ -9400,28 +9310,28 @@ tasks:
         vars:
           node_js_version: "16.15.0"
           dockerfile: amazonlinux2-rpm
-  - name: pkg_test_rpmextract_rhel8_ppc64le
+  - name: pkg_test_rpmextract_rpm_ppc64le
     tags: ["smoke-test"]
     depends_on:
-      - name: package_and_upload_artifact_rhel8_ppc64le
+      - name: package_and_upload_artifact_rpm_ppc64le
         variant: linux_package
     commands:
       - func: checkout
       - func: get_artifact_url
         vars:
-          source_distribution_build_variant: rhel8-ppc64le
+          source_package_variant: rpm-ppc64le
       - func: write_preload_script
       - func: test_artifact_rpmextract
-  - name: pkg_test_rpmextract_rhel7_s390x
+  - name: pkg_test_rpmextract_rpm_s390x
     tags: ["smoke-test"]
     depends_on:
-      - name: package_and_upload_artifact_rhel7_s390x
+      - name: package_and_upload_artifact_rpm_s390x
         variant: linux_package
     commands:
       - func: checkout
       - func: get_artifact_url
         vars:
-          source_distribution_build_variant: rhel7-s390x
+          source_package_variant: rpm-s390x
       - func: write_preload_script
       - func: test_artifact_rpmextract
   - name: pkg_test_ssh_win32_x64
@@ -9433,7 +9343,7 @@ tasks:
       - func: checkout
       - func: get_artifact_url
         vars:
-          source_distribution_build_variant: win32-x64
+          source_package_variant: win32-x64
       - func: write_preload_script
       - func: spawn_host
         vars:
@@ -9452,7 +9362,7 @@ tasks:
       - func: checkout
       - func: get_artifact_url
         vars:
-          source_distribution_build_variant: win32msi-x64
+          source_package_variant: win32msi-x64
       - func: write_preload_script
       - func: spawn_host
         vars:
@@ -9800,30 +9710,24 @@ buildvariants:
     run_on: ubuntu1804-small
     tasks:
       - name: package_and_upload_artifact_linux_x64
-      - name: package_and_upload_artifact_debian_x64
-      - name: package_and_upload_artifact_rhel7_x64
-      - name: package_and_upload_artifact_rhel8_x64
-      - name: package_and_upload_artifact_suse_x64
-      - name: package_and_upload_artifact_amzn1_x64
+      - name: package_and_upload_artifact_deb_x64
+      - name: package_and_upload_artifact_rpm_x64
       - name: package_and_upload_artifact_linux_x64_openssl11
-      - name: package_and_upload_artifact_debian_x64_openssl11
-      - name: package_and_upload_artifact_rhel7_x64_openssl11
-      - name: package_and_upload_artifact_rhel8_x64_openssl11
+      - name: package_and_upload_artifact_deb_x64_openssl11
+      - name: package_and_upload_artifact_rpm_x64_openssl11
       - name: package_and_upload_artifact_linux_x64_openssl3
-      - name: package_and_upload_artifact_debian_x64_openssl3
-      - name: package_and_upload_artifact_rhel8_x64_openssl3
+      - name: package_and_upload_artifact_deb_x64_openssl3
+      - name: package_and_upload_artifact_rpm_x64_openssl3
       - name: package_and_upload_artifact_linux_arm64
-      - name: package_and_upload_artifact_debian_arm64
-      - name: package_and_upload_artifact_rhel8_arm64
-      - name: package_and_upload_artifact_amzn2_arm64
+      - name: package_and_upload_artifact_deb_arm64
+      - name: package_and_upload_artifact_rpm_arm64
       - name: package_and_upload_artifact_linux_arm64_openssl11
-      - name: package_and_upload_artifact_debian_arm64_openssl11
-      - name: package_and_upload_artifact_rhel8_arm64_openssl11
-      - name: package_and_upload_artifact_amzn2_arm64_openssl11
+      - name: package_and_upload_artifact_deb_arm64_openssl11
+      - name: package_and_upload_artifact_rpm_arm64_openssl11
       - name: package_and_upload_artifact_linux_ppc64le
-      - name: package_and_upload_artifact_rhel8_ppc64le
+      - name: package_and_upload_artifact_rpm_ppc64le
       - name: package_and_upload_artifact_linux_s390x
-      - name: package_and_upload_artifact_rhel7_s390x
+      - name: package_and_upload_artifact_rpm_s390x
   - name: linux_x64_build
     display_name: "RHEL 7.0 x64 (build)"
     run_on: rhel70-build
@@ -10116,47 +10020,47 @@ buildvariants:
     run_on: ubuntu1804-small
     tasks:
       - name: pkg_test_docker_linux_x64_ubuntu20_04_tgz
-      - name: pkg_test_docker_debian_x64_ubuntu18_04_deb
-      - name: pkg_test_docker_debian_x64_ubuntu20_04_deb
-      - name: pkg_test_docker_debian_x64_ubuntu22_04_deb
-      - name: pkg_test_docker_debian_x64_debian9_deb
-      - name: pkg_test_docker_debian_x64_debian10_deb
-      - name: pkg_test_docker_debian_x64_debian11_deb
-      - name: pkg_test_docker_rhel7_x64_centos7_rpm
-      - name: pkg_test_docker_rhel7_x64_amazonlinux2_rpm
-      - name: pkg_test_docker_rhel8_x64_rocky8_rpm
-      - name: pkg_test_docker_rhel8_x64_fedora34_rpm
-      - name: pkg_test_docker_suse_x64_suse12_rpm
-      - name: pkg_test_docker_suse_x64_suse15_rpm
-      - name: pkg_test_docker_amzn1_x64_amazonlinux1_rpm
-      - name: pkg_test_docker_debian_x64_openssl11_ubuntu20_04_deb
-      - name: pkg_test_docker_debian_x64_openssl11_debian10_deb
-      - name: pkg_test_docker_debian_x64_openssl11_debian11_deb
-      - name: pkg_test_docker_rhel7_x64_openssl11_centos7_epel_rpm
-      - name: pkg_test_docker_rhel7_x64_openssl11_amazonlinux2_rpm
-      - name: pkg_test_docker_rhel8_x64_openssl11_rocky8_rpm
-      - name: pkg_test_docker_rhel8_x64_openssl11_fedora34_rpm
-      - name: pkg_test_docker_debian_x64_openssl3_ubuntu22_04_deb
-      - name: pkg_test_docker_rhel8_x64_openssl3_rocky8_epel_rpm
+      - name: pkg_test_docker_deb_x64_ubuntu18_04_deb
+      - name: pkg_test_docker_deb_x64_ubuntu20_04_deb
+      - name: pkg_test_docker_deb_x64_ubuntu22_04_deb
+      - name: pkg_test_docker_deb_x64_debian9_deb
+      - name: pkg_test_docker_deb_x64_debian10_deb
+      - name: pkg_test_docker_deb_x64_debian11_deb
+      - name: pkg_test_docker_rpm_x64_centos7_rpm
+      - name: pkg_test_docker_rpm_x64_amazonlinux2_rpm
+      - name: pkg_test_docker_rpm_x64_rocky8_rpm
+      - name: pkg_test_docker_rpm_x64_fedora34_rpm
+      - name: pkg_test_docker_rpm_x64_suse12_rpm
+      - name: pkg_test_docker_rpm_x64_suse15_rpm
+      - name: pkg_test_docker_rpm_x64_amazonlinux1_rpm
+      - name: pkg_test_docker_deb_x64_openssl11_ubuntu20_04_deb
+      - name: pkg_test_docker_deb_x64_openssl11_debian10_deb
+      - name: pkg_test_docker_deb_x64_openssl11_debian11_deb
+      - name: pkg_test_docker_rpm_x64_openssl11_centos7_epel_rpm
+      - name: pkg_test_docker_rpm_x64_openssl11_amazonlinux2_rpm
+      - name: pkg_test_docker_rpm_x64_openssl11_rocky8_rpm
+      - name: pkg_test_docker_rpm_x64_openssl11_fedora34_rpm
+      - name: pkg_test_docker_deb_x64_openssl3_ubuntu22_04_deb
+      - name: pkg_test_docker_rpm_x64_openssl3_rocky8_epel_rpm
   - name: pkg_smoke_tests_docker_arm64
     display_name: "package smoke tests (arm64 Docker)"
     run_on: ubuntu1804-arm64-small
     tasks:
       - name: pkg_test_docker_linux_arm64_ubuntu20_04_tgz
-      - name: pkg_test_docker_debian_arm64_ubuntu18_04_deb
-      - name: pkg_test_docker_debian_arm64_ubuntu20_04_deb
-      - name: pkg_test_docker_debian_arm64_ubuntu22_04_deb
-      - name: pkg_test_docker_debian_arm64_debian10_deb
-      - name: pkg_test_docker_debian_arm64_debian11_deb
-      - name: pkg_test_docker_rhel8_arm64_rocky8_rpm
-      - name: pkg_test_docker_rhel8_arm64_fedora34_rpm
-      - name: pkg_test_docker_amzn2_arm64_amazonlinux2_rpm
-      - name: pkg_test_docker_debian_arm64_openssl11_ubuntu20_04_deb
-      - name: pkg_test_docker_debian_arm64_openssl11_debian10_deb
-      - name: pkg_test_docker_debian_arm64_openssl11_debian11_deb
-      - name: pkg_test_docker_rhel8_arm64_openssl11_rocky8_rpm
-      - name: pkg_test_docker_rhel8_arm64_openssl11_fedora34_rpm
-      - name: pkg_test_docker_amzn2_arm64_openssl11_amazonlinux2_rpm
+      - name: pkg_test_docker_deb_arm64_ubuntu18_04_deb
+      - name: pkg_test_docker_deb_arm64_ubuntu20_04_deb
+      - name: pkg_test_docker_deb_arm64_ubuntu22_04_deb
+      - name: pkg_test_docker_deb_arm64_debian10_deb
+      - name: pkg_test_docker_deb_arm64_debian11_deb
+      - name: pkg_test_docker_rpm_arm64_rocky8_rpm
+      - name: pkg_test_docker_rpm_arm64_fedora34_rpm
+      - name: pkg_test_docker_rpm_arm64_amazonlinux2_rpm
+      - name: pkg_test_docker_deb_arm64_openssl11_ubuntu20_04_deb
+      - name: pkg_test_docker_deb_arm64_openssl11_debian10_deb
+      - name: pkg_test_docker_deb_arm64_openssl11_debian11_deb
+      - name: pkg_test_docker_rpm_arm64_openssl11_rocky8_rpm
+      - name: pkg_test_docker_rpm_arm64_openssl11_fedora34_rpm
+      - name: pkg_test_docker_rpm_arm64_openssl11_amazonlinux2_rpm
   - name: pkg_smoke_tests_win32
     display_name: "package smoke tests (win32)"
     run_on: ubuntu1804-small
@@ -10182,17 +10086,17 @@ buildvariants:
     display_name: "package smoke tests (RHEL 7.2 s390x)"
     run_on: rhel72-zseries-small
     tasks:
-      - name: pkg_test_rpmextract_rhel7_s390x
+      - name: pkg_test_rpmextract_rpm_s390x
   - name: pkg_smoke_tests_rhel83_s390x
     display_name: "package smoke tests (RHEL 8.3 s390x)"
     run_on: rhel83-zseries-small
     tasks:
-      - name: pkg_test_rpmextract_rhel7_s390x
+      - name: pkg_test_rpmextract_rpm_s390x
   - name: pkg_smoke_tests_rhel81_ppc64le
     display_name: "package smoke tests (RHEL 8.1 ppc64le)"
     run_on: rhel81-power8-small
     tasks:
-      - name: pkg_test_rpmextract_rhel8_ppc64le
+      - name: pkg_test_rpmextract_rpm_ppc64le
 
   - name: draft_publish_release
     display_name: "Draft/Publish Release"

--- a/.evergreen/evergreen.yml.in
+++ b/.evergreen/evergreen.yml.in
@@ -54,97 +54,7 @@ for (const packageInfo of MONGOSH_PACKAGES) {
 
 const ALL_UNIT_TEST_BUILD_VARIANTS = ['darwin_unit', 'linux_unit', 'win32_unit'];
 
-const EXECUTABLE_PKG_INFO = [
-  {
-    executableOsId: 'darwin-x64',
-    compileBuildVariant: 'darwin',
-    distributionBuildVariants: [
-      { name: 'darwin-x64', packageOn: 'darwin', smokeTestKind: 'macos' }
-    ]
-  },
-  {
-    executableOsId: 'darwin-arm64',
-    compileBuildVariant: 'darwin_arm64',
-    distributionBuildVariants: [
-      { name: 'darwin-arm64', packageOn: 'darwin', smokeTestKind: 'macos' }
-    ]
-  },
-  {
-    executableOsId: 'linux-x64',
-    compileBuildVariant: 'linux_x64_build',
-    distributionBuildVariants: [
-      { name: 'linux-x64', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['ubuntu20.04-tgz'] },
-      { name: 'debian-x64', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['ubuntu18.04-deb', 'ubuntu20.04-deb', 'ubuntu22.04-deb', 'debian9-deb', 'debian10-deb', 'debian11-deb'] },
-      { name: 'rhel7-x64', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['centos7-rpm', 'amazonlinux2-rpm'] },
-      { name: 'rhel8-x64', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['rocky8-rpm', 'fedora34-rpm'] },
-      { name: 'suse-x64', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['suse12-rpm', 'suse15-rpm'] },
-      { name: 'amzn1-x64', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['amazonlinux1-rpm'] }
-    ]
-  },
-  {
-    executableOsId: 'linux-x64-openssl11',
-    compileBuildVariant: 'linux_x64_build_openssl11',
-    distributionBuildVariants: [
-      { name: 'linux-x64-openssl11', packageOn: 'linux_package', smokeTestKind: 'none' },
-      { name: 'debian-x64-openssl11', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['ubuntu20.04-deb', 'debian10-deb', 'debian11-deb'] },
-      { name: 'rhel7-x64-openssl11', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['centos7-epel-rpm', 'amazonlinux2-rpm'] },
-      { name: 'rhel8-x64-openssl11', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['rocky8-rpm', 'fedora34-rpm'] }
-    ]
-  },
-  {
-    executableOsId: 'linux-x64-openssl3',
-    compileBuildVariant: 'linux_x64_build_openssl3',
-    distributionBuildVariants: [
-      { name: 'linux-x64-openssl3', packageOn: 'linux_package', smokeTestKind: 'none' },
-      { name: 'debian-x64-openssl3', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['ubuntu22.04-deb'] },
-      { name: 'rhel8-x64-openssl3', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['rocky8-epel-rpm'] }
-    ]
-  },
-  {
-    executableOsId: 'linux-arm64',
-    compileBuildVariant: 'linux_arm64_build',
-    distributionBuildVariants: [
-      { name: 'linux-arm64', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['ubuntu20.04-tgz'] },
-      { name: 'debian-arm64', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['ubuntu18.04-deb', 'ubuntu20.04-deb', 'ubuntu22.04-deb', 'debian10-deb', 'debian11-deb'] },
-      { name: 'rhel8-arm64', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['rocky8-rpm', 'fedora34-rpm'] },
-      { name: 'amzn2-arm64', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['amazonlinux2-rpm'] }
-    ]
-  },
-  {
-    executableOsId: 'linux-arm64-openssl11',
-    compileBuildVariant: 'linux_arm64_build_openssl11',
-    distributionBuildVariants: [
-      { name: 'linux-arm64-openssl11', packageOn: 'linux_package', smokeTestKind: 'none' },
-      { name: 'debian-arm64-openssl11', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['ubuntu20.04-deb', 'debian10-deb', 'debian11-deb'] },
-      { name: 'rhel8-arm64-openssl11', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['rocky8-rpm', 'fedora34-rpm'] },
-      { name: 'amzn2-arm64-openssl11', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['amazonlinux2-rpm'] }
-    ]
-  },
-  {
-    executableOsId: 'linux-ppc64le',
-    compileBuildVariant: 'linux_ppc64le_build',
-    distributionBuildVariants: [
-      { name: 'linux-ppc64le', packageOn: 'linux_package', smokeTestKind: 'none' },
-      { name: 'rhel8-ppc64le', packageOn: 'linux_package', smokeTestKind: 'rpmextract' }
-    ]
-  },
-  {
-    executableOsId: 'linux-s390x',
-    compileBuildVariant: 'linux_s390x_build',
-    distributionBuildVariants: [
-      { name: 'linux-s390x', packageOn: 'linux_package', smokeTestKind: 'none' },
-      { name: 'rhel7-s390x', packageOn: 'linux_package', smokeTestKind: 'rpmextract' }
-    ]
-  },
-  {
-    executableOsId: 'win32',
-    compileBuildVariant: 'win32_build',
-    distributionBuildVariants: [
-      { name: 'win32-x64', packageOn: 'win32', smokeTestKind: 'ssh' },
-      { name: 'win32msi-x64', packageOn: 'win32', smokeTestKind: 'ssh' }
-    ]
-  }
-];
+const { RELEASE_PACKAGE_MATRIX } = require('../config/release-package-matrix');
 
 %>
 exec_timeout_secs: 3600
@@ -443,11 +353,11 @@ functions:
   #
   # package_and_upload_artifact expects the following arguments:
   # - distro_id
-  # - distribution_build_variant
+  # - package_variant
   # - executable_os_id
   #
   # get_artifact_url expects the following arguments:
-  # - distribution_build_variant
+  # - package_variant
   ###
   package_and_upload_artifact:
     - command: expansions.write
@@ -469,7 +379,7 @@ functions:
         env:
           NODE_JS_VERSION: ${node_js_version}
           DISTRO_ID_OVERRIDE: ${distro_id}
-          DISTRIBUTION_BUILD_VARIANT: ${distribution_build_variant}
+          PACKAGE_VARIANT: ${package_variant}
           MACOS_NOTARY_KEY: ${macos_notary_key}
           MACOS_NOTARY_SECRET: ${macos_notary_secret}
     - command: s3.put
@@ -477,7 +387,7 @@ functions:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
         local_file: src/artifact-url.txt
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/artifact-url-${distribution_build_variant}.txt
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/artifact-url-${package_variant}.txt
         bucket: mciuploads
         permissions: public-read
         content_type: application/x-gzip
@@ -487,7 +397,7 @@ functions:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
         local_file: artifact-url.txt
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/artifact-url-${source_distribution_build_variant}.txt
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/artifact-url-${source_package_variant}.txt
         bucket: mciuploads
 
   write_preload_script:
@@ -796,7 +706,7 @@ tasks:
   ###
   # E2E TESTS
   ###
-  <% for (const { executableOsId, compileBuildVariant } of EXECUTABLE_PKG_INFO) {
+  <% for (const { executableOsId, compileBuildVariant } of RELEASE_PACKAGE_MATRIX) {
     for (const mVersion of ['stable', 'unstable']) {
     %>
   - name: e2e_tests_<% out(executableOsId.replace(/-/g, '_')) %><% out(mVersion === 'stable' ? '' : '_unstable') %>
@@ -822,9 +732,9 @@ tasks:
   ###
   # PACKAGING
   ###
-  <% for (const { executableOsId, compileBuildVariant, distributionBuildVariants } of EXECUTABLE_PKG_INFO) {
-       for (const { name: distributionBuildVariant } of distributionBuildVariants) { %>
-  - name: package_and_upload_artifact_<% out(distributionBuildVariant.replace(/-/g, '_')) %>
+  <% for (const { executableOsId, compileBuildVariant, packages } of RELEASE_PACKAGE_MATRIX) {
+       for (const { name: packageVariant } of packages) { %>
+  - name: package_and_upload_artifact_<% out(packageVariant.replace(/-/g, '_')) %>
     depends_on:
       - name: compile_artifact
         variant: <% out(compileBuildVariant) %>
@@ -837,15 +747,15 @@ tasks:
       - func: package_and_upload_artifact
         vars:
           node_js_version: "<% out(NODE_JS_VERSION_16) %>"
-          distribution_build_variant: <% out(distributionBuildVariant) %>
+          package_variant: <% out(packageVariant) %>
           executable_os_id: <% out(executableOsId) %>
   <% } } %>
 
   ###
   # SMOKE TESTS
   ###
-  <% for (const { distributionBuildVariants } of EXECUTABLE_PKG_INFO) {
-       for (const { name, packageOn, smokeTestKind, smokeTestDockerfiles } of distributionBuildVariants) if (smokeTestKind !== 'none') {
+  <% for (const { packages } of RELEASE_PACKAGE_MATRIX) {
+       for (const { name, packageOn, smokeTestKind, smokeTestDockerfiles } of packages) if (smokeTestKind !== 'none') {
         for (const dockerfile of smokeTestDockerfiles || ['']) { %>
   - name: pkg_test_<% out(`${smokeTestKind}_${name}${dockerfile ? `_${dockerfile}` : ''}`.replace(/[-.]/g, '_')) %>
     tags: ["smoke-test"]
@@ -856,7 +766,7 @@ tasks:
       - func: checkout
       - func: get_artifact_url
         vars:
-          source_distribution_build_variant: <% out(name) %>
+          source_package_variant: <% out(name) %>
       - func: write_preload_script
     <% switch (smokeTestKind) {
       case 'ssh': { %>
@@ -1005,10 +915,10 @@ buildvariants:
     display_name: "Ubuntu 18.04 x64 (Packaging)"
     run_on: ubuntu1804-small
     tasks:
-      <% for (const { executableOsId, distributionBuildVariants } of EXECUTABLE_PKG_INFO) {
-          for (const { name: distributionBuildVariant } of distributionBuildVariants) {
+      <% for (const { executableOsId, packages } of RELEASE_PACKAGE_MATRIX) {
+          for (const { name: packageVariant } of packages) {
             if (executableOsId.startsWith('linux')) { %>
-      - name: package_and_upload_artifact_<% out(distributionBuildVariant.replace(/-/g, '_')) %>
+      - name: package_and_upload_artifact_<% out(packageVariant.replace(/-/g, '_')) %>
       <% } } } %>
   - name: linux_x64_build
     display_name: "RHEL 7.0 x64 (build)"
@@ -1200,9 +1110,9 @@ buildvariants:
     display_name: "package smoke tests (x64 Docker)"
     run_on: ubuntu1804-small
     tasks:
-  <% for (const { distributionBuildVariants, executableOsId } of EXECUTABLE_PKG_INFO) {
+  <% for (const { packages, executableOsId } of RELEASE_PACKAGE_MATRIX) {
       if (executableOsId.includes('linux-x64')) {
-       for (const { name, smokeTestKind, smokeTestDockerfiles } of distributionBuildVariants) if (smokeTestKind !== 'none') {
+       for (const { name, smokeTestKind, smokeTestDockerfiles } of packages) if (smokeTestKind !== 'none') {
         for (const dockerfile of smokeTestDockerfiles || []) { %>
       - name: pkg_test_<% out(`${smokeTestKind}_${name}${dockerfile ? `_${dockerfile}` : ''}`.replace(/[-.]/g, '_')) %>
   <% } } } } %>
@@ -1210,9 +1120,9 @@ buildvariants:
     display_name: "package smoke tests (arm64 Docker)"
     run_on: ubuntu1804-arm64-small
     tasks:
-  <% for (const { distributionBuildVariants, executableOsId } of EXECUTABLE_PKG_INFO) {
+  <% for (const { packages, executableOsId } of RELEASE_PACKAGE_MATRIX) {
       if (executableOsId.includes('linux-arm64')) {
-       for (const { name, smokeTestKind, smokeTestDockerfiles } of distributionBuildVariants) if (smokeTestKind !== 'none') {
+       for (const { name, smokeTestKind, smokeTestDockerfiles } of packages) if (smokeTestKind !== 'none') {
         for (const dockerfile of smokeTestDockerfiles || []) { %>
       - name: pkg_test_<% out(`${smokeTestKind}_${name}${dockerfile ? `_${dockerfile}` : ''}`.replace(/[-.]/g, '_')) %>
   <% } } } } %>
@@ -1241,17 +1151,17 @@ buildvariants:
     display_name: "package smoke tests (RHEL 7.2 s390x)"
     run_on: rhel72-zseries-small
     tasks:
-      - name: pkg_test_rpmextract_rhel7_s390x
+      - name: pkg_test_rpmextract_rpm_s390x
   - name: pkg_smoke_tests_rhel83_s390x
     display_name: "package smoke tests (RHEL 8.3 s390x)"
     run_on: rhel83-zseries-small
     tasks:
-      - name: pkg_test_rpmextract_rhel7_s390x
+      - name: pkg_test_rpmextract_rpm_s390x
   - name: pkg_smoke_tests_rhel81_ppc64le
     display_name: "package smoke tests (RHEL 8.1 ppc64le)"
     run_on: rhel81-power8-small
     tasks:
-      - name: pkg_test_rpmextract_rhel8_ppc64le
+      - name: pkg_test_rpmextract_rpm_ppc64le
 
   - name: draft_publish_release
     display_name: "Draft/Publish Release"

--- a/.evergreen/package-and-upload-artifact.sh
+++ b/.evergreen/package-and-upload-artifact.sh
@@ -17,12 +17,12 @@ if [ "$(uname)" == Linux ]; then
   docker run -e PUPPETEER_SKIP_CHROMIUM_DOWNLOAD \
     -e EVERGREEN_EXPANSIONS_PATH=/tmp/build/tmp/expansions.yaml \
     -e NODE_JS_VERSION \
-    -e DISTRIBUTION_BUILD_VARIANT \
+    -e PACKAGE_VARIANT \
     -e ARTIFACT_URL_FILE="/tmp/build/artifact-url.txt" \
     --rm -v $PWD:/tmp/build --network host rocky8-package \
     -c 'cd /tmp/build && npm run evergreen-release package && npm run evergreen-release upload'
 else
-  if [[ "$OS" == "Windows_NT" && "$DISTRIBUTION_BUILD_VARIANT" == "win32msi-x64" ]]; then
+  if [[ "$OS" == "Windows_NT" && "$PACKAGE_VARIANT" == "win32msi-x64" ]]; then
     # We have to setup a python venv for the notary client to work
     # in order to sign the MSI
     export PATH="/cygdrive/c/Python27:$PATH"

--- a/config/release-package-matrix.js
+++ b/config/release-package-matrix.js
@@ -1,0 +1,87 @@
+'use strict';
+
+exports.RELEASE_PACKAGE_MATRIX = [
+  {
+    executableOsId: 'darwin-x64',
+    compileBuildVariant: 'darwin',
+    packages: [
+      { name: 'darwin-x64', description: 'MacOS 64-bit (10.14+)', packageOn: 'darwin', smokeTestKind: 'macos' }
+    ]
+  },
+  {
+    executableOsId: 'darwin-arm64',
+    compileBuildVariant: 'darwin_arm64',
+    packages: [
+      { name: 'darwin-arm64', description: 'MacOS M1 (11.0+)', packageOn: 'darwin', smokeTestKind: 'macos' }
+    ]
+  },
+  {
+    executableOsId: 'linux-x64',
+    compileBuildVariant: 'linux_x64_build',
+    packages: [
+      { name: 'linux-x64', description: 'Linux Tarball 64-bit', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['ubuntu20.04-tgz'] },
+      { name: 'deb-x64', description: 'Debian / Ubuntu 64-bit', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['ubuntu18.04-deb', 'ubuntu20.04-deb', 'ubuntu22.04-deb', 'debian9-deb', 'debian10-deb', 'debian11-deb'] },
+      { name: 'rpm-x64', description: 'RHEL / CentOS / Fedora / Suse 64-bit', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['centos7-rpm', 'amazonlinux2-rpm', 'rocky8-rpm', 'fedora34-rpm', 'suse12-rpm', 'suse15-rpm', 'amazonlinux1-rpm'] }
+    ]
+  },
+  {
+    executableOsId: 'linux-x64-openssl11',
+    compileBuildVariant: 'linux_x64_build_openssl11',
+    packages: [
+      { name: 'linux-x64-openssl11', description: 'Linux Tarball 64-bit (shared OpenSSL 1.1)', packageOn: 'linux_package', smokeTestKind: 'none' },
+      { name: 'deb-x64-openssl11', description: 'Debian / Ubuntu 64-bit (shared OpenSSL 1.1)', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['ubuntu20.04-deb', 'debian10-deb', 'debian11-deb'] },
+      { name: 'rpm-x64-openssl11', description: 'RHEL / CentOS 64-bit (shared OpenSSL 1.1)', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['centos7-epel-rpm', 'amazonlinux2-rpm', 'rocky8-rpm', 'fedora34-rpm'] }
+    ]
+  },
+  {
+    executableOsId: 'linux-x64-openssl3',
+    compileBuildVariant: 'linux_x64_build_openssl3',
+    packages: [
+      { name: 'linux-x64-openssl3', description: 'Linux Tarball 64-bit (shared OpenSSL 3)', packageOn: 'linux_package', smokeTestKind: 'none' },
+      { name: 'deb-x64-openssl3', description: 'Debian / Ubuntu 64-bit (shared OpenSSL 3)', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['ubuntu22.04-deb'] },
+      { name: 'rpm-x64-openssl3', description: 'RHEL / CentOS 64-bit (shared OpenSSL 3)', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['rocky8-epel-rpm'] }
+    ]
+  },
+  {
+    executableOsId: 'linux-arm64',
+    compileBuildVariant: 'linux_arm64_build',
+    packages: [
+      { name: 'linux-arm64', description: 'Linux Tarball arm64', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['ubuntu20.04-tgz'] },
+      { name: 'deb-arm64', description: 'Debian / Ubuntu arm64', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['ubuntu18.04-deb', 'ubuntu20.04-deb', 'ubuntu22.04-deb', 'debian10-deb', 'debian11-deb'] },
+      { name: 'rpm-arm64', description: 'RHEL / CentOS arm64', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['rocky8-rpm', 'fedora34-rpm', 'amazonlinux2-rpm'] }
+    ]
+  },
+  {
+    executableOsId: 'linux-arm64-openssl11',
+    compileBuildVariant: 'linux_arm64_build_openssl11',
+    packages: [
+      { name: 'linux-arm64-openssl11', description: 'Linux Tarball arm64 (shared OpenSSL 1.1)', packageOn: 'linux_package', smokeTestKind: 'none' },
+      { name: 'deb-arm64-openssl11', description: 'Debian / Ubuntu arm64 (shared OpenSSL 1.1)', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['ubuntu20.04-deb', 'debian10-deb', 'debian11-deb'] },
+      { name: 'rpm-arm64-openssl11', description: 'Redhat / Centos arm64 (shared OpenSSL 1.1)', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['rocky8-rpm', 'fedora34-rpm', 'amazonlinux2-rpm'] }
+    ]
+  },
+  {
+    executableOsId: 'linux-ppc64le',
+    compileBuildVariant: 'linux_ppc64le_build',
+    packages: [
+      { name: 'linux-ppc64le', description: 'Linux Tarball ppc64le', packageOn: 'linux_package', smokeTestKind: 'none' },
+      { name: 'rpm-ppc64le', description: 'Redhat / Centos ppc64le', packageOn: 'linux_package', smokeTestKind: 'rpmextract' }
+    ]
+  },
+  {
+    executableOsId: 'linux-s390x',
+    compileBuildVariant: 'linux_s390x_build',
+    packages: [
+      { name: 'linux-s390x', description: 'Linux Tarball s390x', packageOn: 'linux_package', smokeTestKind: 'none' },
+      { name: 'rpm-s390x', description: 'Redhat / Centos s390x', packageOn: 'linux_package', smokeTestKind: 'rpmextract' }
+    ]
+  },
+  {
+    executableOsId: 'win32',
+    compileBuildVariant: 'win32_build',
+    packages: [
+      { name: 'win32-x64', description: 'Windows 64-bit (8.1+)', packageOn: 'win32', smokeTestKind: 'ssh' },
+      { name: 'win32msi-x64', description: 'Windows 64-bit (8.1+) (MSI)', packageOn: 'win32', smokeTestKind: 'ssh' }
+    ]
+  }
+];

--- a/packages/build/src/barque.spec.ts
+++ b/packages/build/src/barque.spec.ts
@@ -6,7 +6,7 @@ import path from 'path';
 import sinon from 'sinon';
 import { URL } from 'url';
 import { Barque, LATEST_CURATOR, getReposAndArch } from './barque';
-import { ALL_BUILD_VARIANTS, Config } from './config';
+import { ALL_PACKAGE_VARIANTS, Config } from './config';
 import { dummyConfig } from '../test/helpers';
 
 describe('Barque', () => {
@@ -24,7 +24,7 @@ describe('Barque', () => {
       context('execCurator function succeeds', () => {
         ([
           {
-            variant: 'debian-x64',
+            variant: 'deb-x64',
             url: 'https://s3.amazonaws.com/mciuploads/mongosh/5ed7ee5d8683818eb28d9d3b5c65837cde4a08f5/mongodb-mongosh_0.1.0_amd64.deb',
             publishedUrls: [
               'https://repo.mongodb.org/apt/ubuntu/dists/bionic/mongodb-org/4.4/multiverse/binary-amd64/mongodb-mongosh_0.1.0_amd64.deb',
@@ -60,7 +60,7 @@ describe('Barque', () => {
             ]
           },
           {
-            variant: 'rhel7-x64',
+            variant: 'rpm-x64',
             url: 'https://s3.amazonaws.com/mciuploads/mongosh/5ed7ee5d8683818eb28d9d3b5c65837cde4a08f5/mongodb-mongosh-0.1.0.el7.x86_64.rpm',
             publishedUrls: [
               'https://repo.mongodb.org/yum/redhat/7/mongodb-org/4.4/x86_64/RPMS/mongodb-mongosh-0.1.0.el7.x86_64.rpm',
@@ -69,24 +69,54 @@ describe('Barque', () => {
               'https://repo.mongodb.com/yum/redhat/7/mongodb-enterprise/5.0/x86_64/RPMS/mongodb-mongosh-0.1.0.el7.x86_64.rpm',
               'https://repo.mongodb.org/yum/redhat/7/mongodb-org/6.0/x86_64/RPMS/mongodb-mongosh-0.1.0.el7.x86_64.rpm',
               'https://repo.mongodb.com/yum/redhat/7/mongodb-enterprise/6.0/x86_64/RPMS/mongodb-mongosh-0.1.0.el7.x86_64.rpm',
+              'https://repo.mongodb.org/yum/redhat/8/mongodb-org/4.4/x86_64/RPMS/mongodb-mongosh-0.1.0.el7.x86_64.rpm',
+              'https://repo.mongodb.com/yum/redhat/8/mongodb-enterprise/4.4/x86_64/RPMS/mongodb-mongosh-0.1.0.el7.x86_64.rpm',
+              'https://repo.mongodb.org/yum/redhat/8/mongodb-org/5.0/x86_64/RPMS/mongodb-mongosh-0.1.0.el7.x86_64.rpm',
+              'https://repo.mongodb.com/yum/redhat/8/mongodb-enterprise/5.0/x86_64/RPMS/mongodb-mongosh-0.1.0.el7.x86_64.rpm',
+              'https://repo.mongodb.org/yum/redhat/8/mongodb-org/6.0/x86_64/RPMS/mongodb-mongosh-0.1.0.el7.x86_64.rpm',
+              'https://repo.mongodb.com/yum/redhat/8/mongodb-enterprise/6.0/x86_64/RPMS/mongodb-mongosh-0.1.0.el7.x86_64.rpm',
+              'https://repo.mongodb.org/yum/amazon/2013.03/mongodb-org/4.4/x86_64/RPMS/mongodb-mongosh-0.1.0.el7.x86_64.rpm',
+              'https://repo.mongodb.com/yum/amazon/2013.03/mongodb-enterprise/4.4/x86_64/RPMS/mongodb-mongosh-0.1.0.el7.x86_64.rpm',
+              'https://repo.mongodb.org/yum/amazon/2013.03/mongodb-org/5.0/x86_64/RPMS/mongodb-mongosh-0.1.0.el7.x86_64.rpm',
+              'https://repo.mongodb.com/yum/amazon/2013.03/mongodb-enterprise/5.0/x86_64/RPMS/mongodb-mongosh-0.1.0.el7.x86_64.rpm',
+              'https://repo.mongodb.org/yum/amazon/2013.03/mongodb-org/6.0/x86_64/RPMS/mongodb-mongosh-0.1.0.el7.x86_64.rpm',
+              'https://repo.mongodb.com/yum/amazon/2013.03/mongodb-enterprise/6.0/x86_64/RPMS/mongodb-mongosh-0.1.0.el7.x86_64.rpm',
               'https://repo.mongodb.org/yum/amazon/2/mongodb-org/4.4/x86_64/RPMS/mongodb-mongosh-0.1.0.el7.x86_64.rpm',
               'https://repo.mongodb.com/yum/amazon/2/mongodb-enterprise/4.4/x86_64/RPMS/mongodb-mongosh-0.1.0.el7.x86_64.rpm',
               'https://repo.mongodb.org/yum/amazon/2/mongodb-org/5.0/x86_64/RPMS/mongodb-mongosh-0.1.0.el7.x86_64.rpm',
               'https://repo.mongodb.com/yum/amazon/2/mongodb-enterprise/5.0/x86_64/RPMS/mongodb-mongosh-0.1.0.el7.x86_64.rpm',
               'https://repo.mongodb.org/yum/amazon/2/mongodb-org/6.0/x86_64/RPMS/mongodb-mongosh-0.1.0.el7.x86_64.rpm',
               'https://repo.mongodb.com/yum/amazon/2/mongodb-enterprise/6.0/x86_64/RPMS/mongodb-mongosh-0.1.0.el7.x86_64.rpm',
+              'https://repo.mongodb.org/zypper/suse/12/mongodb-org/4.4/x86_64/RPMS/mongodb-mongosh-0.1.0.el7.x86_64.rpm',
+              'https://repo.mongodb.com/zypper/suse/12/mongodb-enterprise/4.4/x86_64/RPMS/mongodb-mongosh-0.1.0.el7.x86_64.rpm',
+              'https://repo.mongodb.org/zypper/suse/12/mongodb-org/5.0/x86_64/RPMS/mongodb-mongosh-0.1.0.el7.x86_64.rpm',
+              'https://repo.mongodb.com/zypper/suse/12/mongodb-enterprise/5.0/x86_64/RPMS/mongodb-mongosh-0.1.0.el7.x86_64.rpm',
+              'https://repo.mongodb.org/zypper/suse/12/mongodb-org/6.0/x86_64/RPMS/mongodb-mongosh-0.1.0.el7.x86_64.rpm',
+              'https://repo.mongodb.com/zypper/suse/12/mongodb-enterprise/6.0/x86_64/RPMS/mongodb-mongosh-0.1.0.el7.x86_64.rpm',
+              'https://repo.mongodb.org/zypper/suse/15/mongodb-org/4.4/x86_64/RPMS/mongodb-mongosh-0.1.0.el7.x86_64.rpm',
+              'https://repo.mongodb.com/zypper/suse/15/mongodb-enterprise/4.4/x86_64/RPMS/mongodb-mongosh-0.1.0.el7.x86_64.rpm',
+              'https://repo.mongodb.org/zypper/suse/15/mongodb-org/5.0/x86_64/RPMS/mongodb-mongosh-0.1.0.el7.x86_64.rpm',
+              'https://repo.mongodb.com/zypper/suse/15/mongodb-enterprise/5.0/x86_64/RPMS/mongodb-mongosh-0.1.0.el7.x86_64.rpm',
+              'https://repo.mongodb.org/zypper/suse/15/mongodb-org/6.0/x86_64/RPMS/mongodb-mongosh-0.1.0.el7.x86_64.rpm',
+              'https://repo.mongodb.com/zypper/suse/15/mongodb-enterprise/6.0/x86_64/RPMS/mongodb-mongosh-0.1.0.el7.x86_64.rpm',
             ]
           },
           {
-            variant: 'rhel8-x64',
+            variant: 'rpm-arm64',
             url: 'https://s3.amazonaws.com/mciuploads/mongosh/5ed7ee5d8683818eb28d9d3b5c65837cde4a08f5/mongodb-mongosh-0.1.0.el7.x86_64.rpm',
             publishedUrls: [
-              'https://repo.mongodb.org/yum/redhat/8/mongodb-org/4.4/x86_64/RPMS/mongodb-mongosh-0.1.0.el7.x86_64.rpm',
-              'https://repo.mongodb.com/yum/redhat/8/mongodb-enterprise/4.4/x86_64/RPMS/mongodb-mongosh-0.1.0.el7.x86_64.rpm',
-              'https://repo.mongodb.org/yum/redhat/8/mongodb-org/5.0/x86_64/RPMS/mongodb-mongosh-0.1.0.el7.x86_64.rpm',
-              'https://repo.mongodb.com/yum/redhat/8/mongodb-enterprise/5.0/x86_64/RPMS/mongodb-mongosh-0.1.0.el7.x86_64.rpm',
-              'https://repo.mongodb.org/yum/redhat/8/mongodb-org/6.0/x86_64/RPMS/mongodb-mongosh-0.1.0.el7.x86_64.rpm',
-              'https://repo.mongodb.com/yum/redhat/8/mongodb-enterprise/6.0/x86_64/RPMS/mongodb-mongosh-0.1.0.el7.x86_64.rpm'
+              'https://repo.mongodb.org/yum/redhat/8/mongodb-org/4.4/aarch64/RPMS/mongodb-mongosh-0.1.0.el7.x86_64.rpm',
+              'https://repo.mongodb.com/yum/redhat/8/mongodb-enterprise/4.4/aarch64/RPMS/mongodb-mongosh-0.1.0.el7.x86_64.rpm',
+              'https://repo.mongodb.org/yum/redhat/8/mongodb-org/5.0/aarch64/RPMS/mongodb-mongosh-0.1.0.el7.x86_64.rpm',
+              'https://repo.mongodb.com/yum/redhat/8/mongodb-enterprise/5.0/aarch64/RPMS/mongodb-mongosh-0.1.0.el7.x86_64.rpm',
+              'https://repo.mongodb.org/yum/redhat/8/mongodb-org/6.0/aarch64/RPMS/mongodb-mongosh-0.1.0.el7.x86_64.rpm',
+              'https://repo.mongodb.com/yum/redhat/8/mongodb-enterprise/6.0/aarch64/RPMS/mongodb-mongosh-0.1.0.el7.x86_64.rpm',
+              'https://repo.mongodb.org/yum/amazon/2/mongodb-org/4.4/aarch64/RPMS/mongodb-mongosh-0.1.0.el7.x86_64.rpm',
+              'https://repo.mongodb.com/yum/amazon/2/mongodb-enterprise/4.4/aarch64/RPMS/mongodb-mongosh-0.1.0.el7.x86_64.rpm',
+              'https://repo.mongodb.org/yum/amazon/2/mongodb-org/5.0/aarch64/RPMS/mongodb-mongosh-0.1.0.el7.x86_64.rpm',
+              'https://repo.mongodb.com/yum/amazon/2/mongodb-enterprise/5.0/aarch64/RPMS/mongodb-mongosh-0.1.0.el7.x86_64.rpm',
+              'https://repo.mongodb.org/yum/amazon/2/mongodb-org/6.0/aarch64/RPMS/mongodb-mongosh-0.1.0.el7.x86_64.rpm',
+              'https://repo.mongodb.com/yum/amazon/2/mongodb-enterprise/6.0/aarch64/RPMS/mongodb-mongosh-0.1.0.el7.x86_64.rpm',
             ]
           }
         ] as const).forEach(({ variant, url, publishedUrls }) => {
@@ -118,7 +148,7 @@ describe('Barque', () => {
         const debUrl = 'https://s3.amazonaws.com/mciuploads/mongosh/5ed7ee5d8683818eb28d9d3b5c65837cde4a08f5/mongodb-mongosh_0.1.0_amd64.deb';
 
         try {
-          await barque.releaseToBarque('debian-x64', debUrl, false);
+          await barque.releaseToBarque('deb-x64', debUrl, false);
         } catch (error: any) {
           expect(error.message).to.include(`Curator is unable to upload ${debUrl},ubuntu1804,amd64 to barque`);
           expect(barque.createCuratorDir).to.have.been.called;
@@ -143,7 +173,7 @@ describe('Barque', () => {
   });
 
   describe('getReposAndArch', () => {
-    for (const variant of ALL_BUILD_VARIANTS) {
+    for (const variant of ALL_PACKAGE_VARIANTS) {
       it(`returns results for ${variant}`, () => {
         const result = getReposAndArch(variant);
         expect(result.ppas).to.be.an('array');

--- a/packages/build/src/compile/run-compile.ts
+++ b/packages/build/src/compile/run-compile.ts
@@ -1,4 +1,4 @@
-import type { Config } from '../config';
+import type { Config, PackageVariant } from '../config';
 import type { PackageInformation } from '../packaging/package';
 import { generateBundle } from './generate-bundle';
 import { SignableCompiler } from './signable-compiler';
@@ -14,12 +14,13 @@ export async function runCompile(config: Config): Promise<string> {
   await generateBundle(config);
 
   console.info('mongosh: creating binary:', config.executablePath);
+  const packageInformation = config.packageInformation?.(config.packageVariant as PackageVariant);
 
   await new SignableCompiler(
     config.bundleSinglefileOutput,
     config.executablePath,
     config.execNodeVersion,
-    (config.packageInformation?.metadata ?? {}) as PackageInformation['metadata'])
+    (packageInformation?.metadata ?? {}) as PackageInformation['metadata'])
     .compile();
 
   return config.executablePath;

--- a/packages/build/src/config/build-variant.spec.ts
+++ b/packages/build/src/config/build-variant.spec.ts
@@ -1,23 +1,17 @@
 import { expect } from 'chai';
-import { ALL_BUILD_VARIANTS } from './build-variant';
+import { ALL_PACKAGE_VARIANTS } from './build-variant';
 
 describe('BuildVariant', () => {
   describe('all build variants', () => {
     it('has all of them', () => {
-      expect(ALL_BUILD_VARIANTS).to.have.length(18);
-      expect(ALL_BUILD_VARIANTS).to.contain('win32msi-x64');
-      expect(ALL_BUILD_VARIANTS).to.contain('darwin-x64');
-      expect(ALL_BUILD_VARIANTS).to.contain('debian-x64');
-      expect(ALL_BUILD_VARIANTS).to.contain('suse-x64');
-      expect(ALL_BUILD_VARIANTS).to.contain('amzn1-x64');
-      expect(ALL_BUILD_VARIANTS).to.contain('amzn2-arm64');
-      expect(ALL_BUILD_VARIANTS).to.contain('rhel7-x64');
-      expect(ALL_BUILD_VARIANTS).to.contain('rhel7-s390x');
-      expect(ALL_BUILD_VARIANTS).to.contain('rhel8-x64');
-      expect(ALL_BUILD_VARIANTS).to.contain('rhel8-arm64');
-      expect(ALL_BUILD_VARIANTS).to.contain('rhel8-ppc64le');
+      expect(ALL_PACKAGE_VARIANTS).to.have.length(23);
+      expect(ALL_PACKAGE_VARIANTS).to.contain('win32msi-x64');
+      expect(ALL_PACKAGE_VARIANTS).to.contain('darwin-x64');
+      expect(ALL_PACKAGE_VARIANTS).to.contain('deb-x64');
+      expect(ALL_PACKAGE_VARIANTS).to.contain('deb-arm64');
       for (const arch of ['x64', 'arm64', 's390x', 'ppc64le']) {
-        expect(ALL_BUILD_VARIANTS).to.contain(`linux-${arch}`);
+        expect(ALL_PACKAGE_VARIANTS).to.contain(`linux-${arch}`);
+        expect(ALL_PACKAGE_VARIANTS).to.contain(`rpm-${arch}`);
       }
     });
   });

--- a/packages/build/src/config/build-variant.ts
+++ b/packages/build/src/config/build-variant.ts
@@ -1,41 +1,36 @@
-/**
- * Build Variant enum.
- *
- * Different from 'platform': platform is extracted from os.platform() and
- * build variant defines the desired distribution type to build for.
- */
-export type Distro = 'win32' | 'win32msi' | 'darwin' | 'linux' | 'debian' | 'rhel7' | 'rhel8' | 'suse' | 'amzn1' | 'amzn2';
+import { RELEASE_PACKAGE_MATRIX } from '../../../../config/release-package-matrix';
+
+export type Distro = 'win32' | 'win32msi' | 'darwin' | 'linux' | 'deb' | 'rpm';
 export type Arch = 'x64' | 's390x' | 'arm64' | 'ppc64le';
 export type OpenSSLTag = '' | '-openssl11' | '-openssl3';
-export type BuildVariant = `${Distro}-${Arch}${OpenSSLTag}`;
 
-export const ALL_BUILD_VARIANTS: readonly BuildVariant[] = Object.freeze([
-  'win32-x64', 'win32msi-x64',
-  'darwin-x64', 'darwin-arm64',
-  'linux-x64', 'linux-s390x', 'linux-arm64', 'linux-ppc64le',
-  'debian-x64', 'debian-arm64',
-  'rhel7-x64', 'rhel7-s390x', 'rhel8-x64', 'rhel8-arm64', 'rhel8-ppc64le',
-  'suse-x64',
-  'amzn1-x64',
-  'amzn2-arm64'
-] as const);
+/**
+ * Package Variant enum.
+ *
+ * Different from 'platform': platform is extracted from os.platform() and
+ * package variant defines the desired distribution type to build for.
+ */
+export type PackageVariant = `${Distro}-${Arch}${OpenSSLTag}`;
 
-export function validateBuildVariant(variant?: BuildVariant): asserts variant is BuildVariant {
+export const ALL_PACKAGE_VARIANTS = Object.freeze(
+  RELEASE_PACKAGE_MATRIX.flatMap(({ packages }) => packages.map(({ name }) => name))) as readonly PackageVariant[];
+
+export function validatePackageVariant(variant?: PackageVariant): asserts variant is PackageVariant {
   if (
     typeof variant === 'undefined' ||
-    !ALL_BUILD_VARIANTS.includes(variant.replace(/-openssl(11|3)$/, '') as BuildVariant)
+    !ALL_PACKAGE_VARIANTS.includes(variant)
   ) {
     throw new Error(`${variant} is not a valid build variant identifier`);
   }
 }
 
-export function getDistro(variant: BuildVariant): Distro {
-  validateBuildVariant(variant);
+export function getDistro(variant: PackageVariant): Distro {
+  validatePackageVariant(variant);
   return variant.split('-')[0] as Distro;
 }
 
-export function getArch(variant: BuildVariant): Arch {
-  validateBuildVariant(variant);
+export function getArch(variant: PackageVariant): Arch {
+  validatePackageVariant(variant);
   return variant.split('-')[1] as Arch;
 }
 
@@ -59,27 +54,12 @@ export function getRPMArchName(arch: Arch): string {
   }
 }
 
-// eslint-disable-next-line complexity
-export function getDownloadCenterDistroDescription(variant: BuildVariant): string {
-  switch (variant) {
-    case 'win32-x64': return 'Windows 64-bit (8.1+)';
-    case 'win32msi-x64': return 'Windows 64-bit (8.1+) (MSI)';
-    case 'darwin-arm64': return 'MacOS M1 (11.0+)';
-    case 'darwin-x64': return 'MacOS 64-bit (10.12+)';
-    case 'linux-x64': return 'Linux Tarball 64-bit';
-    case 'linux-s390x': return 'Linux Tarball s390x';
-    case 'linux-arm64': return 'Linux Tarball arm64';
-    case 'linux-ppc64le': return 'Linux Tarball ppc64le';
-    case 'debian-x64': return 'Debian / Ubuntu 64-bit';
-    case 'debian-arm64': return 'Debian / Ubuntu arm64';
-    case 'rhel7-x64': return 'Redhat 7 / Centos 7 / Amazon Linux 2 64-bit';
-    case 'rhel7-s390x': return 'Redhat 7 / Centos 7 s390x';
-    case 'rhel8-x64': return 'Redhat 8 / Centos 8 / Fedora 64-bit';
-    case 'rhel8-ppc64le': return 'Redhat 8 / Centos 8 ppc64le';
-    case 'rhel8-arm64': return 'Redhat 8 / Centos 8 arm64';
-    case 'suse-x64': return 'SUSE Linux 64-bit';
-    case 'amzn1-x64': return 'Amazon Linux 1 64-bit';
-    case 'amzn2-arm64': return 'Amazon Linux 2 arm64';
-    default: throw new Error(`${variant} is not a valid build variant`);
+export function getDownloadCenterDistroDescription(variant: PackageVariant): string {
+  for (const { packages } of RELEASE_PACKAGE_MATRIX) {
+    for (const pkg of packages) {
+      if (pkg.name === variant) {return pkg.description;}
+    }
   }
+
+  throw new Error(`${variant} is not a valid build variant`);
 }

--- a/packages/build/src/config/config.ts
+++ b/packages/build/src/config/config.ts
@@ -1,5 +1,5 @@
-import type { PackageInformation } from '../packaging/package';
-import { BuildVariant } from './build-variant';
+import type { PackageInformationProvider } from '../packaging/package';
+import { PackageVariant } from './build-variant';
 
 interface ManPageConfig {
   sourceUrl: string;
@@ -33,7 +33,7 @@ export interface Config {
   isCi?: boolean;
   platform?: string;
   execNodeVersion: string;
-  distributionBuildVariant?: BuildVariant;
+  packageVariant?: PackageVariant;
   repo: {
     owner: string;
     repo: string;
@@ -41,7 +41,7 @@ export interface Config {
   isPatch?: boolean;
   triggeringGitTag?: string;
   csfleLibraryPath: string;
-  packageInformation?: PackageInformation;
+  packageInformation?: PackageInformationProvider;
   artifactUrlFile?: string;
   manpage?: ManPageConfig;
   isDryRun?: boolean;

--- a/packages/build/src/config/redact-config.ts
+++ b/packages/build/src/config/redact-config.ts
@@ -1,11 +1,14 @@
-import { Config } from './config';
+import type { PackageInformation } from '../packaging';
+import type { Config } from './config';
 
-export function redactConfig(config: Config): Partial<Config> {
+export function redactConfig(config: Config): Partial<Config> & {
+  packageInformationInstantiated?: PackageInformation
+} {
   return {
     version: config.version,
     rootDir: config.rootDir,
     bundleEntrypointInput: config.bundleEntrypointInput,
-    distributionBuildVariant: config.distributionBuildVariant,
+    packageVariant: config.packageVariant,
     executablePath: config.executablePath,
     bundleSinglefileOutput: config.bundleSinglefileOutput,
     outputDir: config.outputDir,
@@ -17,6 +20,7 @@ export function redactConfig(config: Config): Partial<Config> {
     repo: config.repo,
     isPatch: config.isPatch,
     packageInformation: config.packageInformation,
+    packageInformationInstantiated: config.packageVariant && config.packageInformation?.(config.packageVariant),
     csfleLibraryPath: config.csfleLibraryPath,
     artifactUrlFile: config.artifactUrlFile,
     isDryRun: config.isDryRun

--- a/packages/build/src/download-center/config.ts
+++ b/packages/build/src/download-center/config.ts
@@ -1,11 +1,11 @@
 import { DownloadCenter as DownloadCenterCls, validateConfigSchema } from '@mongodb-js/dl-center';
 import { DownloadCenterConfig } from '@mongodb-js/dl-center/dist/download-center-config';
 import { CONFIGURATION_KEY, CONFIGURATIONS_BUCKET } from './constants';
-import { BuildVariant, ALL_BUILD_VARIANTS, getDownloadCenterDistroDescription, getArch, getDistro } from '../config';
-import { getPackageFile, PackageInformation } from '../packaging';
+import { PackageVariant, ALL_PACKAGE_VARIANTS, getDownloadCenterDistroDescription, getArch, getDistro } from '../config';
+import { getPackageFile, PackageInformationProvider } from '../packaging';
 
 export async function createAndPublishDownloadCenterConfig(
-  packageInformation: PackageInformation,
+  packageInformation: PackageInformationProvider,
   awsAccessKeyId: string,
   awsSecretAccessKey: string,
   isDryRun: boolean,
@@ -33,18 +33,18 @@ export async function createAndPublishDownloadCenterConfig(
   await dlcenter.uploadConfig(CONFIGURATION_KEY, config);
 }
 
-export function createDownloadCenterConfig(packageInformation: PackageInformation): DownloadCenterConfig {
-  const { version } = packageInformation.metadata;
+export function createDownloadCenterConfig(packageInformation: PackageInformationProvider): DownloadCenterConfig {
+  const { version } = packageInformation('linux-x64').metadata;
   return {
     'versions': [
       {
         '_id': version,
         'version': version,
-        'platform': ALL_BUILD_VARIANTS.map((buildVariant: BuildVariant) => ({
-          arch: getArch(buildVariant),
-          os: getDistro(buildVariant),
-          name: getDownloadCenterDistroDescription(buildVariant),
-          download_link: 'https://downloads.mongodb.com/compass/' + getPackageFile(buildVariant, packageInformation).path
+        'platform': ALL_PACKAGE_VARIANTS.map((packageVariant: PackageVariant) => ({
+          arch: getArch(packageVariant),
+          os: getDistro(packageVariant),
+          name: getDownloadCenterDistroDescription(packageVariant),
+          download_link: 'https://downloads.mongodb.com/compass/' + getPackageFile(packageVariant, packageInformation).path
         }))
       }
     ],

--- a/packages/build/src/index.ts
+++ b/packages/build/src/index.ts
@@ -1,10 +1,10 @@
 import path from 'path';
-import { validateBuildVariant } from './config';
+import { validatePackageVariant } from './config';
 import { downloadMongoDb } from './download-mongodb';
 import { getArtifactUrl } from './evergreen';
 import { triggerRelease } from './local';
 import { release, ReleaseCommand } from './release';
-import type { Config, BuildVariant } from './config';
+import type { Config, PackageVariant } from './config';
 
 export { getArtifactUrl, downloadMongoDb };
 
@@ -24,8 +24,8 @@ if (require.main === module) {
         .map((arg) => arg.match(/^--build-variant=(.+)$/))
         .filter(Boolean)[0];
       if (cliBuildVariant) {
-        config.distributionBuildVariant = cliBuildVariant[1] as BuildVariant;
-        validateBuildVariant(config.distributionBuildVariant);
+        config.packageVariant = cliBuildVariant[1] as PackageVariant;
+        validatePackageVariant(config.packageVariant);
       }
 
       config.isDryRun ||= process.argv.includes('--dry-run');

--- a/packages/build/src/packaging/download-csfle-library.ts
+++ b/packages/build/src/packaging/download-csfle-library.ts
@@ -2,9 +2,9 @@
 import path from 'path';
 import { promises as fs, constants as fsConstants } from 'fs';
 import { downloadMongoDb, DownloadOptions } from '../download-mongodb';
-import { BuildVariant, getDistro, getArch } from '../config';
+import { PackageVariant, getDistro, getArch } from '../config';
 
-export async function downloadCsfleLibrary(variant: BuildVariant | 'host'): Promise<string> {
+export async function downloadCsfleLibrary(variant: PackageVariant | 'host'): Promise<string> {
   const opts: DownloadOptions = {};
   opts.arch = variant === 'host' ? undefined : getArch(variant);
   opts.distro = variant === 'host' ? undefined : lookupReleaseDistro(variant);
@@ -36,8 +36,8 @@ export async function downloadCsfleLibrary(variant: BuildVariant | 'host'): Prom
   return csfleLibrary;
 }
 
-function lookupReleaseDistro(variant: BuildVariant): string {
-  switch (getDistro(variant)) {
+function lookupReleaseDistro(packageVariant: PackageVariant): string {
+  switch (getDistro(packageVariant)) {
     case 'win32':
     case 'win32msi':
       return 'win32';
@@ -45,7 +45,8 @@ function lookupReleaseDistro(variant: BuildVariant): string {
       return 'darwin';
     default: break;
   }
-  switch (getArch(variant)) {
+  // Pick the variant with the lowest supported glibc version.
+  switch (getArch(packageVariant)) {
     case 'ppc64le':
       return 'rhel81';
     case 's390x':

--- a/packages/build/src/packaging/index.ts
+++ b/packages/build/src/packaging/index.ts
@@ -3,7 +3,8 @@ export * from './run-package';
 export {
   getPackageFile,
   PackageFile,
-  PackageInformation
+  PackageInformation,
+  PackageInformationProvider
 } from './package';
 
 export {

--- a/packages/build/src/packaging/package/create-package.spec.ts
+++ b/packages/build/src/packaging/package/create-package.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 import { withTempPackageEach } from '../../../test/helpers';
-import { ALL_BUILD_VARIANTS } from '../../config';
+import { ALL_PACKAGE_VARIANTS } from '../../config';
 import { createPackage } from './create-package';
 
 describe('archive create-archive', () => {
@@ -22,7 +22,7 @@ describe('archive create-archive', () => {
       createZipArchiveStub = sinon.stub();
     });
 
-    ALL_BUILD_VARIANTS.forEach(variant => {
+    ALL_PACKAGE_VARIANTS.forEach(variant => {
       it(`can create a tarball for ${variant}`, async() => {
         const result = await createPackage(
           tmpPkg.tarballDir,

--- a/packages/build/src/packaging/package/debian.spec.ts
+++ b/packages/build/src/packaging/package/debian.spec.ts
@@ -20,7 +20,7 @@ describe('tarball debian', () => {
       this.skip();
     }
 
-    const tarball = await createPackage(tmpPkg.tarballDir, 'debian-x64', tmpPkg.pkgConfig);
+    const tarball = await createPackage(tmpPkg.tarballDir, 'deb-x64', tmpPkg.pkgConfig);
     await fs.access(tarball.path);
     {
       const { stdout } = await execFile('dpkg', ['-c', tarball.path]);

--- a/packages/build/src/packaging/package/get-package-file.spec.ts
+++ b/packages/build/src/packaging/package/get-package-file.spec.ts
@@ -5,7 +5,7 @@ describe('tarball getPackageFile', () => {
   context('when the build variant is windows', () => {
     it('returns the windows tarball name', () => {
       expect(
-        getPackageFile('win32-x64', { metadata: { version: '1.0.0', name: 'mongosh' } } as any)
+        getPackageFile('win32-x64', () => ({ metadata: { version: '1.0.0', name: 'mongosh' } }) as any)
       ).to.deep.equal({
         path: 'mongosh-1.0.0-win32-x64.zip',
         contentType: 'application/zip'
@@ -16,7 +16,7 @@ describe('tarball getPackageFile', () => {
   context('when the build variant is windows MSI', () => {
     it('returns the windows MSI name', () => {
       expect(
-        getPackageFile('win32msi-x64', { metadata: { version: '1.0.0', name: 'mongosh' } } as any)
+        getPackageFile('win32msi-x64', () => ({ metadata: { version: '1.0.0', name: 'mongosh' } }) as any)
       ).to.deep.equal({
         path: 'mongosh-1.0.0-x64.msi',
         contentType: 'application/x-msi'
@@ -27,7 +27,7 @@ describe('tarball getPackageFile', () => {
   context('when the build variant is macos', () => {
     it('returns the tarball details', () => {
       expect(
-        getPackageFile('darwin-x64', { metadata: { version: '1.0.0', name: 'mongosh' } } as any)
+        getPackageFile('darwin-x64', () => ({ metadata: { version: '1.0.0', name: 'mongosh' } }) as any)
       ).to.deep.equal({
         path: 'mongosh-1.0.0-darwin-x64.zip',
         contentType: 'application/zip'
@@ -38,7 +38,7 @@ describe('tarball getPackageFile', () => {
   context('when the build variant is linux', () => {
     it('returns the tarball details', () => {
       expect(
-        getPackageFile('linux-x64', { metadata: { version: '1.0.0', name: 'mongosh' } } as any)
+        getPackageFile('linux-x64', () => ({ metadata: { version: '1.0.0', name: 'mongosh' } }) as any)
       ).to.deep.equal({
         path: 'mongosh-1.0.0-linux-x64.tgz',
         contentType: 'application/gzip'
@@ -49,7 +49,7 @@ describe('tarball getPackageFile', () => {
   context('when the build variant is debian', () => {
     it('returns the tarball details', () => {
       expect(
-        getPackageFile('debian-x64', { metadata: { version: '1.0.0', debName: 'mongodb-mongosh' } } as any)
+        getPackageFile('deb-x64', () => ({ metadata: { version: '1.0.0', debName: 'mongodb-mongosh' } }) as any)
       ).to.deep.equal({
         path: 'mongodb-mongosh_1.0.0_amd64.deb',
         contentType: 'application/vnd.debian.binary-package'
@@ -57,23 +57,12 @@ describe('tarball getPackageFile', () => {
     });
   });
 
-  context('when the build variant is rhel7', () => {
+  context('when the build variant is rhel', () => {
     it('returns the tarball details', () => {
       expect(
-        getPackageFile('rhel7-x64', { metadata: { version: '1.0.0', rpmName: 'mongodb-mongosh' } } as any)
+        getPackageFile('rpm-x64', () => ({ metadata: { version: '1.0.0', rpmName: 'mongodb-mongosh' } }) as any)
       ).to.deep.equal({
-        path: 'mongodb-mongosh-1.0.0.el7.x86_64.rpm',
-        contentType: 'application/x-rpm'
-      });
-    });
-  });
-
-  context('when the build variant is rhel8', () => {
-    it('returns the tarball details', () => {
-      expect(
-        getPackageFile('rhel8-x64', { metadata: { version: '1.0.0', rpmName: 'mongodb-mongosh' } } as any)
-      ).to.deep.equal({
-        path: 'mongodb-mongosh-1.0.0.el8.x86_64.rpm',
+        path: 'mongodb-mongosh-1.0.0.x86_64.rpm',
         contentType: 'application/x-rpm'
       });
     });

--- a/packages/build/src/packaging/package/get-package-file.ts
+++ b/packages/build/src/packaging/package/get-package-file.ts
@@ -1,64 +1,44 @@
-import { BuildVariant, getDistro, getArch, getDebArchName, getRPMArchName } from '../../config';
-import type { PackageInformation } from './package-information';
+import { PackageVariant, getDistro, getArch, getDebArchName, getRPMArchName } from '../../config';
+import type { PackageInformationProvider } from './package-information';
 
 export interface PackageFile {
   path: string;
   contentType: string;
 }
 
-export function getPackageFile(buildVariant: BuildVariant, packageInformation: PackageInformation): PackageFile {
-  const { version, name, debName, rpmName } = packageInformation.metadata;
-  switch (getDistro(buildVariant)) {
+export function getPackageFile(packageVariant: PackageVariant, packageInformation: PackageInformationProvider): PackageFile {
+  const { version, name, debName, rpmName } = packageInformation(packageVariant).metadata;
+  switch (getDistro(packageVariant)) {
     case 'linux':
       return {
-        path: `${name}-${version}-${buildVariant}.tgz`,
+        path: `${name}-${version}-${packageVariant}.tgz`,
         contentType: 'application/gzip'
       };
-    case 'rhel7':
+    case 'rpm':
       return {
-        path: `${rpmName}-${version}.el7.${getRPMArchName(getArch(buildVariant))}.rpm`,
+        path: `${rpmName}-${version}.${getRPMArchName(getArch(packageVariant))}.rpm`,
         contentType: 'application/x-rpm'
       };
-    case 'rhel8':
-      return {
-        path: `${rpmName}-${version}.el8.${getRPMArchName(getArch(buildVariant))}.rpm`,
-        contentType: 'application/x-rpm'
-      };
-    case 'suse':
-      return {
-        path: `${rpmName}-${version}.suse12.${getRPMArchName(getArch(buildVariant))}.rpm`,
-        contentType: 'application/x-rpm'
-      };
-    case 'amzn1':
-      return {
-        path: `${rpmName}-${version}.amzn1.${getRPMArchName(getArch(buildVariant))}.rpm`,
-        contentType: 'application/x-rpm'
-      };
-    case 'amzn2':
-      return {
-        path: `${rpmName}-${version}.amzn2.${getRPMArchName(getArch(buildVariant))}.rpm`,
-        contentType: 'application/x-rpm'
-      };
-    case 'debian':
+    case 'deb':
       // debian packages are required to be separated by _ and have arch in the
       // name: https://www.debian.org/doc/manuals/debian-faq/pkg-basics.en.html
       // sometimes there is also revision number, but we can add that later.
       return {
-        path: `${debName}_${version}_${getDebArchName(getArch(buildVariant))}.deb`,
+        path: `${debName}_${version}_${getDebArchName(getArch(packageVariant))}.deb`,
         contentType: 'application/vnd.debian.binary-package'
       };
     case 'darwin':
     case 'win32':
       return {
-        path: `${name}-${version}-${buildVariant}.zip`,
+        path: `${name}-${version}-${packageVariant}.zip`,
         contentType: 'application/zip'
       };
     case 'win32msi':
       return {
-        path: `${name}-${version}-${getArch(buildVariant)}.msi`,
+        path: `${name}-${version}-${getArch(packageVariant)}.msi`,
         contentType: 'application/x-msi'
       };
     default:
-      throw new Error(`Unknown build variant: ${buildVariant}`);
+      throw new Error(`Unknown build variant: ${packageVariant}`);
   }
 }

--- a/packages/build/src/packaging/package/package-information.ts
+++ b/packages/build/src/packaging/package/package-information.ts
@@ -1,3 +1,4 @@
+import type { PackageVariant } from '../../config';
 interface DocumentationFile {
     sourceFilePath: string;
     packagedFilePath: string;
@@ -38,3 +39,5 @@ export interface PackageInformation {
     rpmTemplateDir: string;
     msiTemplateDir: string;
 }
+
+export type PackageInformationProvider = (packageVariant: PackageVariant) => PackageInformation;

--- a/packages/build/src/packaging/package/redhat.spec.ts
+++ b/packages/build/src/packaging/package/redhat.spec.ts
@@ -22,7 +22,7 @@ describe('tarball redhat', () => {
 
     const tarball = await createPackage(
       tmpPkg.tarballDir,
-      'rhel7-x64',
+      'rpm-x64',
       tmpPkg.pkgConfig
     );
 
@@ -34,7 +34,7 @@ describe('tarball redhat', () => {
     expect(stdout).to.match(/URL\s+:\s+https:\/\/example.org/);
     expect(stdout).to.match(/Summary\s+:\s+Dummy package/);
     expect(stdout).to.match(/^\/usr\/bin\/foo$/m);
-    expect(stdout).to.match(/^\/usr\/lib\/bar$/m);
+    expect(stdout).to.match(/^\/usr\/lib(64)?\/bar$/m);
     expect(stdout).to.match(/^\/usr\/share\/doc\/foobar-1.0.0\/README$/m);
     expect(stdout).to.match(/^\/usr\/share\/licenses\/foobar-1.0.0\/LICENSE_bar$/m);
     expect(stdout).to.match(/^\/usr\/share\/licenses\/foobar-1.0.0\/LICENSE_foo$/m);

--- a/packages/build/src/packaging/run-package.ts
+++ b/packages/build/src/packaging/run-package.ts
@@ -1,6 +1,6 @@
 import { constants as fsConstants, promises as fs } from 'fs';
 import path from 'path';
-import { Config, validateBuildVariant } from '../config';
+import { Config, validatePackageVariant } from '../config';
 import { downloadCsfleLibrary } from './download-csfle-library';
 import { downloadManpage } from './download-manpage';
 import { notarizeArtifact } from './notary-service';
@@ -9,12 +9,12 @@ import { createPackage, PackageFile } from './package';
 export async function runPackage(
   config: Config,
 ): Promise<PackageFile> {
-  const distributionBuildVariant = config.distributionBuildVariant;
-  validateBuildVariant(distributionBuildVariant);
+  const packageVariant = config.packageVariant;
+  validatePackageVariant(packageVariant);
 
   await fs.mkdir(path.dirname(config.csfleLibraryPath), { recursive: true });
   await fs.copyFile(
-    await downloadCsfleLibrary(distributionBuildVariant),
+    await downloadCsfleLibrary(packageVariant),
     config.csfleLibraryPath,
     fsConstants.COPYFILE_FICLONE);
 
@@ -30,14 +30,14 @@ export async function runPackage(
   const runCreatePackage = async(): Promise<PackageFile> => {
     return await createPackage(
       config.outputDir,
-      distributionBuildVariant,
-      config.packageInformation as (Required<Config>['packageInformation'])
+      packageVariant,
+      (config.packageInformation as (Required<Config>['packageInformation']))(packageVariant)
     );
   };
 
   const packaged = await runCreatePackage();
 
-  if (distributionBuildVariant === 'win32msi-x64') {
+  if (packageVariant === 'win32msi-x64') {
     await notarizeArtifact(
       packaged.path,
       {

--- a/packages/build/src/run-draft.spec.ts
+++ b/packages/build/src/run-draft.spec.ts
@@ -1,6 +1,6 @@
 import chai, { expect } from 'chai';
 import sinon from 'ts-sinon';
-import { ALL_BUILD_VARIANTS, Config } from './config';
+import { ALL_PACKAGE_VARIANTS, Config } from './config';
 import { uploadArtifactToDownloadCenter as uploadArtifactToDownloadCenterFn } from './download-center';
 import { downloadArtifactFromEvergreen as downloadArtifactFromEvergreenFn } from './evergreen';
 import { notarizeArtifact as notarizeArtifactFn } from './packaging';
@@ -64,19 +64,19 @@ describe('draft', () => {
       });
 
       it('downloads existing artifacts from evergreen', () => {
-        expect(downloadArtifactFromEvergreen).to.have.been.callCount(ALL_BUILD_VARIANTS.length);
+        expect(downloadArtifactFromEvergreen).to.have.been.callCount(ALL_PACKAGE_VARIANTS.length);
       });
 
       it('asks the notary service to sign files', () => {
-        expect(notarizeArtifact).to.have.been.callCount(ALL_BUILD_VARIANTS.length);
+        expect(notarizeArtifact).to.have.been.callCount(ALL_PACKAGE_VARIANTS.length);
       });
 
       it('uploads artifacts to download center', () => {
-        expect(uploadArtifactToDownloadCenter).to.have.been.callCount(ALL_BUILD_VARIANTS.length);
+        expect(uploadArtifactToDownloadCenter).to.have.been.callCount(ALL_PACKAGE_VARIANTS.length);
       });
 
       it('uploads the artifacts to the github release', () => {
-        expect(uploadReleaseAsset).to.have.been.callCount(ALL_BUILD_VARIANTS.length);
+        expect(uploadReleaseAsset).to.have.been.callCount(ALL_PACKAGE_VARIANTS.length);
       });
     });
 

--- a/packages/build/src/run-draft.ts
+++ b/packages/build/src/run-draft.ts
@@ -1,6 +1,6 @@
 import { promises as fs, constants as fsConstants } from 'fs';
 import path from 'path';
-import { ALL_BUILD_VARIANTS, Config, getReleaseVersionFromTag } from './config';
+import { ALL_PACKAGE_VARIANTS, Config, getReleaseVersionFromTag } from './config';
 import { uploadArtifactToDownloadCenter as uploadArtifactToDownloadCenterFn } from './download-center';
 import { downloadArtifactFromEvergreen as downloadArtifactFromEvergreenFn } from './evergreen';
 import { notarizeArtifact as notarizeArtifactFn } from './packaging';
@@ -33,7 +33,7 @@ export async function runDraft(
   const tmpDir = path.join(__dirname, '..', '..', '..', 'tmp', `draft-${Date.now()}`);
   await fs.mkdir(tmpDir, { recursive: true });
 
-  for await (const variant of ALL_BUILD_VARIANTS) {
+  for await (const variant of ALL_PACKAGE_VARIANTS) {
     const tarballFile = getPackageFile(variant, config.packageInformation);
     console.info(`mongosh: processing artifact for ${variant} - ${tarballFile.path}`);
 

--- a/packages/build/src/run-publish.spec.ts
+++ b/packages/build/src/run-publish.spec.ts
@@ -110,29 +110,6 @@ describe('publish', () => {
         }
         expect.fail('Expected error');
       });
-
-      it('fails if package name is missing', async() => {
-        config.packageInformation = {
-          metadata: {}
-        } as any;
-        try {
-          await runPublish(
-            config,
-            githubRepo,
-            mongoHomebrewCoreForkRepo,
-            homebrewCoreRepo,
-            barque,
-            createAndPublishDownloadCenterConfig,
-            publishNpmPackages,
-            writeBuildInfo,
-            publishToHomebrew,
-            shouldDoPublicRelease
-          );
-        } catch (e: any) {
-          return expect(e.message).to.contain('Missing package name');
-        }
-        expect.fail('Expected error');
-      });
     });
 
     it('publishes artifacts to barque', async() => {
@@ -149,26 +126,18 @@ describe('publish', () => {
         shouldDoPublicRelease
       );
 
-      expect(barque.releaseToBarque).to.have.been.callCount(18);
+      expect(barque.releaseToBarque).to.have.been.callCount(23);
       expect(barque.releaseToBarque).to.have.been.calledWith(
-        'rhel7-x64',
-        'https://s3.amazonaws.com/mciuploads/project/v0.7.0-draft.42/mongodb-mongosh-0.7.0.el7.x86_64.rpm'
+        'rpm-x64',
+        'https://s3.amazonaws.com/mciuploads/project/v0.7.0-draft.42/mongodb-mongosh-0.7.0.x86_64.rpm'
       );
       expect(barque.releaseToBarque).to.have.been.calledWith(
-        'rhel8-x64',
-        'https://s3.amazonaws.com/mciuploads/project/v0.7.0-draft.42/mongodb-mongosh-0.7.0.el8.x86_64.rpm'
-      );
-      expect(barque.releaseToBarque).to.have.been.calledWith(
-        'debian-x64',
+        'deb-x64',
         'https://s3.amazonaws.com/mciuploads/project/v0.7.0-draft.42/mongodb-mongosh_0.7.0_amd64.deb'
       );
       expect(barque.releaseToBarque).to.have.been.calledWith(
-        'amzn2-arm64',
-        'https://s3.amazonaws.com/mciuploads/project/v0.7.0-draft.42/mongodb-mongosh-0.7.0.amzn2.aarch64.rpm'
-      );
-      expect(barque.releaseToBarque).to.have.been.calledWith(
-        'amzn1-x64',
-        'https://s3.amazonaws.com/mciuploads/project/v0.7.0-draft.42/mongodb-mongosh-0.7.0.amzn1.x86_64.rpm'
+        'rpm-arm64',
+        'https://s3.amazonaws.com/mciuploads/project/v0.7.0-draft.42/mongodb-mongosh-0.7.0.aarch64.rpm'
       );
       expect(barque.waitUntilPackagesAreAvailable).to.have.been.called;
     });

--- a/packages/build/test/helpers.ts
+++ b/packages/build/test/helpers.ts
@@ -49,7 +49,7 @@ export const dummyConfig: Config = Object.freeze({
     owner: 'owner',
     repo: 'repo',
   },
-  packageInformation: {
+  packageInformation: () => ({
     metadata: {
       name: 'mongosh',
       rpmName: 'mongodb-mongosh',
@@ -59,7 +59,7 @@ export const dummyConfig: Config = Object.freeze({
       homepage: 'https://mongodb.com',
       maintainer: 'We, us, everyone.'
     }
-  } as PackageInformation,
+  } as PackageInformation),
   execNodeVersion: process.version,
   rootDir: path.resolve(__dirname, '..', '..')
 });


### PR DESCRIPTION
- Move the package matrix definition from the evergreen template
  to a separate file in config/, and add data that would otherwise
  be computed in the build package (e.g. human-readable descriptions)
  there.
- Consistently use “package variant” instead of
  “distribution build variant”. The latter term is a leftover
  from when package artifacts were tightly coupled with evergreen
  build variants, but now these are completely independent
  and it’s probably better to be consistent in referring to
  these as “packages”.
- Make the `packageInformation` property in the build config
  a function that returns the package information for a given
  package variant – this is necessary so that the tasks that
  operate on all packaging variants at once (i.e. the publishing
  tasks) understand that the package information actually varies
  by packaging variant in the case of static OpenSSL/
  shared OpenSSL 1.1/shared OpenSSL 3.
- Merge all .rpm and all .deb package variants into a single
  entity each. Since we started using the crypt_shared library
  (formerly known as CSFLE shared library), our artifacts no longer
  differ between Linux distributions.
  This simplifies picking the correct package from a user perspective
  and reduces the publishing step complexity (i.e. counters the
  increase in the number of package variants coming from the
  shared-openssl additions).
- Adjust build package tests to account for all of the above.
