### PR TITLE
fix(shell-api): don't pass options into cursor.close() MONGOSH-1356

### DIFF
--- a/packages/shell-api/src/abstract-cursor.ts
+++ b/packages/shell-api/src/abstract-cursor.ts
@@ -53,8 +53,8 @@ export abstract class AbstractCursor<CursorType extends ServiceProviderAggregati
   }
 
   @returnsPromise
-  async close(options: Document = {}): Promise<void> {
-    await this._cursor.close(options);
+  async close(): Promise<void> {
+    await this._cursor.close();
   }
 
   @returnsPromise

--- a/packages/shell-api/src/aggregation-cursor.spec.ts
+++ b/packages/shell-api/src/aggregation-cursor.spec.ts
@@ -75,7 +75,6 @@ describe('AggregationCursor', () => {
     describe('#close', () => {
       let spCursor: StubbedInstance<SPAggregationCursor>;
       let shellApiCursor;
-      const options = { skipKillCursors: true };
 
       beforeEach(() => {
         spCursor = stubInterface<SPAggregationCursor>();
@@ -83,8 +82,8 @@ describe('AggregationCursor', () => {
       });
 
       it('closes the cursor', () => {
-        shellApiCursor.close(options);
-        expect(spCursor.close).to.have.been.calledWith(options);
+        shellApiCursor.close();
+        expect(spCursor.close).to.have.been.called;
       });
     });
 

--- a/packages/shell-api/src/cursor.spec.ts
+++ b/packages/shell-api/src/cursor.spec.ts
@@ -174,7 +174,6 @@ describe('Cursor', () => {
     describe('#close', () => {
       let spCursor: StubbedInstance<ServiceProviderCursor>;
       let shellApiCursor;
-      const options = { skipKillCursors: true };
 
       beforeEach(() => {
         spCursor = stubInterface<ServiceProviderCursor>();
@@ -182,8 +181,8 @@ describe('Cursor', () => {
       });
 
       it('closes the cursor', () => {
-        shellApiCursor.close(options);
-        expect(spCursor.close).to.have.been.calledWith(options);
+        shellApiCursor.close();
+        expect(spCursor.close).to.have.been.called;
       });
     });
 


### PR DESCRIPTION
Here's a patch from the driver running against the changes in this branch: 

https://spruce.mongodb.com/version/63b7157961837d672d740cca/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC