### PR TITLE
fix(cli-repl,shell-api): skip/fix tests for latest server alpha

### DIFF
--- a/packages/cli-repl/test/e2e-banners.spec.ts
+++ b/packages/cli-repl/test/e2e-banners.spec.ts
@@ -30,7 +30,8 @@ describe('e2e startup banners', () => {
   });
 
   after(() => {
-    freeMonitoringHttpServer.close();
+    // eslint-disable-next-line chai-friendly/no-unused-expressions
+    freeMonitoringHttpServer?.close?.();
   });
 
   context('without special configuration', () => {

--- a/packages/cli-repl/test/e2e-fle.spec.ts
+++ b/packages/cli-repl/test/e2e-fle.spec.ts
@@ -301,6 +301,7 @@ describe('FLE tests', () => {
 
   context('6.0+', () => {
     skipIfServerVersion(testServer, '< 6.0'); // Queryable Encryption only available on 6.0+
+    skipIfServerVersion(testServer, '> 6.x'); // TODO(MONGOSH-1410): Queryable Encryption made a breaking change for 7.0
 
     it('allows explicit encryption with bypassQueryAnalysis', async function() {
       if (isMacosTooOldForQE()) {
@@ -505,6 +506,7 @@ describe('FLE tests', () => {
 
   context('6.2+', () => {
     skipIfServerVersion(testServer, '< 6.2'); // Range QE only available on 6.2+
+    skipIfServerVersion(testServer, '> 6.x'); // TODO(MONGOSH-1410): Queryable Encryption made a breaking change for 7.0
 
     it('allows explicit range encryption with bypassQueryAnalysis', async function() {
       if (isMacosTooOldForQE()) {

--- a/packages/shell-api/src/collection.ts
+++ b/packages/shell-api/src/collection.ts
@@ -1615,7 +1615,7 @@ export default class Collection extends ShellApiWithMongoClass {
 
     try {
       result.sharded = !!(await config.getCollection('collections').findOne({
-        _id: ns,
+        _id: timeseriesBucketsNs ?? ns,
         // Dropped is gone on newer server versions, so check for !== true
         // rather than for === false (SERVER-51880 and related).
         dropped: { $ne: true }

--- a/packages/shell-api/src/shard.spec.ts
+++ b/packages/shell-api/src/shard.spec.ts
@@ -1321,6 +1321,7 @@ describe('Shard', () => {
       });
     });
     describe('autosplit', () => {
+      skipIfServerVersion(mongos, '> 6.x'); // Auto-splitter is removed in 7.0
       it('disables correctly', async() => {
         expect((await sh.disableAutoSplit()).acknowledged).to.equal(true);
         expect((await sh.status()).value.autosplit['Currently enabled']).to.equal('no');


### PR DESCRIPTION
- Skip FLE tests on 7.x until MONGOSH-1410
- Skip sharding auto-splitter tests entirely after the removal in 7.0
- Make the code in an `after` hook pass if the before hook never ran
- Fix the `collStats` compatibility code in the timeseries case (since now the agg pipeline variant works on timeseries collections in 7.1+)