### PR TITLE
chore(ci): remove `prefix=` entry from `~/.npmrc` MONGOSH-1404

### DIFF
--- a/.evergreen/install-node.sh
+++ b/.evergreen/install-node.sh
@@ -16,7 +16,12 @@ else
   # that breaks nvm because it contains a 'prefix=' option (pointing
   # to a directory that no longer exists anyway).
   if [ -e "$HOME/.npmrc" ]; then
-    sed -i "$HOME/.npmrc" -e 's/^prefix=.*$//'
+    # different `sed` arguments on macOS than for GNU sed ...
+    if [ `uname` == Darwin ]; then
+      sed -i'~' -e 's/^prefix=.*$//' "$HOME/.npmrc"
+    else
+      sed -i "$HOME/.npmrc" -e 's/^prefix=.*$//'
+    fi
   fi
   export NVM_DIR="$HOME/.nvm"
 

--- a/.evergreen/install-node.sh
+++ b/.evergreen/install-node.sh
@@ -15,7 +15,7 @@ else
     # Some Node.js driver versions leave a ~/.npmrc file lying around
     # that breaks nvm because it contains a 'prefix=' option (pointing
     # to a directory that no longer exists anyway).
-    if [ -e "$HOME/.npmrc" ];
+    if [ -e "$HOME/.npmrc" ]; then
       sed -i 's/^prefix=.*$//' "$HOME/.npmrc"
     fi
   fi

--- a/.evergreen/install-node.sh
+++ b/.evergreen/install-node.sh
@@ -11,6 +11,13 @@ if [ "$OS" == "Windows_NT" ]; then
 else
   if which realpath; then # No realpath on macOS, but also not needed there
     export HOME="$(realpath "$HOME")" # Needed to de-confuse nvm when /home is a symlink
+  else
+    # Some Node.js driver versions leave a ~/.npmrc file lying around
+    # that breaks nvm because it contains a 'prefix=' option (pointing
+    # to a directory that no longer exists anyway).
+    if [ -e "$HOME/.npmrc" ];
+      sed -i 's/^prefix=.*$//' "$HOME/.npmrc"
+    fi
   fi
   export NVM_DIR="$HOME/.nvm"
 

--- a/.evergreen/install-node.sh
+++ b/.evergreen/install-node.sh
@@ -11,13 +11,12 @@ if [ "$OS" == "Windows_NT" ]; then
 else
   if which realpath; then # No realpath on macOS, but also not needed there
     export HOME="$(realpath "$HOME")" # Needed to de-confuse nvm when /home is a symlink
-  else
-    # Some Node.js driver versions leave a ~/.npmrc file lying around
-    # that breaks nvm because it contains a 'prefix=' option (pointing
-    # to a directory that no longer exists anyway).
-    if [ -e "$HOME/.npmrc" ]; then
-      sed -i 's/^prefix=.*$//' "$HOME/.npmrc"
-    fi
+  fi
+  # Some Node.js driver versions leave a ~/.npmrc file lying around
+  # that breaks nvm because it contains a 'prefix=' option (pointing
+  # to a directory that no longer exists anyway).
+  if [ -e "$HOME/.npmrc" ]; then
+    sed -i "$HOME/.npmrc" -e 's/^prefix=.*$//'
   fi
   export NVM_DIR="$HOME/.nvm"
 


### PR DESCRIPTION
To counter the effects of the Node.js driver adding these entries (https://github.com/mongodb/node-mongodb-native/blob/4b5be2121fdcca0879447be24e8e935dfcd14764/.evergreen/install-dependencies.sh#L96-L98).