### PR TITLE
feat(cli-repl): allow multiple --eval args MONGOSH-1194

### DIFF
--- a/packages/arg-parser/src/cli-options.ts
+++ b/packages/arg-parser/src/cli-options.ts
@@ -19,7 +19,7 @@ export interface CliOptions {
   csfleLibraryPath?: string;
   cryptSharedLibPath?: string;
   db?: string;
-  eval?: string;
+  eval?: string[];
   gssapiServiceName?: string;
   sspiHostnameCanonicalization?: string;
   sspiRealmOverride?: string;

--- a/packages/cli-repl/src/arg-parser.spec.ts
+++ b/packages/cli-repl/src/arg-parser.spec.ts
@@ -194,7 +194,7 @@ describe('arg-parser', () => {
           });
         });
 
-        context('when providing --eval', () => {
+        context('when providing --eval (single value)', () => {
           const argv = [ ...baseArgv, uri, '--eval', '1+1' ];
 
           it('returns the URI in the object', () => {
@@ -202,7 +202,19 @@ describe('arg-parser', () => {
           });
 
           it('sets the eval value in the object', () => {
-            expect(parseCliArgs(argv).eval).to.equal('1+1');
+            expect(parseCliArgs(argv).eval).to.deep.equal(['1+1']);
+          });
+        });
+
+        context('when providing --eval (multiple values)', () => {
+          const argv = [ ...baseArgv, uri, '--eval', '1+1', '--eval', '2+2' ];
+
+          it('returns the URI in the object', () => {
+            expect(parseCliArgs(argv).connectionSpecifier).to.equal(uri);
+          });
+
+          it('sets the eval value in the object', () => {
+            expect(parseCliArgs(argv).eval).to.deep.equal(['1+1', '2+2']);
           });
         });
 

--- a/packages/cli-repl/src/arg-parser.ts
+++ b/packages/cli-repl/src/arg-parser.ts
@@ -26,7 +26,6 @@ const OPTIONS = {
     'csfleLibraryPath',
     'cryptSharedLibPath',
     'db',
-    'eval',
     'gssapiHostName',
     'gssapiServiceName',
     'sspiHostnameCanonicalization',
@@ -76,6 +75,7 @@ const OPTIONS = {
     'version'
   ],
   array: [
+    'eval',
     'file'
   ],
   alias: {


### PR DESCRIPTION
- Allow `--eval` to be used multiple times on the command line.
- Only print the result of the last `--eval` invocation.
- Remove the special handling for `--eval` without an argument,
  since our args parser does not let us distinguish that case
  from no `--eval` being passed in the case of options that
  can occur multiple times.