### PR TITLE
fix(shell-api): removes the retry behaviour from rs.reconfig - MONGOSH-1304

### DIFF
--- a/packages/shell-api/src/replica-set.spec.ts
+++ b/packages/shell-api/src/replica-set.spec.ts
@@ -986,7 +986,7 @@ describe('ReplicaSet', () => {
       const addArbWithRetry = createRetriableFunc(rs, 'addArb');
       /**
        * Small hack warning:
-       * rs.reconfigForPSASet internally use rs.reconfig twice with different configs
+       * rs.reconfigForPSASet internally uses rs.reconfig twice with different configs
        * rs.reconfig itself could lead to a pseudo test failure because of delay in propogation
        * of new config. This small hack here helps us reduce flakiness in our test runs
        */

--- a/packages/shell-api/src/replica-set.spec.ts
+++ b/packages/shell-api/src/replica-set.spec.ts
@@ -780,7 +780,7 @@ describe('ReplicaSet', () => {
     let instanceState: ShellInstanceState;
     let db: Database;
     let rs: ReplicaSet;
-    let reconfigWithRetry: RetriableFn;
+    let reconfigWithRetry: ReplicaSet['reconfig'];
 
     before(async function() {
       this.timeout(100_000);

--- a/packages/shell-api/src/replica-set.spec.ts
+++ b/packages/shell-api/src/replica-set.spec.ts
@@ -45,7 +45,7 @@ function createRetriableFunc<F extends keyof ReplicaSet>(rs: ReplicaSet, fn: F, 
             await rs._instanceState.shellApi.print(`rs.${fn.toString()} did not succeed yet, starting new attempt...`);
           }
         }
-        result = [ 'success', await func(...fnArgs) ];
+        result = [ 'success', await func.apply(rs, fnArgs) ];
         break;
       } catch (err: any) {
         result = [ 'error', err ];

--- a/packages/shell-api/src/replica-set.spec.ts
+++ b/packages/shell-api/src/replica-set.spec.ts
@@ -27,9 +27,7 @@ function deepClone<T>(value: T): T {
 }
 
 
-type RetriableFn = (...fnArgs: any) => Promise<any>;
-
-function createRetriableFunc(rs: ReplicaSet, fn: keyof ReplicaSet, totalRetries = 12): RetriableFn {
+function createRetriableFunc<F extends keyof ReplicaSet>(rs: ReplicaSet, fn: F, totalRetries = 12): ReplicaSet[F] {
   const func = rs[fn];
   if (typeof func !== 'function') {
     throw new Error(`${fn.toString()} is not a method on replica set`);


### PR DESCRIPTION
This PR removes the retry behaviour from `rs.reconfig` method which instead has now been moved to ReplicaSet tests and only optionally used to reduce flakes during cleanup.