### PR TITLE
fix(service-provider-core): bulk result now marked internal NODE-4034

### DIFF
--- a/packages/service-provider-core/src/all-transport-types.ts
+++ b/packages/service-provider-core/src/all-transport-types.ts
@@ -3,7 +3,6 @@ export type {
   AggregationCursor,
   AnyBulkWriteOperation,
   Batch,
-  BulkResult,
   BulkWriteOptions,
   BulkWriteResult,
   ChangeStream,


### PR DESCRIPTION
`BulkResult` is now marked as internal after https://github.com/mongodb/node-mongodb-native/pull/3515 is merged. This fixes the TS compilation error but has no other effect as it should never have been directly accessed.