### PR TITLE
fix(shell-api): remove KeyVault initialization workaround MONGOSH-1245

### DIFF
--- a/packages/shell-api/src/field-level-encryption.ts
+++ b/packages/shell-api/src/field-level-encryption.ts
@@ -161,9 +161,6 @@ export class KeyVault extends ShellApiWithMongoClass {
   }
 
   async _init(): Promise<void> {
-    if (this._mongo._fleOptions?.bypassQueryAnalysis) {
-      return; // TODO: Re-enable after libmongocrypt createIndex bug is fixed
-    }
     try {
       const existingIndexKeys = await this._keyColl.getIndexKeys();
       if (existingIndexKeys.some(key => key.keyAltNames)) {


### PR DESCRIPTION
In ad9c6bcbb6ebb0, this workaround was added since the interaction
of `createIndex` with `libmongocrypt` was buggy. Since this is
resolved now, we can just re-enable index creation.