### PR TITLE
feat(shell-api, cli-repl): on-boot warnings for fake MongoDBs

### DIFF
--- a/packages/cli-repl/src/mongosh-repl.ts
+++ b/packages/cli-repl/src/mongosh-repl.ts
@@ -406,14 +406,14 @@ class MongoshNodeRepl implements EvaluationListener {
       const banners = await Promise.all([
         (async() => await shellApi.show('startupWarnings'))(),
         (async() => await shellApi.show('freeMonitoring'))(),
-        (async() => await shellApi.show('automationNotices'))()
+        (async() => await shellApi.show('automationNotices'))(),
+        (async() => await shellApi.show('nonGenuineMongoDBCheck'))()
       ]);
       for (const banner of banners) {
         if (banner.value) {
           await shellApi.print(banner);
         }
       }
-      // Omitted, see MONGOSH-57: 'show nonGenuineMongoDBCheck'
     }
 
     return { __initialized: 'yes' };

--- a/packages/service-provider-server/src/cli-service-provider.ts
+++ b/packages/service-provider-server/src/cli-service-provider.ts
@@ -241,7 +241,7 @@ class CliServiceProvider extends ServiceProviderCore implements ServiceProvider 
       this.runCommandWithCheck('admin', { getCmdLineOpts: 1 }, this.baseCmdOptions).catch((e) => {
         // mongodb-build-info.getGenuineMongoDB expects either
         // the successful or failure response from server
-        // Ref: https://github.com/mongodb-js/mongodb-build-info/blob/main/index.js#L89
+        // Ref: https://github.com/mongodb-js/mongodb-build-info/blob/9247eeba730a905397ad09fe5a377067edc49b34/index.js#L89
         return {
           ok: e.ok,
           code: e.code,

--- a/packages/shell-api/src/mongo.spec.ts
+++ b/packages/shell-api/src/mongo.spec.ts
@@ -451,12 +451,22 @@ describe('Mongo', () => {
 
       describe('nonGenuineMongoDBCheck', () => {
         it('returns no warnings for a genuine mongodb connection', async() => {
+          instanceState.connectionInfo = {
+            extraInfo: { is_genuine: true }
+          };
+
           const result = await mongo.show('nonGenuineMongoDBCheck');
           expect(result.type).to.equal('ShowBannerResult');
           expect(result.value).to.be.null;
         });
 
         context('when connected deployment is not a genuine mongodb deployment', () => {
+          beforeEach(() => {
+            instanceState.connectionInfo = {
+              extraInfo: { is_genuine: false }
+            };
+          });
+
           const warning = [
             'This server or service appears to be an emulation of MongoDB rather than an official MongoDB product.',
             'Some documented MongoDB features may work differently, be entirely missing or incomplete, or have unexpected performance characteristics.',
@@ -465,7 +475,6 @@ describe('Mongo', () => {
 
           context('and can be determined by serverBuildInfo', () => {
             it('returns warnings', async() => {
-              database.serverBuildInfo.resolves({ _t: true });
               const result = await mongo.show('nonGenuineMongoDBCheck');
               expect(result.type).to.equal('ShowBannerResult');
               expect(result.value).to.deep.equal({
@@ -477,7 +486,6 @@ describe('Mongo', () => {
 
           context('and can be determined by serverCmdLineOpts', () => {
             it('returns warnings', async() => {
-              database.serverCmdLineOpts.rejects(new Error('Deployment not supported'));
               const result = await mongo.show('nonGenuineMongoDBCheck');
               expect(result.type).to.equal('ShowBannerResult');
               expect(result.value).to.deep.equal({

--- a/packages/shell-api/src/shell-api.ts
+++ b/packages/shell-api/src/shell-api.ts
@@ -114,7 +114,7 @@ async function showCompleter(params: ShellCommandAutocompleteParameters, args: s
   }
   const candidates = [
     'databases', 'dbs', 'collections', 'tables', 'profile', 'users', 'roles', 'log', 'logs',
-    'startupWarnings', 'freeMonitoring', 'automationNotices'
+    'startupWarnings', 'freeMonitoring', 'automationNotices', 'nonGenuineMongoDBCheck'
   ];
   return candidates.filter(str => str.startsWith(args[1] ?? ''));
 }


### PR DESCRIPTION
This PR adds an on-boot on invokable warning when connected to a fake mongodb deployment (DocumentDB for example).

Closes: MONGOSH-57