### PR TITLE
chore(ci): use MacOS 11.00 in unit tests MONGOSH-1058

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -11183,7 +11183,7 @@ tasks:
 buildvariants:
   - name: darwin_unit
     display_name: "MacOS Mojave (Unit tests)"
-    run_on: macos-1014
+    run_on: macos-1100
     expansions:
       executable_os_id: darwin-x64
     tasks:

--- a/.evergreen/evergreen.yml.in
+++ b/.evergreen/evergreen.yml.in
@@ -865,7 +865,7 @@ tasks:
 buildvariants:
   - name: darwin_unit
     display_name: "MacOS Mojave (Unit tests)"
-    run_on: macos-1014
+    run_on: macos-1100
     expansions:
       executable_os_id: darwin-x64
     tasks:


### PR DESCRIPTION
This distro does not exhibit the Python problem that macos-1014 has.
Moving over the unit tests seems like a reasonable workaround at this
point, given that all other attempts at solving this issue have failed,
and we still keep end-to-end test coverage on macos-1014 around.