### PR TITLE
chore(build): add retry logic for barque/curator calls

### DIFF
--- a/packages/build/src/helpers/index.ts
+++ b/packages/build/src/helpers/index.ts
@@ -1,3 +1,4 @@
 
 export * from './spawn-sync';
 export * from './user-input';
+export * from './with-retries';

--- a/packages/build/src/helpers/with-retries.spec.ts
+++ b/packages/build/src/helpers/with-retries.spec.ts
@@ -1,0 +1,33 @@
+import { expect } from 'chai';
+import sinon from 'ts-sinon';
+import { withRetries } from './';
+
+describe('withRetries', () => {
+  let fn: sinon.SinonStub;
+
+  beforeEach(() => {
+    fn = sinon.stub();
+  });
+
+  it('passes an immediate success through', async() => {
+    fn.onFirstCall().resolves(42);
+    expect(await withRetries(fn, 1)).to.equal(42);
+  });
+
+  it('passes a later success through', async() => {
+    fn.onFirstCall().rejects(new Error('failed'));
+    fn.onSecondCall().rejects(new Error('failed'));
+    fn.onThirdCall().resolves(42);
+    expect(await withRetries(fn, 3)).to.equal(42);
+  });
+
+  it('aggregates failures if retries are insufficient', async() => {
+    fn.onFirstCall().rejects(new Error('fail 1'));
+    fn.onSecondCall().rejects(new Error('fail 2'));
+    fn.onThirdCall().resolves(42);
+    const rejection = await withRetries(fn, 2).catch(err => err);
+    expect(rejection.name).to.equal('AggregateError');
+    expect(rejection.errors).to.be.an('array');
+    expect(rejection.errors.map((err: any) => err.message)).to.deep.equal(['fail 1', 'fail 2']);
+  });
+});

--- a/packages/build/src/helpers/with-retries.ts
+++ b/packages/build/src/helpers/with-retries.ts
@@ -1,0 +1,18 @@
+declare class AggregateError extends Error {
+  constructor(errors: Error[], message?: string);
+}
+
+export async function withRetries<T extends() => any>(
+  fn: T,
+  nRetries: number
+): Promise<T extends () => infer R ? R : never> {
+  const errors: Error[] = [];
+  for (let i = 0; i < nRetries; i++) {
+    try {
+      return await fn();
+    } catch (err: any) {
+      errors.push(err);
+    }
+  }
+  throw new AggregateError(errors, `Operation failed after ${nRetries} attempts: ${errors.map(err => err.message).join(', ')}`);
+}


### PR DESCRIPTION
After chatting with the build team, this seems like a reasonable thing to do to make our publish script a bit more resilient without larger efforts.