### PR TITLE
fix(node-runtime-worker-thread): close child process on parent disconnect

### DIFF
--- a/packages/node-runtime-worker-thread/src/child-process-proxy.ts
+++ b/packages/node-runtime-worker-thread/src/child-process-proxy.ts
@@ -114,6 +114,7 @@ const messageBus = createCaller(['emit', 'on'], process);
 
 exposeAll(messageBus, workerProcess);
 
+process.once('disconnect', () => process.exit());
 process.nextTick(() => {
   // eslint-disable-next-line chai-friendly/no-unused-expressions
   process.send?.('ready');


### PR DESCRIPTION
This ensure that the auxilliary child processes stops once its parent process has terminated, even if it did not perform a proper shutdown of the child process.