### PR TITLE
feat(shell-api, cli-repl): pass print type as part of the onPrint callback; do not limit the output of printjson MONGOSH-955

### DIFF
--- a/packages/cli-repl/src/format-output.ts
+++ b/packages/cli-repl/src/format-output.ts
@@ -12,7 +12,7 @@ type EvaluationResult = {
   type?: string | null;
 };
 
-type FormatOptions = {
+export type FormatOptions = {
   colors: boolean;
   compact?: boolean | number;
   depth?: number;

--- a/packages/cli-repl/src/mongosh-repl.spec.ts
+++ b/packages/cli-repl/src/mongosh-repl.spec.ts
@@ -145,10 +145,31 @@ describe('MongoshNodeRepl', () => {
       expect(error.message).to.include('surprise!!!');
     });
 
-    it('prints values when asked to', async() => {
-      input.write('print("see this?"); 42\n');
-      await waitEval(bus);
-      expect(output).to.include('see this?');
+    context('print / printjson', () => {
+      it('prints values when asked to', async() => {
+        output = '';
+        input.write('print("see this?"); 42\n');
+        await waitEval(bus);
+        expect(output).to.include('see this?');
+      });
+
+      it('respects user format output settings when print is used', async() => {
+        input.write('config.set("inspectDepth", 0);\n');
+        await waitEval(bus);
+        output = '';
+        input.write('print({ a: { b: { c: 1 } } });\n');
+        await waitEval(bus);
+        expect(output).to.include('{ a: [Object] }');
+      });
+
+      it('prints out content in a legacy printjson format', async() => {
+        input.write('config.set("inspectDepth", 0);\n');
+        await waitEval(bus);
+        output = '';
+        input.write('printjson({ a: { b: { c: 1 } } });\n');
+        await waitEval(bus);
+        expect(output).to.include('{\n  a: {\n    b: {\n      c: 1\n    }\n  }\n}');
+      });
     });
 
     it('forwards telemetry config requests', async() => {

--- a/packages/cli-repl/src/mongosh-repl.ts
+++ b/packages/cli-repl/src/mongosh-repl.ts
@@ -665,12 +665,10 @@ class MongoshNodeRepl implements EvaluationListener {
   onPrint(values: ShellResult[], type: 'print' | 'printjson'): void {
     const extraOptions: Partial<FormatOptions> | undefined =
       // MONGOSH-955: when `printjson()` is called in mongosh, we will try to
-      // replicate the format of the old shell: disable colors, start every
-      // object on the new line, and set all the collapse options threshold to
-      // infinity
+      // replicate the format of the old shell: start every object on the new
+      // line, and set all the collapse options threshold to infinity
       type === 'printjson'
         ? {
-          colors: false,
           compact: false,
           depth: Infinity,
           maxArrayLength: Infinity,

--- a/packages/cli-repl/src/mongosh-repl.ts
+++ b/packages/cli-repl/src/mongosh-repl.ts
@@ -20,6 +20,7 @@ import { MONGOSH_WIKI, TELEMETRY_GREETING_MESSAGE } from './constants';
 import formatOutput, { formatError } from './format-output';
 import { makeMultilineJSIntoSingleLine } from '@mongosh/js-multiline-to-singleline';
 import { LineByLineInput } from './line-by-line-input';
+import type { FormatOptions } from './format-output';
 
 /**
  * All CLI flags that are useful for {@link MongoshNodeRepl}.
@@ -646,8 +647,14 @@ class MongoshNodeRepl implements EvaluationListener {
    * @param result A ShellResult (or similar) object.
    * @returns The pretty-printed version of the input.
    */
-  formatShellResult(result: { type: null | string, printable: any }): string {
-    return this.formatOutput({ type: result.type, value: result.printable });
+  formatShellResult(
+    result: { type: null | string; printable: any },
+    extraFormatOptions: Partial<FormatOptions> = {}
+  ): string {
+    return this.formatOutput(
+      { type: result.type, value: result.printable },
+      extraFormatOptions
+    );
   }
 
   /**
@@ -655,8 +662,24 @@ class MongoshNodeRepl implements EvaluationListener {
    *
    * @param values A list of values to be printed.
    */
-  onPrint(values: ShellResult[]): void {
-    const joined = values.map((value) => this.formatShellResult(value)).join(' ');
+  onPrint(values: ShellResult[], type: 'print' | 'printjson'): void {
+    const extraOptions: Partial<FormatOptions> | undefined =
+      // MONGOSH-955: when `printjson()` is called in mongosh, we will try to
+      // replicate the format of the old shell: disable colors, start every
+      // object on the new line, and set all the collapse options threshold to
+      // infinity
+      type === 'printjson'
+        ? {
+          colors: false,
+          compact: false,
+          depth: Infinity,
+          maxArrayLength: Infinity,
+          maxStringLength: Infinity
+        }
+        : undefined;
+    const joined = values
+      .map((value) => this.formatShellResult(value, extraOptions))
+      .join(' ');
     this.output.write(joined + '\n');
   }
 
@@ -704,8 +727,14 @@ class MongoshNodeRepl implements EvaluationListener {
    * @param value A value, together with optional type information.
    * @returns The pretty-printed version of the input.
    */
-  formatOutput(value: { value: any, type?: string | null }): string {
-    return formatOutput(value, this.getFormatOptions());
+  formatOutput(
+    value: { value: any; type?: string | null },
+    extraFormatOptions: Partial<FormatOptions> = {}
+  ): string {
+    return formatOutput(value, {
+      ...this.getFormatOptions(),
+      ...extraFormatOptions
+    });
   }
 
   /**
@@ -732,7 +761,7 @@ class MongoshNodeRepl implements EvaluationListener {
   /**
    * Provides the current set of output formatting options used for this shell.
    */
-  getFormatOptions(): { colors: boolean, compact: number | boolean, depth: number, showStackTraces: boolean, bugReportErrorMessageInfo?: string } {
+  getFormatOptions(): FormatOptions {
     const output = this.output as WriteStream;
     return {
       colors: this._runtimeState?.repl?.useColors ??

--- a/packages/shell-api/src/shell-api.spec.ts
+++ b/packages/shell-api/src/shell-api.spec.ts
@@ -671,12 +671,18 @@ describe('ShellApi', () => {
       // eslint-disable-next-line no-loop-func
       describe(cmd, () => {
         it('prints values', async() => {
-          evaluationListener.onPrint.resolves();
+          // eslint-disable-next-line chai-friendly/no-unused-expressions
+          evaluationListener.onPrint?.resolves();
           await instanceState.context[cmd](1, 2);
-          expect(evaluationListener.onPrint).to.have.been.calledWith([
-            { printable: 1, rawValue: 1, type: null },
-            { printable: 2, rawValue: 2, type: null }
-          ]);
+          expect(
+            evaluationListener.onPrint
+          ).to.have.been.calledOnceWithExactly(
+            [
+              { printable: 1, rawValue: 1, type: null },
+              { printable: 2, rawValue: 2, type: null }
+            ],
+            cmd
+          );
         });
       });
     }

--- a/packages/shell-api/src/shell-api.ts
+++ b/packages/shell-api/src/shell-api.ts
@@ -298,17 +298,22 @@ export default class ShellApi extends ShellApiClass {
     return await promisify(setTimeout)(ms);
   }
 
+  private async _print(origArgs: any[], type: 'print' | 'printjson'): Promise<void> {
+    const { evaluationListener } = this._instanceState;
+    const args: ShellResult[] = await Promise.all(
+      origArgs.map((arg) => toShellResult(arg))
+    );
+    await evaluationListener.onPrint?.(args, type);
+  }
+
   @returnsPromise
   async print(...origArgs: any[]): Promise<void> {
-    const { evaluationListener } = this._instanceState;
-    const args: ShellResult[] =
-      await Promise.all(origArgs.map(arg => toShellResult(arg)));
-    await evaluationListener.onPrint?.(args);
+    await this._print(origArgs, 'print');
   }
 
   @returnsPromise
   async printjson(...origArgs: any[]): Promise<void> {
-    return this.print(...origArgs);
+    await this._print(origArgs, 'printjson');
   }
 
   @directShellCommand

--- a/packages/shell-api/src/shell-instance-state.ts
+++ b/packages/shell-api/src/shell-instance-state.ts
@@ -74,7 +74,7 @@ export interface EvaluationListener extends Partial<ConfigProvider<ShellUserConf
   /**
    * Called when print() or printjson() is run from the shell.
    */
-  onPrint?: (value: ShellResult[]) => Promise<void> | void;
+  onPrint?: (value: ShellResult[], type: 'print' | 'printjson') => Promise<void> | void;
 
   /**
    * Called when e.g. passwordPrompt() is called from the shell.


### PR DESCRIPTION
Here's how the output looks for `printjson(Array.from({length: 1000}, (_, idx) => ({_id: ObjectId(), idx})));` now:

|mongo|mongosh|
|---|---|
|<img width="588" alt="image" src="https://user-images.githubusercontent.com/5036933/201730865-bed67dcf-52a2-4eeb-adbe-69cef6e0a175.png">|<img width="454" alt="image" src="https://user-images.githubusercontent.com/5036933/201732397-e5fab13f-17d1-4bc8-9155-c1e2acdf75ed.png">|

TODO:

- [ ] Update tests
