### PR TITLE
feat(autocomplete): upgrades mongodb-constants

### DIFF
--- a/packages/autocomplete/package-lock.json
+++ b/packages/autocomplete/package-lock.json
@@ -9,7 +9,7 @@
 			"version": "0.0.0-dev.0",
 			"license": "Apache-2.0",
 			"dependencies": {
-				"@mongodb-js/mongodb-constants": "^0.1.0",
+				"@mongodb-js/mongodb-constants": "^0.2.1",
 				"semver": "^7.3.2"
 			},
 			"devDependencies": {
@@ -20,9 +20,9 @@
 			}
 		},
 		"node_modules/@mongodb-js/mongodb-constants": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/@mongodb-js/mongodb-constants/-/mongodb-constants-0.1.1.tgz",
-			"integrity": "sha512-0AbPBurNm8zkwYffvsoQIq6Ra1UBnDCxzOp38nt6OuXtrx3hWz0ZyT3vDKNmlHUgfbjbEIve/itpTG4y2mmPKw=="
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/@mongodb-js/mongodb-constants/-/mongodb-constants-0.2.1.tgz",
+			"integrity": "sha512-arCTQYvK9scQszbQQcPba7Ru5HYrc8YINcGcM4HKMCcg+8A17U+3Y3AEI7N/oe2VE+1GFsrh8MoKBch4jEvY1g=="
 		},
 		"node_modules/ansi-colors": {
 			"version": "3.2.3",
@@ -1499,9 +1499,9 @@
 	},
 	"dependencies": {
 		"@mongodb-js/mongodb-constants": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/@mongodb-js/mongodb-constants/-/mongodb-constants-0.1.1.tgz",
-			"integrity": "sha512-0AbPBurNm8zkwYffvsoQIq6Ra1UBnDCxzOp38nt6OuXtrx3hWz0ZyT3vDKNmlHUgfbjbEIve/itpTG4y2mmPKw=="
+			"version": "0.2.1",
+			"resolved": "https://registry.npmjs.org/@mongodb-js/mongodb-constants/-/mongodb-constants-0.2.1.tgz",
+			"integrity": "sha512-arCTQYvK9scQszbQQcPba7Ru5HYrc8YINcGcM4HKMCcg+8A17U+3Y3AEI7N/oe2VE+1GFsrh8MoKBch4jEvY1g=="
 		},
 		"ansi-colors": {
 			"version": "3.2.3",

--- a/packages/autocomplete/package.json
+++ b/packages/autocomplete/package.json
@@ -31,8 +31,8 @@
     "mocha": "^7.1.2"
   },
   "dependencies": {
+    "@mongodb-js/mongodb-constants": "^0.2.1",
     "@mongosh/shell-api": "0.0.0-dev.0",
-    "@mongodb-js/mongodb-constants": "^0.1.0",
     "semver": "^7.3.2"
   }
 }


### PR DESCRIPTION
As a followup for tickets COMPASS-6489 and COMPASS-6490, this PR upgrades mongodb-constants in autocomplete.

New update brings autocomplete for
- missing database aggregation stages
- new `bit` operators introduced for aggregation pipeline in MongoDB 6.3