### PR TITLE
chore(node-runtime-worker-thread): remove unused Params type

### DIFF
--- a/packages/node-runtime-worker-thread/src/index.d.ts
+++ b/packages/node-runtime-worker-thread/src/index.d.ts
@@ -42,12 +42,6 @@ declare module 'inline-entry-loader!*' {
   export default entry;
 }
 
-declare type Params<T extends (...args: any) => any> = T extends (
-  ...args: infer P
-) => any
-  ? P
-  : never;
-
 declare type CancelablePromise<T> = Promise<T> & { cancel(): void };
 
 declare type CancelableMethods<T> = {


### PR DESCRIPTION
This is currently not being used, and if we need it, there is always the builtin `Parameters` type in TS which has the same functionality.