### PR TITLE
fix(shell-api): never pass encryptedFieldsMap to ClientEncryption ctor MONGOSH-1244

### DIFF
--- a/packages/cli-repl/test/e2e-fle.spec.ts
+++ b/packages/cli-repl/test/e2e-fle.spec.ts
@@ -155,7 +155,8 @@ describe('FLE tests', () => {
     await shell.executeLine(`keyMongo = Mongo(${JSON.stringify(await testServer.connectionString())}, { \
       keyVaultNamespace: '${dbname}.keyVault', \
       kmsProviders: { local }, \
-      schemaMap: {} \
+      schemaMap: {}, \
+      encryptedFieldsMap: {} \
     });`);
 
     await shell.executeLine('keyVault = keyMongo.getKeyVault();');

--- a/packages/shell-api/src/field-level-encryption.spec.ts
+++ b/packages/shell-api/src/field-level-encryption.spec.ts
@@ -454,6 +454,7 @@ describe('Field Level Encryption', () => {
           }
         },
         schemaMap: SCHEMA_MAP,
+        encryptedFieldsMap: SCHEMA_MAP,
         bypassAutoEncryption: true
       };
       const mongo = new Mongo(instanceState, 'localhost:27017', localKmsOptions, undefined, sp);

--- a/packages/shell-api/src/field-level-encryption.ts
+++ b/packages/shell-api/src/field-level-encryption.ts
@@ -92,6 +92,7 @@ export class ClientEncryption extends ShellApiWithMongoClass {
     // ClientEncryption does not take a schemaMap and will fail if it receives one
     const fleOptions = { ...this._mongo._fleOptions };
     delete fleOptions.schemaMap;
+    delete fleOptions.encryptedFieldsMap;
 
     this._libmongocrypt = new fle.ClientEncryption(
       mongo._serviceProvider.getRawClient(),


### PR DESCRIPTION
Same as 6f3bff84446, just for QE instead of CSFLE.