### PR TITLE
fix(cli-repl): do not enable telemetry unless user id is persisted MONGOSH-1320

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -10224,6 +10224,25 @@ tasks:
         vars:
           node_js_version: "16.17.0"
           dockerfile: ubuntu22.04-deb
+  - name: pkg_test_docker_deb_x64_ubuntu22_04_nohome_deb
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_deb_x64
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: deb-x64
+      - func: write_preload_script
+      - func: install
+        vars:
+          node_js_version: "16.17.0"
+          npm_deps_mode: cli_build
+      - func: test_artifact_docker
+        vars:
+          node_js_version: "16.17.0"
+          dockerfile: ubuntu22.04-nohome-deb
   - name: pkg_test_docker_deb_x64_debian9_deb
     tags: ["smoke-test"]
     depends_on:
@@ -11826,6 +11845,7 @@ buildvariants:
       - name: pkg_test_docker_deb_x64_ubuntu18_04_deb
       - name: pkg_test_docker_deb_x64_ubuntu20_04_deb
       - name: pkg_test_docker_deb_x64_ubuntu22_04_deb
+      - name: pkg_test_docker_deb_x64_ubuntu22_04_nohome_deb
       - name: pkg_test_docker_deb_x64_debian9_deb
       - name: pkg_test_docker_deb_x64_debian10_deb
       - name: pkg_test_docker_deb_x64_debian11_deb

--- a/config/release-package-matrix.js
+++ b/config/release-package-matrix.js
@@ -20,7 +20,7 @@ exports.RELEASE_PACKAGE_MATRIX = [
     compileBuildVariant: 'linux_x64_build',
     packages: [
       { name: 'linux-x64', description: 'Linux Tarball 64-bit', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['ubuntu20.04-tgz'] },
-      { name: 'deb-x64', description: 'Debian / Ubuntu 64-bit', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['ubuntu18.04-deb', 'ubuntu20.04-deb', 'ubuntu22.04-deb', 'debian9-deb', 'debian10-deb', 'debian11-deb'] },
+      { name: 'deb-x64', description: 'Debian / Ubuntu 64-bit', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['ubuntu18.04-deb', 'ubuntu20.04-deb', 'ubuntu22.04-deb', 'ubuntu22.04-nohome-deb', 'debian9-deb', 'debian10-deb', 'debian11-deb'] },
       { name: 'rpm-x64', description: 'RHEL / CentOS / Fedora / Suse 64-bit', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['centos7-rpm', 'amazonlinux2-rpm', 'amazonlinux2022-rpm', 'rocky8-rpm', 'rocky9-rpm', 'fedora34-rpm', 'suse12-rpm', 'suse15-rpm', 'amazonlinux1-rpm'] }
     ]
   },

--- a/packages/cli-repl/src/cli-repl.ts
+++ b/packages/cli-repl/src/cli-repl.ts
@@ -127,12 +127,12 @@ class CliRepl implements MongoshIOProvider {
         this.bus.emit('mongosh:error', err, 'config');
       })
       .on('new-config', (config: CliUserConfigOnDisk) => {
-        this.hasOnDiskTelemetryId = true;
+        this.hasOnDiskTelemetryId = !!(config.userId || config.telemetryAnonymousId);
         this.setTelemetryEnabled(config.enableTelemetry);
         this.bus.emit('mongosh:new-user', { userId: config.userId, anonymousId: config.telemetryAnonymousId });
       })
       .on('update-config', (config: CliUserConfigOnDisk) => {
-        this.hasOnDiskTelemetryId = true;
+        this.hasOnDiskTelemetryId = !!(config.userId || config.telemetryAnonymousId);
         this.setTelemetryEnabled(config.enableTelemetry);
         this.bus.emit('mongosh:update-user', { userId: config.userId, anonymousId: config.telemetryAnonymousId });
       });

--- a/packages/cli-repl/test/e2e.spec.ts
+++ b/packages/cli-repl/test/e2e.spec.ts
@@ -1058,6 +1058,10 @@ describe('e2e', function() {
           expect(shell.output).to.include('Warning: Could not access file:');
         });
         expect(await shell.executeLine('print(123 + 456)')).to.include('579');
+        await shell.executeLine('sleep(100)');
+        expect(shell.output).to.not.include('anonymousId');
+        expect(shell.output).to.not.include('AssertionError');
+        expect(shell.assertNoErrors());
       });
 
       it('keeps working when the log files cannot be created', async() => {
@@ -1069,6 +1073,10 @@ describe('e2e', function() {
         });
         expect(await shell.executeLine('print(123 + 456)')).to.include('579');
         expect(await shell.executeLine('enableTelemetry()')).to.include('Telemetry is now enabled');
+        await shell.executeLine('sleep(100)');
+        expect(shell.output).to.not.include('anonymousId');
+        expect(shell.output).to.not.include('AssertionError');
+        expect(shell.assertNoErrors());
       });
 
       it('keeps working when the config file is present but not writable', async function() {
@@ -1083,6 +1091,10 @@ describe('e2e', function() {
           expect(shell.output).to.include('Warning: Could not access file:');
         });
         expect(await shell.executeLine('print(123 + 456)')).to.include('579');
+        await shell.executeLine('sleep(100)');
+        expect(shell.output).to.not.include('anonymousId');
+        expect(shell.output).to.not.include('AssertionError');
+        expect(shell.assertNoErrors());
       });
     });
   });

--- a/packages/logging/src/analytics-helpers.spec.ts
+++ b/packages/logging/src/analytics-helpers.spec.ts
@@ -41,4 +41,15 @@ describe('ToggleableAnalytics', () => {
       [ 'track', { userId: 'me', event: 'something2', properties: { mongosh_version: '1.2.3' } } ]
     ]);
   });
+
+  it('emits an error for invalid messages if telemetry is enabled', () => {
+    const toggleable = new ToggleableAnalytics(target);
+
+    toggleable.identify({} as any);
+    expect(() => toggleable.enable()).to.throw('Telemetry setup is missing userId or anonymousId');
+
+    toggleable.disable();
+    expect(() => toggleable.enable()).to.not.throw();
+    expect(() => toggleable.track({} as any)).to.throw('Telemetry setup is missing userId or anonymousId');
+  });
 });

--- a/scripts/docker/ubuntu22.04-nohome-deb.Dockerfile
+++ b/scripts/docker/ubuntu22.04-nohome-deb.Dockerfile
@@ -1,0 +1,18 @@
+FROM ubuntu:22.04
+
+ARG artifact_url=""
+ADD ${artifact_url} /tmp
+RUN apt-get update
+RUN apt-get install -y /tmp/*mongosh*.deb
+RUN /usr/bin/mongosh --build-info
+
+# alternate config for regression-testing https://jira.mongodb.org/browse/MONGOSH-1320
+RUN useradd --user-group --system --create-home --no-log-init mongodb
+RUN mkdir /home/mongodb/.mongodb
+RUN chmod -w /home/mongodb/.mongodb
+RUN touch /home/mongodb/.mongoshrc.js
+
+USER mongodb
+WORKDIR /home/mongodb
+
+ENTRYPOINT [ "mongosh" ]


### PR DESCRIPTION
Do not enable telemetry unless a new config file has been written or an existing one read.

The alternative would be to send telemetry even when user ids cannot be persisted; this would make it appear as if a new user connected every time mongosh runs, which is probably not what we want.