### PR TITLE
chore(shell-api): show deprecation warning for autosplit commands and matching server version MONGOSH-1293

### DIFF
--- a/packages/shell-api/src/shard.spec.ts
+++ b/packages/shell-api/src/shard.spec.ts
@@ -78,6 +78,7 @@ describe('Shard', () => {
       warnSpy = sinon.spy();
       instanceState = new ShellInstanceState(serviceProvider, bus);
       instanceState.printWarning = warnSpy;
+      instanceState.printDeprecationWarning = warnSpy;
       mongo = new Mongo(instanceState, undefined, undefined, undefined, serviceProvider);
       db = new Database(mongo, 'testDb');
       shard = new Shard(db);
@@ -711,6 +712,14 @@ describe('Shard', () => {
         await shard.enableAutoSplit();
         expect(warnSpy.calledOnce).to.equal(true);
       });
+
+      it('prints a deprecation warning for mongodb >= 6.0.3', async() => {
+        instanceState.connectionInfo.buildInfo.version = '6.0.3-alpha0';
+        serviceProvider.runCommandWithCheck.resolves({ ok: 1 });
+        serviceProvider.updateOne.resolves({ acknowledged: 1 } as any);
+        await shard.enableAutoSplit();
+        expect(warnSpy.calledOnce).to.equal(true);
+      });
     });
     describe('disableAutoSplit', () => {
       it('calls serviceProvider.updateOne', async() => {
@@ -766,6 +775,14 @@ describe('Shard', () => {
         const expectedResult = { ok: 1 } as any;
         serviceProvider.runCommandWithCheck.resolves({ ok: 1, msg: 'not dbgrid' });
         serviceProvider.updateOne.resolves(expectedResult);
+        await shard.disableAutoSplit();
+        expect(warnSpy.calledOnce).to.equal(true);
+      });
+
+      it('prints a deprecation warning for mongodb >= 6.0.3', async() => {
+        instanceState.connectionInfo.buildInfo.version = '6.0.3-alpha0';
+        serviceProvider.runCommandWithCheck.resolves({ ok: 1 });
+        serviceProvider.updateOne.resolves({ acknowledged: 1 } as any);
         await shard.disableAutoSplit();
         expect(warnSpy.calledOnce).to.equal(true);
       });

--- a/packages/shell-api/src/shard.ts
+++ b/packages/shell-api/src/shard.ts
@@ -11,6 +11,7 @@ import { CommandResult, UpdateResult } from './result';
 import { redactURICredentials } from '@mongosh/history';
 import Mongo from './mongo';
 import AggregationCursor from './aggregation-cursor';
+import semver from 'semver';
 
 @shellApiClassDefault
 export default class Shard extends ShellApiWithMongoClass {
@@ -277,8 +278,16 @@ export default class Shard extends ShellApiWithMongoClass {
 
   @returnsPromise
   @apiVersions([1])
-  @serverVersions(['3.4.0', ServerVersions.latest])
+  @serverVersions(['3.4.0', '6.0.2'])
   async enableAutoSplit(): Promise<UpdateResult> {
+    if (
+      this._instanceState.connectionInfo.buildInfo.version &&
+      semver.gte(this._instanceState.connectionInfo.buildInfo.version, '6.0.3')
+    ) {
+      await this._instanceState.printDeprecationWarning(
+        'Starting in MongoDB 6.0.3, automatic chunk splitting is not performed. This is because of balancing policy improvements. Auto-splitting commands still exist, but do not perform an operation. For details, see Balancing Policy Changes: https://www.mongodb.com/docs/manual/release-notes/6.0/#balancing-policy-changes\n'
+      );
+    }
     this._emitShardApiCall('enableAutoSplit', {});
     const config = await getConfigDB(this._database);
     return await config.getCollection('settings').updateOne(
@@ -290,8 +299,16 @@ export default class Shard extends ShellApiWithMongoClass {
 
   @returnsPromise
   @apiVersions([1])
-  @serverVersions(['3.4.0', ServerVersions.latest])
+  @serverVersions(['3.4.0', '6.0.2'])
   async disableAutoSplit(): Promise<UpdateResult> {
+    if (
+      this._instanceState.connectionInfo.buildInfo.version &&
+      semver.gte(this._instanceState.connectionInfo.buildInfo.version, '6.0.3')
+    ) {
+      await this._instanceState.printDeprecationWarning(
+        'Starting in MongoDB 6.0.3, automatic chunk splitting is not performed. This is because of balancing policy improvements. Auto-splitting commands still exist, but do not perform an operation. For details, see Balancing Policy Changes: https://www.mongodb.com/docs/manual/release-notes/6.0/#balancing-policy-changes\n'
+      );
+    }
     this._emitShardApiCall('disableAutoSplit', {});
     const config = await getConfigDB(this._database);
     return await config.getCollection('settings').updateOne(


### PR DESCRIPTION
The warning text is from the [helper documentation page](https://www.mongodb.com/docs/manual/reference/method/sh.enableAutoSplit/).

I am not sure whether we would want to completely short circuit here and not run any actual command for servers where this auto split doesn't do anything, but trying this against latest-alpha seems to work just fine so seems to me like it's okay to still run the commands. I am open to feedback here though