### PR TITLE
chore(autocomplete): make autocomplete behavior match node MONGOSH-1087

### DIFF
--- a/packages/autocomplete/src/index.spec.ts
+++ b/packages/autocomplete/src/index.spec.ts
@@ -90,6 +90,16 @@ describe('completer.completer', () => {
     collections = [];
   });
 
+  it('returns case-insensitive results', async() => {
+    const input = 'db.getr';
+    const [completions] = await completer(noParams as any, input);
+    expect(completions).to.deep.eq([
+      'db.getRole',
+      'db.getRoles',
+      'db.getReplicationInfo'
+    ]);
+  });
+
   context('when context is top level shell api', () => {
     it('matches shell completions', async() => {
       const i = 'u';

--- a/packages/autocomplete/src/index.ts
+++ b/packages/autocomplete/src/index.ts
@@ -268,7 +268,7 @@ function filterShellAPI(
   prefix: string,
   split?: string[]): string[] {
   const hits: string[] = Object.keys(completions).filter((c: string) => {
-    if (!c.startsWith(prefix)) return false;
+    if (!c.toLowerCase().startsWith(prefix.toLowerCase())) return false;
     if (completions[c].deprecated) return false;
 
     const apiVersionInfo = params.apiVersionInfo();


### PR DESCRIPTION
I mistakenly assumed that bumping node version was enough to make our autocomplete case-insensitive. This patch changes `filterShellApi` to behave similar to Node.js autocomplete