### PR TITLE
fix(ci): install FIPS-y OpenSSL 3 later in docker tests

### DIFF
--- a/scripts/docker/rocky9-fips-rpm.Dockerfile
+++ b/scripts/docker/rocky9-fips-rpm.Dockerfile
@@ -3,10 +3,10 @@ FROM rockylinux:9
 ARG artifact_url=""
 ADD ${artifact_url} /tmp
 ADD compile-and-install-openssl3.sh /tmp
-RUN bash /tmp/compile-and-install-openssl3.sh
 ADD node_modules /usr/share/mongodb-crypt-library-version/node_modules
 RUN dnf repolist
 RUN dnf install -y man
+RUN bash /tmp/compile-and-install-openssl3.sh
 RUN dnf install -y /tmp/*mongosh*.rpm
 RUN /usr/bin/mongosh --build-info
 RUN env MONGOSH_RUN_NODE_SCRIPT=1 mongosh /usr/share/mongodb-crypt-library-version/node_modules/.bin/mongodb-crypt-library-version /usr/lib64/mongosh_crypt_v1.so | grep -Eq '^mongo_(crypt|csfle)_v1-'

--- a/scripts/docker/ubuntu22.04-fips-deb.Dockerfile
+++ b/scripts/docker/ubuntu22.04-fips-deb.Dockerfile
@@ -3,11 +3,11 @@ FROM ubuntu:22.04
 ARG artifact_url=""
 ADD ${artifact_url} /tmp
 ADD compile-and-install-openssl3.sh /tmp
-RUN bash /tmp/compile-and-install-openssl3.sh
 ADD node_modules /usr/share/mongodb-crypt-library-version/node_modules
 RUN apt-get update
 RUN yes | unminimize
 RUN apt-get install -y man-db
+RUN bash /tmp/compile-and-install-openssl3.sh
 RUN apt-get install -y /tmp/*mongosh*.deb
 RUN /usr/bin/mongosh --build-info
 RUN env MONGOSH_RUN_NODE_SCRIPT=1 mongosh /usr/share/mongodb-crypt-library-version/node_modules/.bin/mongodb-crypt-library-version /usr/lib/mongosh_crypt_v1.so | grep -Eq '^mongo_(crypt|csfle)_v1-'


### PR DESCRIPTION
The Ubuntu 22.04 FIPS docker test recently started failing because something in the `unminimize` step overwrote the files installed from our built “FIPS-y” OpenSSL 3 copy.

Address this by building and installing OpenSSL immediately before installing mongosh itself.