### PR TITLE
chore(deps): bump driver dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
         "karma-typescript": "^5.5.1",
         "lerna": "^4.0.0",
         "mocha": "^10.2.0",
-        "mongodb": "^5.1.0",
+        "mongodb": "^5.3.0",
         "mongodb-download-url": "^1.3.0",
         "mongodb-js-precommit": "^2.0.0",
         "nock": "^13.0.11",
@@ -9035,9 +9035,9 @@
       }
     },
     "node_modules/bson": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-5.0.1.tgz",
-      "integrity": "sha512-y09gBGusgHtinMon/GVbv1J6FrXhnr/+6hqLlSmEFzkz6PodqF6TxjyvfvY3AfO+oG1mgUtbC86xSbOlwvM62Q==",
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-5.2.0.tgz",
+      "integrity": "sha512-HevkSpDbpUfsrHWmWiAsNavANKYIErV2ePXllp1bwq5CDreAaFVj6RVlZpJnxK4WWDCJ/5jMUpaY6G526q3Hjg==",
       "engines": {
         "node": ">=14.20.1"
       }
@@ -18620,11 +18620,11 @@
       }
     },
     "node_modules/mongodb": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.1.0.tgz",
-      "integrity": "sha512-qgKb7y+EI90y4weY3z5+lIgm8wmexbonz0GalHkSElQXVKtRuwqXuhXKccyvIjXCJVy9qPV82zsinY0W1FBnJw==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.3.0.tgz",
+      "integrity": "sha512-Wy/sbahguL8c3TXQWXmuBabiLD+iVmz+tOgQf+FwkCjhUIorqbAxRbbz00g4ZoN4sXIPwpAlTANMaGRjGGTikQ==",
       "dependencies": {
-        "bson": "^5.0.1",
+        "bson": "^5.2.0",
         "mongodb-connection-string-url": "^2.6.0",
         "socks": "^2.7.1"
       },
@@ -18636,7 +18636,7 @@
       },
       "peerDependencies": {
         "@aws-sdk/credential-providers": "^3.201.0",
-        "mongodb-client-encryption": "^2.3.0",
+        "mongodb-client-encryption": ">=2.3.0 <3",
         "snappy": "^7.2.2"
       },
       "peerDependenciesMeta": {
@@ -18660,9 +18660,9 @@
       }
     },
     "node_modules/mongodb-client-encryption": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-2.6.0.tgz",
-      "integrity": "sha512-2fJFZLX+VK7zOyMkOy/LAH2TO1TpBLzPW0YzIujhsng//KRcdvro/JmQ3R/iwptjZJSrPOOZcVUq9yi5KY5akg==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-2.7.1.tgz",
+      "integrity": "sha512-LN1udDf9nZ/paUcuY2AATIVWKf7oGHb2IKMQqGu/7iiqpNlV0M6xjbQix0bxEQvzZZW0T9PG6PN8mYeMR+YDnA==",
       "hasInstallScript": true,
       "optional": true,
       "dependencies": {
@@ -27348,7 +27348,7 @@
       },
       "devDependencies": {
         "@mongodb-js/devtools-connect": "^1.4.4",
-        "mongodb": "^5.1.0"
+        "mongodb": "^5.3.0"
       },
       "engines": {
         "node": ">=14.15.1"
@@ -27871,7 +27871,7 @@
         "mongodb-redact": "^0.2.2"
       },
       "devDependencies": {
-        "mongodb": "^5.1.0"
+        "mongodb": "^5.3.0"
       },
       "engines": {
         "node": ">=14.15.1"
@@ -27904,7 +27904,7 @@
         "@mongosh/service-provider-core": "0.0.0-dev.0",
         "@mongosh/service-provider-server": "0.0.0-dev.0",
         "@mongosh/types": "0.0.0-dev.0",
-        "bson": "^5.0.1",
+        "bson": "^5.2.0",
         "mocha": "^10.2.0",
         "postmsg-rpc": "^2.4.0"
       },
@@ -27919,15 +27919,15 @@
       "dependencies": {
         "@aws-sdk/credential-providers": "^3.262.0",
         "@mongosh/errors": "0.0.0-dev.0",
-        "bson": "^5.0.1",
-        "mongodb": "^5.1.0",
+        "bson": "^5.2.0",
+        "mongodb": "^5.3.0",
         "mongodb-build-info": "^1.5.0"
       },
       "engines": {
         "node": ">=14.15.1"
       },
       "optionalDependencies": {
-        "mongodb-client-encryption": "^2.6.0"
+        "mongodb-client-encryption": "^2.7.1"
       }
     },
     "packages/service-provider-server": {
@@ -27941,16 +27941,16 @@
         "@mongosh/types": "0.0.0-dev.0",
         "@types/sinon-chai": "^3.2.3",
         "aws4": "^1.11.0",
-        "mongodb": "^5.1.0",
+        "mongodb": "^5.3.0",
         "mongodb-connection-string-url": "^2.6.0",
-        "saslprep": "git+ssh://git@github.com/mongodb-js/saslprep.git#9813a626d0685f54e4f2fac6160470d6e01d8c96"
+        "saslprep": "mongodb-js/saslprep#v1.0.4"
       },
       "engines": {
         "node": ">=14.15.1"
       },
       "optionalDependencies": {
         "kerberos": "^2.0.0",
-        "mongodb-client-encryption": "^2.6.0"
+        "mongodb-client-encryption": "^2.7.1"
       }
     },
     "packages/shell-api": {
@@ -27996,7 +27996,7 @@
         "@mongosh/errors": "0.0.0-dev.0",
         "@mongosh/shell-api": "0.0.0-dev.0",
         "@mongosh/types": "0.0.0-dev.0",
-        "bson": "^5.0.1",
+        "bson": "^5.2.0",
         "cross-spawn": "^7.0.3",
         "escape-string-regexp": "^4.0.0",
         "joi": "^17.4.0",
@@ -28021,7 +28021,7 @@
         "@mongodb-js/devtools-connect": "^1.4.4"
       },
       "devDependencies": {
-        "mongodb": "^5.1.0"
+        "mongodb": "^5.3.0"
       },
       "engines": {
         "node": ">=14.15.1"
@@ -32827,7 +32827,7 @@
         "@mongodb-js/devtools-connect": "^1.4.4",
         "@mongosh/errors": "0.0.0-dev.0",
         "@mongosh/i18n": "0.0.0-dev.0",
-        "mongodb": "^5.1.0",
+        "mongodb": "^5.3.0",
         "mongodb-connection-string-url": "^2.6.0"
       }
     },
@@ -33200,7 +33200,7 @@
         "@mongosh/errors": "0.0.0-dev.0",
         "@mongosh/history": "0.0.0-dev.0",
         "@mongosh/types": "0.0.0-dev.0",
-        "mongodb": "^5.1.0",
+        "mongodb": "^5.3.0",
         "mongodb-log-writer": "^1.1.5",
         "mongodb-redact": "^0.2.2"
       }
@@ -33213,7 +33213,7 @@
         "@mongosh/service-provider-core": "0.0.0-dev.0",
         "@mongosh/service-provider-server": "0.0.0-dev.0",
         "@mongosh/types": "0.0.0-dev.0",
-        "bson": "^5.0.1",
+        "bson": "^5.2.0",
         "interruptor": "^1.0.1",
         "mocha": "^10.2.0",
         "postmsg-rpc": "^2.4.0",
@@ -33225,10 +33225,10 @@
       "requires": {
         "@aws-sdk/credential-providers": "^3.262.0",
         "@mongosh/errors": "0.0.0-dev.0",
-        "bson": "^5.0.1",
-        "mongodb": "^5.1.0",
+        "bson": "^5.2.0",
+        "mongodb": "^5.3.0",
         "mongodb-build-info": "^1.5.0",
-        "mongodb-client-encryption": "^2.6.0"
+        "mongodb-client-encryption": "^2.7.1"
       }
     },
     "@mongosh/service-provider-server": {
@@ -33241,10 +33241,10 @@
         "@types/sinon-chai": "^3.2.3",
         "aws4": "^1.11.0",
         "kerberos": "^2.0.0",
-        "mongodb": "^5.1.0",
-        "mongodb-client-encryption": "^2.6.0",
+        "mongodb": "^5.3.0",
+        "mongodb-client-encryption": "^2.7.1",
         "mongodb-connection-string-url": "^2.6.0",
-        "saslprep": "git+ssh://git@github.com/mongodb-js/saslprep.git#9813a626d0685f54e4f2fac6160470d6e01d8c96"
+        "saslprep": "mongodb-js/saslprep#v1.0.4"
       }
     },
     "@mongosh/shell-api": {
@@ -33277,7 +33277,7 @@
         "@types/cross-spawn": "^6.0.2",
         "@types/node-fetch": "^2.5.7",
         "@types/tar": "^4.0.4",
-        "bson": "^5.0.1",
+        "bson": "^5.2.0",
         "cross-spawn": "^7.0.3",
         "escape-string-regexp": "^4.0.0",
         "joi": "^17.4.0",
@@ -33290,7 +33290,7 @@
       "version": "file:packages/types",
       "requires": {
         "@mongodb-js/devtools-connect": "^1.4.4",
-        "mongodb": "^5.1.0"
+        "mongodb": "^5.3.0"
       }
     },
     "@nodelib/fs.scandir": {
@@ -36088,9 +36088,9 @@
       }
     },
     "bson": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-5.0.1.tgz",
-      "integrity": "sha512-y09gBGusgHtinMon/GVbv1J6FrXhnr/+6hqLlSmEFzkz6PodqF6TxjyvfvY3AfO+oG1mgUtbC86xSbOlwvM62Q=="
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-5.2.0.tgz",
+      "integrity": "sha512-HevkSpDbpUfsrHWmWiAsNavANKYIErV2ePXllp1bwq5CDreAaFVj6RVlZpJnxK4WWDCJ/5jMUpaY6G526q3Hjg=="
     },
     "buffer": {
       "version": "4.9.2",
@@ -43662,11 +43662,11 @@
       "dev": true
     },
     "mongodb": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.1.0.tgz",
-      "integrity": "sha512-qgKb7y+EI90y4weY3z5+lIgm8wmexbonz0GalHkSElQXVKtRuwqXuhXKccyvIjXCJVy9qPV82zsinY0W1FBnJw==",
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.3.0.tgz",
+      "integrity": "sha512-Wy/sbahguL8c3TXQWXmuBabiLD+iVmz+tOgQf+FwkCjhUIorqbAxRbbz00g4ZoN4sXIPwpAlTANMaGRjGGTikQ==",
       "requires": {
-        "bson": "^5.0.1",
+        "bson": "^5.2.0",
         "mongodb-connection-string-url": "^2.6.0",
         "saslprep": "^1.0.3",
         "socks": "^2.7.1"
@@ -43681,9 +43681,9 @@
       }
     },
     "mongodb-client-encryption": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-2.6.0.tgz",
-      "integrity": "sha512-2fJFZLX+VK7zOyMkOy/LAH2TO1TpBLzPW0YzIujhsng//KRcdvro/JmQ3R/iwptjZJSrPOOZcVUq9yi5KY5akg==",
+      "version": "2.7.1",
+      "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-2.7.1.tgz",
+      "integrity": "sha512-LN1udDf9nZ/paUcuY2AATIVWKf7oGHb2IKMQqGu/7iiqpNlV0M6xjbQix0bxEQvzZZW0T9PG6PN8mYeMR+YDnA==",
       "optional": true,
       "requires": {
         "bindings": "^1.5.0",

--- a/package.json
+++ b/package.json
@@ -122,7 +122,7 @@
     "karma-typescript": "^5.5.1",
     "lerna": "^4.0.0",
     "mocha": "^10.2.0",
-    "mongodb": "^5.1.0",
+    "mongodb": "^5.3.0",
     "mongodb-download-url": "^1.3.0",
     "mongodb-js-precommit": "^2.0.0",
     "nock": "^13.0.11",

--- a/packages/arg-parser/package.json
+++ b/packages/arg-parser/package.json
@@ -35,6 +35,6 @@
   },
   "devDependencies": {
     "@mongodb-js/devtools-connect": "^1.4.4",
-    "mongodb": "^5.1.0"
+    "mongodb": "^5.3.0"
   }
 }

--- a/packages/logging/package.json
+++ b/packages/logging/package.json
@@ -25,7 +25,7 @@
     "mongodb-redact": "^0.2.2"
   },
   "devDependencies": {
-    "mongodb": "^5.1.0"
+    "mongodb": "^5.3.0"
   },
   "scripts": {
     "test": "mocha -r \"../../scripts/import-expansions.js\" --timeout 15000 -r ts-node/register \"./src/**/*.spec.ts\"",

--- a/packages/node-runtime-worker-thread/package.json
+++ b/packages/node-runtime-worker-thread/package.json
@@ -33,7 +33,7 @@
     "@mongosh/service-provider-core": "0.0.0-dev.0",
     "@mongosh/service-provider-server": "0.0.0-dev.0",
     "@mongosh/types": "0.0.0-dev.0",
-    "bson": "^5.0.1",
+    "bson": "^5.2.0",
     "mocha": "^10.2.0",
     "postmsg-rpc": "^2.4.0"
   },

--- a/packages/service-provider-core/package.json
+++ b/packages/service-provider-core/package.json
@@ -35,12 +35,12 @@
   "dependencies": {
     "@aws-sdk/credential-providers": "^3.262.0",
     "@mongosh/errors": "0.0.0-dev.0",
-    "bson": "^5.0.1",
-    "mongodb": "^5.1.0",
+    "bson": "^5.2.0",
+    "mongodb": "^5.3.0",
     "mongodb-build-info": "^1.5.0"
   },
   "optionalDependencies": {
-    "mongodb-client-encryption": "^2.6.0"
+    "mongodb-client-encryption": "^2.7.1"
   },
   "dependency-check": {
     "entries": [

--- a/packages/service-provider-server/package.json
+++ b/packages/service-provider-server/package.json
@@ -50,12 +50,12 @@
     "@mongosh/types": "0.0.0-dev.0",
     "@types/sinon-chai": "^3.2.3",
     "aws4": "^1.11.0",
-    "mongodb": "^5.1.0",
+    "mongodb": "^5.3.0",
     "mongodb-connection-string-url": "^2.6.0",
     "saslprep": "mongodb-js/saslprep#v1.0.4"
   },
   "optionalDependencies": {
-    "mongodb-client-encryption": "^2.6.0",
+    "mongodb-client-encryption": "^2.7.1",
     "kerberos": "^2.0.0"
   }
 }

--- a/packages/shell-api/src/result.ts
+++ b/packages/shell-api/src/result.ts
@@ -81,7 +81,7 @@ export class InsertOneResult extends ShellApiValueClass {
 @shellApiClassDefault
 export class UpdateResult extends ShellApiValueClass {
   acknowledged: boolean;
-  insertedId: ObjectIdType;
+  insertedId: ObjectIdType | null;
   matchedCount: number;
   modifiedCount: number;
   upsertedCount: number;
@@ -90,7 +90,7 @@ export class UpdateResult extends ShellApiValueClass {
     matchedCount: number,
     modifiedCount: number,
     upsertedCount: number,
-    insertedId: ObjectIdType) {
+    insertedId: ObjectIdType | null) {
     super();
     this.acknowledged = acknowledged;
     this.insertedId = insertedId;

--- a/packages/snippet-manager/package.json
+++ b/packages/snippet-manager/package.json
@@ -32,7 +32,7 @@
     "@mongosh/errors": "0.0.0-dev.0",
     "@mongosh/shell-api": "0.0.0-dev.0",
     "@mongosh/types": "0.0.0-dev.0",
-    "bson": "^5.0.1",
+    "bson": "^5.2.0",
     "cross-spawn": "^7.0.3",
     "escape-string-regexp": "^4.0.0",
     "joi": "^17.4.0",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -35,6 +35,6 @@
     "@mongodb-js/devtools-connect": "^1.4.4"
   },
   "devDependencies": {
-    "mongodb": "^5.1.0"
+    "mongodb": "^5.3.0"
   }
 }


### PR DESCRIPTION
Bump the driver, bson, and mongodb-client-encryption to their latest versions.