### PR TITLE
chore(cli-repl): skip unique index creation test for apistrict

### DIFF
--- a/packages/cli-repl/test/e2e.spec.ts
+++ b/packages/cli-repl/test/e2e.spec.ts
@@ -340,7 +340,11 @@ describe('e2e', function() {
           await shell.executeLine('db.apples.drop()');
         });
 
-        it('prints out violations for unique index creation', async() => {
+        it('prints out violations for unique index creation', async function() {
+          if (process.env.MONGOSH_TEST_FORCE_API_STRICT) {
+            return this.skip(); // collMod.index.unique was removed from the stable API
+          }
+
           await shell.executeLine(`db.apples.insertMany([
             { type: 'Delicious', quantity: 12 },
             { type: 'Macintosh', quantity: 13 },


### PR DESCRIPTION
This recently started failing in CI because of [SERVER-73872](https://jira.mongodb.org/browse/SERVER-73872).