### PR TITLE
chore: bump vscode integration tests to run on Node.js 16

### DIFF
--- a/.evergreen/evergreen.yml.in
+++ b/.evergreen/evergreen.yml.in
@@ -659,11 +659,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "<% out(NODE_JS_VERSION_14) %>"
+          node_js_version: "<% out(NODE_JS_VERSION_16) %>"
           npm_deps_mode: all
       - func: test_vscode
         vars:
-          node_js_version: "<% out(NODE_JS_VERSION_14) %>"
+          node_js_version: "<% out(NODE_JS_VERSION_16) %>"
   - name: test_connectivity
     tags: ["extra-integration-test"]
     depends_on:

--- a/scripts/docker/ubuntu18.04-xvfb.Dockerfile
+++ b/scripts/docker/ubuntu18.04-xvfb.Dockerfile
@@ -6,8 +6,8 @@ RUN apt-get -y -qq install git curl apt-transport-https ca-certificates apt-util
 
 # Add Node.js
 RUN curl -sSL https://deb.nodesource.com/gpgkey/nodesource.gpg.key | apt-key add -
-RUN echo "deb https://deb.nodesource.com/node_14.x bionic main" | tee /etc/apt/sources.list.d/nodesource.list
-RUN echo "deb-src https://deb.nodesource.com/node_14.x bionic main" | tee -a /etc/apt/sources.list.d/nodesource.list
+RUN echo "deb https://deb.nodesource.com/node_16.x bionic main" | tee /etc/apt/sources.list.d/nodesource.list
+RUN echo "deb-src https://deb.nodesource.com/node_16.x bionic main" | tee -a /etc/apt/sources.list.d/nodesource.list
 
 # Install Node.js and vscode dependencies
 RUN apt-get update


### PR DESCRIPTION
These are currently failing because the VSCode testing integration requires at least Node.js 16.