### PR TITLE
chore(cli-repl): Add timeout and disable retries for telemetry flushes MONGOSH-1253

### DIFF
--- a/packages/cli-repl/package-lock.json
+++ b/packages/cli-repl/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.0.0-dev.0",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"analytics-node": "^3.4.0-beta.1",
+				"analytics-node": "^5.1.2",
 				"ansi-escape-sequences": "^5.1.2",
 				"askcharacter": "^1.0.0",
 				"askpassword": "^1.2.4",
@@ -50,17 +50,6 @@
 				"macos-export-certificate-and-key": "^1.1.1",
 				"mongodb-crypt-library-version": "^1.0.3",
 				"win-export-certificate-and-key": "^1.1.1"
-			}
-		},
-		"node_modules/@babel/runtime": {
-			"version": "7.17.8",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.8.tgz",
-			"integrity": "sha512-dQpEpK0O9o6lj6oPu0gRDbbnk+4LeHlNcBpspf6Olzt3GIX4P1lWF1gS+pHLDFlaJvbR6q7jCfQ08zA4QJBnmA==",
-			"dependencies": {
-				"regenerator-runtime": "^0.13.4"
-			},
-			"engines": {
-				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@segment/loosely-validate-event": {
@@ -219,18 +208,18 @@
 			}
 		},
 		"node_modules/analytics-node": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/analytics-node/-/analytics-node-3.5.0.tgz",
-			"integrity": "sha512-XgQq6ejZHCehUSnZS4V7QJPLIP7S9OAWwQDYl4WTLtsRvc5fCxIwzK/yihzmIW51v9PnyBmrl9dMcqvwfOE8WA==",
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/analytics-node/-/analytics-node-5.1.2.tgz",
+			"integrity": "sha512-WZ8gkXtLuqD2Q2xEOr/2/LJiR0AnhWHfXZhfPnMZpB7vEwCsh3HapYAUmA1cPj1abrhAqBX7POWuWo/1wUu/Fw==",
 			"dependencies": {
 				"@segment/loosely-validate-event": "^2.0.0",
-				"axios": "^0.21.1",
-				"axios-retry": "^3.0.2",
+				"axios": "^0.21.4",
+				"axios-retry": "3.2.0",
 				"lodash.isstring": "^4.0.1",
 				"md5": "^2.2.1",
 				"ms": "^2.0.0",
 				"remove-trailing-slash": "^0.1.0",
-				"uuid": "^3.2.1"
+				"uuid": "^8.3.2"
 			},
 			"engines": {
 				"node": ">=4"
@@ -318,12 +307,11 @@
 			}
 		},
 		"node_modules/axios-retry": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.2.4.tgz",
-			"integrity": "sha512-Co3UXiv4npi6lM963mfnuH90/YFLKWWDmoBYfxkHT5xtkSSWNqK9zdG3fw5/CP/dsoKB5aMMJCsgab+tp1OxLQ==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.2.0.tgz",
+			"integrity": "sha512-RK2cLMgIsAQBDhlIsJR5dOhODPigvel18XUv1dDXW+4k1FzebyfRk+C+orot6WPZOYFKSfhLwHPwVmTVOODQ5w==",
 			"dependencies": {
-				"@babel/runtime": "^7.15.4",
-				"is-retry-allowed": "^2.2.0"
+				"is-retry-allowed": "^1.1.0"
 			}
 		},
 		"node_modules/base64-js": {
@@ -652,14 +640,11 @@
 			}
 		},
 		"node_modules/is-retry-allowed": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
-			"integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg==",
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
+			"integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg==",
 			"engines": {
-				"node": ">=10"
-			},
-			"funding": {
-				"url": "https://github.com/sponsors/sindresorhus"
+				"node": ">=0.10.0"
 			}
 		},
 		"node_modules/join-component": {
@@ -882,11 +867,6 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/regenerator-runtime": {
-			"version": "0.13.9",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-			"integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
-		},
 		"node_modules/remove-array-items": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/remove-array-items/-/remove-array-items-1.1.1.tgz",
@@ -960,12 +940,11 @@
 			}
 		},
 		"node_modules/uuid": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-			"deprecated": "Please upgrade  to version 7 or higher.  Older versions may use Math.random() in certain circumstances, which is known to be problematic.  See https://v8.dev/blog/math-random for details.",
+			"version": "8.3.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
 			"bin": {
-				"uuid": "bin/uuid"
+				"uuid": "dist/bin/uuid"
 			}
 		},
 		"node_modules/webidl-conversions": {
@@ -1018,14 +997,6 @@
 		}
 	},
 	"dependencies": {
-		"@babel/runtime": {
-			"version": "7.17.8",
-			"resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.17.8.tgz",
-			"integrity": "sha512-dQpEpK0O9o6lj6oPu0gRDbbnk+4LeHlNcBpspf6Olzt3GIX4P1lWF1gS+pHLDFlaJvbR6q7jCfQ08zA4QJBnmA==",
-			"requires": {
-				"regenerator-runtime": "^0.13.4"
-			}
-		},
 		"@segment/loosely-validate-event": {
 			"version": "2.0.0",
 			"resolved": "https://registry.npmjs.org/@segment/loosely-validate-event/-/loosely-validate-event-2.0.0.tgz",
@@ -1147,18 +1118,18 @@
 			}
 		},
 		"analytics-node": {
-			"version": "3.5.0",
-			"resolved": "https://registry.npmjs.org/analytics-node/-/analytics-node-3.5.0.tgz",
-			"integrity": "sha512-XgQq6ejZHCehUSnZS4V7QJPLIP7S9OAWwQDYl4WTLtsRvc5fCxIwzK/yihzmIW51v9PnyBmrl9dMcqvwfOE8WA==",
+			"version": "5.1.2",
+			"resolved": "https://registry.npmjs.org/analytics-node/-/analytics-node-5.1.2.tgz",
+			"integrity": "sha512-WZ8gkXtLuqD2Q2xEOr/2/LJiR0AnhWHfXZhfPnMZpB7vEwCsh3HapYAUmA1cPj1abrhAqBX7POWuWo/1wUu/Fw==",
 			"requires": {
 				"@segment/loosely-validate-event": "^2.0.0",
-				"axios": "^0.21.1",
-				"axios-retry": "^3.0.2",
+				"axios": "^0.21.4",
+				"axios-retry": "3.2.0",
 				"lodash.isstring": "^4.0.1",
 				"md5": "^2.2.1",
 				"ms": "^2.0.0",
 				"remove-trailing-slash": "^0.1.0",
-				"uuid": "^3.2.1"
+				"uuid": "^8.3.2"
 			}
 		},
 		"ansi-escape-sequences": {
@@ -1225,12 +1196,11 @@
 			}
 		},
 		"axios-retry": {
-			"version": "3.2.4",
-			"resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.2.4.tgz",
-			"integrity": "sha512-Co3UXiv4npi6lM963mfnuH90/YFLKWWDmoBYfxkHT5xtkSSWNqK9zdG3fw5/CP/dsoKB5aMMJCsgab+tp1OxLQ==",
+			"version": "3.2.0",
+			"resolved": "https://registry.npmjs.org/axios-retry/-/axios-retry-3.2.0.tgz",
+			"integrity": "sha512-RK2cLMgIsAQBDhlIsJR5dOhODPigvel18XUv1dDXW+4k1FzebyfRk+C+orot6WPZOYFKSfhLwHPwVmTVOODQ5w==",
 			"requires": {
-				"@babel/runtime": "^7.15.4",
-				"is-retry-allowed": "^2.2.0"
+				"is-retry-allowed": "^1.1.0"
 			}
 		},
 		"base64-js": {
@@ -1447,9 +1417,9 @@
 			}
 		},
 		"is-retry-allowed": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-2.2.0.tgz",
-			"integrity": "sha512-XVm7LOeLpTW4jV19QSH38vkswxoLud8sQ57YwJVTPWdiaI9I8keEhGFpBlslyVsgdQy4Opg8QOLb8YRgsyZiQg=="
+			"version": "1.2.0",
+			"resolved": "https://registry.npmjs.org/is-retry-allowed/-/is-retry-allowed-1.2.0.tgz",
+			"integrity": "sha512-RUbUeKwvm3XG2VYamhJL1xFktgjvPzL0Hq8C+6yrWIswDy3BIXGqCxhxkc30N9jqK311gVU137K8Ei55/zVJRg=="
 		},
 		"join-component": {
 			"version": "1.1.0",
@@ -1638,11 +1608,6 @@
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
 		},
-		"regenerator-runtime": {
-			"version": "0.13.9",
-			"resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.13.9.tgz",
-			"integrity": "sha512-p3VT+cOEgxFsRRA9X4lkI1E+k2/CtnKtU4gcxyaCUreilL/vqI6CdZ3wxVUx3UOUg+gnUOQQcRI7BmSI656MYA=="
-		},
 		"remove-array-items": {
 			"version": "1.1.1",
 			"resolved": "https://registry.npmjs.org/remove-array-items/-/remove-array-items-1.1.1.tgz",
@@ -1698,9 +1663,9 @@
 			"peer": true
 		},
 		"uuid": {
-			"version": "3.4.0",
-			"resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-			"integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A=="
+			"version": "8.3.2",
+			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
+			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
 		},
 		"webidl-conversions": {
 			"version": "7.0.0",

--- a/packages/cli-repl/package.json
+++ b/packages/cli-repl/package.json
@@ -66,7 +66,7 @@
     "@mongosh/shell-evaluator": "0.0.0-dev.0",
     "@mongosh/snippet-manager": "0.0.0-dev.0",
     "@mongosh/types": "0.0.0-dev.0",
-    "analytics-node": "^3.4.0-beta.1",
+    "analytics-node": "^5.1.2",
     "ansi-escape-sequences": "^5.1.2",
     "askcharacter": "^1.0.0",
     "askpassword": "^1.2.4",

--- a/packages/cli-repl/src/cli-repl.ts
+++ b/packages/cli-repl/src/cli-repl.ts
@@ -310,7 +310,14 @@ class CliRepl implements MongoshIOProvider {
     const apiKey = this.analyticsOptions?.apiKey ?? require('./build-info.json').segmentApiKey;
     this.segmentAnalytics = new Analytics(
       apiKey,
-      this.analyticsOptions);
+      {
+        ...this.analyticsOptions,
+        axiosConfig: {
+          timeout: 1000
+        },
+        axiosRetryConfig: { retries: 0 }
+      } as any /* axiosConfig and axiosRetryConfig are existing options, but don't have type definitions */
+    );
     this.toggleableAnalytics = new ToggleableAnalytics(this.segmentAnalytics);
   }
 


### PR DESCRIPTION
Default `analytics-node` behavior is to retry 3 times and have no timeout on the request, we want to mitigate the effect of telemetry flushing on the user experience and so this patch sets timeout to 1 second and disables the retries completely

MONGOSH-1253