### PR TITLE
fix(ci): update Python version for Windows CI

### DIFF
--- a/.evergreen/setup-env.sh
+++ b/.evergreen/setup-env.sh
@@ -1,7 +1,7 @@
 set -e
 set -x
 export BASEDIR="$PWD/.evergreen"
-export PATH="/cygdrive/c/python/Python311/Scripts:/cygdrive/c/python/Python311:/cygdrive/c/Python311/Scripts:/cygdrive/c/Python311:/opt/python/3.6/bin:$BASEDIR/mingit/cmd:$BASEDIR/mingit/mingw64/libexec/git-core:$BASEDIR/git-2:$BASEDIR/npm-8/node_modules/.bin:$BASEDIR/node-v$NODE_JS_VERSION-win-x64:/opt/java/jdk16/bin:/opt/chefdk/gitbin:/cygdrive/c/cmake/bin:/opt/mongodbtoolchain/v3/bin:$PATH"
+export PATH="$BASEDIR/.bin:/cygdrive/c/python/Python311/Scripts:/cygdrive/c/python/Python311:/cygdrive/c/Python311/Scripts:/cygdrive/c/Python311:/opt/python/3.6/bin:$BASEDIR/mingit/cmd:$BASEDIR/mingit/mingw64/libexec/git-core:$BASEDIR/git-2:$BASEDIR/npm-8/node_modules/.bin:$BASEDIR/node-v$NODE_JS_VERSION-win-x64:/opt/java/jdk16/bin:/opt/chefdk/gitbin:/cygdrive/c/cmake/bin:/opt/mongodbtoolchain/v3/bin:$PATH"
 export IS_MONGOSH_EVERGREEN_CI=1
 
 if [ "$OS" != "Windows_NT" ]; then
@@ -26,6 +26,8 @@ if [ "$OS" != "Windows_NT" ]; then
   if [ -x "$BASEDIR/git-2/git" ]; then
     export GIT_EXEC_PATH="$BASEDIR/git-2"
   fi
+else
+  (mkdir -p "$BASEDIR/.bin" && cd "$BASEDIR/.bin" && rm -f python && ln -s $(which python3) python)
 fi
 
 export EVERGREEN_EXPANSIONS_PATH="$BASEDIR/../../tmp/expansions.yaml"
@@ -66,16 +68,19 @@ echo "Full path:"
 echo $PATH
 
 echo "Using node version:"
-node --version
+(which node && node --version)
 
 echo "Using npm version:"
-npm --version
+(which npm && npm --version)
 
 echo "Using git version:"
-git --version
+(which git && git --version)
 
 echo "Using python version:"
-python --version
+(which python && python --version) || true
+
+echo "Using python3 version:"
+(which python3 && python3 --version) || true
 
 echo "Node.js OS info:"
 node -p '[os.arch(), os.platform(), os.endianness(), os.type(), os.release()]'

--- a/.evergreen/setup-env.sh
+++ b/.evergreen/setup-env.sh
@@ -1,7 +1,7 @@
 set -e
 set -x
 export BASEDIR="$PWD/.evergreen"
-export PATH="$BASEDIR/mingit/cmd:$BASEDIR/mingit/mingw64/libexec/git-core:$BASEDIR/git-2:$BASEDIR/npm-8/node_modules/.bin:$BASEDIR/node-v$NODE_JS_VERSION-win-x64:/opt/python/3.6/bin:/opt/java/jdk16/bin:/opt/chefdk/gitbin:/cygdrive/c/python/Python310/Scripts:/cygdrive/c/python/Python310:/cygdrive/c/Python310/Scripts:/cygdrive/c/Python310:/cygdrive/c/cmake/bin:/opt/mongodbtoolchain/v3/bin:$PATH"
+export PATH="$BASEDIR/mingit/cmd:$BASEDIR/mingit/mingw64/libexec/git-core:$BASEDIR/git-2:$BASEDIR/npm-8/node_modules/.bin:$BASEDIR/node-v$NODE_JS_VERSION-win-x64:/opt/python/3.6/bin:/opt/java/jdk16/bin:/opt/chefdk/gitbin:/cygdrive/c/python/Python311/Scripts:/cygdrive/c/python/Python311:/cygdrive/c/Python311/Scripts:/cygdrive/c/Python311:/cygdrive/c/cmake/bin:/opt/mongodbtoolchain/v3/bin:$PATH"
 export IS_MONGOSH_EVERGREEN_CI=1
 
 if [ "$OS" != "Windows_NT" ]; then

--- a/.evergreen/setup-env.sh
+++ b/.evergreen/setup-env.sh
@@ -1,7 +1,7 @@
 set -e
 set -x
 export BASEDIR="$PWD/.evergreen"
-export PATH="$BASEDIR/mingit/cmd:$BASEDIR/mingit/mingw64/libexec/git-core:$BASEDIR/git-2:$BASEDIR/npm-8/node_modules/.bin:$BASEDIR/node-v$NODE_JS_VERSION-win-x64:/opt/python/3.6/bin:/opt/java/jdk16/bin:/opt/chefdk/gitbin:/cygdrive/c/python/Python311/Scripts:/cygdrive/c/python/Python311:/cygdrive/c/Python311/Scripts:/cygdrive/c/Python311:/cygdrive/c/cmake/bin:/opt/mongodbtoolchain/v3/bin:$PATH"
+export PATH="/cygdrive/c/python/Python311/Scripts:/cygdrive/c/python/Python311:/cygdrive/c/Python311/Scripts:/cygdrive/c/Python311:/opt/python/3.6/bin:$BASEDIR/mingit/cmd:$BASEDIR/mingit/mingw64/libexec/git-core:$BASEDIR/git-2:$BASEDIR/npm-8/node_modules/.bin:$BASEDIR/node-v$NODE_JS_VERSION-win-x64:/opt/java/jdk16/bin:/opt/chefdk/gitbin:/cygdrive/c/cmake/bin:/opt/mongodbtoolchain/v3/bin:$PATH"
 export IS_MONGOSH_EVERGREEN_CI=1
 
 if [ "$OS" != "Windows_NT" ]; then

--- a/.evergreen/setup-env.sh
+++ b/.evergreen/setup-env.sh
@@ -1,7 +1,7 @@
 set -e
 set -x
 export BASEDIR="$PWD/.evergreen"
-export PATH="$BASEDIR/.bin:/cygdrive/c/python/Python311/Scripts:/cygdrive/c/python/Python311:/cygdrive/c/Python311/Scripts:/cygdrive/c/Python311:/opt/python/3.6/bin:$BASEDIR/mingit/cmd:$BASEDIR/mingit/mingw64/libexec/git-core:$BASEDIR/git-2:$BASEDIR/npm-8/node_modules/.bin:$BASEDIR/node-v$NODE_JS_VERSION-win-x64:/opt/java/jdk16/bin:/opt/chefdk/gitbin:/cygdrive/c/cmake/bin:/opt/mongodbtoolchain/v3/bin:$PATH"
+export PATH="/cygdrive/c/python/Python311/Scripts:/cygdrive/c/python/Python311:/cygdrive/c/Python311/Scripts:/cygdrive/c/Python311:/opt/python/3.6/bin:$BASEDIR/mingit/cmd:$BASEDIR/mingit/mingw64/libexec/git-core:$BASEDIR/git-2:$BASEDIR/npm-8/node_modules/.bin:$BASEDIR/node-v$NODE_JS_VERSION-win-x64:/opt/java/jdk16/bin:/opt/chefdk/gitbin:/cygdrive/c/cmake/bin:/opt/mongodbtoolchain/v3/bin:$PATH"
 export IS_MONGOSH_EVERGREEN_CI=1
 
 if [ "$OS" != "Windows_NT" ]; then
@@ -26,8 +26,6 @@ if [ "$OS" != "Windows_NT" ]; then
   if [ -x "$BASEDIR/git-2/git" ]; then
     export GIT_EXEC_PATH="$BASEDIR/git-2"
   fi
-else
-  (mkdir -p "$BASEDIR/.bin" && cd "$BASEDIR/.bin" && rm -f python && ln -s $(which python3) python)
 fi
 
 export EVERGREEN_EXPANSIONS_PATH="$BASEDIR/../../tmp/expansions.yaml"

--- a/testing/integration-testing-hooks.ts
+++ b/testing/integration-testing-hooks.ts
@@ -56,6 +56,9 @@ async function tryExtensions(base: string): Promise<[ string, Error ]> {
 
 async function findPython3() {
   try {
+    if (process.env.DISTRO_ID?.startsWith('windows-')) {
+      throw new Error('python3 on Windows in evergreen CI is broken but `python` is working python3');
+    }
     await which('python3');
     return 'python3';
   } catch {


### PR DESCRIPTION
This broke today because the build hosts were updated to a more recent Python version.

https://mongodb.slack.com/archives/C0V896UV8/p1682441001192679