### PR TITLE
fix(shell-api): fix getCollections for Object.prototype keys

### DIFF
--- a/packages/shell-api/src/database.spec.ts
+++ b/packages/shell-api/src/database.spec.ts
@@ -446,6 +446,19 @@ describe('Database', () => {
         expect(coll._database).to.equal(database);
       });
 
+      it('returns a collection for Object.prototype keys', () => {
+        {
+          const coll = database.getCollection('__proto__');
+          expect(coll).to.be.instanceOf(Collection);
+          expect(coll._name).to.equal('__proto__');
+        }
+        {
+          const coll = database.getCollection('hasOwnProperty');
+          expect(coll).to.be.instanceOf(Collection);
+          expect(coll._name).to.equal('__proto__');
+        }
+      });
+
       it('throws if name is not a string', () => {
         expect(() => {
           database.getCollection(undefined);

--- a/packages/shell-api/src/database.spec.ts
+++ b/packages/shell-api/src/database.spec.ts
@@ -455,7 +455,7 @@ describe('Database', () => {
         {
           const coll = database.getCollection('hasOwnProperty');
           expect(coll).to.be.instanceOf(Collection);
-          expect(coll._name).to.equal('__proto__');
+          expect(coll._name).to.equal('hasOwnProperty');
         }
       });
 

--- a/packages/shell-api/src/database.ts
+++ b/packages/shell-api/src/database.ts
@@ -69,7 +69,7 @@ export default class Database extends ShellApiWithMongoClass {
     super();
     this._mongo = mongo;
     this._name = name;
-    const collections: Record<string, Collection> = {};
+    const collections: Record<string, Collection> = Object.create(null);
     this._collections = collections;
     this._session = session;
     const proxy = new Proxy(this, {


### PR DESCRIPTION
Otherwise:

```js
> db.getCollection('hasOwnProperty')
[Function: hasOwnProperty]
```