### PR TITLE
feat(shell-api): added a new shell helper 'getShardedDataInformation' MONGOSH-1254

### DIFF
--- a/packages/i18n/src/locales/en_US.ts
+++ b/packages/i18n/src/locales/en_US.ts
@@ -1634,6 +1634,10 @@ const translations: Catalog = {
               link: 'https://docs.mongodb.com/manual/reference/method/sh.setBalancerState',
               description: 'Calls sh.startBalancer if state is true, otherwise calls sh.stopBalancer',
               example: 'sh.setBalancerState(state)',
+            },
+            getShardedDataDistribution: {
+              description: 'Returns data-size distribution information for all existing sharded collections',
+              example: 'sh.getShardedDataDistribution()',
             }
           }
         }

--- a/packages/shell-api/src/shard.ts
+++ b/packages/shell-api/src/shard.ts
@@ -434,7 +434,7 @@ export default class Shard extends ShellApiWithMongoClass {
   async getShardedDataDistribution(options = {}): Promise<AggregationCursor> {
     this._emitShardApiCall('getShardedDataDistribution', {});
 
-    const cursor = await this._database.aggregate([{ $shardedDataDistribution: options }]);
+    const cursor = await this._database.getSiblingDB('admin').aggregate([{ $shardedDataDistribution: options }]);
 
     try {
       await cursor.hasNext();

--- a/packages/shell-api/src/shard.ts
+++ b/packages/shell-api/src/shard.ts
@@ -431,10 +431,10 @@ export default class Shard extends ShellApiWithMongoClass {
   @apiVersions([])
   @serverVersions(['6.1.0', ServerVersions.latest])
   @returnType('AggregationCursor')
-  async getShardedDataDistribution(): Promise<AggregationCursor> {
+  async getShardedDataDistribution(options = {}): Promise<AggregationCursor> {
     this._emitShardApiCall('getShardedDataDistribution', {});
 
-    const cursor = await this._database.aggregate([{ $shardedDataDistribution: {} }]);
+    const cursor = await this._database.aggregate([{ $shardedDataDistribution: options }]);
 
     try {
       await cursor.hasNext();

--- a/packages/shell-api/src/shard.ts
+++ b/packages/shell-api/src/shard.ts
@@ -1,7 +1,7 @@
 import Database from './database';
 import {
   shellApiClassDefault,
-  returnsPromise, serverVersions, apiVersions, ShellApiWithMongoClass
+  returnsPromise, serverVersions, apiVersions, ShellApiWithMongoClass, returnType
 } from './decorators';
 
 import type { Document } from '@mongosh/service-provider-core';
@@ -9,7 +9,9 @@ import { assertArgsDefinedType, getConfigDB, getPrintableShardStatus } from './h
 import { ServerVersions, asPrintable } from './enums';
 import { CommandResult, UpdateResult } from './result';
 import { redactURICredentials } from '@mongosh/history';
+import { CommonErrors, MongoshRuntimeError } from '@mongosh/errors';
 import Mongo from './mongo';
+import AggregationCursor from './aggregation-cursor';
 
 @shellApiClassDefault
 export default class Shard extends ShellApiWithMongoClass {
@@ -423,5 +425,30 @@ export default class Shard extends ShellApiWithMongoClass {
       return this.startBalancer();
     }
     return this.stopBalancer();
+  }
+
+  @returnsPromise
+  @apiVersions([])
+  @serverVersions(['6.1.0', ServerVersions.latest])
+  @returnType('AggregationCursor')
+  async getShardedDataDistribution(): Promise<AggregationCursor> {
+    this._emitShardApiCall('getShardedDataDistribution', {});
+
+    const cursor = await this._database.aggregate([{ $shardedDataDistribution: {} }]);
+
+    try {
+      await cursor.hasNext();
+    } catch (err: any) {
+      if (err.code?.valueOf() === 40324) { // unrecognized stage error
+        throw new MongoshRuntimeError(
+          'sh.getShardedDataDistribution only works on mongos',
+          CommonErrors.CommandFailed
+        );
+      }
+
+      throw err;
+    }
+
+    return cursor;
   }
 }


### PR DESCRIPTION
Add a shell helper for sharded data distribution info api.

Part of the project [PM-2934](https://jira.mongodb.org/browse/PM-2934).

** This PR wil not be merged until [SERVER-67891](https://jira.mongodb.org/browse/SERVER-67891) is committed.