### PR TITLE
chore(cli-repl): add ubuntu 22.04 kerberos error message

### DIFF
--- a/packages/cli-repl/test/e2e-auth.spec.ts
+++ b/packages/cli-repl/test/e2e-auth.spec.ts
@@ -928,6 +928,7 @@ describe('Auth e2e', function() {
           'No authority could be contacted for authentication',
           'Error from KDC',
           'No credentials cache file found',
+          'No Kerberos credentials available',
           'The logon attempt failed',
           'Received authentication for mechanism GSSAPI which is not enabled',
           'Received authentication for mechanism GSSAPI which is unknown or not enabled',


### PR DESCRIPTION
This makes this test pass locally on Ubuntu 22.04 for me.