### PR TITLE
chore(cli-repl): add back s390x FLE e2e test skip

### DIFF
--- a/packages/cli-repl/test/e2e-fle.spec.ts
+++ b/packages/cli-repl/test/e2e-fle.spec.ts
@@ -23,6 +23,12 @@ describe('FLE tests', () => {
   let cryptLibrary: string;
 
   before(async function() {
+    if (process.platform === 'linux' && process.arch === 's390x') {
+      return this.skip();
+      // There is no CSFLE shared library binary for the rhel72 s390x that we test on.
+      // We will address this once the server provides RHEL7 s390x binaries again.
+    }
+
     kmsServer = makeFakeHTTPServer(fakeAWSHandlers);
     kmsServer.listen(0);
     await once(kmsServer, 'listening');


### PR DESCRIPTION
I removed this in f765c071880e0f when I shouldn’t have, presumably
because the referenced ticket was marked as closed and I didn’t
check whether this is actually working now. The server *does*
provide a shared library for s390x, but only RHEL 8.x, not 7.x.