### PR TITLE
chore(deps): bump `mongodb-client-encryption` to 2.4.0 & related updates MONGOSH-1370

### DIFF
--- a/packages/cli-repl/test/e2e-fle.spec.ts
+++ b/packages/cli-repl/test/e2e-fle.spec.ts
@@ -44,86 +44,122 @@ describe('FLE tests', () => {
   });
   afterEach(TestShell.cleanup);
 
-  for (const useApiStrict of [ false, true ]) {
-    for (const withSessionToken of [ false, true ]) {
-      // eslint-disable-next-line no-loop-func
-      context(`with AWS KMS (apiStrict=${useApiStrict}, ${withSessionToken ? 'with' : 'without'} sessionToken)`, () => {
-        if (useApiStrict) {
-          skipIfServerVersion(testServer, '< 5.0');
+  function* awsTestCases() {
+    for (const useApiStrict of [ false, true ]) {
+      for (const withSessionToken of [ false, true ]) {
+        for (const withEnvVarCredentials of [ false, true ]) {
+          yield {
+            useApiStrict,
+            withSessionToken,
+            withEnvVarCredentials,
+            testDescription: `with AWS KMS (apiStrict=${useApiStrict}, ` +
+              `${withSessionToken ? 'with' : 'without'} sessionToken, ` +
+              `${withEnvVarCredentials ? 'with' : 'without'} credentials in env vars)`
+          };
         }
+      }
+    }
+  }
 
-        const accessKeyId = 'SxHpYMUtB1CEVg9tX0N1';
-        const secretAccessKey = '44mjXTk34uMUmORma3w1viIAx4RCUv78bzwDY0R7';
-        const sessionToken = 'WXWHMnniSqij0CH27KK7H';
-        async function makeTestShell(): Promise<TestShell> {
-          return TestShell.start({
-            args: [
-              `--cryptSharedLibPath=${cryptLibrary}`,
+  for (const {
+    useApiStrict, withSessionToken, withEnvVarCredentials, testDescription
+  } of awsTestCases()) {
+    // eslint-disable-next-line no-loop-func
+    context(testDescription, () => {
+      if (useApiStrict) {
+        skipIfServerVersion(testServer, '< 5.0');
+      }
+
+      const accessKeyId = 'SxHpYMUtB1CEVg9tX0N1';
+      const secretAccessKey = '44mjXTk34uMUmORma3w1viIAx4RCUv78bzwDY0R7';
+      const sessionToken = 'WXWHMnniSqij0CH27KK7H';
+      async function makeTestShell(): Promise<TestShell> {
+        const shell = TestShell.start({
+          args: [
+            `--cryptSharedLibPath=${cryptLibrary}`,
+            ...(withEnvVarCredentials ? [] : [
+              `--keyVaultNamespace=${dbname}.keyVault`,
               `--awsAccessKeyId=${accessKeyId}`,
               `--awsSecretAccessKey=${secretAccessKey}`,
-              `--keyVaultNamespace=${dbname}.keyVault`,
-              ...(withSessionToken ? [`--awsSessionToken=${sessionToken}`] : []),
-              ...(useApiStrict ? ['--apiStrict', '--apiVersion', '1'] : []),
-              await testServer.connectionString()
-            ],
-            env: {
-              ...process.env,
-              NODE_OPTIONS: '--require ./redirect-network-io.js',
-              REDIRECT_NETWORK_SOURCES: serialize(fakeAWSHandlers.map(({ host }) => host)).toString('base64'),
-              REDIRECT_NETWORK_TARGET: `localhost:${(kmsServer.address() as any).port}`,
-            },
-            cwd: path.join(__dirname, 'fixtures')
-          });
+              ...(withSessionToken ? [`--awsSessionToken=${sessionToken}`] : [])
+            ]),
+            ...(useApiStrict ? ['--apiStrict', '--apiVersion', '1'] : []),
+            await testServer.connectionString()
+          ],
+          env: {
+            ...process.env,
+            NODE_OPTIONS: '--require ./redirect-network-io.js',
+            REDIRECT_NETWORK_SOURCES: serialize(fakeAWSHandlers.map(({ host }) => host)).toString('base64'),
+            REDIRECT_NETWORK_TARGET: `localhost:${(kmsServer.address() as any).port}`,
+            ...(withEnvVarCredentials ? {
+              AWS_ACCESS_KEY_ID: accessKeyId,
+              AWS_SECRET_ACCESS_KEY: secretAccessKey,
+              AWS_SESSION_TOKEN: withSessionToken ? sessionToken : undefined,
+            } : {})
+          },
+          cwd: path.join(__dirname, 'fixtures')
+        });
+
+        if (withEnvVarCredentials) {
+          // Need to set up the AWS context inside the shell for enabling
+          // automatic encryption since there are no credentials on the command line
+          // which would indicate that automatic encryption should be enabled
+          await shell.executeLine(`db = new Mongo(db.getMongo(), {
+            keyVaultNamespace: ${JSON.stringify(dbname + '.keyVault')},
+            kmsProviders: { aws: {} }
+          }).getDB(${JSON.stringify(dbname)})`);
+        } else {
+          await shell.executeLine(`use ${dbname}`);
         }
 
-        it('passes through command line options', async() => {
-          const shell = await makeTestShell();
-          await shell.executeLine(`use ${dbname}`);
-          await shell.executeLine(`db.keyVault.insertOne({
-            _id: UUID("e7b4abe7-ff70-48c3-9d3a-3526e18c2646"),
-            keyMaterial: new Binary(Buffer.from("010202007888b7b9089f9cf816059c4c02edf139d50227528b2a74a5c9910c89095d45a9d10133bd4c047f2ba610d7ad4efcc945f863000000c23081bf06092a864886f70d010706a081b13081ae0201003081a806092a864886f70d010701301e060960864801650304012e3011040cf406b9ccb00f83dd632e76e9020110807b9c2b3a676746e10486ec64468d45ec89cac30f59812b711fc24530188166c481f4f4ab376c258f8f54affdc8523468fdd07b84e77b21a14008a23fb6d111c05eb4287b7b973f3a60d5c7d87074119b424477366cbe72c31da8fc76b8f72e31f609c3b423c599d3e4a59c21e4a0fe227ebe1aa53038cb94f79c457b", "hex"), 0),
-            creationDate: ISODate('2021-02-10T15:51:00.567Z'),
-            updateDate: ISODate('2021-02-10T15:51:00.567Z'),
-            status: 0,
-            masterKey: {
-              provider: 'aws',
-              region: 'us-east-2',
-              key: 'arn:aws:kms:us-east-2:398471984214:key/174b7c1d-3651-4517-7521-21988befd8cb'
-            }
-          })`);
-          await shell.executeLine(`db.data.insertOne({
-            _id: ObjectId("602400ec9933cbed7fa92a1c"),
-            taxid: new Binary(Buffer.from("02e7b4abe7ff7048c39d3a3526e18c264602846f122fa8c1ae1b8aff3dc7c20a8a3dbc95541e8d0d75cb8daf0b7e3137d553a788ccb62e31fed2da98ea3a596972c6dc7c17bbe6f9a9edc3a7f3e2ad96a819", "hex"), 6)
-          });`);
-          // This will try to automatically decrypt the data, but it will not succeed.
-          // That does not matter here -- we're just checking that the HTTP requests
-          // made were successful.
-          await eventually(async() => {
-            await shell.executeLine('db.data.find();');
-            shell.assertContainsError('MongoCryptError: decrypted key is incorrect length');
-          });
+        return shell;
+      }
 
-          // The actual assertion here:
-          if (!kmsServer.requests.some(req => req.headers.authorization.includes(accessKeyId)) ||
-              (withSessionToken && !kmsServer.requests.some(req => req.headers['x-amz-security-token'] === sessionToken))) {
-            throw new Error(`Missed expected request to AWS\nShell output:\n${shell.output}\nRequests:\n${kmsServer.requests.map(req => inspect(req.headers))}`);
+      it('passes through command line options', async() => {
+        const shell = await makeTestShell();
+        await shell.executeLine(`db.keyVault.insertOne({
+          _id: UUID("e7b4abe7-ff70-48c3-9d3a-3526e18c2646"),
+          keyMaterial: new Binary(Buffer.from("010202007888b7b9089f9cf816059c4c02edf139d50227528b2a74a5c9910c89095d45a9d10133bd4c047f2ba610d7ad4efcc945f863000000c23081bf06092a864886f70d010706a081b13081ae0201003081a806092a864886f70d010701301e060960864801650304012e3011040cf406b9ccb00f83dd632e76e9020110807b9c2b3a676746e10486ec64468d45ec89cac30f59812b711fc24530188166c481f4f4ab376c258f8f54affdc8523468fdd07b84e77b21a14008a23fb6d111c05eb4287b7b973f3a60d5c7d87074119b424477366cbe72c31da8fc76b8f72e31f609c3b423c599d3e4a59c21e4a0fe227ebe1aa53038cb94f79c457b", "hex"), 0),
+          creationDate: ISODate('2021-02-10T15:51:00.567Z'),
+          updateDate: ISODate('2021-02-10T15:51:00.567Z'),
+          status: 0,
+          masterKey: {
+            provider: 'aws',
+            region: 'us-east-2',
+            key: 'arn:aws:kms:us-east-2:398471984214:key/174b7c1d-3651-4517-7521-21988befd8cb'
           }
+        })`);
+        await shell.executeLine(`db.data.insertOne({
+          _id: ObjectId("602400ec9933cbed7fa92a1c"),
+          taxid: new Binary(Buffer.from("02e7b4abe7ff7048c39d3a3526e18c264602846f122fa8c1ae1b8aff3dc7c20a8a3dbc95541e8d0d75cb8daf0b7e3137d553a788ccb62e31fed2da98ea3a596972c6dc7c17bbe6f9a9edc3a7f3e2ad96a819", "hex"), 6)
+        });`);
+        // This will try to automatically decrypt the data, but it will not succeed.
+        // That does not matter here -- we're just checking that the HTTP requests
+        // made were successful.
+        await eventually(async() => {
+          await shell.executeLine('db.data.find();');
+          shell.assertContainsError('MongoCryptError: decrypted key is incorrect length');
         });
 
-        it('forwards command line options to the main Mongo instance', async() => {
-          const shell = await makeTestShell();
-          await shell.executeLine(`use ${dbname}`);
-          await shell.executeLine('keyId = db.getMongo().getKeyVault().createKey("aws", {' +
-            'region: "us-east-2", key: "arn:aws:kms:us-east-2:398471984214:key/174b7c1d-3651-4517-7521-21988befd8cb" });');
-          await shell.executeLine('clientEncryption = db.getMongo().getClientEncryption();');
-          await shell.executeLine('encrypted = clientEncryption.encrypt(' +
-            'keyId, { someValue: "foo" }, "AEAD_AES_256_CBC_HMAC_SHA_512-Random");');
-          const result = await shell.executeLine('({ decrypted: clientEncryption.decrypt(encrypted) })');
-          expect(result).to.include("{ decrypted: { someValue: 'foo' } }");
-          shell.assertNoErrors();
-        });
+        // The actual assertion here:
+        if (!kmsServer.requests.some(req => req.headers.authorization.includes(accessKeyId)) ||
+            (withSessionToken && !kmsServer.requests.some(req => req.headers['x-amz-security-token'] === sessionToken))) {
+          throw new Error(`Missed expected request to AWS\nShell output:\n${shell.output}\nRequests:\n${kmsServer.requests.map(req => inspect(req.headers))}`);
+        }
       });
-    }
+
+      it('forwards command line options to the main Mongo instance', async() => {
+        const shell = await makeTestShell();
+        await shell.executeLine('keyId = db.getMongo().getKeyVault().createKey("aws", {' +
+          'region: "us-east-2", key: "arn:aws:kms:us-east-2:398471984214:key/174b7c1d-3651-4517-7521-21988befd8cb" });');
+        await shell.executeLine('clientEncryption = db.getMongo().getClientEncryption();');
+        await shell.executeLine('encrypted = clientEncryption.encrypt(' +
+          'keyId, { someValue: "foo" }, "AEAD_AES_256_CBC_HMAC_SHA_512-Random");');
+        const result = await shell.executeLine('({ decrypted: clientEncryption.decrypt(encrypted) })');
+        expect(result).to.include("{ decrypted: { someValue: 'foo' } }");
+        shell.assertNoErrors();
+      });
+    });
   }
 
   it('works when the original shell was started with --nodb', async() => {

--- a/packages/service-provider-core/package-lock.json
+++ b/packages/service-provider-core/package-lock.json
@@ -9,6 +9,7 @@
 			"version": "0.0.0-dev.0",
 			"license": "Apache-2.0",
 			"dependencies": {
+				"@aws-sdk/credential-providers": "^3.262.0",
 				"bson": "^4.7.2",
 				"mongodb": "^4.13.0",
 				"mongodb-build-info": "^1.5.0"
@@ -17,14 +18,13 @@
 				"node": ">=14.15.1"
 			},
 			"optionalDependencies": {
-				"mongodb-client-encryption": "^2.3.0"
+				"mongodb-client-encryption": "^2.4.0"
 			}
 		},
 		"node_modules/@aws-crypto/ie11-detection": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.2.tgz",
-			"integrity": "sha512-5XDMQY98gMAf/WRTic5G++jfmS/VLM0rwpiOpaainKi4L0nqWMSB1SzsrEG5rjFZGYN6ZAefO+/Yta2dFM0kMw==",
-			"optional": true,
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
+			"integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
 			"dependencies": {
 				"tslib": "^1.11.1"
 			}
@@ -32,20 +32,18 @@
 		"node_modules/@aws-crypto/ie11-detection/node_modules/tslib": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-			"optional": true
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 		},
 		"node_modules/@aws-crypto/sha256-browser": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
-			"integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
-			"optional": true,
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
+			"integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
 			"dependencies": {
-				"@aws-crypto/ie11-detection": "^2.0.0",
-				"@aws-crypto/sha256-js": "^2.0.0",
-				"@aws-crypto/supports-web-crypto": "^2.0.0",
-				"@aws-crypto/util": "^2.0.0",
-				"@aws-sdk/types": "^3.1.0",
+				"@aws-crypto/ie11-detection": "^3.0.0",
+				"@aws-crypto/sha256-js": "^3.0.0",
+				"@aws-crypto/supports-web-crypto": "^3.0.0",
+				"@aws-crypto/util": "^3.0.0",
+				"@aws-sdk/types": "^3.222.0",
 				"@aws-sdk/util-locate-window": "^3.0.0",
 				"@aws-sdk/util-utf8-browser": "^3.0.0",
 				"tslib": "^1.11.1"
@@ -54,31 +52,27 @@
 		"node_modules/@aws-crypto/sha256-browser/node_modules/tslib": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-			"optional": true
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 		},
 		"node_modules/@aws-crypto/sha256-js": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
-			"integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
-			"optional": true,
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
+			"integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
 			"dependencies": {
-				"@aws-crypto/util": "^2.0.0",
-				"@aws-sdk/types": "^3.1.0",
+				"@aws-crypto/util": "^3.0.0",
+				"@aws-sdk/types": "^3.222.0",
 				"tslib": "^1.11.1"
 			}
 		},
 		"node_modules/@aws-crypto/sha256-js/node_modules/tslib": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-			"optional": true
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 		},
 		"node_modules/@aws-crypto/supports-web-crypto": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.2.tgz",
-			"integrity": "sha512-6mbSsLHwZ99CTOOswvCRP3C+VCWnzBf+1SnbWxzzJ9lR0mA0JnY2JEAhp8rqmTE0GPFy88rrM27ffgp62oErMQ==",
-			"optional": true,
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
+			"integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
 			"dependencies": {
 				"tslib": "^1.11.1"
 			}
@@ -86,16 +80,14 @@
 		"node_modules/@aws-crypto/supports-web-crypto/node_modules/tslib": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-			"optional": true
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 		},
 		"node_modules/@aws-crypto/util": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.2.tgz",
-			"integrity": "sha512-Lgu5v/0e/BcrZ5m/IWqzPUf3UYFTy/PpeED+uc9SWUR1iZQL8XXbGQg10UfllwwBryO3hFF5dizK+78aoXC1eA==",
-			"optional": true,
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+			"integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
 			"dependencies": {
-				"@aws-sdk/types": "^3.110.0",
+				"@aws-sdk/types": "^3.222.0",
 				"@aws-sdk/util-utf8-browser": "^3.0.0",
 				"tslib": "^1.11.1"
 			}
@@ -103,16 +95,14 @@
 		"node_modules/@aws-crypto/util/node_modules/tslib": {
 			"version": "1.14.1",
 			"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-			"optional": true
+			"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 		},
 		"node_modules/@aws-sdk/abort-controller": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.215.0.tgz",
-			"integrity": "sha512-HTvL542nawhVqe0oC1AJchdcomEOmPivJEzYUT1LqiG3e8ikxMNa2KWSqqLPeKi2t0A/cfQy7wDUyg9+BZhDSQ==",
-			"optional": true,
+			"version": "3.257.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.257.0.tgz",
+			"integrity": "sha512-ekWy391lOerS0ZECdhp/c+X7AToJIpfNrCPjuj3bKr+GMQYckGsYsdbm6AUD4sxBmfvuaQmVniSXWovaxwcFcQ==",
 			"dependencies": {
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/types": "3.257.0",
 				"tslib": "^2.3.1"
 			},
 			"engines": {
@@ -120,45 +110,44 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-cognito-identity": {
-			"version": "3.218.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.218.0.tgz",
-			"integrity": "sha512-IHzM9jpLqdeqj2w7YA7FrmLCQyKaun7eXtu1OJYMFbJT5XHx6B4jlQ1T/N8xivSSzDfjpJxG6/MMmjec4pI+CA==",
-			"optional": true,
+			"version": "3.262.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.262.0.tgz",
+			"integrity": "sha512-Kmms7MZUR8Sl5PzgaWz/8rG+VkhKGQJEiY74VHLqJ/BLg4KyIYpHfqiif+J6/9HWN4SGFic1Aij37D5EFA9kgw==",
 			"dependencies": {
-				"@aws-crypto/sha256-browser": "2.0.0",
-				"@aws-crypto/sha256-js": "2.0.0",
-				"@aws-sdk/client-sts": "3.218.0",
-				"@aws-sdk/config-resolver": "3.215.0",
-				"@aws-sdk/credential-provider-node": "3.218.0",
-				"@aws-sdk/fetch-http-handler": "3.215.0",
-				"@aws-sdk/hash-node": "3.215.0",
-				"@aws-sdk/invalid-dependency": "3.215.0",
-				"@aws-sdk/middleware-content-length": "3.215.0",
-				"@aws-sdk/middleware-endpoint": "3.215.0",
-				"@aws-sdk/middleware-host-header": "3.215.0",
-				"@aws-sdk/middleware-logger": "3.215.0",
-				"@aws-sdk/middleware-recursion-detection": "3.215.0",
-				"@aws-sdk/middleware-retry": "3.215.0",
-				"@aws-sdk/middleware-serde": "3.215.0",
-				"@aws-sdk/middleware-signing": "3.215.0",
-				"@aws-sdk/middleware-stack": "3.215.0",
-				"@aws-sdk/middleware-user-agent": "3.215.0",
-				"@aws-sdk/node-config-provider": "3.215.0",
-				"@aws-sdk/node-http-handler": "3.215.0",
-				"@aws-sdk/protocol-http": "3.215.0",
-				"@aws-sdk/smithy-client": "3.215.0",
-				"@aws-sdk/types": "3.215.0",
-				"@aws-sdk/url-parser": "3.215.0",
+				"@aws-crypto/sha256-browser": "3.0.0",
+				"@aws-crypto/sha256-js": "3.0.0",
+				"@aws-sdk/client-sts": "3.262.0",
+				"@aws-sdk/config-resolver": "3.259.0",
+				"@aws-sdk/credential-provider-node": "3.261.0",
+				"@aws-sdk/fetch-http-handler": "3.257.0",
+				"@aws-sdk/hash-node": "3.257.0",
+				"@aws-sdk/invalid-dependency": "3.257.0",
+				"@aws-sdk/middleware-content-length": "3.257.0",
+				"@aws-sdk/middleware-endpoint": "3.257.0",
+				"@aws-sdk/middleware-host-header": "3.257.0",
+				"@aws-sdk/middleware-logger": "3.257.0",
+				"@aws-sdk/middleware-recursion-detection": "3.257.0",
+				"@aws-sdk/middleware-retry": "3.259.0",
+				"@aws-sdk/middleware-serde": "3.257.0",
+				"@aws-sdk/middleware-signing": "3.257.0",
+				"@aws-sdk/middleware-stack": "3.257.0",
+				"@aws-sdk/middleware-user-agent": "3.257.0",
+				"@aws-sdk/node-config-provider": "3.259.0",
+				"@aws-sdk/node-http-handler": "3.257.0",
+				"@aws-sdk/protocol-http": "3.257.0",
+				"@aws-sdk/smithy-client": "3.261.0",
+				"@aws-sdk/types": "3.257.0",
+				"@aws-sdk/url-parser": "3.257.0",
 				"@aws-sdk/util-base64": "3.208.0",
 				"@aws-sdk/util-body-length-browser": "3.188.0",
 				"@aws-sdk/util-body-length-node": "3.208.0",
-				"@aws-sdk/util-defaults-mode-browser": "3.215.0",
-				"@aws-sdk/util-defaults-mode-node": "3.215.0",
-				"@aws-sdk/util-endpoints": "3.216.0",
-				"@aws-sdk/util-user-agent-browser": "3.215.0",
-				"@aws-sdk/util-user-agent-node": "3.215.0",
-				"@aws-sdk/util-utf8-browser": "3.188.0",
-				"@aws-sdk/util-utf8-node": "3.208.0",
+				"@aws-sdk/util-defaults-mode-browser": "3.261.0",
+				"@aws-sdk/util-defaults-mode-node": "3.261.0",
+				"@aws-sdk/util-endpoints": "3.257.0",
+				"@aws-sdk/util-retry": "3.257.0",
+				"@aws-sdk/util-user-agent-browser": "3.257.0",
+				"@aws-sdk/util-user-agent-node": "3.259.0",
+				"@aws-sdk/util-utf8": "3.254.0",
 				"tslib": "^2.3.1"
 			},
 			"engines": {
@@ -166,42 +155,41 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-sso": {
-			"version": "3.218.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.218.0.tgz",
-			"integrity": "sha512-kVMlpjaVblxgb1G8q3wD65mKxO3RzKwnjUjIBmOHpmseXzlSkAdAvYcikaDoJP+CRmys4uXk5DN8c7ZdL0OmgA==",
-			"optional": true,
+			"version": "3.261.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.261.0.tgz",
+			"integrity": "sha512-tq5hu1WXa9BKsCH9zOBOykyiaoZQvaFHKdOamw5SZ69niyO3AG4xR1TkLqXj/9mDYMLgAIVObKZDGWtBLFTdiQ==",
 			"dependencies": {
-				"@aws-crypto/sha256-browser": "2.0.0",
-				"@aws-crypto/sha256-js": "2.0.0",
-				"@aws-sdk/config-resolver": "3.215.0",
-				"@aws-sdk/fetch-http-handler": "3.215.0",
-				"@aws-sdk/hash-node": "3.215.0",
-				"@aws-sdk/invalid-dependency": "3.215.0",
-				"@aws-sdk/middleware-content-length": "3.215.0",
-				"@aws-sdk/middleware-endpoint": "3.215.0",
-				"@aws-sdk/middleware-host-header": "3.215.0",
-				"@aws-sdk/middleware-logger": "3.215.0",
-				"@aws-sdk/middleware-recursion-detection": "3.215.0",
-				"@aws-sdk/middleware-retry": "3.215.0",
-				"@aws-sdk/middleware-serde": "3.215.0",
-				"@aws-sdk/middleware-stack": "3.215.0",
-				"@aws-sdk/middleware-user-agent": "3.215.0",
-				"@aws-sdk/node-config-provider": "3.215.0",
-				"@aws-sdk/node-http-handler": "3.215.0",
-				"@aws-sdk/protocol-http": "3.215.0",
-				"@aws-sdk/smithy-client": "3.215.0",
-				"@aws-sdk/types": "3.215.0",
-				"@aws-sdk/url-parser": "3.215.0",
+				"@aws-crypto/sha256-browser": "3.0.0",
+				"@aws-crypto/sha256-js": "3.0.0",
+				"@aws-sdk/config-resolver": "3.259.0",
+				"@aws-sdk/fetch-http-handler": "3.257.0",
+				"@aws-sdk/hash-node": "3.257.0",
+				"@aws-sdk/invalid-dependency": "3.257.0",
+				"@aws-sdk/middleware-content-length": "3.257.0",
+				"@aws-sdk/middleware-endpoint": "3.257.0",
+				"@aws-sdk/middleware-host-header": "3.257.0",
+				"@aws-sdk/middleware-logger": "3.257.0",
+				"@aws-sdk/middleware-recursion-detection": "3.257.0",
+				"@aws-sdk/middleware-retry": "3.259.0",
+				"@aws-sdk/middleware-serde": "3.257.0",
+				"@aws-sdk/middleware-stack": "3.257.0",
+				"@aws-sdk/middleware-user-agent": "3.257.0",
+				"@aws-sdk/node-config-provider": "3.259.0",
+				"@aws-sdk/node-http-handler": "3.257.0",
+				"@aws-sdk/protocol-http": "3.257.0",
+				"@aws-sdk/smithy-client": "3.261.0",
+				"@aws-sdk/types": "3.257.0",
+				"@aws-sdk/url-parser": "3.257.0",
 				"@aws-sdk/util-base64": "3.208.0",
 				"@aws-sdk/util-body-length-browser": "3.188.0",
 				"@aws-sdk/util-body-length-node": "3.208.0",
-				"@aws-sdk/util-defaults-mode-browser": "3.215.0",
-				"@aws-sdk/util-defaults-mode-node": "3.215.0",
-				"@aws-sdk/util-endpoints": "3.216.0",
-				"@aws-sdk/util-user-agent-browser": "3.215.0",
-				"@aws-sdk/util-user-agent-node": "3.215.0",
-				"@aws-sdk/util-utf8-browser": "3.188.0",
-				"@aws-sdk/util-utf8-node": "3.208.0",
+				"@aws-sdk/util-defaults-mode-browser": "3.261.0",
+				"@aws-sdk/util-defaults-mode-node": "3.261.0",
+				"@aws-sdk/util-endpoints": "3.257.0",
+				"@aws-sdk/util-retry": "3.257.0",
+				"@aws-sdk/util-user-agent-browser": "3.257.0",
+				"@aws-sdk/util-user-agent-node": "3.259.0",
+				"@aws-sdk/util-utf8": "3.254.0",
 				"tslib": "^2.3.1"
 			},
 			"engines": {
@@ -209,42 +197,41 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-sso-oidc": {
-			"version": "3.216.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.216.0.tgz",
-			"integrity": "sha512-O8kmM86BHwiSwyNoIe+iHXuSpUE9PBWl3re8u+/igt/w5W5VmMVz+zQr7gRUDQ1FDgLWNEdAJa0r+JFx3pZdzA==",
-			"optional": true,
+			"version": "3.261.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.261.0.tgz",
+			"integrity": "sha512-ItgRT/BThv2UxEeGJ5/GCF6JY1Rzk39IcDIPZAfBA8HbYcznXGDsBTRf45MErS+uollwNFX0T/WNlTbmjEDE7g==",
 			"dependencies": {
-				"@aws-crypto/sha256-browser": "2.0.0",
-				"@aws-crypto/sha256-js": "2.0.0",
-				"@aws-sdk/config-resolver": "3.215.0",
-				"@aws-sdk/fetch-http-handler": "3.215.0",
-				"@aws-sdk/hash-node": "3.215.0",
-				"@aws-sdk/invalid-dependency": "3.215.0",
-				"@aws-sdk/middleware-content-length": "3.215.0",
-				"@aws-sdk/middleware-endpoint": "3.215.0",
-				"@aws-sdk/middleware-host-header": "3.215.0",
-				"@aws-sdk/middleware-logger": "3.215.0",
-				"@aws-sdk/middleware-recursion-detection": "3.215.0",
-				"@aws-sdk/middleware-retry": "3.215.0",
-				"@aws-sdk/middleware-serde": "3.215.0",
-				"@aws-sdk/middleware-stack": "3.215.0",
-				"@aws-sdk/middleware-user-agent": "3.215.0",
-				"@aws-sdk/node-config-provider": "3.215.0",
-				"@aws-sdk/node-http-handler": "3.215.0",
-				"@aws-sdk/protocol-http": "3.215.0",
-				"@aws-sdk/smithy-client": "3.215.0",
-				"@aws-sdk/types": "3.215.0",
-				"@aws-sdk/url-parser": "3.215.0",
+				"@aws-crypto/sha256-browser": "3.0.0",
+				"@aws-crypto/sha256-js": "3.0.0",
+				"@aws-sdk/config-resolver": "3.259.0",
+				"@aws-sdk/fetch-http-handler": "3.257.0",
+				"@aws-sdk/hash-node": "3.257.0",
+				"@aws-sdk/invalid-dependency": "3.257.0",
+				"@aws-sdk/middleware-content-length": "3.257.0",
+				"@aws-sdk/middleware-endpoint": "3.257.0",
+				"@aws-sdk/middleware-host-header": "3.257.0",
+				"@aws-sdk/middleware-logger": "3.257.0",
+				"@aws-sdk/middleware-recursion-detection": "3.257.0",
+				"@aws-sdk/middleware-retry": "3.259.0",
+				"@aws-sdk/middleware-serde": "3.257.0",
+				"@aws-sdk/middleware-stack": "3.257.0",
+				"@aws-sdk/middleware-user-agent": "3.257.0",
+				"@aws-sdk/node-config-provider": "3.259.0",
+				"@aws-sdk/node-http-handler": "3.257.0",
+				"@aws-sdk/protocol-http": "3.257.0",
+				"@aws-sdk/smithy-client": "3.261.0",
+				"@aws-sdk/types": "3.257.0",
+				"@aws-sdk/url-parser": "3.257.0",
 				"@aws-sdk/util-base64": "3.208.0",
 				"@aws-sdk/util-body-length-browser": "3.188.0",
 				"@aws-sdk/util-body-length-node": "3.208.0",
-				"@aws-sdk/util-defaults-mode-browser": "3.215.0",
-				"@aws-sdk/util-defaults-mode-node": "3.215.0",
-				"@aws-sdk/util-endpoints": "3.216.0",
-				"@aws-sdk/util-user-agent-browser": "3.215.0",
-				"@aws-sdk/util-user-agent-node": "3.215.0",
-				"@aws-sdk/util-utf8-browser": "3.188.0",
-				"@aws-sdk/util-utf8-node": "3.208.0",
+				"@aws-sdk/util-defaults-mode-browser": "3.261.0",
+				"@aws-sdk/util-defaults-mode-node": "3.261.0",
+				"@aws-sdk/util-endpoints": "3.257.0",
+				"@aws-sdk/util-retry": "3.257.0",
+				"@aws-sdk/util-user-agent-browser": "3.257.0",
+				"@aws-sdk/util-user-agent-node": "3.259.0",
+				"@aws-sdk/util-utf8": "3.254.0",
 				"tslib": "^2.3.1"
 			},
 			"engines": {
@@ -252,45 +239,44 @@
 			}
 		},
 		"node_modules/@aws-sdk/client-sts": {
-			"version": "3.218.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.218.0.tgz",
-			"integrity": "sha512-0A81eHvryKFEPq7IeY34Opzh5b9bVhhLlf2fDy5VuZjCFf4R9vD2ceOANvFSJeMsmdlqVDq8U1mHYl0E6FRUug==",
-			"optional": true,
+			"version": "3.262.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.262.0.tgz",
+			"integrity": "sha512-4Exb/tj3h6/4JsMza0ZpKVIE6N/bY2bS2T96LMB63v5T+yLmpQWUQu/fSZ56x+nuqmN1fz6PZLe0BIp96v4vDg==",
 			"dependencies": {
-				"@aws-crypto/sha256-browser": "2.0.0",
-				"@aws-crypto/sha256-js": "2.0.0",
-				"@aws-sdk/config-resolver": "3.215.0",
-				"@aws-sdk/credential-provider-node": "3.218.0",
-				"@aws-sdk/fetch-http-handler": "3.215.0",
-				"@aws-sdk/hash-node": "3.215.0",
-				"@aws-sdk/invalid-dependency": "3.215.0",
-				"@aws-sdk/middleware-content-length": "3.215.0",
-				"@aws-sdk/middleware-endpoint": "3.215.0",
-				"@aws-sdk/middleware-host-header": "3.215.0",
-				"@aws-sdk/middleware-logger": "3.215.0",
-				"@aws-sdk/middleware-recursion-detection": "3.215.0",
-				"@aws-sdk/middleware-retry": "3.215.0",
-				"@aws-sdk/middleware-sdk-sts": "3.215.0",
-				"@aws-sdk/middleware-serde": "3.215.0",
-				"@aws-sdk/middleware-signing": "3.215.0",
-				"@aws-sdk/middleware-stack": "3.215.0",
-				"@aws-sdk/middleware-user-agent": "3.215.0",
-				"@aws-sdk/node-config-provider": "3.215.0",
-				"@aws-sdk/node-http-handler": "3.215.0",
-				"@aws-sdk/protocol-http": "3.215.0",
-				"@aws-sdk/smithy-client": "3.215.0",
-				"@aws-sdk/types": "3.215.0",
-				"@aws-sdk/url-parser": "3.215.0",
+				"@aws-crypto/sha256-browser": "3.0.0",
+				"@aws-crypto/sha256-js": "3.0.0",
+				"@aws-sdk/config-resolver": "3.259.0",
+				"@aws-sdk/credential-provider-node": "3.261.0",
+				"@aws-sdk/fetch-http-handler": "3.257.0",
+				"@aws-sdk/hash-node": "3.257.0",
+				"@aws-sdk/invalid-dependency": "3.257.0",
+				"@aws-sdk/middleware-content-length": "3.257.0",
+				"@aws-sdk/middleware-endpoint": "3.257.0",
+				"@aws-sdk/middleware-host-header": "3.257.0",
+				"@aws-sdk/middleware-logger": "3.257.0",
+				"@aws-sdk/middleware-recursion-detection": "3.257.0",
+				"@aws-sdk/middleware-retry": "3.259.0",
+				"@aws-sdk/middleware-sdk-sts": "3.257.0",
+				"@aws-sdk/middleware-serde": "3.257.0",
+				"@aws-sdk/middleware-signing": "3.257.0",
+				"@aws-sdk/middleware-stack": "3.257.0",
+				"@aws-sdk/middleware-user-agent": "3.257.0",
+				"@aws-sdk/node-config-provider": "3.259.0",
+				"@aws-sdk/node-http-handler": "3.257.0",
+				"@aws-sdk/protocol-http": "3.257.0",
+				"@aws-sdk/smithy-client": "3.261.0",
+				"@aws-sdk/types": "3.257.0",
+				"@aws-sdk/url-parser": "3.257.0",
 				"@aws-sdk/util-base64": "3.208.0",
 				"@aws-sdk/util-body-length-browser": "3.188.0",
 				"@aws-sdk/util-body-length-node": "3.208.0",
-				"@aws-sdk/util-defaults-mode-browser": "3.215.0",
-				"@aws-sdk/util-defaults-mode-node": "3.215.0",
-				"@aws-sdk/util-endpoints": "3.216.0",
-				"@aws-sdk/util-user-agent-browser": "3.215.0",
-				"@aws-sdk/util-user-agent-node": "3.215.0",
-				"@aws-sdk/util-utf8-browser": "3.188.0",
-				"@aws-sdk/util-utf8-node": "3.208.0",
+				"@aws-sdk/util-defaults-mode-browser": "3.261.0",
+				"@aws-sdk/util-defaults-mode-node": "3.261.0",
+				"@aws-sdk/util-endpoints": "3.257.0",
+				"@aws-sdk/util-retry": "3.257.0",
+				"@aws-sdk/util-user-agent-browser": "3.257.0",
+				"@aws-sdk/util-user-agent-node": "3.259.0",
+				"@aws-sdk/util-utf8": "3.254.0",
 				"fast-xml-parser": "4.0.11",
 				"tslib": "^2.3.1"
 			},
@@ -299,15 +285,14 @@
 			}
 		},
 		"node_modules/@aws-sdk/config-resolver": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.215.0.tgz",
-			"integrity": "sha512-DxX4R+YYLQOtg0qfceKBrjVD4t1mQBG1eb7IVr2QSlckFCX8ztUNymFMuaSEo3938Jyy/NpgfUDpFqPDaSKnng==",
-			"optional": true,
+			"version": "3.259.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.259.0.tgz",
+			"integrity": "sha512-gViMRsc4Ye6+nzJ0OYTZIT8m4glIAdtugN2Sr/t6P2iJW5X0bSL/EcbcHBgsve1lHjeGPeyzVkT7UnyGOZ5Z/A==",
 			"dependencies": {
-				"@aws-sdk/signature-v4": "3.215.0",
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/signature-v4": "3.257.0",
+				"@aws-sdk/types": "3.257.0",
 				"@aws-sdk/util-config-provider": "3.208.0",
-				"@aws-sdk/util-middleware": "3.215.0",
+				"@aws-sdk/util-middleware": "3.257.0",
 				"tslib": "^2.3.1"
 			},
 			"engines": {
@@ -315,14 +300,13 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-cognito-identity": {
-			"version": "3.218.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.218.0.tgz",
-			"integrity": "sha512-ndhlPBvnxUgje23TnVw0fkDgTZHh0GVapKSgeEIxmxAy3IVLN15iMs7dCV7LWvb7z1P0cYx9cwvxa0nTrVxjtg==",
-			"optional": true,
+			"version": "3.262.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.262.0.tgz",
+			"integrity": "sha512-oOVslglkpOoA8XUoc8yGGky+hUdDezx3CfzdrUg0TeyTqj3dVEEo+ghLk/ngne+T2t73revVJ2AAaOgVNomRcA==",
 			"dependencies": {
-				"@aws-sdk/client-cognito-identity": "3.218.0",
-				"@aws-sdk/property-provider": "3.215.0",
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/client-cognito-identity": "3.262.0",
+				"@aws-sdk/property-provider": "3.257.0",
+				"@aws-sdk/types": "3.257.0",
 				"tslib": "^2.3.1"
 			},
 			"engines": {
@@ -330,13 +314,12 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-env": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.215.0.tgz",
-			"integrity": "sha512-n5G7I7Pxfsn81+tNsSOzspKp9SYai78oRfImsfFY4JLTcWutv7szMgFUbtEzBfUUINHpOxLiO2Lk5yu5K1C7IQ==",
-			"optional": true,
+			"version": "3.257.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.257.0.tgz",
+			"integrity": "sha512-GsmBi5Di6hk1JAi1iB6/LCY8o+GmlCvJoB7wuoVmXI3VxRVwptUVjuj8EtJbIrVGrF9dSuIRPCzUoSuzEzYGlg==",
 			"dependencies": {
-				"@aws-sdk/property-provider": "3.215.0",
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/property-provider": "3.257.0",
+				"@aws-sdk/types": "3.257.0",
 				"tslib": "^2.3.1"
 			},
 			"engines": {
@@ -344,15 +327,14 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-imds": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.215.0.tgz",
-			"integrity": "sha512-/4FUUR6u9gkNfxB6mEwBr0kk0myIkrDcXbAocWN3fPd/t7otzxpx/JqPZXgM6kcVP7M4T/QT75l1E1RRHLWCCQ==",
-			"optional": true,
+			"version": "3.259.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.259.0.tgz",
+			"integrity": "sha512-yCxoYWZAaDrCUEWxRfrpB0Mp1cFgJEMYW8T6GIb/+DQ5QLpZmorgaVD/j90QXupqFrR5tlxwuskBIkdD2E9YNg==",
 			"dependencies": {
-				"@aws-sdk/node-config-provider": "3.215.0",
-				"@aws-sdk/property-provider": "3.215.0",
-				"@aws-sdk/types": "3.215.0",
-				"@aws-sdk/url-parser": "3.215.0",
+				"@aws-sdk/node-config-provider": "3.259.0",
+				"@aws-sdk/property-provider": "3.257.0",
+				"@aws-sdk/types": "3.257.0",
+				"@aws-sdk/url-parser": "3.257.0",
 				"tslib": "^2.3.1"
 			},
 			"engines": {
@@ -360,18 +342,18 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-ini": {
-			"version": "3.218.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.218.0.tgz",
-			"integrity": "sha512-tDDrGW+4A+PQThVJ+l9ee03CsDoD0XLpOB5dcf+dr/dCHjcQ7x/CeVFZ8eM+XUtGQnZVvuzXZGwzS8bUWEdJIg==",
-			"optional": true,
+			"version": "3.261.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.261.0.tgz",
+			"integrity": "sha512-638jTnvFbGO0G0So+FijdC1vjn/dhw3l8nJwLq9PYOBJUKhjXDR/fpOhZkUJ+Zwfuqp9SlDDo/yfFa6j2L+F1g==",
 			"dependencies": {
-				"@aws-sdk/credential-provider-env": "3.215.0",
-				"@aws-sdk/credential-provider-imds": "3.215.0",
-				"@aws-sdk/credential-provider-sso": "3.218.0",
-				"@aws-sdk/credential-provider-web-identity": "3.215.0",
-				"@aws-sdk/property-provider": "3.215.0",
-				"@aws-sdk/shared-ini-file-loader": "3.215.0",
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/credential-provider-env": "3.257.0",
+				"@aws-sdk/credential-provider-imds": "3.259.0",
+				"@aws-sdk/credential-provider-process": "3.257.0",
+				"@aws-sdk/credential-provider-sso": "3.261.0",
+				"@aws-sdk/credential-provider-web-identity": "3.257.0",
+				"@aws-sdk/property-provider": "3.257.0",
+				"@aws-sdk/shared-ini-file-loader": "3.257.0",
+				"@aws-sdk/types": "3.257.0",
 				"tslib": "^2.3.1"
 			},
 			"engines": {
@@ -379,20 +361,19 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-node": {
-			"version": "3.218.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.218.0.tgz",
-			"integrity": "sha512-J9PB6XFA+V0mgxleuY5W6Jjh5WejV8HjMViTJQpp2JN+NWZP3bGvquUSQHRqWGRGg2fSJy6Z/J4zQ8fpPbGsdQ==",
-			"optional": true,
+			"version": "3.261.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.261.0.tgz",
+			"integrity": "sha512-7T25a7jbHsXPe7XvIekzhR50b7PTlISKqHdE8LNVUSzFQbSjVXulFk3vyQVIhmt5HKNkSBcMPDr6hKrSl7OLBw==",
 			"dependencies": {
-				"@aws-sdk/credential-provider-env": "3.215.0",
-				"@aws-sdk/credential-provider-imds": "3.215.0",
-				"@aws-sdk/credential-provider-ini": "3.218.0",
-				"@aws-sdk/credential-provider-process": "3.215.0",
-				"@aws-sdk/credential-provider-sso": "3.218.0",
-				"@aws-sdk/credential-provider-web-identity": "3.215.0",
-				"@aws-sdk/property-provider": "3.215.0",
-				"@aws-sdk/shared-ini-file-loader": "3.215.0",
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/credential-provider-env": "3.257.0",
+				"@aws-sdk/credential-provider-imds": "3.259.0",
+				"@aws-sdk/credential-provider-ini": "3.261.0",
+				"@aws-sdk/credential-provider-process": "3.257.0",
+				"@aws-sdk/credential-provider-sso": "3.261.0",
+				"@aws-sdk/credential-provider-web-identity": "3.257.0",
+				"@aws-sdk/property-provider": "3.257.0",
+				"@aws-sdk/shared-ini-file-loader": "3.257.0",
+				"@aws-sdk/types": "3.257.0",
 				"tslib": "^2.3.1"
 			},
 			"engines": {
@@ -400,14 +381,13 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-process": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.215.0.tgz",
-			"integrity": "sha512-JNvj4L5B7W8byoFdfn/8Y4scoPiwCi+Ha/fRsFCrdSC7C+snDuxM/oQj33HI8DpKY1cjuigzEnpnxiNWaA09EA==",
-			"optional": true,
+			"version": "3.257.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.257.0.tgz",
+			"integrity": "sha512-xK8uYeNXaclaBCGrLi4z2pxPRngqLf5BM5jg2fn57zqvlL9V5gJF972FehrVBL0bfp1/laG0ZJtD2K2sapyWAw==",
 			"dependencies": {
-				"@aws-sdk/property-provider": "3.215.0",
-				"@aws-sdk/shared-ini-file-loader": "3.215.0",
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/property-provider": "3.257.0",
+				"@aws-sdk/shared-ini-file-loader": "3.257.0",
+				"@aws-sdk/types": "3.257.0",
 				"tslib": "^2.3.1"
 			},
 			"engines": {
@@ -415,16 +395,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-sso": {
-			"version": "3.218.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.218.0.tgz",
-			"integrity": "sha512-HecWvmxD+xffmY8G4SfLRfCOgSoLFki45wOOU8ESgRM9fQp2+3CfRSyiThKZI5PTmE+xhPTRvmR61HUmQjEv8w==",
-			"optional": true,
+			"version": "3.261.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.261.0.tgz",
+			"integrity": "sha512-Ofj7m85/RuxcZMtghhD+U2GGszrU5tB2kxXcnkcHCudOER6bcOOEXnSfmdZnIv4xG+vma3VFwiWk2JkQo5zB5w==",
 			"dependencies": {
-				"@aws-sdk/client-sso": "3.218.0",
-				"@aws-sdk/property-provider": "3.215.0",
-				"@aws-sdk/shared-ini-file-loader": "3.215.0",
-				"@aws-sdk/token-providers": "3.216.0",
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/client-sso": "3.261.0",
+				"@aws-sdk/property-provider": "3.257.0",
+				"@aws-sdk/shared-ini-file-loader": "3.257.0",
+				"@aws-sdk/token-providers": "3.261.0",
+				"@aws-sdk/types": "3.257.0",
 				"tslib": "^2.3.1"
 			},
 			"engines": {
@@ -432,13 +411,12 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-provider-web-identity": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.215.0.tgz",
-			"integrity": "sha512-AWaDDEE3VU1HeLrXvyUrkQ6Wb3PQij5bvvrMil9L0da3b1yrcpoDanQQy7wBFBXcZIVmcmSFe5MMA/nyh2Le4g==",
-			"optional": true,
+			"version": "3.257.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.257.0.tgz",
+			"integrity": "sha512-Cm0uvRv4JuIbD0Kp3W0J/vwjADIyCx8HoZi5yg+QIi5nilocuTQ3ajvLeuPVSvFvdy+yaxSc5FxNXquWt7Mngw==",
 			"dependencies": {
-				"@aws-sdk/property-provider": "3.215.0",
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/property-provider": "3.257.0",
+				"@aws-sdk/types": "3.257.0",
 				"tslib": "^2.3.1"
 			},
 			"engines": {
@@ -446,25 +424,24 @@
 			}
 		},
 		"node_modules/@aws-sdk/credential-providers": {
-			"version": "3.218.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.218.0.tgz",
-			"integrity": "sha512-MWpb5k+Oq56NrHA5fYPIDX8QRYUAw4Jp8ErTELBd83kLhTgqTw025YQ05YbhIzAs84+viMeWKif0z/5kNshphw==",
-			"optional": true,
+			"version": "3.262.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.262.0.tgz",
+			"integrity": "sha512-sJcLaBcuXkeIqQuCEQK2OFgfsN0AcOpGa/7nRGUzh9/9bif0rl/xBi96Wqyeb7Tf71qZ9gcpBnDUaaK+O9q6mg==",
 			"dependencies": {
-				"@aws-sdk/client-cognito-identity": "3.218.0",
-				"@aws-sdk/client-sso": "3.218.0",
-				"@aws-sdk/client-sts": "3.218.0",
-				"@aws-sdk/credential-provider-cognito-identity": "3.218.0",
-				"@aws-sdk/credential-provider-env": "3.215.0",
-				"@aws-sdk/credential-provider-imds": "3.215.0",
-				"@aws-sdk/credential-provider-ini": "3.218.0",
-				"@aws-sdk/credential-provider-node": "3.218.0",
-				"@aws-sdk/credential-provider-process": "3.215.0",
-				"@aws-sdk/credential-provider-sso": "3.218.0",
-				"@aws-sdk/credential-provider-web-identity": "3.215.0",
-				"@aws-sdk/property-provider": "3.215.0",
-				"@aws-sdk/shared-ini-file-loader": "3.215.0",
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/client-cognito-identity": "3.262.0",
+				"@aws-sdk/client-sso": "3.261.0",
+				"@aws-sdk/client-sts": "3.262.0",
+				"@aws-sdk/credential-provider-cognito-identity": "3.262.0",
+				"@aws-sdk/credential-provider-env": "3.257.0",
+				"@aws-sdk/credential-provider-imds": "3.259.0",
+				"@aws-sdk/credential-provider-ini": "3.261.0",
+				"@aws-sdk/credential-provider-node": "3.261.0",
+				"@aws-sdk/credential-provider-process": "3.257.0",
+				"@aws-sdk/credential-provider-sso": "3.261.0",
+				"@aws-sdk/credential-provider-web-identity": "3.257.0",
+				"@aws-sdk/property-provider": "3.257.0",
+				"@aws-sdk/shared-ini-file-loader": "3.257.0",
+				"@aws-sdk/types": "3.257.0",
 				"tslib": "^2.3.1"
 			},
 			"engines": {
@@ -472,26 +449,25 @@
 			}
 		},
 		"node_modules/@aws-sdk/fetch-http-handler": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.215.0.tgz",
-			"integrity": "sha512-JfZyrJOE+0ik1PumsIUZd0NfgEx4sZ43VSdPCD9GRhssRWudNsSF1B5fz3xA5v+1y5oQPjXZyaWCzKtnYruiWw==",
-			"optional": true,
+			"version": "3.257.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.257.0.tgz",
+			"integrity": "sha512-zOF+RzQ+wfF7tq7tGUdPcqUTh3+k2f8KCVJE07A8kCopVq4nBu4NH6Eq29Tjpwdya3YlKvE+kFssuQRRRRex+Q==",
 			"dependencies": {
-				"@aws-sdk/protocol-http": "3.215.0",
-				"@aws-sdk/querystring-builder": "3.215.0",
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/protocol-http": "3.257.0",
+				"@aws-sdk/querystring-builder": "3.257.0",
+				"@aws-sdk/types": "3.257.0",
 				"@aws-sdk/util-base64": "3.208.0",
 				"tslib": "^2.3.1"
 			}
 		},
 		"node_modules/@aws-sdk/hash-node": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.215.0.tgz",
-			"integrity": "sha512-MkSRuZvo1RCRmI0VNEmRYCGGD/DkMd9lqnLtOyglMPnSX1mhyD4/DyXmcc3rYa7PsjDRAfykGWJRiMqpoMLjiQ==",
-			"optional": true,
+			"version": "3.257.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.257.0.tgz",
+			"integrity": "sha512-W/USUuea5Ep3OJ2U7Ve8/5KN1YsDun2WzOFUxc1PyxXP5pW6OgC15/op0e+bmWPG851clvp5S8ZuroUr3aKi3Q==",
 			"dependencies": {
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/types": "3.257.0",
 				"@aws-sdk/util-buffer-from": "3.208.0",
+				"@aws-sdk/util-utf8": "3.254.0",
 				"tslib": "^2.3.1"
 			},
 			"engines": {
@@ -499,12 +475,11 @@
 			}
 		},
 		"node_modules/@aws-sdk/invalid-dependency": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.215.0.tgz",
-			"integrity": "sha512-++bK4BUQe8/CL/YcLZcQB8qPOhiXxhbuhYzfFS7PNVvW1QOLqKRZL/lKs24gzjcOmw7IhAbCybDZwvu2TM4DAg==",
-			"optional": true,
+			"version": "3.257.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.257.0.tgz",
+			"integrity": "sha512-T68SAPRNMEhpke0wlxURgogL7q0B8dfqZsSeS20BVR/lksJxLse9+pbmCDxiu1RrXoEIsEwl5rbLN+Hw8BFFYw==",
 			"dependencies": {
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/types": "3.257.0",
 				"tslib": "^2.3.1"
 			}
 		},
@@ -512,7 +487,6 @@
 			"version": "3.201.0",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
 			"integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
-			"optional": true,
 			"dependencies": {
 				"tslib": "^2.3.1"
 			},
@@ -521,13 +495,12 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-content-length": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.215.0.tgz",
-			"integrity": "sha512-zKJRb6jDLFl9nl/muSFbiQHA4uK3skinuDRcyLbpMvvzhuK/PVodv9QI1+wIUsFdXkaSxAlva1oG4bL8ZFi+sQ==",
-			"optional": true,
+			"version": "3.257.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.257.0.tgz",
+			"integrity": "sha512-yiawbV2azm6QnMY1L2ypG8PDRdjOcEIvFmT0T7y0F49rfbKJOu21j1ONAoCkLrINK6kMqcD5JSQLVCoURxiTxQ==",
 			"dependencies": {
-				"@aws-sdk/protocol-http": "3.215.0",
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/protocol-http": "3.257.0",
+				"@aws-sdk/types": "3.257.0",
 				"tslib": "^2.3.1"
 			},
 			"engines": {
@@ -535,18 +508,17 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-endpoint": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.215.0.tgz",
-			"integrity": "sha512-W0QXL5emcN9IXtMbnWT/abLxBFH2tGIfnre2jPNmZ9M7uVFxUwwv5OTUXxNLGNehJHKhiJPwhfQvMy20IDzVcw==",
-			"optional": true,
+			"version": "3.257.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.257.0.tgz",
+			"integrity": "sha512-RQNQe/jeVuWZtXXfcOm+e3qMFICY6ERsXUrbt0rjHgvajZCklcrRJgxJSCwrcS7Le3nl9azFPMAMj9L7uSK28g==",
 			"dependencies": {
-				"@aws-sdk/middleware-serde": "3.215.0",
-				"@aws-sdk/protocol-http": "3.215.0",
-				"@aws-sdk/signature-v4": "3.215.0",
-				"@aws-sdk/types": "3.215.0",
-				"@aws-sdk/url-parser": "3.215.0",
+				"@aws-sdk/middleware-serde": "3.257.0",
+				"@aws-sdk/protocol-http": "3.257.0",
+				"@aws-sdk/signature-v4": "3.257.0",
+				"@aws-sdk/types": "3.257.0",
+				"@aws-sdk/url-parser": "3.257.0",
 				"@aws-sdk/util-config-provider": "3.208.0",
-				"@aws-sdk/util-middleware": "3.215.0",
+				"@aws-sdk/util-middleware": "3.257.0",
 				"tslib": "^2.3.1"
 			},
 			"engines": {
@@ -554,13 +526,12 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-host-header": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.215.0.tgz",
-			"integrity": "sha512-GOqI7VwoENZwn+6tIMrrJ4SipIqL2JCh+BNvORVcy7CQxn1ViKkna7iaCx+QMjpg/kn9cR6kfY0n1FmgZR1w9A==",
-			"optional": true,
+			"version": "3.257.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.257.0.tgz",
+			"integrity": "sha512-gEi9AJdJfRfU8Qr6HK1hfhxTzyV3Giq4B/h7um99hIFAT/GCg9xiPvAOKPo6UeuiKEv3b7RpSL4s6cBvnJMJBA==",
 			"dependencies": {
-				"@aws-sdk/protocol-http": "3.215.0",
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/protocol-http": "3.257.0",
+				"@aws-sdk/types": "3.257.0",
 				"tslib": "^2.3.1"
 			},
 			"engines": {
@@ -568,12 +539,11 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-logger": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.215.0.tgz",
-			"integrity": "sha512-0h4GGF0rV3jnY3jxmcAWsOdqHCYf25s0biSjmgTei+l/5S+geOGrovRPCNep0LLg0i9D8bkZsXISojilETbf+g==",
-			"optional": true,
+			"version": "3.257.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.257.0.tgz",
+			"integrity": "sha512-8RDXW/VbMKBsXDfcCLmROZcWKyrekyiPa3J1aIaBy0tq9o4xpGoXw/lwwIrNVvISAFslb57rteup34bfn6ta6w==",
 			"dependencies": {
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/types": "3.257.0",
 				"tslib": "^2.3.1"
 			},
 			"engines": {
@@ -581,13 +551,12 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-recursion-detection": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.215.0.tgz",
-			"integrity": "sha512-KQ+kiEsaluM4i6opjusUukxY78+UhfR7vzXHDkzZK/GplQ1hY0B+rwVO1eaULmlnmf3FK+Wd6lwrPV7xS2W+EA==",
-			"optional": true,
+			"version": "3.257.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.257.0.tgz",
+			"integrity": "sha512-rUCih6zHh8k9Edf5N5Er4s508FYbwLM0MWTD2axzlj9TjLqEQ9OKED3wHaLffXSDzodd3oTAfJCLPbWQyoZ3ZQ==",
 			"dependencies": {
-				"@aws-sdk/protocol-http": "3.215.0",
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/protocol-http": "3.257.0",
+				"@aws-sdk/types": "3.257.0",
 				"tslib": "^2.3.1"
 			},
 			"engines": {
@@ -595,15 +564,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-retry": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.215.0.tgz",
-			"integrity": "sha512-I/dnUPVg2Kp3lW+MywBoPp06EOng8IfuaS9ph4bcJpQKrhNU5ekRgCHH2C4k1A6GcP8uyHxQ5TVV6j+l0QPIsA==",
-			"optional": true,
+			"version": "3.259.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.259.0.tgz",
+			"integrity": "sha512-pVh1g8e84MAi7eVtWLiiiCtn82LzxOP7+LxTRHatmgIeN22yGQBZILliPDJypUPvDYlwxI1ekiK+oPTcte0Uww==",
 			"dependencies": {
-				"@aws-sdk/protocol-http": "3.215.0",
-				"@aws-sdk/service-error-classification": "3.215.0",
-				"@aws-sdk/types": "3.215.0",
-				"@aws-sdk/util-middleware": "3.215.0",
+				"@aws-sdk/protocol-http": "3.257.0",
+				"@aws-sdk/service-error-classification": "3.257.0",
+				"@aws-sdk/types": "3.257.0",
+				"@aws-sdk/util-middleware": "3.257.0",
+				"@aws-sdk/util-retry": "3.257.0",
 				"tslib": "^2.3.1",
 				"uuid": "^8.3.2"
 			},
@@ -612,16 +581,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-sdk-sts": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.215.0.tgz",
-			"integrity": "sha512-wJRxoDf+2egbRgochaQL8+zzADx8FM/2W0spKNj8x+t/3iqw70QwxCfuEKW/uFQ3ph6eaIrv7gYc8RRjwhD8rg==",
-			"optional": true,
+			"version": "3.257.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.257.0.tgz",
+			"integrity": "sha512-d6IJCLRi3O2tm4AFK60WNhIwmMmspj1WzKR1q1TaoPzoREPG2xg+Am18wZBRkCyYuRPPrbizmkvAmAJiUolMAw==",
 			"dependencies": {
-				"@aws-sdk/middleware-signing": "3.215.0",
-				"@aws-sdk/property-provider": "3.215.0",
-				"@aws-sdk/protocol-http": "3.215.0",
-				"@aws-sdk/signature-v4": "3.215.0",
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/middleware-signing": "3.257.0",
+				"@aws-sdk/property-provider": "3.257.0",
+				"@aws-sdk/protocol-http": "3.257.0",
+				"@aws-sdk/signature-v4": "3.257.0",
+				"@aws-sdk/types": "3.257.0",
 				"tslib": "^2.3.1"
 			},
 			"engines": {
@@ -629,12 +597,11 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-serde": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.215.0.tgz",
-			"integrity": "sha512-+uhLXdKvvQZcRRFc3UmemSr/YUHA4Jc+1YMjHxc3v8vvfztFJBb0wgBx999myOi8PmkYThlRBQDzXy9UCIhIJw==",
-			"optional": true,
+			"version": "3.257.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.257.0.tgz",
+			"integrity": "sha512-/JasfXPWFq24mnCrx9fxW/ISBSp07RJwhsF14qzm8Qy3Z0z470C+QRM6otTwAkYuuVt1wuLjja5agq3Jtzq7dQ==",
 			"dependencies": {
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/types": "3.257.0",
 				"tslib": "^2.3.1"
 			},
 			"engines": {
@@ -642,16 +609,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-signing": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.215.0.tgz",
-			"integrity": "sha512-3BqzYqkmdPeOxjI8DVQE7Bm7J5QIvDy30abglXqrDg6npw6KonKI2Q3FIPFf+oLpZTMStwkoQOnwXHTPrSZ6Tg==",
-			"optional": true,
+			"version": "3.257.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.257.0.tgz",
+			"integrity": "sha512-hCH3D83LHmm6nqmtNrGTWZCVjsQXrGHIXbd17/qrw7aPFvcAhsiiCncGFP+XsUXEKa2ZqcSNMUyPrx69ofNRZQ==",
 			"dependencies": {
-				"@aws-sdk/property-provider": "3.215.0",
-				"@aws-sdk/protocol-http": "3.215.0",
-				"@aws-sdk/signature-v4": "3.215.0",
-				"@aws-sdk/types": "3.215.0",
-				"@aws-sdk/util-middleware": "3.215.0",
+				"@aws-sdk/property-provider": "3.257.0",
+				"@aws-sdk/protocol-http": "3.257.0",
+				"@aws-sdk/signature-v4": "3.257.0",
+				"@aws-sdk/types": "3.257.0",
+				"@aws-sdk/util-middleware": "3.257.0",
 				"tslib": "^2.3.1"
 			},
 			"engines": {
@@ -659,10 +625,9 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-stack": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.215.0.tgz",
-			"integrity": "sha512-rdSVL7LxRgjlvoluqwODD4ypBy2k/YVl6FrDplyCMSi8m2WHZG99FzdmR9bpnWK+0DGzYZSMRYx6ynJ9N9PsSw==",
-			"optional": true,
+			"version": "3.257.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.257.0.tgz",
+			"integrity": "sha512-awg2F0SvwACBaw4HIObK8pQGfSqAc4Vy+YFzWSfZNVC35oRO6RsRdKHVU99lRC0LrT2Ptmfghl2DMPSrRDbvlQ==",
 			"dependencies": {
 				"tslib": "^2.3.1"
 			},
@@ -671,13 +636,12 @@
 			}
 		},
 		"node_modules/@aws-sdk/middleware-user-agent": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.215.0.tgz",
-			"integrity": "sha512-X6GfoMNoEITTw7rGL/gWs8UZ0cmmmezvKcl+KtHsA642R05OR4mY5G7LdbWAw0bcrwKsuKOGmwUrC9lzGqbWUw==",
-			"optional": true,
+			"version": "3.257.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.257.0.tgz",
+			"integrity": "sha512-37rt75LZyD0UWpbcFuxEGqwF3DZKSixQPl7AsDe6q3KtrO5gGQB+diH5vbY0txNNYyv5IK9WMwvY73mVmoWRmw==",
 			"dependencies": {
-				"@aws-sdk/protocol-http": "3.215.0",
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/protocol-http": "3.257.0",
+				"@aws-sdk/types": "3.257.0",
 				"tslib": "^2.3.1"
 			},
 			"engines": {
@@ -685,14 +649,13 @@
 			}
 		},
 		"node_modules/@aws-sdk/node-config-provider": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.215.0.tgz",
-			"integrity": "sha512-notckD94QwwxC0GsfpTxB7VH8SREIIlMsUSddqGtpModa0cq/wRb9rqnydZSoznbYpK1ND6h0C9hr/2PNz89zw==",
-			"optional": true,
+			"version": "3.259.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.259.0.tgz",
+			"integrity": "sha512-DUOqr71oonBvM6yKPdhDBmraqgXHCFrVWFw7hc5ZNxL2wS/EsbKfGPJp+C+SUgpn1upIWPNnh/bNoLAbBkcLsA==",
 			"dependencies": {
-				"@aws-sdk/property-provider": "3.215.0",
-				"@aws-sdk/shared-ini-file-loader": "3.215.0",
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/property-provider": "3.257.0",
+				"@aws-sdk/shared-ini-file-loader": "3.257.0",
+				"@aws-sdk/types": "3.257.0",
 				"tslib": "^2.3.1"
 			},
 			"engines": {
@@ -700,15 +663,14 @@
 			}
 		},
 		"node_modules/@aws-sdk/node-http-handler": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.215.0.tgz",
-			"integrity": "sha512-btKWSR7m0UuWIN3p5MfSIvhqeYik7xri7U6nWuVI5GVzIYjzxEZOMvPAinDLDxL5wipodi0ZvTUNdDJdm7BcGQ==",
-			"optional": true,
+			"version": "3.257.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.257.0.tgz",
+			"integrity": "sha512-8KnWHVVwaGKyTlkTU9BSOAiSovNDoagxemU2l10QqBbzUCVpljCUMUkABEGRJ1yoQCl6DJ7RtNkAyZ8Ne/E15A==",
 			"dependencies": {
-				"@aws-sdk/abort-controller": "3.215.0",
-				"@aws-sdk/protocol-http": "3.215.0",
-				"@aws-sdk/querystring-builder": "3.215.0",
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/abort-controller": "3.257.0",
+				"@aws-sdk/protocol-http": "3.257.0",
+				"@aws-sdk/querystring-builder": "3.257.0",
+				"@aws-sdk/types": "3.257.0",
 				"tslib": "^2.3.1"
 			},
 			"engines": {
@@ -716,12 +678,11 @@
 			}
 		},
 		"node_modules/@aws-sdk/property-provider": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.215.0.tgz",
-			"integrity": "sha512-dDPjMCCopkRURAmOJCMSlpIQ5BGWCpYj0+FIfZ5qWQs24fn1PAkQHecOiBhJO0ZSVuQy3xcIyWsAp1NE5e+7ug==",
-			"optional": true,
+			"version": "3.257.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.257.0.tgz",
+			"integrity": "sha512-3rUbRAcF0GZ5PhDiXhS4yREfZ5hOEtvYEa9S/19OdM5eoypOaLU5XnFcCKfnccSP8SkdgpJujzxOMRWNWadlAQ==",
 			"dependencies": {
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/types": "3.257.0",
 				"tslib": "^2.3.1"
 			},
 			"engines": {
@@ -729,12 +690,11 @@
 			}
 		},
 		"node_modules/@aws-sdk/protocol-http": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.215.0.tgz",
-			"integrity": "sha512-qp6Y6v4S534LAjadiVl9p7ErK7ImphOKq6yhFyQwxko6iITLcz8ib3yU27fs4QJcnNj5ZooqW/YlL/0EikDxCQ==",
-			"optional": true,
+			"version": "3.257.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.257.0.tgz",
+			"integrity": "sha512-xt7LGOgZIvbLS3418AYQLacOqx+mo5j4mPiIMz7f6AaUg+/fBUgESVsncKDqxbEJVwwCXSka8Ca0cntJmoeMSw==",
 			"dependencies": {
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/types": "3.257.0",
 				"tslib": "^2.3.1"
 			},
 			"engines": {
@@ -742,12 +702,11 @@
 			}
 		},
 		"node_modules/@aws-sdk/querystring-builder": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.215.0.tgz",
-			"integrity": "sha512-eilk8CqG37BVhQklLif00K2dOJgDzacUi8h3KVQ72ry1V3h345i4HsmaFIxvnz8XtNyDvV8qFAzeYg9n2P9RQA==",
-			"optional": true,
+			"version": "3.257.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.257.0.tgz",
+			"integrity": "sha512-mZHWLP7XIkzx1GIXO5WfX/iJ+aY9TWs02RE9FkdL2+by0HEMR65L3brQTbU1mIBJ7BjaPwYH24dljUOSABX7yg==",
 			"dependencies": {
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/types": "3.257.0",
 				"@aws-sdk/util-uri-escape": "3.201.0",
 				"tslib": "^2.3.1"
 			},
@@ -756,12 +715,11 @@
 			}
 		},
 		"node_modules/@aws-sdk/querystring-parser": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.215.0.tgz",
-			"integrity": "sha512-8h/9H8dWM4fZO27UGzo8W5JXln4yJMugPyUl4qFA437gzPgNFN95+oLJWXtHMlfCHC5T/PDKetY9TarMDgBD0Q==",
-			"optional": true,
+			"version": "3.257.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.257.0.tgz",
+			"integrity": "sha512-UDrE1dEwWrWT8dG2VCrGYrPxCWOkZ1fPTPkjpkR4KZEdQDZBqU5gYZF2xPj8Nz7pjQVHFuW2wFm3XYEk56GEjg==",
 			"dependencies": {
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/types": "3.257.0",
 				"tslib": "^2.3.1"
 			},
 			"engines": {
@@ -769,21 +727,19 @@
 			}
 		},
 		"node_modules/@aws-sdk/service-error-classification": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.215.0.tgz",
-			"integrity": "sha512-SKBvClGFGzMPsjBBKjneaUazLCNr6bSxe9eFvOr3gCwuwE2jPQwW3VE1mb62howuvm6cLthEDwLQp/FsT1gMsw==",
-			"optional": true,
+			"version": "3.257.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.257.0.tgz",
+			"integrity": "sha512-FAyR0XsueGkkqDtkP03cTJQk52NdQ9sZelLynmmlGPUP75LApRPvFe1riKrou6+LsDbwVNVffj6mbDfIcOhaOw==",
 			"engines": {
 				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/@aws-sdk/shared-ini-file-loader": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.215.0.tgz",
-			"integrity": "sha512-unzQeLOyUiYHr8WxxandHo0OaCj31gx0wpt8dn2cZcHm/MdCqHcHcsQqOVnQsWQrrxY/XZ27cPyMVQeicNKYwQ==",
-			"optional": true,
+			"version": "3.257.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.257.0.tgz",
+			"integrity": "sha512-HNjC1+Wx3xHiJc+CP14GhIdVhfQGSjroAsWseRxAhONocA9Fl1ZX4hx7+sA5c9nOoMVOovi6ivJ/6lCRPTDRrQ==",
 			"dependencies": {
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/types": "3.257.0",
 				"tslib": "^2.3.1"
 			},
 			"engines": {
@@ -791,16 +747,16 @@
 			}
 		},
 		"node_modules/@aws-sdk/signature-v4": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.215.0.tgz",
-			"integrity": "sha512-Rc73uUCi3eJneO25DydLTfJYamXeuKS9YIhNMTKlpvcN1UQAmAnUbAmCuEmqvkYOiGD1i4/kd8kBga708iIikQ==",
-			"optional": true,
+			"version": "3.257.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.257.0.tgz",
+			"integrity": "sha512-aLQQN59X/D0+ShzPD3Anj5ntdMA/RFeNLOUCDyDvremViGi6yxUS98usQ/8bG5Rq0sW2GGMdbFUFmrDvqdiqEQ==",
 			"dependencies": {
 				"@aws-sdk/is-array-buffer": "3.201.0",
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/types": "3.257.0",
 				"@aws-sdk/util-hex-encoding": "3.201.0",
-				"@aws-sdk/util-middleware": "3.215.0",
+				"@aws-sdk/util-middleware": "3.257.0",
 				"@aws-sdk/util-uri-escape": "3.201.0",
+				"@aws-sdk/util-utf8": "3.254.0",
 				"tslib": "^2.3.1"
 			},
 			"engines": {
@@ -808,13 +764,12 @@
 			}
 		},
 		"node_modules/@aws-sdk/smithy-client": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.215.0.tgz",
-			"integrity": "sha512-PiZfCdZkPohzMPrRmJ46TPOf2Tr/dhKYdwQArRnOOIsJABUGXjlzCUE8vysDN35XZYRx5f9hd+/U7kayhniq2w==",
-			"optional": true,
+			"version": "3.261.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.261.0.tgz",
+			"integrity": "sha512-j8XQEa3caZUVFVZfhJjaskw80O/tB+IXu84HMN44N7UkXaCFHirUsNjTDztJhnVXf/gKXzIqUqprfRnOvwLtIg==",
 			"dependencies": {
-				"@aws-sdk/middleware-stack": "3.215.0",
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/middleware-stack": "3.257.0",
+				"@aws-sdk/types": "3.257.0",
 				"tslib": "^2.3.1"
 			},
 			"engines": {
@@ -822,15 +777,14 @@
 			}
 		},
 		"node_modules/@aws-sdk/token-providers": {
-			"version": "3.216.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.216.0.tgz",
-			"integrity": "sha512-cEmOfG7njWl0OA5lR65Sp2SW1i8ZLjf7C95TZ1e6t2Oo5aUFeN3aKBxMOV//1yc+BNzcFBnoHP/f29GhWxUOxA==",
-			"optional": true,
+			"version": "3.261.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.261.0.tgz",
+			"integrity": "sha512-Vi/GOnx8rPvQz5TdJJl5CwpTX6uRsSE3fzh94O4FEAIxIFtb4P5juqg92+2CJ81C7iNduB6eEeSHtwWUylypXQ==",
 			"dependencies": {
-				"@aws-sdk/client-sso-oidc": "3.216.0",
-				"@aws-sdk/property-provider": "3.215.0",
-				"@aws-sdk/shared-ini-file-loader": "3.215.0",
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/client-sso-oidc": "3.261.0",
+				"@aws-sdk/property-provider": "3.257.0",
+				"@aws-sdk/shared-ini-file-loader": "3.257.0",
+				"@aws-sdk/types": "3.257.0",
 				"tslib": "^2.3.1"
 			},
 			"engines": {
@@ -838,22 +792,23 @@
 			}
 		},
 		"node_modules/@aws-sdk/types": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.215.0.tgz",
-			"integrity": "sha512-eRbCVjwzTYd9C5e2mceScJ6D2kYDDEC3PLkYfJa+1wH9iiF2JlbiYozAokyeYBHQ+AjmD93MK58RBoM8iZfH0Q==",
-			"optional": true,
+			"version": "3.257.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.257.0.tgz",
+			"integrity": "sha512-LmqXuBQBGeaGi/3Rp7XiEX1B5IPO2UUfBVvu0wwGqVsmstT0SbOVDZGPmxygACbm64n+PRx3uTSDefRfoiWYZg==",
+			"dependencies": {
+				"tslib": "^2.3.1"
+			},
 			"engines": {
 				"node": ">=14.0.0"
 			}
 		},
 		"node_modules/@aws-sdk/url-parser": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.215.0.tgz",
-			"integrity": "sha512-r/qIk3TUlV36JvoRjTErFm0LzzgNKLB1YUG8zVZCGAc2TEATi8OVEmsZvi+KfTmsbszulITJVcjZKbHLbGoUzg==",
-			"optional": true,
+			"version": "3.257.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.257.0.tgz",
+			"integrity": "sha512-Qe/AcFe/NFZHa6cN2afXEQn9ehXxh57dWGdRjfjd2lQqNV4WW1R2pl2Tm1ZJ1dwuCNLJi4NHLMk8lrD3QQ8rdg==",
 			"dependencies": {
-				"@aws-sdk/querystring-parser": "3.215.0",
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/querystring-parser": "3.257.0",
+				"@aws-sdk/types": "3.257.0",
 				"tslib": "^2.3.1"
 			}
 		},
@@ -861,7 +816,6 @@
 			"version": "3.208.0",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.208.0.tgz",
 			"integrity": "sha512-PQniZph5A6N7uuEOQi+1hnMz/FSOK/8kMFyFO+4DgA1dZ5pcKcn5wiFwHkcTb/BsgVqQa3Jx0VHNnvhlS8JyTg==",
-			"optional": true,
 			"dependencies": {
 				"@aws-sdk/util-buffer-from": "3.208.0",
 				"tslib": "^2.3.1"
@@ -874,7 +828,6 @@
 			"version": "3.188.0",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
 			"integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
-			"optional": true,
 			"dependencies": {
 				"tslib": "^2.3.1"
 			}
@@ -883,7 +836,6 @@
 			"version": "3.208.0",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
 			"integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
-			"optional": true,
 			"dependencies": {
 				"tslib": "^2.3.1"
 			},
@@ -895,7 +847,6 @@
 			"version": "3.208.0",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
 			"integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
-			"optional": true,
 			"dependencies": {
 				"@aws-sdk/is-array-buffer": "3.201.0",
 				"tslib": "^2.3.1"
@@ -908,7 +859,6 @@
 			"version": "3.208.0",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
 			"integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
-			"optional": true,
 			"dependencies": {
 				"tslib": "^2.3.1"
 			},
@@ -917,13 +867,12 @@
 			}
 		},
 		"node_modules/@aws-sdk/util-defaults-mode-browser": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.215.0.tgz",
-			"integrity": "sha512-MiNfZgB0I4dR8CBxH163W7c9KvE38sgCHNPWopMqSX5ezz7cuCPohCU0XsWd4I7K31PvzuqmKgOiKBAZraQJMA==",
-			"optional": true,
+			"version": "3.261.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.261.0.tgz",
+			"integrity": "sha512-lX3X1NfzQVV6cakepGV24uRcqevlDnQ8VgaCV8dhnw1FVThueFigyoFaUA02+uRXbV9KIbNWkEvweNtm2wvyDw==",
 			"dependencies": {
-				"@aws-sdk/property-provider": "3.215.0",
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/property-provider": "3.257.0",
+				"@aws-sdk/types": "3.257.0",
 				"bowser": "^2.11.0",
 				"tslib": "^2.3.1"
 			},
@@ -932,16 +881,15 @@
 			}
 		},
 		"node_modules/@aws-sdk/util-defaults-mode-node": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.215.0.tgz",
-			"integrity": "sha512-mSp3R8GljQ+4UT3QMOksQk9L0cWbFLvR7bBmAlt4+GobgTjpRfzFjBP3uwrCqFa3BKDUR3FeJq3qwo+xeY1Krg==",
-			"optional": true,
+			"version": "3.261.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.261.0.tgz",
+			"integrity": "sha512-4AK6yu4bOmHSocUdbGoEHbNXB09UA58ON2HBHY4NxMBuFBAd9XB2tYiyhce+Cm+o+lHbS8oQnw0VZw16WMzzew==",
 			"dependencies": {
-				"@aws-sdk/config-resolver": "3.215.0",
-				"@aws-sdk/credential-provider-imds": "3.215.0",
-				"@aws-sdk/node-config-provider": "3.215.0",
-				"@aws-sdk/property-provider": "3.215.0",
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/config-resolver": "3.259.0",
+				"@aws-sdk/credential-provider-imds": "3.259.0",
+				"@aws-sdk/node-config-provider": "3.259.0",
+				"@aws-sdk/property-provider": "3.257.0",
+				"@aws-sdk/types": "3.257.0",
 				"tslib": "^2.3.1"
 			},
 			"engines": {
@@ -949,12 +897,11 @@
 			}
 		},
 		"node_modules/@aws-sdk/util-endpoints": {
-			"version": "3.216.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.216.0.tgz",
-			"integrity": "sha512-uHje4H6Qj/z/op8UZoSuvGpEZhz/r+AGY0rCihFo7XjhT4RYVxb2Eb9uHRK/IAeHU4kjHAdpQiWGMSmnT/UacA==",
-			"optional": true,
+			"version": "3.257.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.257.0.tgz",
+			"integrity": "sha512-3bvmRn5XGYzPPWjLuvHBKdJOb+fijnb8Ungu9bfXnTYFsng/ndHUWeHC22O/p8w3OWoRYUIMaZHxdxe27BFozg==",
 			"dependencies": {
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/types": "3.257.0",
 				"tslib": "^2.3.1"
 			},
 			"engines": {
@@ -965,7 +912,6 @@
 			"version": "3.201.0",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
 			"integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
-			"optional": true,
 			"dependencies": {
 				"tslib": "^2.3.1"
 			},
@@ -977,7 +923,6 @@
 			"version": "3.208.0",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.208.0.tgz",
 			"integrity": "sha512-iua1A2+P7JJEDHVgvXrRJSvsnzG7stYSGQnBVphIUlemwl6nN5D+QrgbjECtrbxRz8asYFHSzhdhECqN+tFiBg==",
-			"optional": true,
 			"dependencies": {
 				"tslib": "^2.3.1"
 			},
@@ -986,10 +931,9 @@
 			}
 		},
 		"node_modules/@aws-sdk/util-middleware": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.215.0.tgz",
-			"integrity": "sha512-DfHGlFlQCr+T/xhjS36HH8JEThDVB5lg5NZ6x4Cibhyeps9YX/4ovLAIx3B19H34sdWhZi7q6LfslCHLRu2+7Q==",
-			"optional": true,
+			"version": "3.257.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.257.0.tgz",
+			"integrity": "sha512-F9ieon8B8eGVs5tyZtAIG3DZEObDvujkspho0qRbUTHUosM0ylJLsMU800fmC/uRHLRrZvb/RSp59+kNDwSAMw==",
 			"dependencies": {
 				"tslib": "^2.3.1"
 			},
@@ -997,11 +941,22 @@
 				"node": ">=14.0.0"
 			}
 		},
+		"node_modules/@aws-sdk/util-retry": {
+			"version": "3.257.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.257.0.tgz",
+			"integrity": "sha512-l9TOsOAYtZxwW3q5fQKW4rsD9t2HVaBfQ4zBamHkNTfB4vBVvCnz4oxkvSvA2MlxCA6am+K1K/oj917Tpqk53g==",
+			"dependencies": {
+				"@aws-sdk/service-error-classification": "3.257.0",
+				"tslib": "^2.3.1"
+			},
+			"engines": {
+				"node": ">= 14.0.0"
+			}
+		},
 		"node_modules/@aws-sdk/util-uri-escape": {
 			"version": "3.201.0",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
 			"integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
-			"optional": true,
 			"dependencies": {
 				"tslib": "^2.3.1"
 			},
@@ -1010,24 +965,22 @@
 			}
 		},
 		"node_modules/@aws-sdk/util-user-agent-browser": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.215.0.tgz",
-			"integrity": "sha512-uZz6BJWr8sJcA+onveS1lFqnbIXBHwvkyHLgCuuGhAxd5yY6YNLhpJBnhy9Fb8/aSbk6yao3qxlokqw9gthmAw==",
-			"optional": true,
+			"version": "3.257.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.257.0.tgz",
+			"integrity": "sha512-YdavWK6/8Cw6mypEgysGGX/dT9p9qnzFbnN5PQsUY+JJk2Nx8fKFydjGiQ+6rWPeW17RAv9mmbboh9uPVWxVlw==",
 			"dependencies": {
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/types": "3.257.0",
 				"bowser": "^2.11.0",
 				"tslib": "^2.3.1"
 			}
 		},
 		"node_modules/@aws-sdk/util-user-agent-node": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.215.0.tgz",
-			"integrity": "sha512-4lrdd1oGRwJEwfvgvg1jcJ2O0bwElsvtiqZfTRHN6MNTFUqsKl0xHlgFChQsz3Hfrc1niWtZCmbqQKGdO5ARpw==",
-			"optional": true,
+			"version": "3.259.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.259.0.tgz",
+			"integrity": "sha512-R0VTmNs+ySDDebU98BUbsLyeIM5YmAEr9esPpy15XfSy3AWmAeru8nLlztdaLilHZzLIDzvM2t7NGk/FzZFCvA==",
 			"dependencies": {
-				"@aws-sdk/node-config-provider": "3.215.0",
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/node-config-provider": "3.259.0",
+				"@aws-sdk/types": "3.257.0",
 				"tslib": "^2.3.1"
 			},
 			"engines": {
@@ -1042,26 +995,24 @@
 				}
 			}
 		},
-		"node_modules/@aws-sdk/util-utf8-browser": {
-			"version": "3.188.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
-			"integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
-			"optional": true,
-			"dependencies": {
-				"tslib": "^2.3.1"
-			}
-		},
-		"node_modules/@aws-sdk/util-utf8-node": {
-			"version": "3.208.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz",
-			"integrity": "sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==",
-			"optional": true,
+		"node_modules/@aws-sdk/util-utf8": {
+			"version": "3.254.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.254.0.tgz",
+			"integrity": "sha512-14Kso/eIt5/qfIBmhEL9L1IfyUqswjSTqO2mY7KOzUZ9SZbwn3rpxmtkhmATkRjD7XIlLKaxBkI7tU9Zjzj8Kw==",
 			"dependencies": {
 				"@aws-sdk/util-buffer-from": "3.208.0",
 				"tslib": "^2.3.1"
 			},
 			"engines": {
 				"node": ">=14.0.0"
+			}
+		},
+		"node_modules/@aws-sdk/util-utf8-browser": {
+			"version": "3.259.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
+			"integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
+			"dependencies": {
+				"tslib": "^2.3.1"
 			}
 		},
 		"node_modules/@types/node": {
@@ -1125,8 +1076,7 @@
 		"node_modules/bowser": {
 			"version": "2.11.0",
 			"resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
-			"integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
-			"optional": true
+			"integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
 		},
 		"node_modules/bson": {
 			"version": "4.7.2",
@@ -1223,7 +1173,6 @@
 			"version": "4.0.11",
 			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
 			"integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
-			"optional": true,
 			"dependencies": {
 				"strnum": "^1.0.5"
 			},
@@ -1357,9 +1306,9 @@
 			}
 		},
 		"node_modules/mongodb-client-encryption": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-2.3.0.tgz",
-			"integrity": "sha512-cXuRYBmCj43rLeqP8gHa+CrloFe7TUCd/f16VduFGQzAN9ef5buMGIfSr2CEGBul/EjTCLlioctSSDmHAmpTqA==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-2.4.0.tgz",
+			"integrity": "sha512-AKBlh20HWqUTl+US8yfJAMVchk6nD3RtBPfU6IfG7/iuK6OWQufLgBduvC/jYkLxPJU1+iMel5pSJQA0aMN+bg==",
 			"hasInstallScript": true,
 			"optional": true,
 			"dependencies": {
@@ -1372,7 +1321,13 @@
 				"node": ">=12.9.0"
 			},
 			"peerDependencies": {
+				"@aws-sdk/credential-providers": "^3.186.0",
 				"mongodb": ">=3.4.0"
+			},
+			"peerDependenciesMeta": {
+				"@aws-sdk/credential-providers": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/mongodb-connection-string-url": {
@@ -1634,8 +1589,7 @@
 		"node_modules/strnum": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
-			"integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
-			"optional": true
+			"integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
 		},
 		"node_modules/tar-fs": {
 			"version": "2.1.1",
@@ -1677,10 +1631,9 @@
 			}
 		},
 		"node_modules/tslib": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-			"integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
-			"optional": true
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+			"integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
 		},
 		"node_modules/tunnel-agent": {
 			"version": "0.6.0",
@@ -1704,7 +1657,6 @@
 			"version": "8.3.2",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
 			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-			"optional": true,
 			"bin": {
 				"uuid": "dist/bin/uuid"
 			}
@@ -1744,10 +1696,9 @@
 	},
 	"dependencies": {
 		"@aws-crypto/ie11-detection": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-2.0.2.tgz",
-			"integrity": "sha512-5XDMQY98gMAf/WRTic5G++jfmS/VLM0rwpiOpaainKi4L0nqWMSB1SzsrEG5rjFZGYN6ZAefO+/Yta2dFM0kMw==",
-			"optional": true,
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/ie11-detection/-/ie11-detection-3.0.0.tgz",
+			"integrity": "sha512-341lBBkiY1DfDNKai/wXM3aujNBkXR7tq1URPQDL9wi3AUbI80NR74uF1TXHMm7po1AcnFk8iu2S2IeU/+/A+Q==",
 			"requires": {
 				"tslib": "^1.11.1"
 			},
@@ -1755,22 +1706,20 @@
 				"tslib": {
 					"version": "1.14.1",
 					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-					"optional": true
+					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 				}
 			}
 		},
 		"@aws-crypto/sha256-browser": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-2.0.0.tgz",
-			"integrity": "sha512-rYXOQ8BFOaqMEHJrLHul/25ckWH6GTJtdLSajhlqGMx0PmSueAuvboCuZCTqEKlxR8CQOwRarxYMZZSYlhRA1A==",
-			"optional": true,
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-browser/-/sha256-browser-3.0.0.tgz",
+			"integrity": "sha512-8VLmW2B+gjFbU5uMeqtQM6Nj0/F1bro80xQXCW6CQBWgosFWXTx77aeOF5CAIAmbOK64SdMBJdNr6J41yP5mvQ==",
 			"requires": {
-				"@aws-crypto/ie11-detection": "^2.0.0",
-				"@aws-crypto/sha256-js": "^2.0.0",
-				"@aws-crypto/supports-web-crypto": "^2.0.0",
-				"@aws-crypto/util": "^2.0.0",
-				"@aws-sdk/types": "^3.1.0",
+				"@aws-crypto/ie11-detection": "^3.0.0",
+				"@aws-crypto/sha256-js": "^3.0.0",
+				"@aws-crypto/supports-web-crypto": "^3.0.0",
+				"@aws-crypto/util": "^3.0.0",
+				"@aws-sdk/types": "^3.222.0",
 				"@aws-sdk/util-locate-window": "^3.0.0",
 				"@aws-sdk/util-utf8-browser": "^3.0.0",
 				"tslib": "^1.11.1"
@@ -1779,35 +1728,31 @@
 				"tslib": {
 					"version": "1.14.1",
 					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-					"optional": true
+					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 				}
 			}
 		},
 		"@aws-crypto/sha256-js": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-2.0.0.tgz",
-			"integrity": "sha512-VZY+mCY4Nmrs5WGfitmNqXzaE873fcIZDu54cbaDaaamsaTOP1DBImV9F4pICc3EHjQXujyE8jig+PFCaew9ig==",
-			"optional": true,
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/sha256-js/-/sha256-js-3.0.0.tgz",
+			"integrity": "sha512-PnNN7os0+yd1XvXAy23CFOmTbMaDxgxXtTKHybrJ39Y8kGzBATgBFibWJKH6BhytLI/Zyszs87xCOBNyBig6vQ==",
 			"requires": {
-				"@aws-crypto/util": "^2.0.0",
-				"@aws-sdk/types": "^3.1.0",
+				"@aws-crypto/util": "^3.0.0",
+				"@aws-sdk/types": "^3.222.0",
 				"tslib": "^1.11.1"
 			},
 			"dependencies": {
 				"tslib": {
 					"version": "1.14.1",
 					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-					"optional": true
+					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 				}
 			}
 		},
 		"@aws-crypto/supports-web-crypto": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-2.0.2.tgz",
-			"integrity": "sha512-6mbSsLHwZ99CTOOswvCRP3C+VCWnzBf+1SnbWxzzJ9lR0mA0JnY2JEAhp8rqmTE0GPFy88rrM27ffgp62oErMQ==",
-			"optional": true,
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/supports-web-crypto/-/supports-web-crypto-3.0.0.tgz",
+			"integrity": "sha512-06hBdMwUAb2WFTuGG73LSC0wfPu93xWwo5vL2et9eymgmu3Id5vFAHBbajVWiGhPO37qcsdCap/FqXvJGJWPIg==",
 			"requires": {
 				"tslib": "^1.11.1"
 			},
@@ -1815,18 +1760,16 @@
 				"tslib": {
 					"version": "1.14.1",
 					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-					"optional": true
+					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 				}
 			}
 		},
 		"@aws-crypto/util": {
-			"version": "2.0.2",
-			"resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-2.0.2.tgz",
-			"integrity": "sha512-Lgu5v/0e/BcrZ5m/IWqzPUf3UYFTy/PpeED+uc9SWUR1iZQL8XXbGQg10UfllwwBryO3hFF5dizK+78aoXC1eA==",
-			"optional": true,
+			"version": "3.0.0",
+			"resolved": "https://registry.npmjs.org/@aws-crypto/util/-/util-3.0.0.tgz",
+			"integrity": "sha512-2OJlpeJpCR48CC8r+uKVChzs9Iungj9wkZrl8Z041DWEWvyIHILYKCPNzJghKsivj+S3mLo6BVc7mBNzdxA46w==",
 			"requires": {
-				"@aws-sdk/types": "^3.110.0",
+				"@aws-sdk/types": "^3.222.0",
 				"@aws-sdk/util-utf8-browser": "^3.0.0",
 				"tslib": "^1.11.1"
 			},
@@ -1834,362 +1777,345 @@
 				"tslib": {
 					"version": "1.14.1",
 					"resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-					"optional": true
+					"integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
 				}
 			}
 		},
 		"@aws-sdk/abort-controller": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.215.0.tgz",
-			"integrity": "sha512-HTvL542nawhVqe0oC1AJchdcomEOmPivJEzYUT1LqiG3e8ikxMNa2KWSqqLPeKi2t0A/cfQy7wDUyg9+BZhDSQ==",
-			"optional": true,
+			"version": "3.257.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/abort-controller/-/abort-controller-3.257.0.tgz",
+			"integrity": "sha512-ekWy391lOerS0ZECdhp/c+X7AToJIpfNrCPjuj3bKr+GMQYckGsYsdbm6AUD4sxBmfvuaQmVniSXWovaxwcFcQ==",
 			"requires": {
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/types": "3.257.0",
 				"tslib": "^2.3.1"
 			}
 		},
 		"@aws-sdk/client-cognito-identity": {
-			"version": "3.218.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.218.0.tgz",
-			"integrity": "sha512-IHzM9jpLqdeqj2w7YA7FrmLCQyKaun7eXtu1OJYMFbJT5XHx6B4jlQ1T/N8xivSSzDfjpJxG6/MMmjec4pI+CA==",
-			"optional": true,
+			"version": "3.262.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-cognito-identity/-/client-cognito-identity-3.262.0.tgz",
+			"integrity": "sha512-Kmms7MZUR8Sl5PzgaWz/8rG+VkhKGQJEiY74VHLqJ/BLg4KyIYpHfqiif+J6/9HWN4SGFic1Aij37D5EFA9kgw==",
 			"requires": {
-				"@aws-crypto/sha256-browser": "2.0.0",
-				"@aws-crypto/sha256-js": "2.0.0",
-				"@aws-sdk/client-sts": "3.218.0",
-				"@aws-sdk/config-resolver": "3.215.0",
-				"@aws-sdk/credential-provider-node": "3.218.0",
-				"@aws-sdk/fetch-http-handler": "3.215.0",
-				"@aws-sdk/hash-node": "3.215.0",
-				"@aws-sdk/invalid-dependency": "3.215.0",
-				"@aws-sdk/middleware-content-length": "3.215.0",
-				"@aws-sdk/middleware-endpoint": "3.215.0",
-				"@aws-sdk/middleware-host-header": "3.215.0",
-				"@aws-sdk/middleware-logger": "3.215.0",
-				"@aws-sdk/middleware-recursion-detection": "3.215.0",
-				"@aws-sdk/middleware-retry": "3.215.0",
-				"@aws-sdk/middleware-serde": "3.215.0",
-				"@aws-sdk/middleware-signing": "3.215.0",
-				"@aws-sdk/middleware-stack": "3.215.0",
-				"@aws-sdk/middleware-user-agent": "3.215.0",
-				"@aws-sdk/node-config-provider": "3.215.0",
-				"@aws-sdk/node-http-handler": "3.215.0",
-				"@aws-sdk/protocol-http": "3.215.0",
-				"@aws-sdk/smithy-client": "3.215.0",
-				"@aws-sdk/types": "3.215.0",
-				"@aws-sdk/url-parser": "3.215.0",
+				"@aws-crypto/sha256-browser": "3.0.0",
+				"@aws-crypto/sha256-js": "3.0.0",
+				"@aws-sdk/client-sts": "3.262.0",
+				"@aws-sdk/config-resolver": "3.259.0",
+				"@aws-sdk/credential-provider-node": "3.261.0",
+				"@aws-sdk/fetch-http-handler": "3.257.0",
+				"@aws-sdk/hash-node": "3.257.0",
+				"@aws-sdk/invalid-dependency": "3.257.0",
+				"@aws-sdk/middleware-content-length": "3.257.0",
+				"@aws-sdk/middleware-endpoint": "3.257.0",
+				"@aws-sdk/middleware-host-header": "3.257.0",
+				"@aws-sdk/middleware-logger": "3.257.0",
+				"@aws-sdk/middleware-recursion-detection": "3.257.0",
+				"@aws-sdk/middleware-retry": "3.259.0",
+				"@aws-sdk/middleware-serde": "3.257.0",
+				"@aws-sdk/middleware-signing": "3.257.0",
+				"@aws-sdk/middleware-stack": "3.257.0",
+				"@aws-sdk/middleware-user-agent": "3.257.0",
+				"@aws-sdk/node-config-provider": "3.259.0",
+				"@aws-sdk/node-http-handler": "3.257.0",
+				"@aws-sdk/protocol-http": "3.257.0",
+				"@aws-sdk/smithy-client": "3.261.0",
+				"@aws-sdk/types": "3.257.0",
+				"@aws-sdk/url-parser": "3.257.0",
 				"@aws-sdk/util-base64": "3.208.0",
 				"@aws-sdk/util-body-length-browser": "3.188.0",
 				"@aws-sdk/util-body-length-node": "3.208.0",
-				"@aws-sdk/util-defaults-mode-browser": "3.215.0",
-				"@aws-sdk/util-defaults-mode-node": "3.215.0",
-				"@aws-sdk/util-endpoints": "3.216.0",
-				"@aws-sdk/util-user-agent-browser": "3.215.0",
-				"@aws-sdk/util-user-agent-node": "3.215.0",
-				"@aws-sdk/util-utf8-browser": "3.188.0",
-				"@aws-sdk/util-utf8-node": "3.208.0",
+				"@aws-sdk/util-defaults-mode-browser": "3.261.0",
+				"@aws-sdk/util-defaults-mode-node": "3.261.0",
+				"@aws-sdk/util-endpoints": "3.257.0",
+				"@aws-sdk/util-retry": "3.257.0",
+				"@aws-sdk/util-user-agent-browser": "3.257.0",
+				"@aws-sdk/util-user-agent-node": "3.259.0",
+				"@aws-sdk/util-utf8": "3.254.0",
 				"tslib": "^2.3.1"
 			}
 		},
 		"@aws-sdk/client-sso": {
-			"version": "3.218.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.218.0.tgz",
-			"integrity": "sha512-kVMlpjaVblxgb1G8q3wD65mKxO3RzKwnjUjIBmOHpmseXzlSkAdAvYcikaDoJP+CRmys4uXk5DN8c7ZdL0OmgA==",
-			"optional": true,
+			"version": "3.261.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso/-/client-sso-3.261.0.tgz",
+			"integrity": "sha512-tq5hu1WXa9BKsCH9zOBOykyiaoZQvaFHKdOamw5SZ69niyO3AG4xR1TkLqXj/9mDYMLgAIVObKZDGWtBLFTdiQ==",
 			"requires": {
-				"@aws-crypto/sha256-browser": "2.0.0",
-				"@aws-crypto/sha256-js": "2.0.0",
-				"@aws-sdk/config-resolver": "3.215.0",
-				"@aws-sdk/fetch-http-handler": "3.215.0",
-				"@aws-sdk/hash-node": "3.215.0",
-				"@aws-sdk/invalid-dependency": "3.215.0",
-				"@aws-sdk/middleware-content-length": "3.215.0",
-				"@aws-sdk/middleware-endpoint": "3.215.0",
-				"@aws-sdk/middleware-host-header": "3.215.0",
-				"@aws-sdk/middleware-logger": "3.215.0",
-				"@aws-sdk/middleware-recursion-detection": "3.215.0",
-				"@aws-sdk/middleware-retry": "3.215.0",
-				"@aws-sdk/middleware-serde": "3.215.0",
-				"@aws-sdk/middleware-stack": "3.215.0",
-				"@aws-sdk/middleware-user-agent": "3.215.0",
-				"@aws-sdk/node-config-provider": "3.215.0",
-				"@aws-sdk/node-http-handler": "3.215.0",
-				"@aws-sdk/protocol-http": "3.215.0",
-				"@aws-sdk/smithy-client": "3.215.0",
-				"@aws-sdk/types": "3.215.0",
-				"@aws-sdk/url-parser": "3.215.0",
+				"@aws-crypto/sha256-browser": "3.0.0",
+				"@aws-crypto/sha256-js": "3.0.0",
+				"@aws-sdk/config-resolver": "3.259.0",
+				"@aws-sdk/fetch-http-handler": "3.257.0",
+				"@aws-sdk/hash-node": "3.257.0",
+				"@aws-sdk/invalid-dependency": "3.257.0",
+				"@aws-sdk/middleware-content-length": "3.257.0",
+				"@aws-sdk/middleware-endpoint": "3.257.0",
+				"@aws-sdk/middleware-host-header": "3.257.0",
+				"@aws-sdk/middleware-logger": "3.257.0",
+				"@aws-sdk/middleware-recursion-detection": "3.257.0",
+				"@aws-sdk/middleware-retry": "3.259.0",
+				"@aws-sdk/middleware-serde": "3.257.0",
+				"@aws-sdk/middleware-stack": "3.257.0",
+				"@aws-sdk/middleware-user-agent": "3.257.0",
+				"@aws-sdk/node-config-provider": "3.259.0",
+				"@aws-sdk/node-http-handler": "3.257.0",
+				"@aws-sdk/protocol-http": "3.257.0",
+				"@aws-sdk/smithy-client": "3.261.0",
+				"@aws-sdk/types": "3.257.0",
+				"@aws-sdk/url-parser": "3.257.0",
 				"@aws-sdk/util-base64": "3.208.0",
 				"@aws-sdk/util-body-length-browser": "3.188.0",
 				"@aws-sdk/util-body-length-node": "3.208.0",
-				"@aws-sdk/util-defaults-mode-browser": "3.215.0",
-				"@aws-sdk/util-defaults-mode-node": "3.215.0",
-				"@aws-sdk/util-endpoints": "3.216.0",
-				"@aws-sdk/util-user-agent-browser": "3.215.0",
-				"@aws-sdk/util-user-agent-node": "3.215.0",
-				"@aws-sdk/util-utf8-browser": "3.188.0",
-				"@aws-sdk/util-utf8-node": "3.208.0",
+				"@aws-sdk/util-defaults-mode-browser": "3.261.0",
+				"@aws-sdk/util-defaults-mode-node": "3.261.0",
+				"@aws-sdk/util-endpoints": "3.257.0",
+				"@aws-sdk/util-retry": "3.257.0",
+				"@aws-sdk/util-user-agent-browser": "3.257.0",
+				"@aws-sdk/util-user-agent-node": "3.259.0",
+				"@aws-sdk/util-utf8": "3.254.0",
 				"tslib": "^2.3.1"
 			}
 		},
 		"@aws-sdk/client-sso-oidc": {
-			"version": "3.216.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.216.0.tgz",
-			"integrity": "sha512-O8kmM86BHwiSwyNoIe+iHXuSpUE9PBWl3re8u+/igt/w5W5VmMVz+zQr7gRUDQ1FDgLWNEdAJa0r+JFx3pZdzA==",
-			"optional": true,
+			"version": "3.261.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sso-oidc/-/client-sso-oidc-3.261.0.tgz",
+			"integrity": "sha512-ItgRT/BThv2UxEeGJ5/GCF6JY1Rzk39IcDIPZAfBA8HbYcznXGDsBTRf45MErS+uollwNFX0T/WNlTbmjEDE7g==",
 			"requires": {
-				"@aws-crypto/sha256-browser": "2.0.0",
-				"@aws-crypto/sha256-js": "2.0.0",
-				"@aws-sdk/config-resolver": "3.215.0",
-				"@aws-sdk/fetch-http-handler": "3.215.0",
-				"@aws-sdk/hash-node": "3.215.0",
-				"@aws-sdk/invalid-dependency": "3.215.0",
-				"@aws-sdk/middleware-content-length": "3.215.0",
-				"@aws-sdk/middleware-endpoint": "3.215.0",
-				"@aws-sdk/middleware-host-header": "3.215.0",
-				"@aws-sdk/middleware-logger": "3.215.0",
-				"@aws-sdk/middleware-recursion-detection": "3.215.0",
-				"@aws-sdk/middleware-retry": "3.215.0",
-				"@aws-sdk/middleware-serde": "3.215.0",
-				"@aws-sdk/middleware-stack": "3.215.0",
-				"@aws-sdk/middleware-user-agent": "3.215.0",
-				"@aws-sdk/node-config-provider": "3.215.0",
-				"@aws-sdk/node-http-handler": "3.215.0",
-				"@aws-sdk/protocol-http": "3.215.0",
-				"@aws-sdk/smithy-client": "3.215.0",
-				"@aws-sdk/types": "3.215.0",
-				"@aws-sdk/url-parser": "3.215.0",
+				"@aws-crypto/sha256-browser": "3.0.0",
+				"@aws-crypto/sha256-js": "3.0.0",
+				"@aws-sdk/config-resolver": "3.259.0",
+				"@aws-sdk/fetch-http-handler": "3.257.0",
+				"@aws-sdk/hash-node": "3.257.0",
+				"@aws-sdk/invalid-dependency": "3.257.0",
+				"@aws-sdk/middleware-content-length": "3.257.0",
+				"@aws-sdk/middleware-endpoint": "3.257.0",
+				"@aws-sdk/middleware-host-header": "3.257.0",
+				"@aws-sdk/middleware-logger": "3.257.0",
+				"@aws-sdk/middleware-recursion-detection": "3.257.0",
+				"@aws-sdk/middleware-retry": "3.259.0",
+				"@aws-sdk/middleware-serde": "3.257.0",
+				"@aws-sdk/middleware-stack": "3.257.0",
+				"@aws-sdk/middleware-user-agent": "3.257.0",
+				"@aws-sdk/node-config-provider": "3.259.0",
+				"@aws-sdk/node-http-handler": "3.257.0",
+				"@aws-sdk/protocol-http": "3.257.0",
+				"@aws-sdk/smithy-client": "3.261.0",
+				"@aws-sdk/types": "3.257.0",
+				"@aws-sdk/url-parser": "3.257.0",
 				"@aws-sdk/util-base64": "3.208.0",
 				"@aws-sdk/util-body-length-browser": "3.188.0",
 				"@aws-sdk/util-body-length-node": "3.208.0",
-				"@aws-sdk/util-defaults-mode-browser": "3.215.0",
-				"@aws-sdk/util-defaults-mode-node": "3.215.0",
-				"@aws-sdk/util-endpoints": "3.216.0",
-				"@aws-sdk/util-user-agent-browser": "3.215.0",
-				"@aws-sdk/util-user-agent-node": "3.215.0",
-				"@aws-sdk/util-utf8-browser": "3.188.0",
-				"@aws-sdk/util-utf8-node": "3.208.0",
+				"@aws-sdk/util-defaults-mode-browser": "3.261.0",
+				"@aws-sdk/util-defaults-mode-node": "3.261.0",
+				"@aws-sdk/util-endpoints": "3.257.0",
+				"@aws-sdk/util-retry": "3.257.0",
+				"@aws-sdk/util-user-agent-browser": "3.257.0",
+				"@aws-sdk/util-user-agent-node": "3.259.0",
+				"@aws-sdk/util-utf8": "3.254.0",
 				"tslib": "^2.3.1"
 			}
 		},
 		"@aws-sdk/client-sts": {
-			"version": "3.218.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.218.0.tgz",
-			"integrity": "sha512-0A81eHvryKFEPq7IeY34Opzh5b9bVhhLlf2fDy5VuZjCFf4R9vD2ceOANvFSJeMsmdlqVDq8U1mHYl0E6FRUug==",
-			"optional": true,
+			"version": "3.262.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/client-sts/-/client-sts-3.262.0.tgz",
+			"integrity": "sha512-4Exb/tj3h6/4JsMza0ZpKVIE6N/bY2bS2T96LMB63v5T+yLmpQWUQu/fSZ56x+nuqmN1fz6PZLe0BIp96v4vDg==",
 			"requires": {
-				"@aws-crypto/sha256-browser": "2.0.0",
-				"@aws-crypto/sha256-js": "2.0.0",
-				"@aws-sdk/config-resolver": "3.215.0",
-				"@aws-sdk/credential-provider-node": "3.218.0",
-				"@aws-sdk/fetch-http-handler": "3.215.0",
-				"@aws-sdk/hash-node": "3.215.0",
-				"@aws-sdk/invalid-dependency": "3.215.0",
-				"@aws-sdk/middleware-content-length": "3.215.0",
-				"@aws-sdk/middleware-endpoint": "3.215.0",
-				"@aws-sdk/middleware-host-header": "3.215.0",
-				"@aws-sdk/middleware-logger": "3.215.0",
-				"@aws-sdk/middleware-recursion-detection": "3.215.0",
-				"@aws-sdk/middleware-retry": "3.215.0",
-				"@aws-sdk/middleware-sdk-sts": "3.215.0",
-				"@aws-sdk/middleware-serde": "3.215.0",
-				"@aws-sdk/middleware-signing": "3.215.0",
-				"@aws-sdk/middleware-stack": "3.215.0",
-				"@aws-sdk/middleware-user-agent": "3.215.0",
-				"@aws-sdk/node-config-provider": "3.215.0",
-				"@aws-sdk/node-http-handler": "3.215.0",
-				"@aws-sdk/protocol-http": "3.215.0",
-				"@aws-sdk/smithy-client": "3.215.0",
-				"@aws-sdk/types": "3.215.0",
-				"@aws-sdk/url-parser": "3.215.0",
+				"@aws-crypto/sha256-browser": "3.0.0",
+				"@aws-crypto/sha256-js": "3.0.0",
+				"@aws-sdk/config-resolver": "3.259.0",
+				"@aws-sdk/credential-provider-node": "3.261.0",
+				"@aws-sdk/fetch-http-handler": "3.257.0",
+				"@aws-sdk/hash-node": "3.257.0",
+				"@aws-sdk/invalid-dependency": "3.257.0",
+				"@aws-sdk/middleware-content-length": "3.257.0",
+				"@aws-sdk/middleware-endpoint": "3.257.0",
+				"@aws-sdk/middleware-host-header": "3.257.0",
+				"@aws-sdk/middleware-logger": "3.257.0",
+				"@aws-sdk/middleware-recursion-detection": "3.257.0",
+				"@aws-sdk/middleware-retry": "3.259.0",
+				"@aws-sdk/middleware-sdk-sts": "3.257.0",
+				"@aws-sdk/middleware-serde": "3.257.0",
+				"@aws-sdk/middleware-signing": "3.257.0",
+				"@aws-sdk/middleware-stack": "3.257.0",
+				"@aws-sdk/middleware-user-agent": "3.257.0",
+				"@aws-sdk/node-config-provider": "3.259.0",
+				"@aws-sdk/node-http-handler": "3.257.0",
+				"@aws-sdk/protocol-http": "3.257.0",
+				"@aws-sdk/smithy-client": "3.261.0",
+				"@aws-sdk/types": "3.257.0",
+				"@aws-sdk/url-parser": "3.257.0",
 				"@aws-sdk/util-base64": "3.208.0",
 				"@aws-sdk/util-body-length-browser": "3.188.0",
 				"@aws-sdk/util-body-length-node": "3.208.0",
-				"@aws-sdk/util-defaults-mode-browser": "3.215.0",
-				"@aws-sdk/util-defaults-mode-node": "3.215.0",
-				"@aws-sdk/util-endpoints": "3.216.0",
-				"@aws-sdk/util-user-agent-browser": "3.215.0",
-				"@aws-sdk/util-user-agent-node": "3.215.0",
-				"@aws-sdk/util-utf8-browser": "3.188.0",
-				"@aws-sdk/util-utf8-node": "3.208.0",
+				"@aws-sdk/util-defaults-mode-browser": "3.261.0",
+				"@aws-sdk/util-defaults-mode-node": "3.261.0",
+				"@aws-sdk/util-endpoints": "3.257.0",
+				"@aws-sdk/util-retry": "3.257.0",
+				"@aws-sdk/util-user-agent-browser": "3.257.0",
+				"@aws-sdk/util-user-agent-node": "3.259.0",
+				"@aws-sdk/util-utf8": "3.254.0",
 				"fast-xml-parser": "4.0.11",
 				"tslib": "^2.3.1"
 			}
 		},
 		"@aws-sdk/config-resolver": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.215.0.tgz",
-			"integrity": "sha512-DxX4R+YYLQOtg0qfceKBrjVD4t1mQBG1eb7IVr2QSlckFCX8ztUNymFMuaSEo3938Jyy/NpgfUDpFqPDaSKnng==",
-			"optional": true,
+			"version": "3.259.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/config-resolver/-/config-resolver-3.259.0.tgz",
+			"integrity": "sha512-gViMRsc4Ye6+nzJ0OYTZIT8m4glIAdtugN2Sr/t6P2iJW5X0bSL/EcbcHBgsve1lHjeGPeyzVkT7UnyGOZ5Z/A==",
 			"requires": {
-				"@aws-sdk/signature-v4": "3.215.0",
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/signature-v4": "3.257.0",
+				"@aws-sdk/types": "3.257.0",
 				"@aws-sdk/util-config-provider": "3.208.0",
-				"@aws-sdk/util-middleware": "3.215.0",
+				"@aws-sdk/util-middleware": "3.257.0",
 				"tslib": "^2.3.1"
 			}
 		},
 		"@aws-sdk/credential-provider-cognito-identity": {
-			"version": "3.218.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.218.0.tgz",
-			"integrity": "sha512-ndhlPBvnxUgje23TnVw0fkDgTZHh0GVapKSgeEIxmxAy3IVLN15iMs7dCV7LWvb7z1P0cYx9cwvxa0nTrVxjtg==",
-			"optional": true,
+			"version": "3.262.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-cognito-identity/-/credential-provider-cognito-identity-3.262.0.tgz",
+			"integrity": "sha512-oOVslglkpOoA8XUoc8yGGky+hUdDezx3CfzdrUg0TeyTqj3dVEEo+ghLk/ngne+T2t73revVJ2AAaOgVNomRcA==",
 			"requires": {
-				"@aws-sdk/client-cognito-identity": "3.218.0",
-				"@aws-sdk/property-provider": "3.215.0",
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/client-cognito-identity": "3.262.0",
+				"@aws-sdk/property-provider": "3.257.0",
+				"@aws-sdk/types": "3.257.0",
 				"tslib": "^2.3.1"
 			}
 		},
 		"@aws-sdk/credential-provider-env": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.215.0.tgz",
-			"integrity": "sha512-n5G7I7Pxfsn81+tNsSOzspKp9SYai78oRfImsfFY4JLTcWutv7szMgFUbtEzBfUUINHpOxLiO2Lk5yu5K1C7IQ==",
-			"optional": true,
+			"version": "3.257.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-env/-/credential-provider-env-3.257.0.tgz",
+			"integrity": "sha512-GsmBi5Di6hk1JAi1iB6/LCY8o+GmlCvJoB7wuoVmXI3VxRVwptUVjuj8EtJbIrVGrF9dSuIRPCzUoSuzEzYGlg==",
 			"requires": {
-				"@aws-sdk/property-provider": "3.215.0",
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/property-provider": "3.257.0",
+				"@aws-sdk/types": "3.257.0",
 				"tslib": "^2.3.1"
 			}
 		},
 		"@aws-sdk/credential-provider-imds": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.215.0.tgz",
-			"integrity": "sha512-/4FUUR6u9gkNfxB6mEwBr0kk0myIkrDcXbAocWN3fPd/t7otzxpx/JqPZXgM6kcVP7M4T/QT75l1E1RRHLWCCQ==",
-			"optional": true,
+			"version": "3.259.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-imds/-/credential-provider-imds-3.259.0.tgz",
+			"integrity": "sha512-yCxoYWZAaDrCUEWxRfrpB0Mp1cFgJEMYW8T6GIb/+DQ5QLpZmorgaVD/j90QXupqFrR5tlxwuskBIkdD2E9YNg==",
 			"requires": {
-				"@aws-sdk/node-config-provider": "3.215.0",
-				"@aws-sdk/property-provider": "3.215.0",
-				"@aws-sdk/types": "3.215.0",
-				"@aws-sdk/url-parser": "3.215.0",
+				"@aws-sdk/node-config-provider": "3.259.0",
+				"@aws-sdk/property-provider": "3.257.0",
+				"@aws-sdk/types": "3.257.0",
+				"@aws-sdk/url-parser": "3.257.0",
 				"tslib": "^2.3.1"
 			}
 		},
 		"@aws-sdk/credential-provider-ini": {
-			"version": "3.218.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.218.0.tgz",
-			"integrity": "sha512-tDDrGW+4A+PQThVJ+l9ee03CsDoD0XLpOB5dcf+dr/dCHjcQ7x/CeVFZ8eM+XUtGQnZVvuzXZGwzS8bUWEdJIg==",
-			"optional": true,
+			"version": "3.261.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-ini/-/credential-provider-ini-3.261.0.tgz",
+			"integrity": "sha512-638jTnvFbGO0G0So+FijdC1vjn/dhw3l8nJwLq9PYOBJUKhjXDR/fpOhZkUJ+Zwfuqp9SlDDo/yfFa6j2L+F1g==",
 			"requires": {
-				"@aws-sdk/credential-provider-env": "3.215.0",
-				"@aws-sdk/credential-provider-imds": "3.215.0",
-				"@aws-sdk/credential-provider-sso": "3.218.0",
-				"@aws-sdk/credential-provider-web-identity": "3.215.0",
-				"@aws-sdk/property-provider": "3.215.0",
-				"@aws-sdk/shared-ini-file-loader": "3.215.0",
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/credential-provider-env": "3.257.0",
+				"@aws-sdk/credential-provider-imds": "3.259.0",
+				"@aws-sdk/credential-provider-process": "3.257.0",
+				"@aws-sdk/credential-provider-sso": "3.261.0",
+				"@aws-sdk/credential-provider-web-identity": "3.257.0",
+				"@aws-sdk/property-provider": "3.257.0",
+				"@aws-sdk/shared-ini-file-loader": "3.257.0",
+				"@aws-sdk/types": "3.257.0",
 				"tslib": "^2.3.1"
 			}
 		},
 		"@aws-sdk/credential-provider-node": {
-			"version": "3.218.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.218.0.tgz",
-			"integrity": "sha512-J9PB6XFA+V0mgxleuY5W6Jjh5WejV8HjMViTJQpp2JN+NWZP3bGvquUSQHRqWGRGg2fSJy6Z/J4zQ8fpPbGsdQ==",
-			"optional": true,
+			"version": "3.261.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-node/-/credential-provider-node-3.261.0.tgz",
+			"integrity": "sha512-7T25a7jbHsXPe7XvIekzhR50b7PTlISKqHdE8LNVUSzFQbSjVXulFk3vyQVIhmt5HKNkSBcMPDr6hKrSl7OLBw==",
 			"requires": {
-				"@aws-sdk/credential-provider-env": "3.215.0",
-				"@aws-sdk/credential-provider-imds": "3.215.0",
-				"@aws-sdk/credential-provider-ini": "3.218.0",
-				"@aws-sdk/credential-provider-process": "3.215.0",
-				"@aws-sdk/credential-provider-sso": "3.218.0",
-				"@aws-sdk/credential-provider-web-identity": "3.215.0",
-				"@aws-sdk/property-provider": "3.215.0",
-				"@aws-sdk/shared-ini-file-loader": "3.215.0",
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/credential-provider-env": "3.257.0",
+				"@aws-sdk/credential-provider-imds": "3.259.0",
+				"@aws-sdk/credential-provider-ini": "3.261.0",
+				"@aws-sdk/credential-provider-process": "3.257.0",
+				"@aws-sdk/credential-provider-sso": "3.261.0",
+				"@aws-sdk/credential-provider-web-identity": "3.257.0",
+				"@aws-sdk/property-provider": "3.257.0",
+				"@aws-sdk/shared-ini-file-loader": "3.257.0",
+				"@aws-sdk/types": "3.257.0",
 				"tslib": "^2.3.1"
 			}
 		},
 		"@aws-sdk/credential-provider-process": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.215.0.tgz",
-			"integrity": "sha512-JNvj4L5B7W8byoFdfn/8Y4scoPiwCi+Ha/fRsFCrdSC7C+snDuxM/oQj33HI8DpKY1cjuigzEnpnxiNWaA09EA==",
-			"optional": true,
+			"version": "3.257.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-process/-/credential-provider-process-3.257.0.tgz",
+			"integrity": "sha512-xK8uYeNXaclaBCGrLi4z2pxPRngqLf5BM5jg2fn57zqvlL9V5gJF972FehrVBL0bfp1/laG0ZJtD2K2sapyWAw==",
 			"requires": {
-				"@aws-sdk/property-provider": "3.215.0",
-				"@aws-sdk/shared-ini-file-loader": "3.215.0",
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/property-provider": "3.257.0",
+				"@aws-sdk/shared-ini-file-loader": "3.257.0",
+				"@aws-sdk/types": "3.257.0",
 				"tslib": "^2.3.1"
 			}
 		},
 		"@aws-sdk/credential-provider-sso": {
-			"version": "3.218.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.218.0.tgz",
-			"integrity": "sha512-HecWvmxD+xffmY8G4SfLRfCOgSoLFki45wOOU8ESgRM9fQp2+3CfRSyiThKZI5PTmE+xhPTRvmR61HUmQjEv8w==",
-			"optional": true,
+			"version": "3.261.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-sso/-/credential-provider-sso-3.261.0.tgz",
+			"integrity": "sha512-Ofj7m85/RuxcZMtghhD+U2GGszrU5tB2kxXcnkcHCudOER6bcOOEXnSfmdZnIv4xG+vma3VFwiWk2JkQo5zB5w==",
 			"requires": {
-				"@aws-sdk/client-sso": "3.218.0",
-				"@aws-sdk/property-provider": "3.215.0",
-				"@aws-sdk/shared-ini-file-loader": "3.215.0",
-				"@aws-sdk/token-providers": "3.216.0",
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/client-sso": "3.261.0",
+				"@aws-sdk/property-provider": "3.257.0",
+				"@aws-sdk/shared-ini-file-loader": "3.257.0",
+				"@aws-sdk/token-providers": "3.261.0",
+				"@aws-sdk/types": "3.257.0",
 				"tslib": "^2.3.1"
 			}
 		},
 		"@aws-sdk/credential-provider-web-identity": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.215.0.tgz",
-			"integrity": "sha512-AWaDDEE3VU1HeLrXvyUrkQ6Wb3PQij5bvvrMil9L0da3b1yrcpoDanQQy7wBFBXcZIVmcmSFe5MMA/nyh2Le4g==",
-			"optional": true,
+			"version": "3.257.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-provider-web-identity/-/credential-provider-web-identity-3.257.0.tgz",
+			"integrity": "sha512-Cm0uvRv4JuIbD0Kp3W0J/vwjADIyCx8HoZi5yg+QIi5nilocuTQ3ajvLeuPVSvFvdy+yaxSc5FxNXquWt7Mngw==",
 			"requires": {
-				"@aws-sdk/property-provider": "3.215.0",
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/property-provider": "3.257.0",
+				"@aws-sdk/types": "3.257.0",
 				"tslib": "^2.3.1"
 			}
 		},
 		"@aws-sdk/credential-providers": {
-			"version": "3.218.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.218.0.tgz",
-			"integrity": "sha512-MWpb5k+Oq56NrHA5fYPIDX8QRYUAw4Jp8ErTELBd83kLhTgqTw025YQ05YbhIzAs84+viMeWKif0z/5kNshphw==",
-			"optional": true,
+			"version": "3.262.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/credential-providers/-/credential-providers-3.262.0.tgz",
+			"integrity": "sha512-sJcLaBcuXkeIqQuCEQK2OFgfsN0AcOpGa/7nRGUzh9/9bif0rl/xBi96Wqyeb7Tf71qZ9gcpBnDUaaK+O9q6mg==",
 			"requires": {
-				"@aws-sdk/client-cognito-identity": "3.218.0",
-				"@aws-sdk/client-sso": "3.218.0",
-				"@aws-sdk/client-sts": "3.218.0",
-				"@aws-sdk/credential-provider-cognito-identity": "3.218.0",
-				"@aws-sdk/credential-provider-env": "3.215.0",
-				"@aws-sdk/credential-provider-imds": "3.215.0",
-				"@aws-sdk/credential-provider-ini": "3.218.0",
-				"@aws-sdk/credential-provider-node": "3.218.0",
-				"@aws-sdk/credential-provider-process": "3.215.0",
-				"@aws-sdk/credential-provider-sso": "3.218.0",
-				"@aws-sdk/credential-provider-web-identity": "3.215.0",
-				"@aws-sdk/property-provider": "3.215.0",
-				"@aws-sdk/shared-ini-file-loader": "3.215.0",
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/client-cognito-identity": "3.262.0",
+				"@aws-sdk/client-sso": "3.261.0",
+				"@aws-sdk/client-sts": "3.262.0",
+				"@aws-sdk/credential-provider-cognito-identity": "3.262.0",
+				"@aws-sdk/credential-provider-env": "3.257.0",
+				"@aws-sdk/credential-provider-imds": "3.259.0",
+				"@aws-sdk/credential-provider-ini": "3.261.0",
+				"@aws-sdk/credential-provider-node": "3.261.0",
+				"@aws-sdk/credential-provider-process": "3.257.0",
+				"@aws-sdk/credential-provider-sso": "3.261.0",
+				"@aws-sdk/credential-provider-web-identity": "3.257.0",
+				"@aws-sdk/property-provider": "3.257.0",
+				"@aws-sdk/shared-ini-file-loader": "3.257.0",
+				"@aws-sdk/types": "3.257.0",
 				"tslib": "^2.3.1"
 			}
 		},
 		"@aws-sdk/fetch-http-handler": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.215.0.tgz",
-			"integrity": "sha512-JfZyrJOE+0ik1PumsIUZd0NfgEx4sZ43VSdPCD9GRhssRWudNsSF1B5fz3xA5v+1y5oQPjXZyaWCzKtnYruiWw==",
-			"optional": true,
+			"version": "3.257.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/fetch-http-handler/-/fetch-http-handler-3.257.0.tgz",
+			"integrity": "sha512-zOF+RzQ+wfF7tq7tGUdPcqUTh3+k2f8KCVJE07A8kCopVq4nBu4NH6Eq29Tjpwdya3YlKvE+kFssuQRRRRex+Q==",
 			"requires": {
-				"@aws-sdk/protocol-http": "3.215.0",
-				"@aws-sdk/querystring-builder": "3.215.0",
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/protocol-http": "3.257.0",
+				"@aws-sdk/querystring-builder": "3.257.0",
+				"@aws-sdk/types": "3.257.0",
 				"@aws-sdk/util-base64": "3.208.0",
 				"tslib": "^2.3.1"
 			}
 		},
 		"@aws-sdk/hash-node": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.215.0.tgz",
-			"integrity": "sha512-MkSRuZvo1RCRmI0VNEmRYCGGD/DkMd9lqnLtOyglMPnSX1mhyD4/DyXmcc3rYa7PsjDRAfykGWJRiMqpoMLjiQ==",
-			"optional": true,
+			"version": "3.257.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/hash-node/-/hash-node-3.257.0.tgz",
+			"integrity": "sha512-W/USUuea5Ep3OJ2U7Ve8/5KN1YsDun2WzOFUxc1PyxXP5pW6OgC15/op0e+bmWPG851clvp5S8ZuroUr3aKi3Q==",
 			"requires": {
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/types": "3.257.0",
 				"@aws-sdk/util-buffer-from": "3.208.0",
+				"@aws-sdk/util-utf8": "3.254.0",
 				"tslib": "^2.3.1"
 			}
 		},
 		"@aws-sdk/invalid-dependency": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.215.0.tgz",
-			"integrity": "sha512-++bK4BUQe8/CL/YcLZcQB8qPOhiXxhbuhYzfFS7PNVvW1QOLqKRZL/lKs24gzjcOmw7IhAbCybDZwvu2TM4DAg==",
-			"optional": true,
+			"version": "3.257.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/invalid-dependency/-/invalid-dependency-3.257.0.tgz",
+			"integrity": "sha512-T68SAPRNMEhpke0wlxURgogL7q0B8dfqZsSeS20BVR/lksJxLse9+pbmCDxiu1RrXoEIsEwl5rbLN+Hw8BFFYw==",
 			"requires": {
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/types": "3.257.0",
 				"tslib": "^2.3.1"
 			}
 		},
@@ -2197,276 +2123,256 @@
 			"version": "3.201.0",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/is-array-buffer/-/is-array-buffer-3.201.0.tgz",
 			"integrity": "sha512-UPez5qLh3dNgt0DYnPD/q0mVJY84rA17QE26hVNOW3fAji8W2wrwrxdacWOxyXvlxWsVRcKmr+lay1MDqpAMfg==",
-			"optional": true,
 			"requires": {
 				"tslib": "^2.3.1"
 			}
 		},
 		"@aws-sdk/middleware-content-length": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.215.0.tgz",
-			"integrity": "sha512-zKJRb6jDLFl9nl/muSFbiQHA4uK3skinuDRcyLbpMvvzhuK/PVodv9QI1+wIUsFdXkaSxAlva1oG4bL8ZFi+sQ==",
-			"optional": true,
+			"version": "3.257.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-content-length/-/middleware-content-length-3.257.0.tgz",
+			"integrity": "sha512-yiawbV2azm6QnMY1L2ypG8PDRdjOcEIvFmT0T7y0F49rfbKJOu21j1ONAoCkLrINK6kMqcD5JSQLVCoURxiTxQ==",
 			"requires": {
-				"@aws-sdk/protocol-http": "3.215.0",
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/protocol-http": "3.257.0",
+				"@aws-sdk/types": "3.257.0",
 				"tslib": "^2.3.1"
 			}
 		},
 		"@aws-sdk/middleware-endpoint": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.215.0.tgz",
-			"integrity": "sha512-W0QXL5emcN9IXtMbnWT/abLxBFH2tGIfnre2jPNmZ9M7uVFxUwwv5OTUXxNLGNehJHKhiJPwhfQvMy20IDzVcw==",
-			"optional": true,
+			"version": "3.257.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-endpoint/-/middleware-endpoint-3.257.0.tgz",
+			"integrity": "sha512-RQNQe/jeVuWZtXXfcOm+e3qMFICY6ERsXUrbt0rjHgvajZCklcrRJgxJSCwrcS7Le3nl9azFPMAMj9L7uSK28g==",
 			"requires": {
-				"@aws-sdk/middleware-serde": "3.215.0",
-				"@aws-sdk/protocol-http": "3.215.0",
-				"@aws-sdk/signature-v4": "3.215.0",
-				"@aws-sdk/types": "3.215.0",
-				"@aws-sdk/url-parser": "3.215.0",
+				"@aws-sdk/middleware-serde": "3.257.0",
+				"@aws-sdk/protocol-http": "3.257.0",
+				"@aws-sdk/signature-v4": "3.257.0",
+				"@aws-sdk/types": "3.257.0",
+				"@aws-sdk/url-parser": "3.257.0",
 				"@aws-sdk/util-config-provider": "3.208.0",
-				"@aws-sdk/util-middleware": "3.215.0",
+				"@aws-sdk/util-middleware": "3.257.0",
 				"tslib": "^2.3.1"
 			}
 		},
 		"@aws-sdk/middleware-host-header": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.215.0.tgz",
-			"integrity": "sha512-GOqI7VwoENZwn+6tIMrrJ4SipIqL2JCh+BNvORVcy7CQxn1ViKkna7iaCx+QMjpg/kn9cR6kfY0n1FmgZR1w9A==",
-			"optional": true,
+			"version": "3.257.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-host-header/-/middleware-host-header-3.257.0.tgz",
+			"integrity": "sha512-gEi9AJdJfRfU8Qr6HK1hfhxTzyV3Giq4B/h7um99hIFAT/GCg9xiPvAOKPo6UeuiKEv3b7RpSL4s6cBvnJMJBA==",
 			"requires": {
-				"@aws-sdk/protocol-http": "3.215.0",
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/protocol-http": "3.257.0",
+				"@aws-sdk/types": "3.257.0",
 				"tslib": "^2.3.1"
 			}
 		},
 		"@aws-sdk/middleware-logger": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.215.0.tgz",
-			"integrity": "sha512-0h4GGF0rV3jnY3jxmcAWsOdqHCYf25s0biSjmgTei+l/5S+geOGrovRPCNep0LLg0i9D8bkZsXISojilETbf+g==",
-			"optional": true,
+			"version": "3.257.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-logger/-/middleware-logger-3.257.0.tgz",
+			"integrity": "sha512-8RDXW/VbMKBsXDfcCLmROZcWKyrekyiPa3J1aIaBy0tq9o4xpGoXw/lwwIrNVvISAFslb57rteup34bfn6ta6w==",
 			"requires": {
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/types": "3.257.0",
 				"tslib": "^2.3.1"
 			}
 		},
 		"@aws-sdk/middleware-recursion-detection": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.215.0.tgz",
-			"integrity": "sha512-KQ+kiEsaluM4i6opjusUukxY78+UhfR7vzXHDkzZK/GplQ1hY0B+rwVO1eaULmlnmf3FK+Wd6lwrPV7xS2W+EA==",
-			"optional": true,
+			"version": "3.257.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-recursion-detection/-/middleware-recursion-detection-3.257.0.tgz",
+			"integrity": "sha512-rUCih6zHh8k9Edf5N5Er4s508FYbwLM0MWTD2axzlj9TjLqEQ9OKED3wHaLffXSDzodd3oTAfJCLPbWQyoZ3ZQ==",
 			"requires": {
-				"@aws-sdk/protocol-http": "3.215.0",
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/protocol-http": "3.257.0",
+				"@aws-sdk/types": "3.257.0",
 				"tslib": "^2.3.1"
 			}
 		},
 		"@aws-sdk/middleware-retry": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.215.0.tgz",
-			"integrity": "sha512-I/dnUPVg2Kp3lW+MywBoPp06EOng8IfuaS9ph4bcJpQKrhNU5ekRgCHH2C4k1A6GcP8uyHxQ5TVV6j+l0QPIsA==",
-			"optional": true,
+			"version": "3.259.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-retry/-/middleware-retry-3.259.0.tgz",
+			"integrity": "sha512-pVh1g8e84MAi7eVtWLiiiCtn82LzxOP7+LxTRHatmgIeN22yGQBZILliPDJypUPvDYlwxI1ekiK+oPTcte0Uww==",
 			"requires": {
-				"@aws-sdk/protocol-http": "3.215.0",
-				"@aws-sdk/service-error-classification": "3.215.0",
-				"@aws-sdk/types": "3.215.0",
-				"@aws-sdk/util-middleware": "3.215.0",
+				"@aws-sdk/protocol-http": "3.257.0",
+				"@aws-sdk/service-error-classification": "3.257.0",
+				"@aws-sdk/types": "3.257.0",
+				"@aws-sdk/util-middleware": "3.257.0",
+				"@aws-sdk/util-retry": "3.257.0",
 				"tslib": "^2.3.1",
 				"uuid": "^8.3.2"
 			}
 		},
 		"@aws-sdk/middleware-sdk-sts": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.215.0.tgz",
-			"integrity": "sha512-wJRxoDf+2egbRgochaQL8+zzADx8FM/2W0spKNj8x+t/3iqw70QwxCfuEKW/uFQ3ph6eaIrv7gYc8RRjwhD8rg==",
-			"optional": true,
+			"version": "3.257.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-sdk-sts/-/middleware-sdk-sts-3.257.0.tgz",
+			"integrity": "sha512-d6IJCLRi3O2tm4AFK60WNhIwmMmspj1WzKR1q1TaoPzoREPG2xg+Am18wZBRkCyYuRPPrbizmkvAmAJiUolMAw==",
 			"requires": {
-				"@aws-sdk/middleware-signing": "3.215.0",
-				"@aws-sdk/property-provider": "3.215.0",
-				"@aws-sdk/protocol-http": "3.215.0",
-				"@aws-sdk/signature-v4": "3.215.0",
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/middleware-signing": "3.257.0",
+				"@aws-sdk/property-provider": "3.257.0",
+				"@aws-sdk/protocol-http": "3.257.0",
+				"@aws-sdk/signature-v4": "3.257.0",
+				"@aws-sdk/types": "3.257.0",
 				"tslib": "^2.3.1"
 			}
 		},
 		"@aws-sdk/middleware-serde": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.215.0.tgz",
-			"integrity": "sha512-+uhLXdKvvQZcRRFc3UmemSr/YUHA4Jc+1YMjHxc3v8vvfztFJBb0wgBx999myOi8PmkYThlRBQDzXy9UCIhIJw==",
-			"optional": true,
+			"version": "3.257.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-serde/-/middleware-serde-3.257.0.tgz",
+			"integrity": "sha512-/JasfXPWFq24mnCrx9fxW/ISBSp07RJwhsF14qzm8Qy3Z0z470C+QRM6otTwAkYuuVt1wuLjja5agq3Jtzq7dQ==",
 			"requires": {
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/types": "3.257.0",
 				"tslib": "^2.3.1"
 			}
 		},
 		"@aws-sdk/middleware-signing": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.215.0.tgz",
-			"integrity": "sha512-3BqzYqkmdPeOxjI8DVQE7Bm7J5QIvDy30abglXqrDg6npw6KonKI2Q3FIPFf+oLpZTMStwkoQOnwXHTPrSZ6Tg==",
-			"optional": true,
+			"version": "3.257.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-signing/-/middleware-signing-3.257.0.tgz",
+			"integrity": "sha512-hCH3D83LHmm6nqmtNrGTWZCVjsQXrGHIXbd17/qrw7aPFvcAhsiiCncGFP+XsUXEKa2ZqcSNMUyPrx69ofNRZQ==",
 			"requires": {
-				"@aws-sdk/property-provider": "3.215.0",
-				"@aws-sdk/protocol-http": "3.215.0",
-				"@aws-sdk/signature-v4": "3.215.0",
-				"@aws-sdk/types": "3.215.0",
-				"@aws-sdk/util-middleware": "3.215.0",
+				"@aws-sdk/property-provider": "3.257.0",
+				"@aws-sdk/protocol-http": "3.257.0",
+				"@aws-sdk/signature-v4": "3.257.0",
+				"@aws-sdk/types": "3.257.0",
+				"@aws-sdk/util-middleware": "3.257.0",
 				"tslib": "^2.3.1"
 			}
 		},
 		"@aws-sdk/middleware-stack": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.215.0.tgz",
-			"integrity": "sha512-rdSVL7LxRgjlvoluqwODD4ypBy2k/YVl6FrDplyCMSi8m2WHZG99FzdmR9bpnWK+0DGzYZSMRYx6ynJ9N9PsSw==",
-			"optional": true,
+			"version": "3.257.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-stack/-/middleware-stack-3.257.0.tgz",
+			"integrity": "sha512-awg2F0SvwACBaw4HIObK8pQGfSqAc4Vy+YFzWSfZNVC35oRO6RsRdKHVU99lRC0LrT2Ptmfghl2DMPSrRDbvlQ==",
 			"requires": {
 				"tslib": "^2.3.1"
 			}
 		},
 		"@aws-sdk/middleware-user-agent": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.215.0.tgz",
-			"integrity": "sha512-X6GfoMNoEITTw7rGL/gWs8UZ0cmmmezvKcl+KtHsA642R05OR4mY5G7LdbWAw0bcrwKsuKOGmwUrC9lzGqbWUw==",
-			"optional": true,
+			"version": "3.257.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/middleware-user-agent/-/middleware-user-agent-3.257.0.tgz",
+			"integrity": "sha512-37rt75LZyD0UWpbcFuxEGqwF3DZKSixQPl7AsDe6q3KtrO5gGQB+diH5vbY0txNNYyv5IK9WMwvY73mVmoWRmw==",
 			"requires": {
-				"@aws-sdk/protocol-http": "3.215.0",
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/protocol-http": "3.257.0",
+				"@aws-sdk/types": "3.257.0",
 				"tslib": "^2.3.1"
 			}
 		},
 		"@aws-sdk/node-config-provider": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.215.0.tgz",
-			"integrity": "sha512-notckD94QwwxC0GsfpTxB7VH8SREIIlMsUSddqGtpModa0cq/wRb9rqnydZSoznbYpK1ND6h0C9hr/2PNz89zw==",
-			"optional": true,
+			"version": "3.259.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/node-config-provider/-/node-config-provider-3.259.0.tgz",
+			"integrity": "sha512-DUOqr71oonBvM6yKPdhDBmraqgXHCFrVWFw7hc5ZNxL2wS/EsbKfGPJp+C+SUgpn1upIWPNnh/bNoLAbBkcLsA==",
 			"requires": {
-				"@aws-sdk/property-provider": "3.215.0",
-				"@aws-sdk/shared-ini-file-loader": "3.215.0",
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/property-provider": "3.257.0",
+				"@aws-sdk/shared-ini-file-loader": "3.257.0",
+				"@aws-sdk/types": "3.257.0",
 				"tslib": "^2.3.1"
 			}
 		},
 		"@aws-sdk/node-http-handler": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.215.0.tgz",
-			"integrity": "sha512-btKWSR7m0UuWIN3p5MfSIvhqeYik7xri7U6nWuVI5GVzIYjzxEZOMvPAinDLDxL5wipodi0ZvTUNdDJdm7BcGQ==",
-			"optional": true,
+			"version": "3.257.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/node-http-handler/-/node-http-handler-3.257.0.tgz",
+			"integrity": "sha512-8KnWHVVwaGKyTlkTU9BSOAiSovNDoagxemU2l10QqBbzUCVpljCUMUkABEGRJ1yoQCl6DJ7RtNkAyZ8Ne/E15A==",
 			"requires": {
-				"@aws-sdk/abort-controller": "3.215.0",
-				"@aws-sdk/protocol-http": "3.215.0",
-				"@aws-sdk/querystring-builder": "3.215.0",
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/abort-controller": "3.257.0",
+				"@aws-sdk/protocol-http": "3.257.0",
+				"@aws-sdk/querystring-builder": "3.257.0",
+				"@aws-sdk/types": "3.257.0",
 				"tslib": "^2.3.1"
 			}
 		},
 		"@aws-sdk/property-provider": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.215.0.tgz",
-			"integrity": "sha512-dDPjMCCopkRURAmOJCMSlpIQ5BGWCpYj0+FIfZ5qWQs24fn1PAkQHecOiBhJO0ZSVuQy3xcIyWsAp1NE5e+7ug==",
-			"optional": true,
+			"version": "3.257.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/property-provider/-/property-provider-3.257.0.tgz",
+			"integrity": "sha512-3rUbRAcF0GZ5PhDiXhS4yREfZ5hOEtvYEa9S/19OdM5eoypOaLU5XnFcCKfnccSP8SkdgpJujzxOMRWNWadlAQ==",
 			"requires": {
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/types": "3.257.0",
 				"tslib": "^2.3.1"
 			}
 		},
 		"@aws-sdk/protocol-http": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.215.0.tgz",
-			"integrity": "sha512-qp6Y6v4S534LAjadiVl9p7ErK7ImphOKq6yhFyQwxko6iITLcz8ib3yU27fs4QJcnNj5ZooqW/YlL/0EikDxCQ==",
-			"optional": true,
+			"version": "3.257.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/protocol-http/-/protocol-http-3.257.0.tgz",
+			"integrity": "sha512-xt7LGOgZIvbLS3418AYQLacOqx+mo5j4mPiIMz7f6AaUg+/fBUgESVsncKDqxbEJVwwCXSka8Ca0cntJmoeMSw==",
 			"requires": {
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/types": "3.257.0",
 				"tslib": "^2.3.1"
 			}
 		},
 		"@aws-sdk/querystring-builder": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.215.0.tgz",
-			"integrity": "sha512-eilk8CqG37BVhQklLif00K2dOJgDzacUi8h3KVQ72ry1V3h345i4HsmaFIxvnz8XtNyDvV8qFAzeYg9n2P9RQA==",
-			"optional": true,
+			"version": "3.257.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/querystring-builder/-/querystring-builder-3.257.0.tgz",
+			"integrity": "sha512-mZHWLP7XIkzx1GIXO5WfX/iJ+aY9TWs02RE9FkdL2+by0HEMR65L3brQTbU1mIBJ7BjaPwYH24dljUOSABX7yg==",
 			"requires": {
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/types": "3.257.0",
 				"@aws-sdk/util-uri-escape": "3.201.0",
 				"tslib": "^2.3.1"
 			}
 		},
 		"@aws-sdk/querystring-parser": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.215.0.tgz",
-			"integrity": "sha512-8h/9H8dWM4fZO27UGzo8W5JXln4yJMugPyUl4qFA437gzPgNFN95+oLJWXtHMlfCHC5T/PDKetY9TarMDgBD0Q==",
-			"optional": true,
+			"version": "3.257.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/querystring-parser/-/querystring-parser-3.257.0.tgz",
+			"integrity": "sha512-UDrE1dEwWrWT8dG2VCrGYrPxCWOkZ1fPTPkjpkR4KZEdQDZBqU5gYZF2xPj8Nz7pjQVHFuW2wFm3XYEk56GEjg==",
 			"requires": {
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/types": "3.257.0",
 				"tslib": "^2.3.1"
 			}
 		},
 		"@aws-sdk/service-error-classification": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.215.0.tgz",
-			"integrity": "sha512-SKBvClGFGzMPsjBBKjneaUazLCNr6bSxe9eFvOr3gCwuwE2jPQwW3VE1mb62howuvm6cLthEDwLQp/FsT1gMsw==",
-			"optional": true
+			"version": "3.257.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/service-error-classification/-/service-error-classification-3.257.0.tgz",
+			"integrity": "sha512-FAyR0XsueGkkqDtkP03cTJQk52NdQ9sZelLynmmlGPUP75LApRPvFe1riKrou6+LsDbwVNVffj6mbDfIcOhaOw=="
 		},
 		"@aws-sdk/shared-ini-file-loader": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.215.0.tgz",
-			"integrity": "sha512-unzQeLOyUiYHr8WxxandHo0OaCj31gx0wpt8dn2cZcHm/MdCqHcHcsQqOVnQsWQrrxY/XZ27cPyMVQeicNKYwQ==",
-			"optional": true,
+			"version": "3.257.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/shared-ini-file-loader/-/shared-ini-file-loader-3.257.0.tgz",
+			"integrity": "sha512-HNjC1+Wx3xHiJc+CP14GhIdVhfQGSjroAsWseRxAhONocA9Fl1ZX4hx7+sA5c9nOoMVOovi6ivJ/6lCRPTDRrQ==",
 			"requires": {
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/types": "3.257.0",
 				"tslib": "^2.3.1"
 			}
 		},
 		"@aws-sdk/signature-v4": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.215.0.tgz",
-			"integrity": "sha512-Rc73uUCi3eJneO25DydLTfJYamXeuKS9YIhNMTKlpvcN1UQAmAnUbAmCuEmqvkYOiGD1i4/kd8kBga708iIikQ==",
-			"optional": true,
+			"version": "3.257.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/signature-v4/-/signature-v4-3.257.0.tgz",
+			"integrity": "sha512-aLQQN59X/D0+ShzPD3Anj5ntdMA/RFeNLOUCDyDvremViGi6yxUS98usQ/8bG5Rq0sW2GGMdbFUFmrDvqdiqEQ==",
 			"requires": {
 				"@aws-sdk/is-array-buffer": "3.201.0",
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/types": "3.257.0",
 				"@aws-sdk/util-hex-encoding": "3.201.0",
-				"@aws-sdk/util-middleware": "3.215.0",
+				"@aws-sdk/util-middleware": "3.257.0",
 				"@aws-sdk/util-uri-escape": "3.201.0",
+				"@aws-sdk/util-utf8": "3.254.0",
 				"tslib": "^2.3.1"
 			}
 		},
 		"@aws-sdk/smithy-client": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.215.0.tgz",
-			"integrity": "sha512-PiZfCdZkPohzMPrRmJ46TPOf2Tr/dhKYdwQArRnOOIsJABUGXjlzCUE8vysDN35XZYRx5f9hd+/U7kayhniq2w==",
-			"optional": true,
+			"version": "3.261.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/smithy-client/-/smithy-client-3.261.0.tgz",
+			"integrity": "sha512-j8XQEa3caZUVFVZfhJjaskw80O/tB+IXu84HMN44N7UkXaCFHirUsNjTDztJhnVXf/gKXzIqUqprfRnOvwLtIg==",
 			"requires": {
-				"@aws-sdk/middleware-stack": "3.215.0",
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/middleware-stack": "3.257.0",
+				"@aws-sdk/types": "3.257.0",
 				"tslib": "^2.3.1"
 			}
 		},
 		"@aws-sdk/token-providers": {
-			"version": "3.216.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.216.0.tgz",
-			"integrity": "sha512-cEmOfG7njWl0OA5lR65Sp2SW1i8ZLjf7C95TZ1e6t2Oo5aUFeN3aKBxMOV//1yc+BNzcFBnoHP/f29GhWxUOxA==",
-			"optional": true,
+			"version": "3.261.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/token-providers/-/token-providers-3.261.0.tgz",
+			"integrity": "sha512-Vi/GOnx8rPvQz5TdJJl5CwpTX6uRsSE3fzh94O4FEAIxIFtb4P5juqg92+2CJ81C7iNduB6eEeSHtwWUylypXQ==",
 			"requires": {
-				"@aws-sdk/client-sso-oidc": "3.216.0",
-				"@aws-sdk/property-provider": "3.215.0",
-				"@aws-sdk/shared-ini-file-loader": "3.215.0",
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/client-sso-oidc": "3.261.0",
+				"@aws-sdk/property-provider": "3.257.0",
+				"@aws-sdk/shared-ini-file-loader": "3.257.0",
+				"@aws-sdk/types": "3.257.0",
 				"tslib": "^2.3.1"
 			}
 		},
 		"@aws-sdk/types": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.215.0.tgz",
-			"integrity": "sha512-eRbCVjwzTYd9C5e2mceScJ6D2kYDDEC3PLkYfJa+1wH9iiF2JlbiYozAokyeYBHQ+AjmD93MK58RBoM8iZfH0Q==",
-			"optional": true
+			"version": "3.257.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/types/-/types-3.257.0.tgz",
+			"integrity": "sha512-LmqXuBQBGeaGi/3Rp7XiEX1B5IPO2UUfBVvu0wwGqVsmstT0SbOVDZGPmxygACbm64n+PRx3uTSDefRfoiWYZg==",
+			"requires": {
+				"tslib": "^2.3.1"
+			}
 		},
 		"@aws-sdk/url-parser": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.215.0.tgz",
-			"integrity": "sha512-r/qIk3TUlV36JvoRjTErFm0LzzgNKLB1YUG8zVZCGAc2TEATi8OVEmsZvi+KfTmsbszulITJVcjZKbHLbGoUzg==",
-			"optional": true,
+			"version": "3.257.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/url-parser/-/url-parser-3.257.0.tgz",
+			"integrity": "sha512-Qe/AcFe/NFZHa6cN2afXEQn9ehXxh57dWGdRjfjd2lQqNV4WW1R2pl2Tm1ZJ1dwuCNLJi4NHLMk8lrD3QQ8rdg==",
 			"requires": {
-				"@aws-sdk/querystring-parser": "3.215.0",
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/querystring-parser": "3.257.0",
+				"@aws-sdk/types": "3.257.0",
 				"tslib": "^2.3.1"
 			}
 		},
@@ -2474,7 +2380,6 @@
 			"version": "3.208.0",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/util-base64/-/util-base64-3.208.0.tgz",
 			"integrity": "sha512-PQniZph5A6N7uuEOQi+1hnMz/FSOK/8kMFyFO+4DgA1dZ5pcKcn5wiFwHkcTb/BsgVqQa3Jx0VHNnvhlS8JyTg==",
-			"optional": true,
 			"requires": {
 				"@aws-sdk/util-buffer-from": "3.208.0",
 				"tslib": "^2.3.1"
@@ -2484,7 +2389,6 @@
 			"version": "3.188.0",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-browser/-/util-body-length-browser-3.188.0.tgz",
 			"integrity": "sha512-8VpnwFWXhnZ/iRSl9mTf+VKOX9wDE8QtN4bj9pBfxwf90H1X7E8T6NkiZD3k+HubYf2J94e7DbeHs7fuCPW5Qg==",
-			"optional": true,
 			"requires": {
 				"tslib": "^2.3.1"
 			}
@@ -2493,7 +2397,6 @@
 			"version": "3.208.0",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/util-body-length-node/-/util-body-length-node-3.208.0.tgz",
 			"integrity": "sha512-3zj50e5g7t/MQf53SsuuSf0hEELzMtD8RX8C76f12OSRo2Bca4FLLYHe0TZbxcfQHom8/hOaeZEyTyMogMglqg==",
-			"optional": true,
 			"requires": {
 				"tslib": "^2.3.1"
 			}
@@ -2502,7 +2405,6 @@
 			"version": "3.208.0",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/util-buffer-from/-/util-buffer-from-3.208.0.tgz",
 			"integrity": "sha512-7L0XUixNEFcLUGPeBF35enCvB9Xl+K6SQsmbrPk1P3mlV9mguWSDQqbOBwY1Ir0OVbD6H/ZOQU7hI/9RtRI0Zw==",
-			"optional": true,
 			"requires": {
 				"@aws-sdk/is-array-buffer": "3.201.0",
 				"tslib": "^2.3.1"
@@ -2512,44 +2414,40 @@
 			"version": "3.208.0",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/util-config-provider/-/util-config-provider-3.208.0.tgz",
 			"integrity": "sha512-DSRqwrERUsT34ug+anlMBIFooBEGwM8GejC7q00Y/9IPrQy50KnG5PW2NiTjuLKNi7pdEOlwTSEocJE15eDZIg==",
-			"optional": true,
 			"requires": {
 				"tslib": "^2.3.1"
 			}
 		},
 		"@aws-sdk/util-defaults-mode-browser": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.215.0.tgz",
-			"integrity": "sha512-MiNfZgB0I4dR8CBxH163W7c9KvE38sgCHNPWopMqSX5ezz7cuCPohCU0XsWd4I7K31PvzuqmKgOiKBAZraQJMA==",
-			"optional": true,
+			"version": "3.261.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-browser/-/util-defaults-mode-browser-3.261.0.tgz",
+			"integrity": "sha512-lX3X1NfzQVV6cakepGV24uRcqevlDnQ8VgaCV8dhnw1FVThueFigyoFaUA02+uRXbV9KIbNWkEvweNtm2wvyDw==",
 			"requires": {
-				"@aws-sdk/property-provider": "3.215.0",
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/property-provider": "3.257.0",
+				"@aws-sdk/types": "3.257.0",
 				"bowser": "^2.11.0",
 				"tslib": "^2.3.1"
 			}
 		},
 		"@aws-sdk/util-defaults-mode-node": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.215.0.tgz",
-			"integrity": "sha512-mSp3R8GljQ+4UT3QMOksQk9L0cWbFLvR7bBmAlt4+GobgTjpRfzFjBP3uwrCqFa3BKDUR3FeJq3qwo+xeY1Krg==",
-			"optional": true,
+			"version": "3.261.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-defaults-mode-node/-/util-defaults-mode-node-3.261.0.tgz",
+			"integrity": "sha512-4AK6yu4bOmHSocUdbGoEHbNXB09UA58ON2HBHY4NxMBuFBAd9XB2tYiyhce+Cm+o+lHbS8oQnw0VZw16WMzzew==",
 			"requires": {
-				"@aws-sdk/config-resolver": "3.215.0",
-				"@aws-sdk/credential-provider-imds": "3.215.0",
-				"@aws-sdk/node-config-provider": "3.215.0",
-				"@aws-sdk/property-provider": "3.215.0",
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/config-resolver": "3.259.0",
+				"@aws-sdk/credential-provider-imds": "3.259.0",
+				"@aws-sdk/node-config-provider": "3.259.0",
+				"@aws-sdk/property-provider": "3.257.0",
+				"@aws-sdk/types": "3.257.0",
 				"tslib": "^2.3.1"
 			}
 		},
 		"@aws-sdk/util-endpoints": {
-			"version": "3.216.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.216.0.tgz",
-			"integrity": "sha512-uHje4H6Qj/z/op8UZoSuvGpEZhz/r+AGY0rCihFo7XjhT4RYVxb2Eb9uHRK/IAeHU4kjHAdpQiWGMSmnT/UacA==",
-			"optional": true,
+			"version": "3.257.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-endpoints/-/util-endpoints-3.257.0.tgz",
+			"integrity": "sha512-3bvmRn5XGYzPPWjLuvHBKdJOb+fijnb8Ungu9bfXnTYFsng/ndHUWeHC22O/p8w3OWoRYUIMaZHxdxe27BFozg==",
 			"requires": {
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/types": "3.257.0",
 				"tslib": "^2.3.1"
 			}
 		},
@@ -2557,7 +2455,6 @@
 			"version": "3.201.0",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/util-hex-encoding/-/util-hex-encoding-3.201.0.tgz",
 			"integrity": "sha512-7t1vR1pVxKx0motd3X9rI3m/xNp78p3sHtP5yo4NP4ARpxyJ0fokBomY8ScaH2D/B+U5o9ARxldJUdMqyBlJcA==",
-			"optional": true,
 			"requires": {
 				"tslib": "^2.3.1"
 			}
@@ -2566,17 +2463,24 @@
 			"version": "3.208.0",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/util-locate-window/-/util-locate-window-3.208.0.tgz",
 			"integrity": "sha512-iua1A2+P7JJEDHVgvXrRJSvsnzG7stYSGQnBVphIUlemwl6nN5D+QrgbjECtrbxRz8asYFHSzhdhECqN+tFiBg==",
-			"optional": true,
 			"requires": {
 				"tslib": "^2.3.1"
 			}
 		},
 		"@aws-sdk/util-middleware": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.215.0.tgz",
-			"integrity": "sha512-DfHGlFlQCr+T/xhjS36HH8JEThDVB5lg5NZ6x4Cibhyeps9YX/4ovLAIx3B19H34sdWhZi7q6LfslCHLRu2+7Q==",
-			"optional": true,
+			"version": "3.257.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-middleware/-/util-middleware-3.257.0.tgz",
+			"integrity": "sha512-F9ieon8B8eGVs5tyZtAIG3DZEObDvujkspho0qRbUTHUosM0ylJLsMU800fmC/uRHLRrZvb/RSp59+kNDwSAMw==",
 			"requires": {
+				"tslib": "^2.3.1"
+			}
+		},
+		"@aws-sdk/util-retry": {
+			"version": "3.257.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-retry/-/util-retry-3.257.0.tgz",
+			"integrity": "sha512-l9TOsOAYtZxwW3q5fQKW4rsD9t2HVaBfQ4zBamHkNTfB4vBVvCnz4oxkvSvA2MlxCA6am+K1K/oj917Tpqk53g==",
+			"requires": {
+				"@aws-sdk/service-error-classification": "3.257.0",
 				"tslib": "^2.3.1"
 			}
 		},
@@ -2584,49 +2488,44 @@
 			"version": "3.201.0",
 			"resolved": "https://registry.npmjs.org/@aws-sdk/util-uri-escape/-/util-uri-escape-3.201.0.tgz",
 			"integrity": "sha512-TeTWbGx4LU2c5rx0obHeDFeO9HvwYwQtMh1yniBz00pQb6Qt6YVOETVQikRZ+XRQwEyCg/dA375UplIpiy54mA==",
-			"optional": true,
 			"requires": {
 				"tslib": "^2.3.1"
 			}
 		},
 		"@aws-sdk/util-user-agent-browser": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.215.0.tgz",
-			"integrity": "sha512-uZz6BJWr8sJcA+onveS1lFqnbIXBHwvkyHLgCuuGhAxd5yY6YNLhpJBnhy9Fb8/aSbk6yao3qxlokqw9gthmAw==",
-			"optional": true,
+			"version": "3.257.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-browser/-/util-user-agent-browser-3.257.0.tgz",
+			"integrity": "sha512-YdavWK6/8Cw6mypEgysGGX/dT9p9qnzFbnN5PQsUY+JJk2Nx8fKFydjGiQ+6rWPeW17RAv9mmbboh9uPVWxVlw==",
 			"requires": {
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/types": "3.257.0",
 				"bowser": "^2.11.0",
 				"tslib": "^2.3.1"
 			}
 		},
 		"@aws-sdk/util-user-agent-node": {
-			"version": "3.215.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.215.0.tgz",
-			"integrity": "sha512-4lrdd1oGRwJEwfvgvg1jcJ2O0bwElsvtiqZfTRHN6MNTFUqsKl0xHlgFChQsz3Hfrc1niWtZCmbqQKGdO5ARpw==",
-			"optional": true,
+			"version": "3.259.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-user-agent-node/-/util-user-agent-node-3.259.0.tgz",
+			"integrity": "sha512-R0VTmNs+ySDDebU98BUbsLyeIM5YmAEr9esPpy15XfSy3AWmAeru8nLlztdaLilHZzLIDzvM2t7NGk/FzZFCvA==",
 			"requires": {
-				"@aws-sdk/node-config-provider": "3.215.0",
-				"@aws-sdk/types": "3.215.0",
+				"@aws-sdk/node-config-provider": "3.259.0",
+				"@aws-sdk/types": "3.257.0",
+				"tslib": "^2.3.1"
+			}
+		},
+		"@aws-sdk/util-utf8": {
+			"version": "3.254.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8/-/util-utf8-3.254.0.tgz",
+			"integrity": "sha512-14Kso/eIt5/qfIBmhEL9L1IfyUqswjSTqO2mY7KOzUZ9SZbwn3rpxmtkhmATkRjD7XIlLKaxBkI7tU9Zjzj8Kw==",
+			"requires": {
+				"@aws-sdk/util-buffer-from": "3.208.0",
 				"tslib": "^2.3.1"
 			}
 		},
 		"@aws-sdk/util-utf8-browser": {
-			"version": "3.188.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.188.0.tgz",
-			"integrity": "sha512-jt627x0+jE+Ydr9NwkFstg3cUvgWh56qdaqAMDsqgRlKD21md/6G226z/Qxl7lb1VEW2LlmCx43ai/37Qwcj2Q==",
-			"optional": true,
+			"version": "3.259.0",
+			"resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-browser/-/util-utf8-browser-3.259.0.tgz",
+			"integrity": "sha512-UvFa/vR+e19XookZF8RzFZBrw2EUkQWxiBW0yYQAhvk3C+QVGl0H3ouca8LDBlBfQKXwmW3huo/59H8rwb1wJw==",
 			"requires": {
-				"tslib": "^2.3.1"
-			}
-		},
-		"@aws-sdk/util-utf8-node": {
-			"version": "3.208.0",
-			"resolved": "https://registry.npmjs.org/@aws-sdk/util-utf8-node/-/util-utf8-node-3.208.0.tgz",
-			"integrity": "sha512-jKY87Acv0yWBdFxx6bveagy5FYjz+dtV8IPT7ay1E2WPWH1czoIdMAkc8tSInK31T6CRnHWkLZ1qYwCbgRfERQ==",
-			"optional": true,
-			"requires": {
-				"@aws-sdk/util-buffer-from": "3.208.0",
 				"tslib": "^2.3.1"
 			}
 		},
@@ -2677,8 +2576,7 @@
 		"bowser": {
 			"version": "2.11.0",
 			"resolved": "https://registry.npmjs.org/bowser/-/bowser-2.11.0.tgz",
-			"integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA==",
-			"optional": true
+			"integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
 		},
 		"bson": {
 			"version": "4.7.2",
@@ -2743,7 +2641,6 @@
 			"version": "4.0.11",
 			"resolved": "https://registry.npmjs.org/fast-xml-parser/-/fast-xml-parser-4.0.11.tgz",
 			"integrity": "sha512-4aUg3aNRR/WjQAcpceODG1C3x3lFANXRo8+1biqfieHmg9pyMt7qB4lQV/Ta6sJCTbA5vfD8fnA8S54JATiFUA==",
-			"optional": true,
 			"requires": {
 				"strnum": "^1.0.5"
 			}
@@ -2842,9 +2739,9 @@
 			}
 		},
 		"mongodb-client-encryption": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-2.3.0.tgz",
-			"integrity": "sha512-cXuRYBmCj43rLeqP8gHa+CrloFe7TUCd/f16VduFGQzAN9ef5buMGIfSr2CEGBul/EjTCLlioctSSDmHAmpTqA==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-2.4.0.tgz",
+			"integrity": "sha512-AKBlh20HWqUTl+US8yfJAMVchk6nD3RtBPfU6IfG7/iuK6OWQufLgBduvC/jYkLxPJU1+iMel5pSJQA0aMN+bg==",
 			"optional": true,
 			"requires": {
 				"bindings": "^1.5.0",
@@ -3032,8 +2929,7 @@
 		"strnum": {
 			"version": "1.0.5",
 			"resolved": "https://registry.npmjs.org/strnum/-/strnum-1.0.5.tgz",
-			"integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA==",
-			"optional": true
+			"integrity": "sha512-J8bbNyKKXl5qYcR36TIO8W3mVGVHrmmxsd5PAItGkmyzwJvybiw2IVq5nqd0i4LSNSkB/sx9VHllbfFdr9k1JA=="
 		},
 		"tar-fs": {
 			"version": "2.1.1",
@@ -3069,10 +2965,9 @@
 			}
 		},
 		"tslib": {
-			"version": "2.4.1",
-			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.4.1.tgz",
-			"integrity": "sha512-tGyy4dAjRIEwI7BzsB0lynWgOpfqjUdq91XXAlIWD2OwKBH7oCl/GZG/HT4BOHrTlPMOASlMQ7veyTqpmRcrNA==",
-			"optional": true
+			"version": "2.5.0",
+			"resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+			"integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
 		},
 		"tunnel-agent": {
 			"version": "0.6.0",
@@ -3092,8 +2987,7 @@
 		"uuid": {
 			"version": "8.3.2",
 			"resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
-			"optional": true
+			"integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg=="
 		},
 		"webidl-conversions": {
 			"version": "7.0.0",

--- a/packages/service-provider-core/package.json
+++ b/packages/service-provider-core/package.json
@@ -33,13 +33,14 @@
     }
   },
   "dependencies": {
+    "@aws-sdk/credential-providers": "^3.262.0",
     "@mongosh/errors": "0.0.0-dev.0",
     "bson": "^4.7.2",
     "mongodb": "^4.13.0",
     "mongodb-build-info": "^1.5.0"
   },
   "optionalDependencies": {
-    "mongodb-client-encryption": "^2.3.0"
+    "mongodb-client-encryption": "^2.4.0"
   },
   "dependency-check": {
     "entries": [

--- a/packages/service-provider-server/package-lock.json
+++ b/packages/service-provider-server/package-lock.json
@@ -21,7 +21,7 @@
 			},
 			"optionalDependencies": {
 				"kerberos": "^2.0.0",
-				"mongodb-client-encryption": "^2.3.0"
+				"mongodb-client-encryption": "^2.4.0"
 			}
 		},
 		"node_modules/@aws-crypto/ie11-detection": {
@@ -1564,9 +1564,9 @@
 			}
 		},
 		"node_modules/mongodb-client-encryption": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-2.3.0.tgz",
-			"integrity": "sha512-cXuRYBmCj43rLeqP8gHa+CrloFe7TUCd/f16VduFGQzAN9ef5buMGIfSr2CEGBul/EjTCLlioctSSDmHAmpTqA==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-2.4.0.tgz",
+			"integrity": "sha512-AKBlh20HWqUTl+US8yfJAMVchk6nD3RtBPfU6IfG7/iuK6OWQufLgBduvC/jYkLxPJU1+iMel5pSJQA0aMN+bg==",
 			"hasInstallScript": true,
 			"optional": true,
 			"dependencies": {
@@ -1579,7 +1579,13 @@
 				"node": ">=12.9.0"
 			},
 			"peerDependencies": {
+				"@aws-sdk/credential-providers": "^3.186.0",
 				"mongodb": ">=3.4.0"
+			},
+			"peerDependenciesMeta": {
+				"@aws-sdk/credential-providers": {
+					"optional": true
+				}
 			}
 		},
 		"node_modules/mongodb-client-encryption/node_modules/prebuild-install": {
@@ -3437,9 +3443,9 @@
 			}
 		},
 		"mongodb-client-encryption": {
-			"version": "2.3.0",
-			"resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-2.3.0.tgz",
-			"integrity": "sha512-cXuRYBmCj43rLeqP8gHa+CrloFe7TUCd/f16VduFGQzAN9ef5buMGIfSr2CEGBul/EjTCLlioctSSDmHAmpTqA==",
+			"version": "2.4.0",
+			"resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-2.4.0.tgz",
+			"integrity": "sha512-AKBlh20HWqUTl+US8yfJAMVchk6nD3RtBPfU6IfG7/iuK6OWQufLgBduvC/jYkLxPJU1+iMel5pSJQA0aMN+bg==",
 			"optional": true,
 			"requires": {
 				"bindings": "^1.5.0",

--- a/packages/service-provider-server/package.json
+++ b/packages/service-provider-server/package.json
@@ -55,7 +55,7 @@
     "saslprep": "mongodb-js/saslprep#v1.0.4"
   },
   "optionalDependencies": {
-    "mongodb-client-encryption": "^2.3.0",
+    "mongodb-client-encryption": "^2.4.0",
     "kerberos": "^2.0.0"
   }
 }

--- a/testing/fake-kms.ts
+++ b/testing/fake-kms.ts
@@ -77,7 +77,14 @@ function awsHandler({ body }: RequestData): any {
       KeyId: request.KeyId
     };
   } else {
-    const [ KeyId, Plaintext ] = Buffer.from(request.CiphertextBlob, 'base64').toString().split('\0');
+    let [ KeyId, Plaintext ] = Buffer.from(request.CiphertextBlob, 'base64').toString().split('\0');
+    // Do not return invalid base64 https://jira.mongodb.org/browse/MONGOCRYPT-525
+    if (Buffer.from(KeyId, 'base64').toString('base64') !== KeyId) {
+      KeyId = 'invalid0';
+    }
+    if (Buffer.from(Plaintext, 'base64').toString('base64') !== Plaintext) {
+      Plaintext = 'invalid1';
+    }
     return {
       Plaintext,
       EncryptionAlgorithm: 'SYMMETRIC_DEFAULT',


### PR DESCRIPTION
This PR is adjusting our dependencies, fixing our mock so that the updated libmongocrypt does not crash, and adds a new test for the Node.js bindings now being able to pick up AWS KMS credentials from environment variables if that is desired.

##### chore(deps): bump `mongodb-client-encryption` to 2.4.0

Also add `@aws-sdk/credential-prociders` as an explicit dependency.

The `mongodb-client-encryption` package can use this as an optional
peer dependency, and the `mongodb` package currently depends on this
as a peer dependency but will switch to making it an optional peer
dependency as well in the v5.0.0 release.

Installing it as an explicit dependency ensures its presence regardless
of optionality (instead of just relying on the package-lock.json file
for keeping it available).

##### chore: fix mock AWS KMS server

The latest version of mongodb-client-encryption crashes when
receiving invalid base64 from the AWS server; work around that
by never returning invalid base64 from the mock.

##### chore(cli-repl): add e2e test for automatic AWS KMS credentials


MONGOSH-1370