### PR TITLE
chore(browser-repl): add data-testid to lines in shell

### DIFF
--- a/packages/browser-repl/src/components/shell-input.tsx
+++ b/packages/browser-repl/src/components/shell-input.tsx
@@ -152,7 +152,11 @@ export class ShellInput extends Component<ShellInputProps, ShellInputState> {
     );
 
     return (
-      <LineWithIcon className={shellInput} icon={prompt}>
+      <LineWithIcon
+        className={shellInput}
+        icon={prompt}
+        data-testid="shell-input"
+      >
         {editor}
       </LineWithIcon>
     );

--- a/packages/browser-repl/src/components/shell-output-line.tsx
+++ b/packages/browser-repl/src/components/shell-output-line.tsx
@@ -166,6 +166,7 @@ export class ShellOutputLine extends Component<ShellOutputLineProps> {
           format === 'error' && shellOutputLineError
         )}
         icon={icon}
+        data-testid="shell-output"
       >
         {this.renderValue()}
       </LineWithIcon>

--- a/packages/browser-repl/src/components/utils/expandable.tsx
+++ b/packages/browser-repl/src/components/utils/expandable.tsx
@@ -47,11 +47,12 @@ export class Expandable extends Component<ExpandableProps, ExpandableState> {
       onClick={this.toggle}
     />);
 
-    return (<LineWithIcon icon={icon}>
-      {typeof this.props.children === 'function'
-        ? this.props.children(this.state.expanded, this.toggle)
-        : this.props.children}
-
-    </LineWithIcon>);
+    return (
+      <LineWithIcon icon={icon} data-testid="shell-output">
+        {typeof this.props.children === 'function'
+          ? this.props.children(this.state.expanded, this.toggle)
+          : this.props.children}
+      </LineWithIcon>
+    );
   }
 }

--- a/packages/browser-repl/src/components/utils/line-with-icon.tsx
+++ b/packages/browser-repl/src/components/utils/line-with-icon.tsx
@@ -22,23 +22,26 @@ const lineWithIconContent = css({
 interface LineWithIconProps {
   icon: JSX.Element;
   className?: string;
+  ['data-testid']?: string;
 }
 
 export class LineWithIcon extends Component<LineWithIconProps> {
   static propTypes = {
     icon: PropTypes.object.isRequired,
-    className: PropTypes.string
+    className: PropTypes.string,
+    ['data-testid']: PropTypes.string
   };
 
   render(): JSX.Element {
-    return (<div className={cx(this.props.className, lineWithIcon)}>
-      <span className={lineWithIconIcon}>
-        {this.props.icon}
-      </span>
-      <div className={lineWithIconContent}>
-        {this.props.children}
+    return (
+      <div
+        className={cx(this.props.className, lineWithIcon)}
+        data-testid={this.props['data-testid']}
+      >
+        <span className={lineWithIconIcon}>{this.props.icon}</span>
+        <div className={lineWithIconContent}>{this.props.children}</div>
       </div>
-    </div>);
+    );
   }
 }
 


### PR DESCRIPTION
When trying to update e2e tests in compass to expect new codemirror shell, I noticed that we currently rely on shell output being codemirror which is not true anymore (it's not true in 100% cases anyway, but works for what we are doing in e2e) and makes it hard to pick up expected shell output. This adds a few test ids so that it's easier to make this distinction