### PR TITLE
feat(cli-repl): add --json CLI flag MONGOSH-1249

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,8 @@ variable. For detailed instructions for each of our supported platforms, please 
         --nodb                                 Don't connect to mongod on startup - no 'db address' [arg] expected
         --norc                                 Will not run the '.mongoshrc.js' file on start up
         --eval [arg]                           Evaluate javascript
-        --retryWrites=[true|false]             Automatically retry write operations upon transient network errors (Default: true)
+        --json[=canonical|relaxed]             Print result of --eval as Extended JSON, including errors
+        --retryWrites[=true|false]             Automatically retry write operations upon transient network errors (Default: true)
 
   Authentication Options:
 

--- a/packages/arg-parser/src/cli-options.ts
+++ b/packages/arg-parser/src/cli-options.ts
@@ -26,6 +26,7 @@ export interface CliOptions {
   help?: boolean;
   host?: string;
   ipv6?: boolean;
+  json?: boolean | 'canonical' | 'relaxed';
   keyVaultNamespace?: string;
   kmsURL?: string;
   nodb?: boolean;

--- a/packages/cli-repl/README.md
+++ b/packages/cli-repl/README.md
@@ -21,7 +21,8 @@ CLI interface for [MongoDB Shell][mongosh], an extension to Node.js REPL with Mo
         --nodb                                 Don't connect to mongod on startup - no 'db address' [arg] expected
         --norc                                 Will not run the '.mongoshrc.js' file on start up
         --eval [arg]                           Evaluate javascript
-        --retryWrites=[true|false]             Automatically retry write operations upon transient network errors (Default: true)
+        --json[=canonical|relaxed]             Print result of --eval as Extended JSON, including errors
+        --retryWrites[=true|false]             Automatically retry write operations upon transient network errors (Default: true)
 
   Authentication Options:
 

--- a/packages/cli-repl/src/arg-parser.ts
+++ b/packages/cli-repl/src/arg-parser.ts
@@ -83,7 +83,8 @@ const OPTIONS = {
     p: 'password',
     u: 'username',
     f: 'file',
-    'build-info': 'buildInfo'
+    'build-info': 'buildInfo',
+    json: 'json' // List explicitly here since it can be a boolean or a string
   },
   configuration: {
     'camel-case-expansion': false,
@@ -192,6 +193,13 @@ export function verifyCliArguments(args: any /* CliOptions */): string[] {
         CommonErrors.InvalidArgument
       );
     }
+  }
+
+  if (![undefined, true, false, 'relaxed', 'canonical'].includes(args.json)) {
+    throw new MongoshUnimplementedError(
+      '--json can only have the values relaxed or canonical',
+      CommonErrors.InvalidArgument
+    );
   }
 
   const messages = [];

--- a/packages/cli-repl/src/constants.ts
+++ b/packages/cli-repl/src/constants.ts
@@ -29,7 +29,8 @@ export const USAGE = `
         --nodb                                 ${i18n.__('cli-repl.args.nodb')}
         --norc                                 ${i18n.__('cli-repl.args.norc')}
         --eval [arg]                           ${i18n.__('cli-repl.args.eval')}
-        --retryWrites                          ${i18n.__('cli-repl.args.retryWrites')}
+        --json[=canonical|relaxed]             ${i18n.__('cli-repl.args.json')}
+        --retryWrites[=true|false]             ${i18n.__('cli-repl.args.retryWrites')}
 
   ${clr(i18n.__('cli-repl.args.authenticationOptions'), 'mongosh:section-header')}
 

--- a/packages/cli-repl/src/format-json.ts
+++ b/packages/cli-repl/src/format-json.ts
@@ -1,0 +1,17 @@
+import { types } from 'util';
+import { bson } from '@mongosh/service-provider-core';
+
+export function formatForJSONOutput(value: any, mode: 'relaxed' | 'canonical' | true): string {
+  if (types.isNativeError(value)) {
+    value = {
+      ...value,
+      message: value.message,
+      stack: value.stack,
+      name: value.name
+    };
+  }
+
+  return bson.EJSON.stringify(value, undefined, 2, {
+    relaxed: mode === 'relaxed'
+  });
+}

--- a/packages/i18n/src/locales/en_US.ts
+++ b/packages/i18n/src/locales/en_US.ts
@@ -22,6 +22,7 @@ const translations: Catalog = {
       nodb: "Don't connect to mongod on startup - no 'db address' [arg] expected",
       norc: "Will not run the '.mongoshrc.js' file on start up",
       eval: 'Evaluate javascript',
+      json: 'Print result of --eval as Extended JSON, including errors',
       retryWrites: 'Automatically retry write operations upon transient network errors (Default: true)',
       authenticationOptions: 'Authentication Options:',
       username: 'Username for authentication',


### PR DESCRIPTION
Add a `--json` CLI flag with possible `--json=canonical` and
`--json=relaxed` flags, the default being `canonical`.
When used, mongosh will print Extended JSON as output. This
flag can only be used in conjunction with `--eval`, and is
mutually exclusive with `--shell` and providing files on
the command line.

Errors and regular output are not distinguished based on
the output alone, only in the exit code of mongosh.
Repeated errors while trying to serialize the output to
Extended JSON will not be serialized.