### PR TITLE
feat(shell-api): introduces public Mongo.getURI

### DIFF
--- a/packages/i18n/src/locales/en_US.ts
+++ b/packages/i18n/src/locales/en_US.ts
@@ -1736,6 +1736,10 @@ const translations: Catalog = {
               description: 'Returns an array of all database names. Uses the listDatabases command.',
               example: 'db.getMongo().getDBNames().map(name => db.getSiblingDB(name).getCollectionNames())'
             },
+            getURI: {
+              link: 'https://docs.mongodb.com/manual/reference/method/Mongo.getURI',
+              description: 'Returns the connection string for current session'
+            },
             connect: {
               link: 'https://docs.mongodb.com/manual/reference/method/connect',
               description: 'Creates a connection to a MongoDB instance and returns the reference to the database.'

--- a/packages/shell-api/src/mongo.spec.ts
+++ b/packages/shell-api/src/mongo.spec.ts
@@ -57,13 +57,22 @@ describe('Mongo', () => {
     });
   });
   describe('Metadata', () => {
+    const MONGO_URI = 'localhost:37017';
+    const MONGO_CONNECTION_STRING = 'mongodb://localhost:37017/?directConnection=true&serverSelectionTimeoutMS=2000';
+    const mongo = new Mongo({} as any, MONGO_URI);
+
     describe('toShellResult', () => {
-      const mongo = new Mongo({} as any, 'localhost:37017');
       it('value', async() => {
-        expect((await toShellResult(mongo)).printable).to.equal('mongodb://localhost:37017/?directConnection=true&serverSelectionTimeoutMS=2000');
+        expect((await toShellResult(mongo)).printable).to.equal(MONGO_CONNECTION_STRING);
       });
       it('type', async() => {
         expect((await toShellResult(mongo)).type).to.equal('Mongo');
+      });
+    });
+
+    describe('getURI', () => {
+      it('returns the connection string of active connection', () => {
+        expect(mongo.getURI()).to.equal(MONGO_CONNECTION_STRING);
       });
     });
   });

--- a/packages/shell-api/src/mongo.ts
+++ b/packages/shell-api/src/mongo.ts
@@ -249,6 +249,10 @@ export default class Mongo extends ShellApiClass {
     return this._getDb(db).getCollection(coll);
   }
 
+  getURI(): string {
+    return this._uri;
+  }
+
   use(db: string): string {
     assertArgsDefinedType([db], ['string'], 'Mongo.use');
     this._instanceState.messageBus.emit('mongosh:use', { db });


### PR DESCRIPTION
MONGOSH-545

This PR introduces a public method `getURI` on Mongo which returns connection string of current active connection.