### PR TITLE
fix(shell-api): adjust .drop() return value for server changes

### DIFF
--- a/packages/shell-api/src/integration.spec.ts
+++ b/packages/shell-api/src/integration.spec.ts
@@ -875,8 +875,8 @@ describe('Shell API (integration)', function() {
       });
 
       context('when a collection does not exist', () => {
-        it('returns false', async() => {
-          expect(await collection.exists()).to.be.false;
+        it('returns null', async() => {
+          expect(await collection.exists()).to.be.null;
         });
       });
     });

--- a/packages/shell-api/src/integration.spec.ts
+++ b/packages/shell-api/src/integration.spec.ts
@@ -857,7 +857,7 @@ describe('Shell API (integration)', function() {
         context('post-7.0', () => {
           skipIfServerVersion(testServer, '< 7.0');
           it('returns true', async() => {
-            expect(await collection.drop()).to.be.false;
+            expect(await collection.drop()).to.be.true;
           });
         });
       });

--- a/packages/shell-api/src/integration.spec.ts
+++ b/packages/shell-api/src/integration.spec.ts
@@ -847,8 +847,18 @@ describe('Shell API (integration)', function() {
       });
 
       context('when a collection does not exist', () => {
-        it('returns false', async() => {
-          expect(await collection.drop()).to.be.false;
+        context('pre-7.0', () => {
+          skipIfServerVersion(testServer, '>= 7.0');
+          it('returns false', async() => {
+            expect(await collection.drop()).to.be.false;
+          });
+        });
+
+        context('post-7.0', () => {
+          skipIfServerVersion(testServer, '< 7.0');
+          it('returns true', async() => {
+            expect(await collection.drop()).to.be.false;
+          });
         });
       });
     });
@@ -866,7 +876,7 @@ describe('Shell API (integration)', function() {
 
       context('when a collection does not exist', () => {
         it('returns false', async() => {
-          expect(await collection.drop()).to.be.false;
+          expect(await collection.exists()).to.be.false;
         });
       });
     });


### PR DESCRIPTION
See SERVER-43894, the server now returns no error when dropping non-existent collections.