### PR TITLE
feat(shell-api): add new key management helpers MONGOSH-1206

### DIFF
--- a/packages/i18n/src/locales/en_US.ts
+++ b/packages/i18n/src/locales/en_US.ts
@@ -2147,7 +2147,23 @@ const translations: Catalog = {
             getKeyByAltName: {
               description: 'Retrieves keys with the specified key alternative name.',
               link: 'https://docs.mongodb.com/manual/reference/method/KeyVault.getKeyByAltName/#KeyVault.getKeyByAltName'
-            }
+            },
+            rewrapManyDataKey: {
+              description: 'Re-wrap one, more, or all data keys with another KMS provider, or re-wrap using the same one.',
+              link: 'https://docs.mongodb.com/manual/reference/method/KeyVault.rewrapManyDataKey/#KeyVault.rewrapManyDataKey'
+            },
+            createDataKey: {
+              description: 'Alias of KeyVault.createKey()',
+              link: 'https://docs.mongodb.com/manual/reference/method/KeyVault.createKey/#KeyVault.createKey'
+            },
+            removeKeyAltName: {
+              description: 'Alias of KeyVault.removeKeyAlternateName()',
+              link: 'https://docs.mongodb.com/manual/reference/method/KeyVault.removeKeyAlternateName/#KeyVault.removeKeyAlternateName'
+            },
+            addKeyAltName: {
+              description: 'Alias of KeyVault.addKeyAlternateName()',
+              link: 'https://docs.mongodb.com/manual/reference/method/KeyVault.addKeyAlternateName/#KeyVault.addKeyAlternateName'
+            },
           }
         }
       },

--- a/packages/shell-api/src/field-level-encryption.spec.ts
+++ b/packages/shell-api/src/field-level-encryption.spec.ts
@@ -385,6 +385,15 @@ describe('Field Level Encryption', () => {
         expect(result).to.deep.equal(r2.value);
       });
     });
+    describe('rewrapManyDataKey', () => {
+      it('calls rewrapManyDataKey on clientEncryption', async() => {
+        const rawResult = { result: 1 };
+        libmongoc.rewrapManyDataKey.resolves(rawResult);
+        const result = await keyVault.rewrapManyDataKey({ status: 0 }, { provider: 'local' });
+        expect(libmongoc.rewrapManyDataKey).calledOnceWithExactly({ status: 0 }, { provider: 'local' });
+        expect(result).to.deep.equal(rawResult);
+      });
+    });
   });
   describe('Mongo constructor FLE options', () => {
     before(() => {

--- a/packages/shell-api/src/field-level-encryption.ts
+++ b/packages/shell-api/src/field-level-encryption.ts
@@ -277,4 +277,31 @@ export class KeyVault extends ShellApiWithMongoClass {
     }
     return ret;
   }
+
+  @returnsPromise
+  @apiVersions([1])
+  async rewrapManyDataKey(filter: Document, options?: Document): Promise<Document> {
+    return this._clientEncryption._libmongocrypt.rewrapManyDataKey(filter, options as any);
+  }
+
+  // Alias for compatibility with the driver API.
+  @returnsPromise
+  @apiVersions([1])
+  async createDataKey(...args: Parameters<KeyVault['createKey']>): ReturnType<KeyVault['createKey']> {
+    return await this.createKey(...args);
+  }
+
+  // Alias for compatibility with the driver API.
+  @returnsPromise
+  @apiVersions([1])
+  async removeKeyAltName(...args: Parameters<KeyVault['removeKeyAlternateName']>): ReturnType<KeyVault['removeKeyAlternateName']> {
+    return await this.removeKeyAlternateName(...args);
+  }
+
+  // Alias for compatibility with the driver API.
+  @returnsPromise
+  @apiVersions([1])
+  async addKeyAltName(...args: Parameters<KeyVault['addKeyAlternateName']>): ReturnType<KeyVault['addKeyAlternateName']> {
+    return await this.addKeyAlternateName(...args);
+  }
 }


### PR DESCRIPTION
This also adds the aliases suggested in MONGOSH-1239, since
doing so is straightforward and touches the same code.