### PR TITLE
fix(server-provider-core): don't import MapReduceOptions from Node driver

### DIFF
--- a/packages/service-provider-core/src/all-transport-types.ts
+++ b/packages/service-provider-core/src/all-transport-types.ts
@@ -46,7 +46,6 @@ export type {
   ListCollectionsOptions,
   ListDatabasesOptions,
   ListIndexesOptions,
-  MapReduceOptions,
   MongoClientOptions,
   OrderedBulkOperation,
   ReadConcern,

--- a/packages/service-provider-core/src/index.ts
+++ b/packages/service-provider-core/src/index.ts
@@ -26,6 +26,8 @@ import ShellAuthOptions from './shell-auth-options';
 export * from './all-transport-types';
 export * from './all-fle-types';
 
+export { MapReduceOptions, FinalizeFunction } from './map-reduce-options';
+
 const bson = {
   ObjectId,
   DBRef,

--- a/packages/service-provider-core/src/map-reduce-options.ts
+++ b/packages/service-provider-core/src/map-reduce-options.ts
@@ -1,4 +1,4 @@
-import { CommandOperationOptions, Document, ObjectId, Sort } from 'mongodb';
+import type { CommandOperationOptions, Document, ObjectId, Sort } from 'mongodb';
 
 export type FinalizeFunction<TKey = ObjectId, TValue = Document> = (
   key: TKey,

--- a/packages/service-provider-core/src/map-reduce-options.ts
+++ b/packages/service-provider-core/src/map-reduce-options.ts
@@ -1,0 +1,30 @@
+import { CommandOperationOptions, Document, ObjectId, Sort } from 'mongodb';
+
+export type FinalizeFunction<TKey = ObjectId, TValue = Document> = (
+  key: TKey,
+  reducedValue: TValue
+) => TValue;
+
+export interface MapReduceOptions<TKey = ObjectId, TValue = Document>
+  extends CommandOperationOptions {
+  /** Sets the output target for the map reduce job. */
+  out?: 'inline' | { inline: 1 } | { replace: string } | { merge: string } | { reduce: string };
+  /** Query filter object. */
+  query?: Document;
+  /** Sorts the input objects using this key. Useful for optimization, like sorting by the emit key for fewer reduces. */
+  sort?: Sort;
+  /** Number of objects to return from collection. */
+  limit?: number;
+  /** Keep temporary data. */
+  keeptemp?: boolean;
+  /** Finalize function. */
+  finalize?: FinalizeFunction<TKey, TValue> | string;
+  /** Can pass in variables that can be access from map/reduce/finalize. */
+  scope?: Document;
+  /** It is possible to make the execution stay in JS. Provided in MongoDB \> 2.0.X. */
+  jsMode?: boolean;
+  /** Provide statistics on job execution time. */
+  verbose?: boolean;
+  /** Allow driver to bypass schema validation in MongoDB 3.2 or higher. */
+  bypassDocumentValidation?: boolean;
+}


### PR DESCRIPTION
https://github.com/mongodb/node-mongodb-native/pull/3511 removes support for `MapReduce` in the Node driver. 

This PR moves `MapReduceOptions` and `FinalizeFunction` from the driver into mongosh.

Alternatively, we could replace `MapReduceOptions` with `Document` instead of moving the definition out of the driver but since it's only two small interfaces, I felt that it's not a huge burden to maintain.

Example CI run from the driver with no MapReduce and the changes in this PR: https://spruce.mongodb.com/version/63bc2438d6d80a31a0a43fb3/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC