### PR TITLE
chore(shell-api): make single-doc KeyVault methods return Documents MONGOSH-1266

### DIFF
--- a/packages/cli-repl/test/e2e-fle.spec.ts
+++ b/packages/cli-repl/test/e2e-fle.spec.ts
@@ -447,21 +447,88 @@ describe('FLE tests', () => {
     await runSingleLine('keyId = keyVault.createKey("local", "", ["testaltname"]);');
     expect(await runSingleLine('db.keyVault.countDocuments({ _id: keyId, keyAltNames: "testaltname" })'))
       .to.equal('1');
-    expect(await runSingleLine('keyVault.getKey(keyId).next()._id.toString() == keyId.toString()'))
+    expect(await runSingleLine('keyVault.getKey(keyId)._id.toString() == keyId.toString()'))
       .to.equal('true');
     expect(await runSingleLine('keyVault.getKeys().next()._id.toString() == keyId.toString()'))
       .to.equal('true');
     expect(await runSingleLine('keyVault.addKeyAlternateName(keyId, "otheraltname").keyAltNames.join(",")'))
       .to.equal('testaltname');
-    expect(await runSingleLine('keyVault.getKeyByAltName("otheraltname").next().keyAltNames.join(",")'))
+    expect(await runSingleLine('keyVault.getKeyByAltName("otheraltname").keyAltNames.join(",")'))
       .to.equal('testaltname,otheraltname');
     expect(await runSingleLine('keyVault.removeKeyAlternateName(keyId, "testaltname").keyAltNames.join(",")'))
       .to.equal('testaltname,otheraltname');
-    expect(await runSingleLine('keyVault.getKeyByAltName("otheraltname").next().keyAltNames.join(",")'))
+    expect(await runSingleLine('keyVault.getKeyByAltName("otheraltname").keyAltNames.join(",")'))
       .to.equal('otheraltname');
     expect(await runSingleLine('keyVault.deleteKey(keyId).deletedCount'))
       .to.equal('1');
     expect(await runSingleLine('db.keyVault.countDocuments()'))
       .to.equal('0');
+  });
+
+  it('allows a migration path for users from cursor getKey[ByAltName] to single document getKey[ByAltName]', async() => {
+    const shell = TestShell.start({
+      args: [await testServer.connectionString(), `--cryptSharedLibPath=${cryptLibrary}`]
+    });
+    await shell.waitForPrompt();
+    // Wrapper for executeLine that expects single-line output
+    const runSingleLine = async(line) => (await shell.executeLine(line)).split('\n')[0].trim();
+    await runSingleLine('local = { key: BinData(0, "kh4Gv2N8qopZQMQYMEtww/AkPsIrXNmEMxTrs3tUoTQZbZu4msdRUaR8U5fXD7A7QXYHcEvuu4WctJLoT+NvvV3eeIg3MD+K8H9SR794m/safgRHdIfy6PD+rFpvmFbY") }');
+    await runSingleLine(`keyMongo = Mongo(db.getMongo()._uri, { \
+      keyVaultNamespace: '${dbname}.keyVault', \
+      kmsProviders: { local }, \
+      explicitEncryptionOnly: true \
+    });`);
+    await runSingleLine(`use('${dbname}')`);
+    await runSingleLine('keyVault = keyMongo.getKeyVault();');
+    await runSingleLine('keyId = keyVault.createKey("local", "", ["testaltname"]);');
+
+    // Can access values with cursor methods, but get a deprecation warning
+    {
+      const output = await shell.executeLine('keyVault.getKey(keyId).next().masterKey.provider');
+      expect(output).to.include('DeprecationWarning: KeyVault.getKey returns a single document and will stop providing cursor methods in future versions of mongosh');
+      expect(output).to.match(/\blocal\b/);
+    }
+    {
+      const output = await shell.executeLine('keyVault.getKeyByAltName("testaltname").next().masterKey.provider');
+      expect(output).to.include('DeprecationWarning: KeyVault.getKeyByAltName returns a single document and will stop providing cursor methods in future versions of mongosh');
+      expect(output).to.match(/\blocal\b/);
+    }
+
+    // Can access values on document directly
+    {
+      const output = await shell.executeLine('keyVault.getKey(keyId).masterKey.provider');
+      expect(output).to.not.include('DeprecationWarning');
+      expect(output).to.match(/\blocal\b/);
+    }
+    {
+      const output = await shell.executeLine('keyVault.getKeyByAltName("testaltname").masterKey.provider');
+      expect(output).to.not.include('DeprecationWarning');
+      expect(output).to.match(/\blocal\b/);
+    }
+
+    // Works when no doc is returned
+    {
+      const output = await shell.executeLine('keyVault.getKey("nonexistent")');
+      expect(output).to.include('no result -- will return `null` in future mongosh versions');
+    }
+    {
+      const output = await shell.executeLine('keyVault.getKeyByAltName("nonexistent")');
+      expect(output).to.include('no result -- will return `null` in future mongosh versions');
+    }
+
+    // Hack to reset deprecation warning cache
+    await shell.executeLine('db.getMongo()._instanceState.warningsShown.clear()');
+
+    // Works when no doc is returned with cursor methods
+    {
+      const output = await shell.executeLine('keyVault.getKey("nonexistent").next()');
+      expect(output).to.include('DeprecationWarning');
+      expect(output).to.match(/\bnull\b/);
+    }
+    {
+      const output = await shell.executeLine('keyVault.getKeyByAltName("nonexistent").next()');
+      expect(output).to.include('DeprecationWarning');
+      expect(output).to.match(/\bnull\b/);
+    }
   });
 });

--- a/packages/shell-api/src/field-level-encryption.ts
+++ b/packages/shell-api/src/field-level-encryption.ts
@@ -24,10 +24,11 @@ import Collection from './collection';
 import Cursor from './cursor';
 import { DeleteResult } from './result';
 import { assertArgsDefinedType } from './helpers';
-import { asPrintable } from './enums';
+import { asPrintable, shellApiType } from './enums';
 import { redactURICredentials } from '@mongosh/history';
 import type Mongo from './mongo';
 import { CommonErrors, MongoshInvalidInputError, MongoshRuntimeError } from '@mongosh/errors';
+import ShellInstanceState from './shell-instance-state';
 
 export type ClientSideFieldLevelEncryptionKmsProvider = Omit<KMSProviders, 'local'> & {
   local?: {
@@ -73,6 +74,68 @@ const isMasterKey = (options?: MasterKeyOrAltNamesOrDataKeyOptions): options is 
     !isDataKeyEncryptionKeyOptions(options)
   );
 };
+
+// The KeyVault.getKey() and KeyVault.getKeyByAltName() are special because:
+// - the legacy shell and mongosh versions up to 1.5.4 return a *cursor* (that returns at most one document)
+// - drivers implementing the key management API return a *document* (or null)
+// The driver API design is the right choice here. While we are migrating to it, to keep
+// backwards compatibility with previous mongosh versions, we return a Proxy object
+// that returns the document but provides access to cursor methods, either by
+// rewinding the cursor from which we retrieved the result document (if possible)
+// or re-creating the cursor altogether.
+// Unfortunately, we cannot return a Proxy for `null` in the no-result case, so
+// we return a Proxy for a dummy object in that case.
+const NO_RESULT_PLACEHOLDER_DOC = Object.freeze({
+  // A bit hacky but probably as good as it gets.
+  [Symbol('no result -- will return `null` in future mongosh versions')]: true
+});
+async function makeSingleDocReturnValue(makeCursor: () => Promise<Cursor>, method: string, instanceState: ShellInstanceState): Promise<Document> {
+  let cursor = await makeCursor();
+  let doc: Document | null = null;
+  try {
+    doc = await cursor.limit(1).next();
+  } catch { /* ignore */ } finally {
+    if (typeof cursor._cursor.rewind === 'function') {
+      cursor._cursor.rewind();
+    } else {
+      // Not all service providers provide a .rewind() function,
+      // fall back to just re-creating the cursor.
+      cursor = await makeCursor();
+    }
+  }
+
+  const warn = () => {
+    void instanceState.printDeprecationWarning(
+      `${method} returns a single document and will stop providing cursor methods in future versions of mongosh.`);
+  };
+  return new Proxy(doc ?? NO_RESULT_PLACEHOLDER_DOC, {
+    get(target, property, receiver) {
+      if (property === shellApiType) { return 'Document'; }
+      if (property === asPrintable) { return; }
+      if (property in target) {
+        return Reflect.get(target, property, receiver);
+      }
+      if (typeof property !== 'symbol' && property in cursor) {
+        warn();
+      }
+      return Reflect.get(cursor, property);
+    },
+
+    getOwnPropertyDescriptor(target, property) {
+      if (property in target) {
+        return Reflect.getOwnPropertyDescriptor(target, property);
+      }
+      if (typeof property !== 'symbol' && property in cursor) {
+        warn();
+      }
+      return Reflect.getOwnPropertyDescriptor(cursor, property);
+    },
+
+    has(target, property) {
+      return property in target || property in cursor;
+    }
+  });
+}
 
 @shellApiClassDefault
 @classPlatforms([ ReplPlatform.CLI ] )
@@ -275,17 +338,17 @@ export class KeyVault extends ShellApiWithMongoClass {
   @returnType('Cursor')
   @apiVersions([1])
   @returnsPromise
-  async getKey(keyId: BinaryType): Promise<Cursor> {
+  async getKey(keyId: BinaryType): Promise<Document> {
     assertArgsDefinedType([keyId], [true], 'KeyVault.getKey');
-    return this._keyColl.find({ '_id': keyId });
+    return await makeSingleDocReturnValue(() => this._keyColl.find({ '_id': keyId }), 'KeyVault.getKey', this._instanceState);
   }
 
   @returnType('Cursor')
   @apiVersions([1])
   @returnsPromise
-  async getKeyByAltName(keyAltName: string): Promise<Cursor> {
+  async getKeyByAltName(keyAltName: string): Promise<Document> {
     assertArgsDefinedType([keyAltName], ['string'], 'KeyVault.getKeyByAltName');
-    return this._keyColl.find({ 'keyAltNames': keyAltName });
+    return await makeSingleDocReturnValue(() => this._keyColl.find({ 'keyAltNames': keyAltName }), 'KeyVault.getKeyByAltName', this._instanceState);
   }
 
   @returnType('Cursor')


### PR DESCRIPTION
Return a Proxy that merges the single returned `Document` from a cursor
with the cursor itself (or a copy of it) to migrate users to a more
driver-key-management-like API.