### PR TITLE
fix(shell-api): fix connection string readPref check in mongo.ts

### DIFF
--- a/packages/shell-api/src/mongo.ts
+++ b/packages/shell-api/src/mongo.ts
@@ -100,7 +100,7 @@ export default class Mongo extends ShellApiClass {
     this._connectionInfo = generateConnectionInfoFromCliArgs({
       connectionSpecifier: uri
     });
-    this._readPreferenceWasExplicitlyRequested = /\breadPreference=/.test(this._uri);
+    this._readPreferenceWasExplicitlyRequested = /\breadPreference=/i.test(this._uri);
     if (fleOptions) {
       if (fleOptions.explicitEncryptionOnly !== undefined) {
         if (fleOptions.schemaMap !== undefined) {


### PR DESCRIPTION
Connection string options are case-insensitive, so we should widen this check here a bit.