### PR TITLE
chore(shell-api): update error message for getShardedDataDistribution MONGOSH-1301

### DIFF
--- a/packages/shell-api/src/shard.spec.ts
+++ b/packages/shell-api/src/shard.spec.ts
@@ -1194,9 +1194,9 @@ describe('Shard', () => {
       it('throws if not mongos', async() => {
         const serviceProviderCursor = stubInterface<ServiceProviderAggCursor>();
         serviceProvider.aggregateDb.returns(serviceProviderCursor as any);
-        serviceProviderCursor.hasNext.throws(Object.assign(new Error(), { code: 40324 }));
+        serviceProviderCursor.hasNext.throws(Object.assign(new Error(), { code: 40324, message: "Unrecognized pipeline stage name: '$shardedDataDistribution'" }));
         const error: any = await shard.getShardedDataDistribution().catch(err => err);
-        expect(error.message).to.match(/sh\.getShardedDataDistribution only works on mongos/);
+        expect(error.message).to.match(/sh\.getShardedDataDistribution only works on mongos and MongoDB server versions greater than 6\.0\.3 \[Original Error: Unrecognized pipeline stage name: '\$shardedDataDistribution']/);
       });
     });
   });

--- a/packages/shell-api/src/shard.ts
+++ b/packages/shell-api/src/shard.ts
@@ -9,7 +9,6 @@ import { assertArgsDefinedType, getConfigDB, getPrintableShardStatus } from './h
 import { ServerVersions, asPrintable } from './enums';
 import { CommandResult, UpdateResult } from './result';
 import { redactURICredentials } from '@mongosh/history';
-import { CommonErrors, MongoshRuntimeError } from '@mongosh/errors';
 import Mongo from './mongo';
 import AggregationCursor from './aggregation-cursor';
 
@@ -440,10 +439,7 @@ export default class Shard extends ShellApiWithMongoClass {
       await cursor.hasNext();
     } catch (err: any) {
       if (err.code?.valueOf() === 40324) { // unrecognized stage error
-        throw new MongoshRuntimeError(
-          'sh.getShardedDataDistribution only works on mongos',
-          CommonErrors.CommandFailed
-        );
+        err.message = `sh.getShardedDataDistribution only works on mongos and MongoDB server versions greater than 6.0.3 [Original Error: ${err.message}]`;
       }
 
       throw err;


### PR DESCRIPTION
MONGOSH-1301

Two questions for reviewers:
- Are there specific cases for when we show `MongoshRuntimeError`? I wasn't sure if that should be used here, in these changes we are going back to showing `MongoServerError`.
- Should we make this do a full check for the server version before showing the server version part of the error message? We can do something like https://github.com/mongodb-js/mongosh/blob/bed1edfe73b4b374d4ba6089d8c48d01fa56f93f/packages/shell-api/src/database.ts#L620 in that case.

```ts
async _improveErrorMessageForGetShardedDataDistribution(err: Error): Promise<void> {
  try {
    const serverVersion = await this.version();
    if (serverVersion && +serverVersion.split('.')[0] < 6) {
      err.message = `Your server version is ${serverVersion}, which does not support the sh.getShardedDataDistribution command [Original Error: ${err.message}]`;
      return;
    }
  } catch { /* ignore error from fetching server version */ }

  err.message = `sh.getShardedDataDistribution only works on mongos [Original Error: ${err.message}]`;
}
```


<img width="1069" alt="Screen Shot 2022-12-12 at 12 45 01 PM" src="https://user-images.githubusercontent.com/1791149/207116763-963a08f4-af75-43e0-939e-cfb5198fb382.png">
