### PR TITLE
Fix path for built libs

### DIFF
--- a/scripts/prep-fle-addon.sh
+++ b/scripts/prep-fle-addon.sh
@@ -89,6 +89,6 @@ fi
 if [ x"$FLE_NODE_SOURCE_PATH" != x"" ]; then
   mkdir -p "$FLE_NODE_SOURCE_PATH"/deps/lib
   mkdir -p "$FLE_NODE_SOURCE_PATH"/deps/include
-  cp -rv "$BUILDROOT"/lib/*-static* "$FLE_NODE_SOURCE_PATH"/deps/lib
+  cp -rv "$BUILDROOT"/lib*/*-static* "$FLE_NODE_SOURCE_PATH"/deps/lib
   cp -rv "$BUILDROOT"/include/*{kms,mongocrypt}* "$FLE_NODE_SOURCE_PATH"/deps/include
 fi


### PR DESCRIPTION
The suggested change is for the case when someone wants to build libmongocrypt locally, instead of using prebuilt binaries, but the build fails, because "*-static*" libs cannot be found.

Depending on the system used for the build, libraries can be put into
"lib64" folder, instead of "lib", for example(oraclelinux 8):

[jenkins@464de3faf24f cmake-build]$ cmake -DCMAKE_INSTALL_PREFIX=./tmp/fle-buildroot -DCMAKE_PREFIX_PATH=./tmp/fle-buildroot -DDISABLE_NATIVE_CRYPTO=1 ..
...
[jenkins@464de3faf24f cmake-build]$ make -j8 install
...
[100%] Linking C executable test-mongocrypt
[100%] Built target test-mongocrypt
Install the project...
-- Install configuration: ""
-- Installing: /home/jenkins/libmongocrypt/cmake-build/tmp/fle-buildroot/**lib64**/libbson-static-for-libmongocrypt.a
-- Installing: /home/jenkins/libmongocrypt/cmake-build/tmp/fle-buildroot/**lib64**/libmongocrypt.so.0.0.0
-- Installing: /home/jenkins/libmongocrypt/cmake-build/tmp/fle-buildroot/**lib64**/libmongocrypt.so.0
-- Installing: /home/jenkins/libmongocrypt/cmake-build/tmp/fle-buildroot/**lib64**/libmongocrypt.so
-- Installing: /home/jenkins/libmongocrypt/cmake-build/tmp/fle-buildroot/**lib64**/libmongocrypt-static.a
...
