### PR TITLE
chore(build): enable ascii_only terser flag MONGOSH-1345

### DIFF
--- a/config/webpack.base.config.js
+++ b/config/webpack.base.config.js
@@ -21,6 +21,11 @@ module.exports = {
     minimizer: [
       new TerserPlugin({
         terserOptions: {
+          // Using ASCII-only output means a slightly larger bundle file,
+          // but a significantly smaller executable, since V8 only allows
+          // storing strings as either ISO-8859-1 or UTF-16 and UTF-16 takes
+          // up twice the space that ISO-8859-1 strings do.
+          output: { ascii_only: true },
           // Not keeping classnames breaks shell-api during minification
           keep_classnames: true,
           compress: {


### PR DESCRIPTION
This results in:

- A 2.5 % larger generated CLI JS bundle file
- A 15.7 % smaller generated CLI executable file
- A 3.5 % faster startup time overall (measured for `--version`)