### PR TITLE
feat: lower crypt library version to rhel72 on s390x

### DIFF
--- a/packages/build/src/packaging/download-crypt-library.ts
+++ b/packages/build/src/packaging/download-crypt-library.ts
@@ -50,7 +50,7 @@ function lookupReleaseDistro(packageVariant: PackageVariant): string {
     case 'ppc64le':
       return 'rhel81';
     case 's390x':
-      return 'rhel83';
+      return 'rhel72';
     case 'arm64':
       return 'amazon2';
     case 'x64':

--- a/packages/cli-repl/src/smoke-tests-fle.ts
+++ b/packages/cli-repl/src/smoke-tests-fle.ts
@@ -12,12 +12,6 @@ const assert = function(value, message) {
     process.exit(1);
   }
 };
-if (process.platform === 'linux' && process.arch === 's390x') {
-  // There is no crypt shared library binary for the rhel72 s390x that we test on.
-  // We will address this in MONGOSH-862.
-  print('Test skipped')
-  process.exit(0);
-}
 if (db.version().startsWith('4.0.') ||
     !db.runCommand({buildInfo:1}).modules.includes('enterprise')) {
   // No FLE on mongod < 4.2 or community

--- a/packages/cli-repl/test/e2e-fle.spec.ts
+++ b/packages/cli-repl/test/e2e-fle.spec.ts
@@ -23,12 +23,6 @@ describe('FLE tests', () => {
   let cryptLibrary: string;
 
   before(async function() {
-    if (process.platform === 'linux' && process.arch === 's390x') {
-      return this.skip();
-      // There is no CSFLE shared library binary for the rhel72 s390x that we test on.
-      // We will address this once the server provides RHEL7 s390x binaries again.
-    }
-
     kmsServer = makeFakeHTTPServer(fakeAWSHandlers);
     kmsServer.listen(0);
     await once(kmsServer, 'listening');


### PR DESCRIPTION
The crypt shared library is now (since 6.0.0-rc8) also available
on RHEL 7.2 for s390x. Downgrading it should not affect RHEL 8 support
on s390x, and allows us to also run the FLE tests on all platforms.