### PR TITLE
feat(shell-api): use collStats aggregation stage instead of command for collection.stats() MONGOSH-1157

### DIFF
--- a/packages/shell-api/src/collection.spec.ts
+++ b/packages/shell-api/src/collection.spec.ts
@@ -1143,15 +1143,10 @@ describe('Collection', () => {
       context('deprecated fallback', () => {
         context('when the aggregation fails with error code that is not `13388`', () => {
           beforeEach(() => {
-            // const getCollStats = sinon.stub();
-            // getCollStats.onCall(0).resolves({ storageStats: {} });
-            // serviceProvider.runCommandWithCheck.resolves(expectedResult);
-
             const tryNext = sinon.stub();
             const mockError: any = new Error('test error');
             mockError.code = 123;
             tryNext.onCall(0).rejects(mockError);
-            // tryNext.onCall(1).resolves(null);
             serviceProvider.aggregate.returns({ tryNext } as any);
           });
 
@@ -1165,15 +1160,10 @@ describe('Collection', () => {
 
         context('when the aggregation fails with error code `13388`', () => {
           beforeEach(() => {
-            // const getCollStats = sinon.stub();
-            // getCollStats.onCall(0).resolves({ storageStats: {} });
-            // serviceProvider.runCommandWithCheck.resolves(expectedResult);
-
             const tryNext = sinon.stub();
             const mockError: any = new Error('test error');
             mockError.code = 13388;
             tryNext.onCall(0).rejects(mockError);
-            // tryNext.onCall(1).resolves(null);
             serviceProvider.aggregate.returns({ tryNext } as any);
           });
 

--- a/packages/shell-api/src/collection.spec.ts
+++ b/packages/shell-api/src/collection.spec.ts
@@ -1083,7 +1083,7 @@ describe('Collection', () => {
     describe('stats', () => {
       beforeEach(() => {
         const tryNext = sinon.stub();
-        tryNext.onCall(0).resolves({ value: 1000 });
+        tryNext.onCall(0).resolves({ storageStats: {} });
         tryNext.onCall(1).resolves(null);
         serviceProvider.aggregate.returns({ tryNext } as any);
       });
@@ -1137,10 +1137,14 @@ describe('Collection', () => {
         let expectedResult;
         let indexesResult;
         beforeEach(() => {
-          expectedResult = { ok: 1, indexDetails: { k1_1: { details: 1 }, k2_1: { details: 2 } } };
+          expectedResult = {
+            indexDetails: { k1_1: { details: 1 }, k2_1: { details: 2 } },
+          };
           indexesResult = [ { v: 2, key: { k1: 1 }, name: 'k1_1' }, { v: 2, key: { k2: 1 }, name: 'k2_1' }];
           const tryNext = sinon.stub();
-          tryNext.onCall(0).resolves(expectedResult);
+          tryNext.onCall(0).resolves({
+            storageStats: expectedResult
+          });
           tryNext.onCall(1).resolves(null);
           serviceProvider.aggregate.returns({ tryNext } as any);
           serviceProvider.getIndexes.resolves(indexesResult);

--- a/packages/shell-api/src/collection.spec.ts
+++ b/packages/shell-api/src/collection.spec.ts
@@ -1082,6 +1082,11 @@ describe('Collection', () => {
 
     describe('stats', () => {
       beforeEach(() => {
+        const serviceProviderCursor = stubInterface<ServiceProviderCursor>();
+        serviceProviderCursor.limit.returns(serviceProviderCursor);
+        serviceProviderCursor.tryNext.returns();
+        serviceProvider.find.returns(serviceProviderCursor);
+
         const tryNext = sinon.stub();
         tryNext.onCall(0).resolves({ storageStats: {} });
         tryNext.onCall(1).resolves(null);
@@ -1103,7 +1108,7 @@ describe('Collection', () => {
         });
       });
 
-      it('calls serviceProvider.aggregate on the database with scale option', async() => {
+      it('calls serviceProvider.aggregate on the database with the default scale option', async() => {
         await collection.stats({ scale: 2 });
 
         expect(serviceProvider.aggregate).to.have.been.calledOnce;
@@ -1112,13 +1117,14 @@ describe('Collection', () => {
         expect(serviceProvider.aggregate.firstCall.args[2][0]).to.deep.equal({
           '$collStats': {
             storageStats: {
-              scale: 2
+              // We scale the results ourselves, this checks we are passing the default scale.
+              scale: 1
             }
           }
         });
       });
 
-      it('calls serviceProvider.aggregate on the database with legacy scale', async() => {
+      it('calls serviceProvider.aggregate on the database with default scale when legacy scale is passed', async() => {
         await collection.stats(2);
 
         expect(serviceProvider.aggregate).to.have.been.calledOnce;
@@ -1127,23 +1133,116 @@ describe('Collection', () => {
         expect(serviceProvider.aggregate.firstCall.args[2][0]).to.deep.equal({
           '$collStats': {
             storageStats: {
-              scale: 2
+              // We scale the results ourselves, this checks we are passing the default scale.
+              scale: 1
             }
           }
+        });
+      });
+
+      context('deprecated fallback', () => {
+        context('when the aggregation fails with error code that is not `13388`', () => {
+          beforeEach(() => {
+            // const getCollStats = sinon.stub();
+            // getCollStats.onCall(0).resolves({ storageStats: {} });
+            // serviceProvider.runCommandWithCheck.resolves(expectedResult);
+
+            const tryNext = sinon.stub();
+            const mockError: any = new Error('test error');
+            mockError.code = 123;
+            tryNext.onCall(0).rejects(mockError);
+            // tryNext.onCall(1).resolves(null);
+            serviceProvider.aggregate.returns({ tryNext } as any);
+          });
+
+          it('does not run the deprecated collStats command', async() => {
+            const error = await collection.stats().catch(e => e);
+
+            expect(serviceProvider.runCommandWithCheck).to.not.have.been.called;
+            expect(error.message).to.equal('test error');
+          });
+        });
+
+        context('when the aggregation fails with error code `13388`', () => {
+          beforeEach(() => {
+            // const getCollStats = sinon.stub();
+            // getCollStats.onCall(0).resolves({ storageStats: {} });
+            // serviceProvider.runCommandWithCheck.resolves(expectedResult);
+
+            const tryNext = sinon.stub();
+            const mockError: any = new Error('test error');
+            mockError.code = 13388;
+            tryNext.onCall(0).rejects(mockError);
+            // tryNext.onCall(1).resolves(null);
+            serviceProvider.aggregate.returns({ tryNext } as any);
+          });
+
+          it('runs the deprecated collStats command with the default scale', async() => {
+            await collection.stats();
+
+            expect(serviceProvider.runCommandWithCheck).to.have.been.calledWith(
+              database._name,
+              { collStats: collection._name, scale: 1 }
+            );
+          });
+
+          it('runs the deprecated collStats command with a custom scale', async() => {
+            await collection.stats({
+              scale: 1024 // Scale to kilobytes.
+            });
+
+            expect(serviceProvider.runCommandWithCheck).to.have.been.calledWith(
+              database._name,
+              { collStats: collection._name, scale: 1024 }
+            );
+          });
+
+          it('runs the deprecated collStats command with the legacy scale parameter', async() => {
+            await collection.stats(2);
+
+            expect(serviceProvider.runCommandWithCheck).to.have.been.calledWith(
+              database._name,
+              { collStats: collection._name, scale: 2 }
+            );
+          });
+
+          context('when the fallback collStats command fails', () => {
+            beforeEach(() => {
+              serviceProvider.runCommandWithCheck.rejects(new Error('not our error'));
+            });
+
+            it('surfaces the original aggregation error', async() => {
+              const error = await collection.stats().catch(e => e);
+
+              expect(serviceProvider.runCommandWithCheck).to.have.been.called;
+              expect(error.message).to.equal('test error');
+            });
+          });
         });
       });
 
       context('indexDetails', () => {
         let expectedResult;
         let indexesResult;
+
         beforeEach(() => {
           expectedResult = {
+            avgObjSize: 0,
+            indexSizes: {},
+            maxSize: 0,
+            nindexes: 0,
+            scaleFactor: 1,
             indexDetails: { k1_1: { details: 1 }, k2_1: { details: 2 } },
+            ok: 1,
+            ns: 'db1.coll1',
+            sharded: false,
           };
           indexesResult = [ { v: 2, key: { k1: 1 }, name: 'k1_1' }, { v: 2, key: { k2: 1 }, name: 'k2_1' }];
           const tryNext = sinon.stub();
           tryNext.onCall(0).resolves({
-            storageStats: expectedResult
+            storageStats: {
+              indexDetails: expectedResult.indexDetails
+            }
           });
           tryNext.onCall(1).resolves(null);
           serviceProvider.aggregate.returns({ tryNext } as any);
@@ -1151,11 +1250,15 @@ describe('Collection', () => {
         });
         it('not returned when no args', async() => {
           const result = await collection.stats();
-          expect(result).to.deep.equal({ ok: 1 });
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          const { indexDetails, ...expectedResultWithoutIndexDetails } = expectedResult;
+          expect(result).to.deep.equal(expectedResultWithoutIndexDetails);
         });
         it('not returned when options indexDetails: false', async() => {
           const result = await collection.stats({ indexDetails: false });
-          expect(result).to.deep.equal({ ok: 1 });
+          // eslint-disable-next-line @typescript-eslint/no-unused-vars
+          const { indexDetails, ...expectedResultWithoutIndexDetails } = expectedResult;
+          expect(result).to.deep.equal(expectedResultWithoutIndexDetails);
         });
         it('returned all when true, even if no key/name set', async() => {
           const result = await collection.stats({ indexDetails: true });
@@ -1163,7 +1266,7 @@ describe('Collection', () => {
         });
         it('returned only 1 when indexDetailsName set', async() => {
           const result = await collection.stats({ indexDetails: true, indexDetailsName: 'k2_1' });
-          expect(result).to.deep.equal({ ok: 1, indexDetails: { 'k2_1': expectedResult.indexDetails.k2_1 } });
+          expect(result).to.deep.equal({ ...expectedResult, indexDetails: { 'k2_1': expectedResult.indexDetails.k2_1 } });
         });
         it('returned all when indexDetailsName set but not found', async() => {
           const result = await collection.stats({ indexDetails: true, indexDetailsName: 'k3_1' });
@@ -1171,7 +1274,7 @@ describe('Collection', () => {
         });
         it('returned only 1 when indexDetailsKey set', async() => {
           const result = await collection.stats({ indexDetails: true, indexDetailsKey: indexesResult[1].key });
-          expect(result).to.deep.equal({ ok: 1, indexDetails: { 'k2_1': expectedResult.indexDetails.k2_1 } });
+          expect(result).to.deep.equal({ ...expectedResult, indexDetails: { 'k2_1': expectedResult.indexDetails.k2_1 } });
         });
         it('returned all when indexDetailsKey set but not found', async() => {
           const result = await collection.stats({ indexDetails: true, indexDetailsKey: { other: 1 } });

--- a/packages/shell-api/src/collection.spec.ts
+++ b/packages/shell-api/src/collection.spec.ts
@@ -1220,7 +1220,6 @@ describe('Collection', () => {
             avgObjSize: 0,
             indexSizes: {},
             nindexes: 0,
-            scaleFactor: 1,
             indexDetails: { k1_1: { details: 1 }, k2_1: { details: 2 } },
             ok: 1,
             ns: 'db1.coll1',

--- a/packages/shell-api/src/collection.spec.ts
+++ b/packages/shell-api/src/collection.spec.ts
@@ -1219,7 +1219,6 @@ describe('Collection', () => {
           expectedResult = {
             avgObjSize: 0,
             indexSizes: {},
-            maxSize: 0,
             nindexes: 0,
             scaleFactor: 1,
             indexDetails: { k1_1: { details: 1 }, k2_1: { details: 2 } },

--- a/packages/shell-api/src/collection.ts
+++ b/packages/shell-api/src/collection.ts
@@ -1571,7 +1571,7 @@ export default class Collection extends ShellApiWithMongoClass {
             }
           }
         } else if (
-          // NOTE: `numOrphanDocs` is new in 6.0.
+          // NOTE: `numOrphanDocs` is new in 6.0. `totalSize` is new in 4.4.
           ['count', 'size', 'storageSize', 'totalIndexSize', 'totalSize', 'numOrphanDocs'].includes(fieldName)
         ) {
           if (counts[fieldName] === undefined) {
@@ -1654,7 +1654,10 @@ export default class Collection extends ShellApiWithMongoClass {
     }
     result.ns = ns;
     result.nindexes = nindexes;
-    result.scaleFactor = scale;
+    if (collStats[0].storageStats.scaleFactor !== undefined) {
+      // The `scaleFactor` property started being returned in 4.2.
+      result.scaleFactor = scale;
+    }
     result.ok = 1;
 
     return result;

--- a/packages/shell-api/src/collection.ts
+++ b/packages/shell-api/src/collection.ts
@@ -1730,32 +1730,6 @@ export default class Collection extends ShellApiWithMongoClass {
 
     const result = await this._getAggregatedCollStats(options.scale);
 
-    // Unknowns/TODO:
-    // - Do we want to use the fallback for Data Lake until https://jira.mongodb.org/browse/MHOUSE-5872
-    // - Is it alright that the output format of db.coll.stats() is changing?
-    //      Using the aggregation $collStats stage does not return the same data
-    //      as the deprecated collStats command. We're making it similar,
-    //      but I don't think it's the same. Let's write a diff:
-    //        - `primary` is not given now.
-    //        - `nchunks` is not given now.
-    // - Previously db.coll.stats() took a number of options like indexDetailsKey
-    //      Can we remove those options?
-    //      Should the options more transparently map to the $collStats options?
-    //      Can we remove the legacy scale argument handling?
-    //      Original server ticket: https://jira.mongodb.org/browse/SERVER-16782
-    //      My thoughts:
-    //        - Let's try to remove all of them if we can but that should be in a separate pr with a separate ticket.
-    // - Previously db.coll.stats() would error on view.
-    //      We could make it so that it doesn't supply the storageStats option on views for the agg
-    //      so that it doesn't error... do we want to?
-    //      My thoughts: Not much data to give back, so I'm thinking no. (looks like it would only be returning `ns`, `host`, and `localTime`).
-    // - Do we have the scale argument handled correctly?
-    //      We may need to scale everything ourselves so that the sums work nicely.
-    // - Do we want to keep passing `ok: 1` in the command result?
-    //      Now that we're using the aggregation it's something we're adding ourselves.
-    // - Is the way we're checking for sharding okay? Is there a better way? Does the current way require permissions?
-    // - Coerce to js number for everything? (maybe only for max size as it's a long?)
-
     let filterIndexName = options.indexDetailsName;
     if (!filterIndexName && options.indexDetailsKey) {
       const indexes = await this._mongo._serviceProvider.getIndexes(this._database._name, this._name, await this._database._baseOptions());

--- a/packages/shell-api/src/collection.ts
+++ b/packages/shell-api/src/collection.ts
@@ -1561,13 +1561,13 @@ export default class Collection extends ShellApiWithMongoClass {
                 timeseriesBucketsNs = timeseriesStat;
               }
             } else if (timeseriesStatName === 'avgBucketSize') {
-              timeseriesTotalBucketSize += shardTimeseriesStats.bucketCount * timeseriesStat;
+              timeseriesTotalBucketSize += coerceToJSNumber(shardTimeseriesStats.bucketCount) * coerceToJSNumber(timeseriesStat);
             } else {
               // Simple summation for other types of stats.
               if (clusterTimeseriesStats[timeseriesStatName] === undefined) {
                 clusterTimeseriesStats[timeseriesStatName] = 0;
               }
-              clusterTimeseriesStats[timeseriesStatName] += timeseriesStat;
+              clusterTimeseriesStats[timeseriesStatName] += coerceToJSNumber(timeseriesStat);
             }
           }
         } else if (
@@ -1577,19 +1577,19 @@ export default class Collection extends ShellApiWithMongoClass {
           if (counts[fieldName] === undefined) {
             counts[fieldName] = 0;
           }
-          counts[fieldName] += shardStorageStats[fieldName];
+          counts[fieldName] += coerceToJSNumber(shardStorageStats[fieldName]);
         } else if (fieldName === 'avgObjSize') {
-          const shardAvgObjSize = shardStorageStats[fieldName];
+          const shardAvgObjSize = coerceToJSNumber(shardStorageStats[fieldName]);
           unscaledCollSize += shardAvgObjSize * shardObjCount;
         } else if (fieldName === 'maxSize') {
-          const shardMaxSize = shardStorageStats[fieldName];
+          const shardMaxSize = coerceToJSNumber(shardStorageStats[fieldName]);
           maxSize = Math.max(maxSize, shardMaxSize);
         } else if (fieldName === 'indexSizes') {
           for (const indexName of Object.keys(shardStorageStats[fieldName])) {
             if (indexSizes[indexName] === undefined) {
               indexSizes[indexName] = 0;
             }
-            indexSizes[indexName] += shardStorageStats[fieldName][indexName];
+            indexSizes[indexName] += coerceToJSNumber(shardStorageStats[fieldName][indexName]);
           }
         } else if (fieldName === 'nindexes') {
           const shardIndexes = shardStorageStats[fieldName];

--- a/packages/shell-api/src/collection.ts
+++ b/packages/shell-api/src/collection.ts
@@ -1627,7 +1627,6 @@ export default class Collection extends ShellApiWithMongoClass {
         result[countField] = count;
       }
     }
-
     if (timeseriesBucketsNs && Object.keys(clusterTimeseriesStats).length > 0) {
       result.timeseries = {
         ...clusterTimeseriesStats,
@@ -1643,7 +1642,6 @@ export default class Collection extends ShellApiWithMongoClass {
       // Scale the index sizes with the scale option passed by the user.
       result.indexSizes[indexName] = indexSize / scale;
     }
-
     // The unscaled avgObjSize for each shard is used to get the unscaledCollSize because the
     // raw size returned by the shard is affected by the command's scale parameter
     if (counts.count > 0) {
@@ -1651,9 +1649,10 @@ export default class Collection extends ShellApiWithMongoClass {
     } else {
       result.avgObjSize = 0;
     }
-
+    if (result.capped) {
+      result.maxSize = maxSize / scale;
+    }
     result.ns = ns;
-    result.maxSize = maxSize / scale;
     result.nindexes = nindexes;
     result.scaleFactor = scale;
     result.ok = 1;

--- a/packages/shell-api/src/database.spec.ts
+++ b/packages/shell-api/src/database.spec.ts
@@ -2056,7 +2056,11 @@ describe('Database', () => {
       });
       it('returns an object with per-collection stats', async() => {
         serviceProvider.listCollections.resolves([{ name: 'abc' }]);
-        serviceProvider.runCommandWithCheck.resolves({ ok: 1, totalSize: 1000 });
+        const expectedResult = { ok: 1, totalSize: 1000 };
+        const tryNext = sinon.stub();
+        tryNext.onCall(0).resolves(expectedResult);
+        tryNext.onCall(1).resolves(null);
+        serviceProvider.aggregate.returns({ tryNext } as any);
         const result = await database.printCollectionStats(1);
         expect(result.value.abc).to.deep.equal({ ok: 1, totalSize: 1000 });
       });

--- a/packages/shell-api/src/database.spec.ts
+++ b/packages/shell-api/src/database.spec.ts
@@ -2073,7 +2073,6 @@ describe('Database', () => {
           indexSizes: {},
           nindexes: 0,
           ns: 'db1.abc',
-          scaleFactor: 1,
           sharded: false,
           totalSize: 1000
         });

--- a/packages/shell-api/src/helpers.ts
+++ b/packages/shell-api/src/helpers.ts
@@ -527,7 +527,7 @@ export function scaleIndividualShardStatistics(shardStats: Document, scale: numb
 
   for (const fieldName of Object.keys(shardStats)) {
     if (['size', 'maxSize', 'storageSize', 'totalIndexSize', 'totalSize'].includes(fieldName)) {
-      scaledStats[fieldName] = shardStats[fieldName] / scale;
+      scaledStats[fieldName] = coerceToJSNumber(shardStats[fieldName]) / scale;
     } else if (fieldName === 'scaleFactor') {
       // Explicitly change the scale factor as we removed the scaling before getting the
       // individual shards statistics.
@@ -535,7 +535,7 @@ export function scaleIndividualShardStatistics(shardStats: Document, scale: numb
     } else if (fieldName === 'indexSizes') {
       const scaledIndexSizes: Document = {};
       for (const indexKey of Object.keys(shardStats[fieldName])) {
-        scaledIndexSizes[indexKey] = shardStats[fieldName][indexKey] / scale;
+        scaledIndexSizes[indexKey] = coerceToJSNumber(shardStats[fieldName][indexKey]) / scale;
       }
       scaledStats[fieldName] = scaledIndexSizes;
     } else {

--- a/packages/shell-api/src/helpers.ts
+++ b/packages/shell-api/src/helpers.ts
@@ -527,7 +527,7 @@ export function scaleIndividualShardStatistics(shardStats: Document, scale: numb
 
   for (const fieldName of Object.keys(shardStats)) {
     if (['size', 'maxSize', 'storageSize', 'totalIndexSize', 'totalSize'].includes(fieldName)) {
-      scaledStats[fieldName] = Number(shardStats[fieldName]) / scale;
+      scaledStats[fieldName] = shardStats[fieldName] / scale;
     } else if (fieldName === 'scaleFactor') {
       // Explicitly change the scale factor as we removed the scaling before getting the
       // individual shards statistics.
@@ -535,8 +535,7 @@ export function scaleIndividualShardStatistics(shardStats: Document, scale: numb
     } else if (fieldName === 'indexSizes') {
       const scaledIndexSizes: Document = {};
       for (const indexKey of Object.keys(shardStats[fieldName])) {
-        // TODO: Do we need to number convert?
-        scaledIndexSizes[indexKey] = Number(shardStats[fieldName][indexKey]) / scale;
+        scaledIndexSizes[indexKey] = shardStats[fieldName][indexKey] / scale;
       }
       scaledStats[fieldName] = scaledIndexSizes;
     } else {

--- a/packages/shell-api/src/helpers.ts
+++ b/packages/shell-api/src/helpers.ts
@@ -530,7 +530,7 @@ export function scaleIndividualShardStatistics(shardStats: Document, scale: numb
       scaledStats[fieldName] = coerceToJSNumber(shardStats[fieldName]) / scale;
     } else if (fieldName === 'scaleFactor') {
       // Explicitly change the scale factor as we removed the scaling before getting the
-      // individual shards statistics.
+      // individual shards statistics. This started being returned in 4.2.
       scaledStats[fieldName] = scale;
     } else if (fieldName === 'indexSizes') {
       const scaledIndexSizes: Document = {};

--- a/packages/shell-api/src/helpers.ts
+++ b/packages/shell-api/src/helpers.ts
@@ -522,6 +522,32 @@ export function dataFormat(bytes?: number): string {
   return Math.floor((Math.floor(bytes / (1024 * 1024)) / 1024) * 100) / 100 + 'GiB';
 }
 
+export function scaleIndividualShardStatistics(shardStats: Document, scale: number) {
+  const scaledStats: Document = {};
+
+  for (const fieldName of Object.keys(shardStats)) {
+    if (['size', 'maxSize', 'storageSize', 'totalIndexSize', 'totalSize'].includes(fieldName)) {
+      scaledStats[fieldName] = Number(shardStats[fieldName]) / scale;
+    } else if (fieldName === 'scaleFactor') {
+      // Explicitly change the scale factor as we removed the scaling before getting the
+      // individual shards statistics.
+      scaledStats[fieldName] = scale;
+    } else if (fieldName === 'indexSizes') {
+      const scaledIndexSizes: Document = {};
+      for (const indexKey of Object.keys(shardStats[fieldName])) {
+        // TODO: Do we need to number convert?
+        scaledIndexSizes[indexKey] = Number(shardStats[fieldName][indexKey]) / scale;
+      }
+      scaledStats[fieldName] = scaledIndexSizes;
+    } else {
+      // All the other fields that do not require further scaling.
+      scaledStats[fieldName] = shardStats[fieldName];
+    }
+  }
+
+  return scaledStats;
+}
+
 export function tsToSeconds(x: any): number {
   if (x.t && x.i) {
     return x.t;

--- a/packages/shell-api/src/integration.spec.ts
+++ b/packages/shell-api/src/integration.spec.ts
@@ -702,11 +702,6 @@ describe('Shell API (integration)', function() {
           'wiredTiger'
         );
       });
-
-      // TODO: Show scale.
-      // TODO: Accuracy checks.
-      // TODO: Sharded check.
-      // TODO: Time series check.
     });
 
     describe('drop', () => {

--- a/packages/shell-api/src/integration.spec.ts
+++ b/packages/shell-api/src/integration.spec.ts
@@ -702,6 +702,11 @@ describe('Shell API (integration)', function() {
           'wiredTiger'
         );
       });
+
+      // TODO: Show scale.
+      // TODO: Accuracy checks.
+      // TODO: Sharded check.
+      // TODO: Time series check.
     });
 
     describe('drop', () => {
@@ -1173,7 +1178,9 @@ describe('Shell API (integration)', function() {
 
       it('creates a collection without options', async() => {
         await database.createCollection('newcoll');
-        const stats = await serviceProvider.runCommand(dbName, { collStats: 'newcoll' });
+        const stats = await (
+          serviceProvider.aggregate(dbName, 'newcoll', [{ $collStats: { storageStats: {} } }])
+        ).toArray()[0];
         expect(stats.nindexes).to.equal(1);
       });
 
@@ -1183,7 +1190,9 @@ describe('Shell API (integration)', function() {
           size: 1024,
           max: 5000
         });
-        const stats = await serviceProvider.runCommand(dbName, { collStats: 'newcoll' });
+        const stats = await (
+          serviceProvider.aggregate(dbName, 'newcoll', [{ $collStats: { storageStats: {} } }])
+        ).toArray()[0];
         expect(stats.nindexes).to.equal(1);
         expect(stats.capped).to.equal(true);
         expect(stats.maxSize).to.equal(1024);

--- a/packages/shell-api/src/integration.spec.ts
+++ b/packages/shell-api/src/integration.spec.ts
@@ -702,6 +702,31 @@ describe('Shell API (integration)', function() {
           'wiredTiger'
         );
       });
+
+      context('with a capped collection', () => {
+        const cappedCollectionName = 'cappedcoll';
+        beforeEach(async() => {
+          await serviceProvider.createCollection(
+            dbName,
+            cappedCollectionName,
+            {
+              capped: true,
+              size: 8192,
+              max: 5000
+            }
+          );
+        });
+
+        it('returns the scaled maxSize', async() => {
+          const cappedCollection = database.getCollection(cappedCollectionName);
+          const stats = await cappedCollection.stats({ scale: 1024 });
+
+          expect(stats.maxSize).to.equal(8);
+          expect(stats.max).to.equal(5000);
+        });
+      });
+
+      // TODO: Time series collection.
     });
 
     describe('drop', () => {

--- a/packages/shell-api/src/integration.spec.ts
+++ b/packages/shell-api/src/integration.spec.ts
@@ -1178,10 +1178,10 @@ describe('Shell API (integration)', function() {
 
       it('creates a collection without options', async() => {
         await database.createCollection('newcoll');
-        const stats = await (
+        const stats = (await (
           serviceProvider.aggregate(dbName, 'newcoll', [{ $collStats: { storageStats: {} } }])
-        ).toArray()[0];
-        expect(stats.nindexes).to.equal(1);
+        ).toArray())[0];
+        expect(stats.storageStats.nindexes).to.equal(1);
       });
 
       it('creates a collection with options', async() => {
@@ -1190,13 +1190,13 @@ describe('Shell API (integration)', function() {
           size: 1024,
           max: 5000
         });
-        const stats = await (
+        const stats = (await (
           serviceProvider.aggregate(dbName, 'newcoll', [{ $collStats: { storageStats: {} } }])
-        ).toArray()[0];
-        expect(stats.nindexes).to.equal(1);
-        expect(stats.capped).to.equal(true);
-        expect(stats.maxSize).to.equal(1024);
-        expect(stats.max).to.equal(5000);
+        ).toArray())[0];
+        expect(stats.storageStats.nindexes).to.equal(1);
+        expect(stats.storageStats.capped).to.equal(true);
+        expect(stats.storageStats.maxSize).to.equal(1024);
+        expect(stats.storageStats.max).to.equal(5000);
       });
     });
     describe('createView', () => {

--- a/packages/shell-api/src/shard.spec.ts
+++ b/packages/shell-api/src/shard.spec.ts
@@ -1504,6 +1504,8 @@ describe('Shard', () => {
             expect(shard.indexDetails._id_.metadata.formatVersion).to.be.a('number');
           }
         });
+        // TODO: Scale output.
+        // TODO: Timeseries?
       });
     });
     describe('collection.isCapped', () => {

--- a/packages/shell-api/src/shard.spec.ts
+++ b/packages/shell-api/src/shard.spec.ts
@@ -1507,6 +1507,43 @@ describe('Shard', () => {
         // TODO: Scale output.
         // TODO: Timeseries?
       });
+      // context('sharded timeseries collections', () => {
+      //   beforeEach(async() => {
+      //     expect((await sh.enableSharding(dbName)).ok).to.equal(1);
+      //     expect((await sh.shardCollection(ns, { key: 1 })).collectionsharded).to.equal(ns);
+      //   });
+
+      //   it('works without indexDetails', async() => {
+      //     const result = await db.getCollection('test').stats();
+      //     expect(result.sharded).to.equal(true);
+      //     expect(result.count).to.equal(1);
+      //     expect(result.primary).to.equal(undefined);
+      //     for (const shard of Object.values(result.shards) as any[]) {
+      //       if (hasTotalSize) {
+      //         expect(shard.totalSize).to.be.a('number');
+      //       }
+      //       expect(shard.indexDetails).to.equal(undefined);
+      //     }
+      //   });
+      //   it('works with indexDetails', async() => {
+      //     const result = await db.getCollection('test').stats({ indexDetails: true });
+      //     for (const shard of Object.values(result.shards) as any[]) {
+      //       if (hasTotalSize) {
+      //         expect(shard.totalSize).to.be.a('number');
+      //       }
+      //       expect(shard.indexDetails._id_.metadata.formatVersion).to.be.a('number');
+      //     }
+      //   });
+      //   it('scales the results properly', async() => {
+      //     const result = await db.getCollection('test').stats({ indexDetails: true });
+      //     for (const shard of Object.values(result.shards) as any[]) {
+      //       if (hasTotalSize) {
+      //         expect(shard.totalSize).to.be.a('number');
+      //       }
+      //       expect(shard.indexDetails._id_.metadata.formatVersion).to.be.a('number');
+      //     }
+      //   });
+      // });
     });
     describe('collection.isCapped', () => {
       it('returns true for config.changelog', async() => {


### PR DESCRIPTION
MONGOSH-1157

This PR updates our `db.collection.stats()` shell api method to use the [aggregation stage `$collStats`](https://www.mongodb.com/docs/manual/reference/operator/aggregation/collStats/) for fetching collection statistics instead of the [`db.runCommand({ collStats: collectionName })`](https://www.mongodb.com/docs/manual/reference/command/collStats/) form. The run command form is to be deprecated by 7.0 (PM-2362)

The [`$collStats`](https://www.mongodb.com/docs/manual/reference/operator/aggregation/collStats/) stage returns a document for each individual shard's statistics. A lot of the code of this pr involves aggregating those documents into one document to be returned. I initially was trying to do this all in one aggregation pipeline, however I found it was going to be a bit harder to test and maintain. Things like new keys like `numOrphanDocs` added in 6.0 make an aggregation a lot more complex. If curious a fairly non-optimized implementation (without `timeseries` support) can be found on this gist: https://gist.github.com/Anemy/1e3b38f8f4f07f055a8c18d4b6ab443b

The [`$collStats`](https://www.mongodb.com/docs/manual/reference/operator/aggregation/collStats/) aggregation stage fails on sharded timeseries collections so we fallback to the old command form when that error code is encountered.

### Notes

- These changes alter the output format of `db.collection.stats()`
     Using the aggregation $collStats stage does not return the same data
     as the soon to be deprecated collStats command. Namely:
       - `primary` is not given now.
       - `nchunks` is not given now.
    These fields already aren't listed in our documentation: https://www.mongodb.com/docs/manual/reference/command/collStats/ but I'm curious to hear if folks feel we should work to re-add them or have more insights.
