### PR TITLE
chore: add driver as explicit dependency where it is a peer dep

### DIFF
--- a/packages/arg-parser/.depcheckrc
+++ b/packages/arg-parser/.depcheckrc
@@ -1,0 +1,2 @@
+# needed as a peer dependency of @mongodb-js/devtools-connect
+ignores: ['mongodb']

--- a/packages/arg-parser/package.json
+++ b/packages/arg-parser/package.json
@@ -34,6 +34,7 @@
     "@mongosh/i18n": "0.0.0-dev.0"
   },
   "devDependencies": {
-    "@mongodb-js/devtools-connect": "^1.4.3"
+    "@mongodb-js/devtools-connect": "^1.4.3",
+    "mongodb": "^4.9.0"
   }
 }

--- a/packages/logging/.depcheckrc
+++ b/packages/logging/.depcheckrc
@@ -1,0 +1,2 @@
+# needed as a peer dependency of @mongodb-js/devtools-connect
+ignores: ['mongodb']

--- a/packages/logging/package.json
+++ b/packages/logging/package.json
@@ -24,6 +24,9 @@
     "mongodb-log-writer": "^1.1.3",
     "mongodb-redact": "^0.2.2"
   },
+  "devDependencies": {
+    "mongodb": "^4.9.0"
+  },
   "scripts": {
     "test": "mocha -r \"../../scripts/import-expansions.js\" --timeout 15000 -r ts-node/register \"./src/**/*.spec.ts\"",
     "test-ci": "node ../../scripts/run-if-package-requested.js npm test",

--- a/packages/types/.depcheckrc
+++ b/packages/types/.depcheckrc
@@ -1,0 +1,2 @@
+# needed as a peer dependency of @mongodb-js/devtools-connect
+ignores: ['mongodb']

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -33,5 +33,8 @@
   },
   "dependencies": {
     "@mongodb-js/devtools-connect": "^1.4.3"
+  },
+  "devDependencies": {
+    "mongodb": "^4.9.0"
   }
 }


### PR DESCRIPTION
Add the driver package as an explicit `devDependencies` entry
for packages where a dependency uses it as a peer dependency.

This is not strictly necessary with modern npm versions,
and hopefully goes away once we move to a more Compass-style
monorepo where dependencies are hoisted, but for now, this is
convenient because it makes it quite a bit easier to update
the driver, and hopefully also paves the way for fixing the
(currently broken) driver integration tests.

(Previously, updating the driver often involved adding the
driver as a dependency to these packages, running bootstrap
to update the package-lock.json, then removing it from the
package.json again, and then running bootstrap again, since
otherwise driver types would start mismatching the driver types
from other packages.)