### PR TITLE
fix(browser-repl): account for node-runtime-worker-thread-specific result rendering MONGOSH-1323

### DIFF
--- a/packages/browser-repl/src/components/shell-output-line.spec.tsx
+++ b/packages/browser-repl/src/components/shell-output-line.spec.tsx
@@ -12,7 +12,13 @@ import { ErrorOutput } from './types/error-output';
 
 describe('<ShellOutputLine />', () => {
   it('renders a string value', () => {
-    const wrapper = shallow(<ShellOutputLine entry={{ format: 'output', value: 'some text' }} />);
+    const wrapper = mount(<ShellOutputLine entry={{ format: 'output', value: 'some text' }} />);
+    expect(wrapper.find('pre')).to.have.lengthOf(1);
+    expect(wrapper.text()).to.contain('some text');
+  });
+
+  it('renders a pre-inspected string value from node-runtime-worker-thread', () => {
+    const wrapper = shallow(<ShellOutputLine entry={{ format: 'output', value: 'some text', type: 'InspectResult' }} />);
     expect(wrapper.find(SimpleTypeOutput)).to.have.lengthOf(1);
   });
 

--- a/packages/browser-repl/src/components/shell-output-line.tsx
+++ b/packages/browser-repl/src/components/shell-output-line.tsx
@@ -59,7 +59,11 @@ export class ShellOutputLine extends Component<ShellOutputLineProps> {
       return <pre>{value}</pre>;
     }
 
-    if (typeof value === 'string' && !type) {
+    // 'InspectResult' is a special value used by node-runtime-worker-thread
+    // which indicates that the value has already been inspect()ed prior to
+    // serialization, in which case we also want to print its raw contents
+    // rather than calling inspect() again;
+    if (typeof value === 'string' && type === 'InspectResult') {
       return <SimpleTypeOutput value={value} raw />;
     }
 
@@ -115,9 +119,10 @@ export class ShellOutputLine extends Component<ShellOutputLineProps> {
   }
 
   private isPreformattedResult(value: any, type?: string | null): boolean {
-    return typeof value === 'string' &&
-    type === 'Database' ||
-    type === 'Collection';
+    return typeof value === 'string' && (
+      type === 'Database' ||
+      type === 'Collection' ||
+      !type);
   }
 
   private isPrimitiveOrFunction(value: any): boolean {


### PR DESCRIPTION
d1278ecd5d7d attempted to address MONGOSH-1323 but failed to do so properly because node-runtime-worker-thread adjusts behavior so that most values result in reporting a `string` result back to the frontend.