### PR TITLE
fix(shell-api): fix broken tsToSeconds conversion MONGOSH-1428

### DIFF
--- a/packages/shell-api/src/helpers.spec.ts
+++ b/packages/shell-api/src/helpers.spec.ts
@@ -3,7 +3,8 @@ import {
   coerceToJSNumber,
   dataFormat,
   getPrintableShardStatus,
-  scaleIndividualShardStatistics
+  scaleIndividualShardStatistics,
+  tsToSeconds
 } from './helpers';
 import { Database, Mongo, ShellInstanceState } from './index';
 import constructShellBson from './shell-bson';
@@ -301,5 +302,14 @@ describe('scaleIndividualShardStatistics', () => {
         name: 30
       }
     });
+  });
+});
+
+describe('tsToSeconds', function() {
+  it('accepts a range of formats', function() {
+    expect(tsToSeconds(new bson.Timestamp({ t: 12345, i: 0 }))).to.equal(12345);
+    expect(tsToSeconds(new bson.Timestamp({ t: 12345, i: 10 }))).to.equal(12345);
+    expect(tsToSeconds(new bson.Double(12345 * 2 ** 32))).to.equal(12345);
+    expect(tsToSeconds(12345 * 2 ** 32)).to.equal(12345);
   });
 });

--- a/packages/shell-api/src/helpers.ts
+++ b/packages/shell-api/src/helpers.ts
@@ -548,11 +548,11 @@ export function scaleIndividualShardStatistics(shardStats: Document, scale: numb
   return scaledStats;
 }
 
-export function tsToSeconds(x: any): number {
-  if (x.t && x.i) {
-    return x.t;
+export function tsToSeconds(x: typeof bson.Timestamp.prototype | number | { valueOf(): number }): number {
+  if (typeof x === 'object' && x && 'getHighBits' in x && 'getLowBits' in x) {
+    return x.getHighBits(); // extract 't' from { t, i }
   }
-  return x / 4294967296; // low 32 bits are ordinal #s within a second
+  return Number(x) / 4294967296; // low 32 bits are ordinal #s within a second
 }
 
 export function addHiddenDataProperty<T = any>(target: T, key: string|symbol, value: any): T {


### PR DESCRIPTION
`tsToSeconds()` has not been working as intended since it was first written. BSON `Timestamp` objects never had direct `t` or `i` properties, so the `if` condition here would never be met. Instead, if the function received a `Timestamp` object, it would implicitly convert it to a number (via the `Long` class’s `.toString()` conversion method). This happens to work out because `x/(2**32)` corresponds roughly to the time part for a `Timestamp` object `t` when interpreted as a `Long`.

I am not sure why exactly this breaks in the way it does described in the ticket (where this function seems to return `NaN`), but making this function work as intended should address the issue.