### PR TITLE
fix(cli-repl): drop nanobus in production usage MONGOSH-1330

### DIFF
--- a/packages/cli-repl/package-lock.json
+++ b/packages/cli-repl/package-lock.json
@@ -17,7 +17,6 @@
 				"js-yaml": "^4.1.0",
 				"mongodb-connection-string-url": "^2.5.3",
 				"mongodb-log-writer": "^1.1.3",
-				"nanobus": "^4.4.0",
 				"numeral": "^2.0.6",
 				"pretty-repl": "^3.1.1",
 				"semver": "^7.1.2",
@@ -780,38 +779,6 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
 		},
-		"node_modules/nanoassert": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/nanoassert/-/nanoassert-1.1.0.tgz",
-			"integrity": "sha1-TzFS4JVA/eKMdvRLGbvNHVpCR40="
-		},
-		"node_modules/nanobus": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/nanobus/-/nanobus-4.5.0.tgz",
-			"integrity": "sha512-7sBZo9wthqNJ7QXnfVXZL7fkKJLN55GLOdX+RyZT34UOvxxnFtJe/c7K0ZRLAKOvaY1xJThFFn0Usw2H9R6Frg==",
-			"dependencies": {
-				"nanoassert": "^1.1.0",
-				"nanotiming": "^7.2.0",
-				"remove-array-items": "^1.0.0"
-			}
-		},
-		"node_modules/nanoscheduler": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/nanoscheduler/-/nanoscheduler-1.0.3.tgz",
-			"integrity": "sha512-jBbrF3qdU9321r8n9X7yu18DjP31Do2ItJm3mWrt90wJTrnDO+HXpoV7ftaUglAtjgj9s+OaCxGufbvx6pvbEQ==",
-			"dependencies": {
-				"nanoassert": "^1.1.0"
-			}
-		},
-		"node_modules/nanotiming": {
-			"version": "7.3.1",
-			"resolved": "https://registry.npmjs.org/nanotiming/-/nanotiming-7.3.1.tgz",
-			"integrity": "sha512-l3lC7v/PfOuRWQa8vV29Jo6TG10wHtnthLElFXs4Te4Aas57Fo4n1Q8LH9n+NDh9riOzTVvb2QNBhTS4JUKNjw==",
-			"dependencies": {
-				"nanoassert": "^1.1.0",
-				"nanoscheduler": "^1.0.2"
-			}
-		},
 		"node_modules/node-addon-api": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
@@ -866,11 +833,6 @@
 			"engines": {
 				"node": ">=6"
 			}
-		},
-		"node_modules/remove-array-items": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/remove-array-items/-/remove-array-items-1.1.1.tgz",
-			"integrity": "sha512-MXW/jtHyl5F1PZI7NbpS8SOtympdLuF20aoWJT5lELR1p/HJDd5nqW8Eu9uLh/hCRY3FgvrIT5AwDCgBODklcA=="
 		},
 		"node_modules/remove-trailing-slash": {
 			"version": "0.1.1",
@@ -1536,38 +1498,6 @@
 			"resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
 			"integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
 		},
-		"nanoassert": {
-			"version": "1.1.0",
-			"resolved": "https://registry.npmjs.org/nanoassert/-/nanoassert-1.1.0.tgz",
-			"integrity": "sha1-TzFS4JVA/eKMdvRLGbvNHVpCR40="
-		},
-		"nanobus": {
-			"version": "4.5.0",
-			"resolved": "https://registry.npmjs.org/nanobus/-/nanobus-4.5.0.tgz",
-			"integrity": "sha512-7sBZo9wthqNJ7QXnfVXZL7fkKJLN55GLOdX+RyZT34UOvxxnFtJe/c7K0ZRLAKOvaY1xJThFFn0Usw2H9R6Frg==",
-			"requires": {
-				"nanoassert": "^1.1.0",
-				"nanotiming": "^7.2.0",
-				"remove-array-items": "^1.0.0"
-			}
-		},
-		"nanoscheduler": {
-			"version": "1.0.3",
-			"resolved": "https://registry.npmjs.org/nanoscheduler/-/nanoscheduler-1.0.3.tgz",
-			"integrity": "sha512-jBbrF3qdU9321r8n9X7yu18DjP31Do2ItJm3mWrt90wJTrnDO+HXpoV7ftaUglAtjgj9s+OaCxGufbvx6pvbEQ==",
-			"requires": {
-				"nanoassert": "^1.1.0"
-			}
-		},
-		"nanotiming": {
-			"version": "7.3.1",
-			"resolved": "https://registry.npmjs.org/nanotiming/-/nanotiming-7.3.1.tgz",
-			"integrity": "sha512-l3lC7v/PfOuRWQa8vV29Jo6TG10wHtnthLElFXs4Te4Aas57Fo4n1Q8LH9n+NDh9riOzTVvb2QNBhTS4JUKNjw==",
-			"requires": {
-				"nanoassert": "^1.1.0",
-				"nanoscheduler": "^1.0.2"
-			}
-		},
 		"node-addon-api": {
 			"version": "4.3.0",
 			"resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-4.3.0.tgz",
@@ -1607,11 +1537,6 @@
 			"version": "2.1.1",
 			"resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
 			"integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
-		},
-		"remove-array-items": {
-			"version": "1.1.1",
-			"resolved": "https://registry.npmjs.org/remove-array-items/-/remove-array-items-1.1.1.tgz",
-			"integrity": "sha512-MXW/jtHyl5F1PZI7NbpS8SOtympdLuF20aoWJT5lELR1p/HJDd5nqW8Eu9uLh/hCRY3FgvrIT5AwDCgBODklcA=="
 		},
 		"remove-trailing-slash": {
 			"version": "0.1.1",

--- a/packages/cli-repl/package.json
+++ b/packages/cli-repl/package.json
@@ -74,7 +74,6 @@
     "js-yaml": "^4.1.0",
     "mongodb-connection-string-url": "^2.5.3",
     "mongodb-log-writer": "^1.1.3",
-    "nanobus": "^4.4.0",
     "numeral": "^2.0.6",
     "pretty-repl": "^3.1.1",
     "semver": "^7.1.2",

--- a/packages/cli-repl/src/cli-repl.ts
+++ b/packages/cli-repl/src/cli-repl.ts
@@ -9,9 +9,9 @@ import { Editor } from '@mongosh/editor';
 import { redactSensitiveData } from '@mongosh/history';
 import Analytics from 'analytics-node';
 import askpassword from 'askpassword';
+import { EventEmitter } from 'events';
 import yaml from 'js-yaml';
 import ConnectionString from 'mongodb-connection-string-url';
-import Nanobus from 'nanobus';
 import semver from 'semver';
 import { Readable, Writable } from 'stream';
 import { buildInfo } from './build-info';
@@ -104,7 +104,7 @@ class CliRepl implements MongoshIOProvider {
    * Instantiate the new CLI Repl.
    */
   constructor(options: CliReplOptions) {
-    this.bus = new Nanobus('mongosh');
+    this.bus = new EventEmitter();
     this.cliOptions = options.shellCliOptions;
     this.input = options.input;
     this.output = options.output;


### PR DESCRIPTION
nanobus inherently leaks memory, which means that it can make mongosh crash in certain scenarios.

Since we do not actually use the features of nanobus (mostly being able to listen for a generic `'*'` event), just replace it with the standard `EventEmitter` to fix this.