### PR TITLE
chore(ci): add Amazon Linux 2022 smoke tests MONGOSH-1147

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -9159,6 +9159,25 @@ tasks:
         vars:
           node_js_version: "16.15.0"
           dockerfile: amazonlinux2-rpm
+  - name: pkg_test_docker_rpm_x64_amazonlinux2022_rpm
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_rpm_x64
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: rpm-x64
+      - func: write_preload_script
+      - func: install
+        vars:
+          node_js_version: "16.15.0"
+          npm_deps_mode: cli_build
+      - func: test_artifact_docker
+        vars:
+          node_js_version: "16.15.0"
+          dockerfile: amazonlinux2022-rpm
   - name: pkg_test_docker_rpm_x64_rocky8_rpm
     tags: ["smoke-test"]
     depends_on:
@@ -9349,6 +9368,25 @@ tasks:
         vars:
           node_js_version: "16.15.0"
           dockerfile: amazonlinux2-rpm
+  - name: pkg_test_docker_rpm_x64_openssl11_amazonlinux2022_rpm
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_rpm_x64_openssl11
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: rpm-x64-openssl11
+      - func: write_preload_script
+      - func: install
+        vars:
+          node_js_version: "16.15.0"
+          npm_deps_mode: cli_build
+      - func: test_artifact_docker
+        vars:
+          node_js_version: "16.15.0"
+          dockerfile: amazonlinux2022-rpm
   - name: pkg_test_docker_rpm_x64_openssl11_rocky8_rpm
     tags: ["smoke-test"]
     depends_on:
@@ -9425,6 +9463,25 @@ tasks:
         vars:
           node_js_version: "16.15.0"
           dockerfile: rocky8-epel-rpm
+  - name: pkg_test_docker_rpm_x64_openssl3_amazonlinux2022_rpm
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_rpm_x64_openssl3
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: rpm-x64-openssl3
+      - func: write_preload_script
+      - func: install
+        vars:
+          node_js_version: "16.15.0"
+          npm_deps_mode: cli_build
+      - func: test_artifact_docker
+        vars:
+          node_js_version: "16.15.0"
+          dockerfile: amazonlinux2022-rpm
   - name: pkg_test_docker_linux_arm64_ubuntu20_04_tgz
     tags: ["smoke-test"]
     depends_on:
@@ -9596,6 +9653,25 @@ tasks:
         vars:
           node_js_version: "16.15.0"
           dockerfile: amazonlinux2-rpm
+  - name: pkg_test_docker_rpm_arm64_amazonlinux2022_rpm
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_rpm_arm64
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: rpm-arm64
+      - func: write_preload_script
+      - func: install
+        vars:
+          node_js_version: "16.15.0"
+          npm_deps_mode: cli_build
+      - func: test_artifact_docker
+        vars:
+          node_js_version: "16.15.0"
+          dockerfile: amazonlinux2022-rpm
   - name: pkg_test_docker_deb_arm64_openssl11_ubuntu20_04_deb
     tags: ["smoke-test"]
     depends_on:
@@ -9710,6 +9786,25 @@ tasks:
         vars:
           node_js_version: "16.15.0"
           dockerfile: amazonlinux2-rpm
+  - name: pkg_test_docker_rpm_arm64_openssl11_amazonlinux2022_rpm
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_rpm_arm64_openssl11
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: rpm-arm64-openssl11
+      - func: write_preload_script
+      - func: install
+        vars:
+          node_js_version: "16.15.0"
+          npm_deps_mode: cli_build
+      - func: test_artifact_docker
+        vars:
+          node_js_version: "16.15.0"
+          dockerfile: amazonlinux2022-rpm
   - name: pkg_test_rpmextract_rpm_ppc64le
     tags: ["smoke-test"]
     depends_on:
@@ -10429,6 +10524,7 @@ buildvariants:
       - name: pkg_test_docker_deb_x64_debian11_deb
       - name: pkg_test_docker_rpm_x64_centos7_rpm
       - name: pkg_test_docker_rpm_x64_amazonlinux2_rpm
+      - name: pkg_test_docker_rpm_x64_amazonlinux2022_rpm
       - name: pkg_test_docker_rpm_x64_rocky8_rpm
       - name: pkg_test_docker_rpm_x64_fedora34_rpm
       - name: pkg_test_docker_rpm_x64_suse12_rpm
@@ -10439,10 +10535,12 @@ buildvariants:
       - name: pkg_test_docker_deb_x64_openssl11_debian11_deb
       - name: pkg_test_docker_rpm_x64_openssl11_centos7_epel_rpm
       - name: pkg_test_docker_rpm_x64_openssl11_amazonlinux2_rpm
+      - name: pkg_test_docker_rpm_x64_openssl11_amazonlinux2022_rpm
       - name: pkg_test_docker_rpm_x64_openssl11_rocky8_rpm
       - name: pkg_test_docker_rpm_x64_openssl11_fedora34_rpm
       - name: pkg_test_docker_deb_x64_openssl3_ubuntu22_04_deb
       - name: pkg_test_docker_rpm_x64_openssl3_rocky8_epel_rpm
+      - name: pkg_test_docker_rpm_x64_openssl3_amazonlinux2022_rpm
   - name: pkg_smoke_tests_docker_arm64
     display_name: "package smoke tests (arm64 Docker)"
     run_on: ubuntu1804-arm64-small
@@ -10456,12 +10554,14 @@ buildvariants:
       - name: pkg_test_docker_rpm_arm64_rocky8_rpm
       - name: pkg_test_docker_rpm_arm64_fedora34_rpm
       - name: pkg_test_docker_rpm_arm64_amazonlinux2_rpm
+      - name: pkg_test_docker_rpm_arm64_amazonlinux2022_rpm
       - name: pkg_test_docker_deb_arm64_openssl11_ubuntu20_04_deb
       - name: pkg_test_docker_deb_arm64_openssl11_debian10_deb
       - name: pkg_test_docker_deb_arm64_openssl11_debian11_deb
       - name: pkg_test_docker_rpm_arm64_openssl11_rocky8_rpm
       - name: pkg_test_docker_rpm_arm64_openssl11_fedora34_rpm
       - name: pkg_test_docker_rpm_arm64_openssl11_amazonlinux2_rpm
+      - name: pkg_test_docker_rpm_arm64_openssl11_amazonlinux2022_rpm
   - name: pkg_smoke_tests_win32
     display_name: "package smoke tests (win32)"
     run_on: ubuntu1804-small

--- a/config/release-package-matrix.js
+++ b/config/release-package-matrix.js
@@ -21,7 +21,7 @@ exports.RELEASE_PACKAGE_MATRIX = [
     packages: [
       { name: 'linux-x64', description: 'Linux Tarball 64-bit', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['ubuntu20.04-tgz'] },
       { name: 'deb-x64', description: 'Debian / Ubuntu 64-bit', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['ubuntu18.04-deb', 'ubuntu20.04-deb', 'ubuntu22.04-deb', 'debian9-deb', 'debian10-deb', 'debian11-deb'] },
-      { name: 'rpm-x64', description: 'RHEL / CentOS / Fedora / Suse 64-bit', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['centos7-rpm', 'amazonlinux2-rpm', 'rocky8-rpm', 'fedora34-rpm', 'suse12-rpm', 'suse15-rpm', 'amazonlinux1-rpm'] }
+      { name: 'rpm-x64', description: 'RHEL / CentOS / Fedora / Suse 64-bit', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['centos7-rpm', 'amazonlinux2-rpm', 'amazonlinux2022-rpm', 'rocky8-rpm', 'fedora34-rpm', 'suse12-rpm', 'suse15-rpm', 'amazonlinux1-rpm'] }
     ]
   },
   {
@@ -30,7 +30,7 @@ exports.RELEASE_PACKAGE_MATRIX = [
     packages: [
       { name: 'linux-x64-openssl11', description: 'Linux Tarball 64-bit (shared OpenSSL 1.1)', packageOn: 'linux_package', smokeTestKind: 'none' },
       { name: 'deb-x64-openssl11', description: 'Debian / Ubuntu 64-bit (shared OpenSSL 1.1)', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['ubuntu20.04-deb', 'debian10-deb', 'debian11-deb'] },
-      { name: 'rpm-x64-openssl11', description: 'RHEL / CentOS 64-bit (shared OpenSSL 1.1)', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['centos7-epel-rpm', 'amazonlinux2-rpm', 'rocky8-rpm', 'fedora34-rpm'] }
+      { name: 'rpm-x64-openssl11', description: 'RHEL / CentOS 64-bit (shared OpenSSL 1.1)', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['centos7-epel-rpm', 'amazonlinux2-rpm', 'amazonlinux2022-rpm', 'rocky8-rpm', 'fedora34-rpm'] }
     ]
   },
   {
@@ -39,7 +39,7 @@ exports.RELEASE_PACKAGE_MATRIX = [
     packages: [
       { name: 'linux-x64-openssl3', description: 'Linux Tarball 64-bit (shared OpenSSL 3)', packageOn: 'linux_package', smokeTestKind: 'none' },
       { name: 'deb-x64-openssl3', description: 'Debian / Ubuntu 64-bit (shared OpenSSL 3)', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['ubuntu22.04-deb'] },
-      { name: 'rpm-x64-openssl3', description: 'RHEL / CentOS 64-bit (shared OpenSSL 3)', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['rocky8-epel-rpm'] }
+      { name: 'rpm-x64-openssl3', description: 'RHEL / CentOS 64-bit (shared OpenSSL 3)', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['rocky8-epel-rpm', 'amazonlinux2022-rpm'] }
     ]
   },
   {
@@ -48,7 +48,7 @@ exports.RELEASE_PACKAGE_MATRIX = [
     packages: [
       { name: 'linux-arm64', description: 'Linux Tarball arm64', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['ubuntu20.04-tgz'] },
       { name: 'deb-arm64', description: 'Debian / Ubuntu arm64', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['ubuntu18.04-deb', 'ubuntu20.04-deb', 'ubuntu22.04-deb', 'debian10-deb', 'debian11-deb'] },
-      { name: 'rpm-arm64', description: 'RHEL / CentOS arm64', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['rocky8-rpm', 'fedora34-rpm', 'amazonlinux2-rpm'] }
+      { name: 'rpm-arm64', description: 'RHEL / CentOS arm64', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['rocky8-rpm', 'fedora34-rpm', 'amazonlinux2-rpm', 'amazonlinux2022-rpm'] }
     ]
   },
   {
@@ -57,7 +57,7 @@ exports.RELEASE_PACKAGE_MATRIX = [
     packages: [
       { name: 'linux-arm64-openssl11', description: 'Linux Tarball arm64 (shared OpenSSL 1.1)', packageOn: 'linux_package', smokeTestKind: 'none' },
       { name: 'deb-arm64-openssl11', description: 'Debian / Ubuntu arm64 (shared OpenSSL 1.1)', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['ubuntu20.04-deb', 'debian10-deb', 'debian11-deb'] },
-      { name: 'rpm-arm64-openssl11', description: 'Redhat / Centos arm64 (shared OpenSSL 1.1)', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['rocky8-rpm', 'fedora34-rpm', 'amazonlinux2-rpm'] }
+      { name: 'rpm-arm64-openssl11', description: 'Redhat / Centos arm64 (shared OpenSSL 1.1)', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['rocky8-rpm', 'fedora34-rpm', 'amazonlinux2-rpm', 'amazonlinux2022-rpm'] }
     ]
   },
   {

--- a/scripts/docker/amazonlinux2022-rpm.Dockerfile
+++ b/scripts/docker/amazonlinux2022-rpm.Dockerfile
@@ -1,0 +1,10 @@
+FROM amazonlinux:2022
+
+ARG artifact_url=""
+ADD ${artifact_url} /tmp
+ADD node_modules /usr/share/mongodb-crypt-library-version/node_modules
+RUN yum repolist
+RUN yum install -y /tmp/*mongosh*.rpm
+RUN /usr/bin/mongosh --build-info
+RUN env MONGOSH_RUN_NODE_SCRIPT=1 mongosh /usr/share/mongodb-crypt-library-version/node_modules/.bin/mongodb-crypt-library-version /usr/lib64/mongosh_crypt_v1.so | grep -Eq '^mongo_(crypt|csfle)_v1-'
+ENTRYPOINT [ "mongosh" ]


### PR DESCRIPTION
No e2e tests since those will require a working server version
on the platform.