### PR TITLE
chore: update build documentation in README MONGOSH-1225

### DIFF
--- a/.evergreen/compile-artifact.sh
+++ b/.evergreen/compile-artifact.sh
@@ -23,9 +23,9 @@ export TMPDIR=/tmp/m
 # able to compile OpenSSL with assembly support,
 # so we revert back to the slower version.
 if [ "$OS" == "Windows_NT" ]; then
-  export NODE_JS_CONFIGURE_ARGS='["openssl-no-asm"]'
+  export BOXEDNODE_CONFIGURE_ARGS='openssl-no-asm'
 elif uname -a | grep -q 'Darwin.*x86_64'; then
-  export NODE_JS_CONFIGURE_ARGS='["--openssl-no-asm"]'
+  export BOXEDNODE_CONFIGURE_ARGS='--openssl-no-asm'
 elif [ -n "$MONGOSH_SHARED_OPENSSL" ]; then
   pushd /tmp/m
   if [ "$MONGOSH_SHARED_OPENSSL" == "openssl11" ]; then
@@ -48,7 +48,7 @@ elif [ -n "$MONGOSH_SHARED_OPENSSL" ]; then
   popd # openssl-*
   popd # /tmp/m
 
-  export NODE_JS_CONFIGURE_ARGS='[
+  export BOXEDNODE_CONFIGURE_ARGS='[
     "--shared-openssl",
     "--shared-openssl-includes=/tmp/m/opt/include",
     "--shared-openssl-libpath=/tmp/m/opt/lib",

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behavior may be
-reported by contacting the project team at . All
+reported by contacting the project team at compass@mongodb.com. All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.

--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ variable. For detailed instructions for each of our supported platforms, please 
 
 ### Requirements
 
-- Node.js v14.x
+- Node.js v16.x
 - Python 3.x
   - The test suite uses [mlaunch](http://blog.rueckstiess.com/mtools/mlaunch.html)
     for managing running mongod, you can install that manually as well via
@@ -171,12 +171,21 @@ Compile the standalone executable (this may take some time):
 npm run compile-exec
 ```
 
+Relevant environment variables for compiling are:
+- `NODE_JS_VERSION`: Specify a Node.js version to use for compilation, e.g. `16.15.0` or `16.x`
+- `BOXEDNODE_CONFIGURE_ARGS`: Node.js configure flags as a comma-separated list
+  or JSON array, e.g. `--shared-openssl,--shared-zlib`
+- `BOXEDNODE_MAKE_ARGS`: Node.js make args (no distinction from `BOXEDNODE_CONFIGURE_ARGS` on Windows)
+  as a comma-separated list or JSON array, e.g. `-j12`
+
 Compile a specific package, e.g. the `.deb` for Debian:
 
 ```shell
 npm run compile-exec
-npm run evergreen-release package -- --build-variant=debian-x64
+npm run evergreen-release package -- --build-variant=deb-x64
 ```
+
+Compilation and packaging output is written to `dist/`.
 
 ### Releasing
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
         "@typescript-eslint/parser": "^4.28.4",
         "aws-sdk": "^2.674.0",
         "axios": "^0.21.1",
-        "boxednode": "^1.10.6",
+        "boxednode": "^1.10.8",
         "browserify": "^16.5.0",
         "chai": "^4.2.0",
         "command-exists": "^1.2.9",
@@ -6313,9 +6313,9 @@
       "dev": true
     },
     "node_modules/boxednode": {
-      "version": "1.10.7",
-      "resolved": "https://registry.npmjs.org/boxednode/-/boxednode-1.10.7.tgz",
-      "integrity": "sha512-LxEsnvA9tfkaqmlbSBShpm9vUcfxt3S6SI6aCtQYbP4Xi4qlhi/xP0f31+b8UJgobgN/FGPRrbBIh8RPKdedug==",
+      "version": "1.10.8",
+      "resolved": "https://registry.npmjs.org/boxednode/-/boxednode-1.10.8.tgz",
+      "integrity": "sha512-Z9tx/Ni1Mqp1h4DKGNdCG1o6G+GFsU9iggnKQVdheLeWo4e+xXJ1AIE2demi8qwmJtW6o11fZaFoo+hs1J7gkg==",
       "dev": true,
       "dependencies": {
         "@pkgjs/nv": "^0.1.0",
@@ -33006,9 +33006,9 @@
       "dev": true
     },
     "boxednode": {
-      "version": "1.10.7",
-      "resolved": "https://registry.npmjs.org/boxednode/-/boxednode-1.10.7.tgz",
-      "integrity": "sha512-LxEsnvA9tfkaqmlbSBShpm9vUcfxt3S6SI6aCtQYbP4Xi4qlhi/xP0f31+b8UJgobgN/FGPRrbBIh8RPKdedug==",
+      "version": "1.10.8",
+      "resolved": "https://registry.npmjs.org/boxednode/-/boxednode-1.10.8.tgz",
+      "integrity": "sha512-Z9tx/Ni1Mqp1h4DKGNdCG1o6G+GFsU9iggnKQVdheLeWo4e+xXJ1AIE2demi8qwmJtW6o11fZaFoo+hs1J7gkg==",
       "dev": true,
       "requires": {
         "@pkgjs/nv": "^0.1.0",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "mongosh": "packages/cli-repl/bin/mongosh.js"
   },
   "homepage": "https://github.com/mongodb-js/mongosh",
-  "author": "Compass Team <team-compass@10gen.com>",
+  "author": "Compass Team <compass@mongodb.com>",
   "scripts": {
     "prebootstrap-with-chromium": "npm install",
     "bootstrap-with-chromium": "lerna bootstrap --concurrency=1",
@@ -100,7 +100,7 @@
     "@typescript-eslint/parser": "^4.28.4",
     "aws-sdk": "^2.674.0",
     "axios": "^0.21.1",
-    "boxednode": "^1.10.6",
+    "boxednode": "^1.10.8",
     "browserify": "^16.5.0",
     "chai": "^4.2.0",
     "command-exists": "^1.2.9",

--- a/packages/build/src/compile/signable-compiler.ts
+++ b/packages/build/src/compile/signable-compiler.ts
@@ -114,15 +114,8 @@ export class SignableCompiler {
       requireRegexp: /\bget_console_process_list\.node$/
     } : null;
 
-    let configureArgs: string[] = [];
-
-    if (process.env.NODE_JS_CONFIGURE_ARGS) {
-      configureArgs = JSON.parse(process.env.NODE_JS_CONFIGURE_ARGS);
-    }
-
     // This compiles the executable along with Node from source.
     await compileJSFileAsBinary({
-      configureArgs,
       sourceFile: this.sourceFile,
       targetFile: this.targetFile,
       nodeVersionRange: this.nodeVersionRange,

--- a/packages/cli-repl/package.json
+++ b/packages/cli-repl/package.json
@@ -3,7 +3,7 @@
   "version": "0.0.0-dev.0",
   "description": "MongoDB Shell CLI REPL Package",
   "homepage": "https://github.com/mongodb-js/mongosh",
-  "author": "Compass Team <team-compass@10gen.com>",
+  "author": "Compass Team <compass@mongodb.com>",
   "manufacturer": "MongoDB Inc.",
   "main": "lib/index.js",
   "types": "lib/index.d.ts",


### PR DESCRIPTION
Also bump boxednode, deduplicate the `NODE_JS_CONFIGURE_ARGS`
env var that we introduced that is already supported by boxednode,
and perform various minor updates to the rest of our docs.