### PR TITLE
[do not merge] try mongodb-client-encryption@2.8.0-alpha.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -21622,6 +21622,7 @@
       "integrity": "sha512-LN1udDf9nZ/paUcuY2AATIVWKf7oGHb2IKMQqGu/7iiqpNlV0M6xjbQix0bxEQvzZZW0T9PG6PN8mYeMR+YDnA==",
       "hasInstallScript": true,
       "optional": true,
+      "peer": true,
       "dependencies": {
         "bindings": "^1.5.0",
         "node-addon-api": "^4.3.0",
@@ -30353,8 +30354,8 @@
         "@babel/plugin-proposal-class-properties": "^7.8.3",
         "@babel/preset-react": "^7.18.6",
         "@babel/preset-typescript": "^7.18.6",
-        "@mongodb-js/compass-components": "^1.8.0",
-        "@mongodb-js/compass-editor": "^0.7.0",
+        "@mongodb-js/compass-components": "*",
+        "@mongodb-js/compass-editor": "*",
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.8",
         "@types/numeral": "^2.0.2",
         "@types/react": "^16.9.17",
@@ -30819,7 +30820,36 @@
         "node": ">=14.15.1"
       },
       "optionalDependencies": {
-        "mongodb-client-encryption": "^2.7.1"
+        "mongodb-client-encryption": "^2.8.0-alpha.0"
+      }
+    },
+    "packages/service-provider-core/node_modules/mongodb-client-encryption": {
+      "version": "2.8.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-2.8.0-alpha.0.tgz",
+      "integrity": "sha512-WrXs0jGSGmL3CJiJYyWJt+poQzYgXiZzY3Uh8mwnMjkQr6CosfKP2Ae7oQwm6Ss5oFTja5hoHuxrZR8lwhcJZg==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "node-addon-api": "^4.3.0",
+        "prebuild-install": "^7.1.1",
+        "socks": "^2.6.1"
+      },
+      "engines": {
+        "node": ">=12.9.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.186.0",
+        "gcp-metadata": "^5.2.0",
+        "mongodb": ">=3.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "gcp-metadata": {
+          "optional": true
+        }
       }
     },
     "packages/service-provider-server": {
@@ -30842,7 +30872,36 @@
       },
       "optionalDependencies": {
         "kerberos": "^2.0.0",
-        "mongodb-client-encryption": "^2.7.1"
+        "mongodb-client-encryption": "^2.8.0-alpha.0"
+      }
+    },
+    "packages/service-provider-server/node_modules/mongodb-client-encryption": {
+      "version": "2.8.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-2.8.0-alpha.0.tgz",
+      "integrity": "sha512-WrXs0jGSGmL3CJiJYyWJt+poQzYgXiZzY3Uh8mwnMjkQr6CosfKP2Ae7oQwm6Ss5oFTja5hoHuxrZR8lwhcJZg==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "node-addon-api": "^4.3.0",
+        "prebuild-install": "^7.1.1",
+        "socks": "^2.6.1"
+      },
+      "engines": {
+        "node": ">=12.9.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.186.0",
+        "gcp-metadata": "^5.2.0",
+        "mongodb": ">=3.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "gcp-metadata": {
+          "optional": true
+        }
       }
     },
     "packages/shell-api": {
@@ -38126,8 +38185,8 @@
         "@babel/plugin-proposal-class-properties": "^7.8.3",
         "@babel/preset-react": "^7.18.6",
         "@babel/preset-typescript": "^7.18.6",
-        "@mongodb-js/compass-components": "1.8.0",
-        "@mongodb-js/compass-editor": "0.7.0",
+        "@mongodb-js/compass-components": "*",
+        "@mongodb-js/compass-editor": "*",
         "@mongosh/browser-runtime-core": "0.0.0-dev.0",
         "@mongosh/errors": "0.0.0-dev.0",
         "@mongosh/history": "0.0.0-dev.0",
@@ -38457,7 +38516,21 @@
         "bson": "^5.2.0",
         "mongodb": "^5.3.0",
         "mongodb-build-info": "^1.5.0",
-        "mongodb-client-encryption": "^2.7.1"
+        "mongodb-client-encryption": "^2.8.0-alpha.0"
+      },
+      "dependencies": {
+        "mongodb-client-encryption": {
+          "version": "2.8.0-alpha.0",
+          "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-2.8.0-alpha.0.tgz",
+          "integrity": "sha512-WrXs0jGSGmL3CJiJYyWJt+poQzYgXiZzY3Uh8mwnMjkQr6CosfKP2Ae7oQwm6Ss5oFTja5hoHuxrZR8lwhcJZg==",
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "node-addon-api": "^4.3.0",
+            "prebuild-install": "^7.1.1",
+            "socks": "^2.6.1"
+          }
+        }
       }
     },
     "@mongosh/service-provider-server": {
@@ -38471,9 +38544,23 @@
         "aws4": "^1.11.0",
         "kerberos": "^2.0.0",
         "mongodb": "^5.3.0",
-        "mongodb-client-encryption": "^2.7.1",
+        "mongodb-client-encryption": "^2.8.0-alpha.0",
         "mongodb-connection-string-url": "^2.6.0",
         "saslprep": "mongodb-js/saslprep#v1.0.4"
+      },
+      "dependencies": {
+        "mongodb-client-encryption": {
+          "version": "2.8.0-alpha.0",
+          "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-2.8.0-alpha.0.tgz",
+          "integrity": "sha512-WrXs0jGSGmL3CJiJYyWJt+poQzYgXiZzY3Uh8mwnMjkQr6CosfKP2Ae7oQwm6Ss5oFTja5hoHuxrZR8lwhcJZg==",
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "node-addon-api": "^4.3.0",
+            "prebuild-install": "^7.1.1",
+            "socks": "^2.6.1"
+          }
+        }
       }
     },
     "@mongosh/shell-api": {
@@ -49205,6 +49292,7 @@
       "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-2.7.1.tgz",
       "integrity": "sha512-LN1udDf9nZ/paUcuY2AATIVWKf7oGHb2IKMQqGu/7iiqpNlV0M6xjbQix0bxEQvzZZW0T9PG6PN8mYeMR+YDnA==",
       "optional": true,
+      "peer": true,
       "requires": {
         "bindings": "^1.5.0",
         "node-addon-api": "^4.3.0",

--- a/packages/service-provider-core/package.json
+++ b/packages/service-provider-core/package.json
@@ -40,7 +40,7 @@
     "mongodb-build-info": "^1.5.0"
   },
   "optionalDependencies": {
-    "mongodb-client-encryption": "^2.7.1"
+    "mongodb-client-encryption": "^2.8.0-alpha.0"
   },
   "dependency-check": {
     "entries": [

--- a/packages/service-provider-server/package.json
+++ b/packages/service-provider-server/package.json
@@ -55,7 +55,7 @@
     "saslprep": "mongodb-js/saslprep#v1.0.4"
   },
   "optionalDependencies": {
-    "mongodb-client-encryption": "^2.7.1",
+    "mongodb-client-encryption": "^2.8.0-alpha.0",
     "kerberos": "^2.0.0"
   }
 }


### PR DESCRIPTION
Just attempting to create alternative builds of 1.8.1 that are QEv2-enabled.