### PR TITLE
feat!: update libmongocrypt and switch QE tests to only run on 7.0 MONGOSH-1411

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8648,9 +8648,9 @@
       }
     },
     "node_modules/@octokit/core/node_modules/@octokit/openapi-types": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-16.0.0.tgz",
-      "integrity": "sha512-JbFWOqTJVLHZSUUoF4FzAZKYtqdxWu9Z5m2QQnOyEa04fOFljvyh7D3GYKbfuaSWisqehImiVIMG4eyJeP5VEA==",
+      "version": "17.1.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-17.1.0.tgz",
+      "integrity": "sha512-rnI26BAITDZTo5vqFOmA7oX4xRd18rO+gcK4MiTpJmsRMxAw0JmevNjPsjpry1bb9SVNo56P/0kbiyXXa4QluA==",
       "dev": true,
       "peer": true
     },
@@ -8688,13 +8688,13 @@
       }
     },
     "node_modules/@octokit/core/node_modules/@octokit/types": {
-      "version": "9.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.0.0.tgz",
-      "integrity": "sha512-LUewfj94xCMH2rbD5YJ+6AQ4AVjFYTgpp6rboWM5T7N3IsIF65SBEOVcYMGAEzO/kKNiNaW4LoWtoThOhH06gw==",
+      "version": "9.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.2.0.tgz",
+      "integrity": "sha512-xySzJG4noWrIBFyMu4lg4tu9vAgNg9S0aoLRONhAEz6ueyi1evBzb40HitIosaYS4XOexphG305IVcLrIX/30g==",
       "dev": true,
       "peer": true,
       "dependencies": {
-        "@octokit/openapi-types": "^16.0.0"
+        "@octokit/openapi-types": "^17.1.0"
       }
     },
     "node_modules/@octokit/endpoint": {
@@ -21622,6 +21622,7 @@
       "integrity": "sha512-LN1udDf9nZ/paUcuY2AATIVWKf7oGHb2IKMQqGu/7iiqpNlV0M6xjbQix0bxEQvzZZW0T9PG6PN8mYeMR+YDnA==",
       "hasInstallScript": true,
       "optional": true,
+      "peer": true,
       "dependencies": {
         "bindings": "^1.5.0",
         "node-addon-api": "^4.3.0",
@@ -30353,8 +30354,8 @@
         "@babel/plugin-proposal-class-properties": "^7.8.3",
         "@babel/preset-react": "^7.18.6",
         "@babel/preset-typescript": "^7.18.6",
-        "@mongodb-js/compass-components": "^1.8.0",
-        "@mongodb-js/compass-editor": "^0.7.0",
+        "@mongodb-js/compass-components": "*",
+        "@mongodb-js/compass-editor": "*",
         "@pmmmwh/react-refresh-webpack-plugin": "^0.5.8",
         "@types/numeral": "^2.0.2",
         "@types/react": "^16.9.17",
@@ -30819,7 +30820,36 @@
         "node": ">=14.15.1"
       },
       "optionalDependencies": {
-        "mongodb-client-encryption": "^2.7.1"
+        "mongodb-client-encryption": "^2.8.0-alpha.1"
+      }
+    },
+    "packages/service-provider-core/node_modules/mongodb-client-encryption": {
+      "version": "2.8.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-2.8.0-alpha.1.tgz",
+      "integrity": "sha512-7i3ZCkCJL5hbQlX0QjX4jishuuIpzgXd8PkB1oXqTqrp0yLFgIPfmczhxgbc3kHIsWGaeJLXX5w28spJTgNY8w==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "node-addon-api": "^4.3.0",
+        "prebuild-install": "^7.1.1",
+        "socks": "^2.6.1"
+      },
+      "engines": {
+        "node": ">=12.9.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.186.0",
+        "gcp-metadata": "^5.2.0",
+        "mongodb": ">=3.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "gcp-metadata": {
+          "optional": true
+        }
       }
     },
     "packages/service-provider-server": {
@@ -30842,7 +30872,36 @@
       },
       "optionalDependencies": {
         "kerberos": "^2.0.0",
-        "mongodb-client-encryption": "^2.7.1"
+        "mongodb-client-encryption": "^2.8.0-alpha.1"
+      }
+    },
+    "packages/service-provider-server/node_modules/mongodb-client-encryption": {
+      "version": "2.8.0-alpha.1",
+      "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-2.8.0-alpha.1.tgz",
+      "integrity": "sha512-7i3ZCkCJL5hbQlX0QjX4jishuuIpzgXd8PkB1oXqTqrp0yLFgIPfmczhxgbc3kHIsWGaeJLXX5w28spJTgNY8w==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "node-addon-api": "^4.3.0",
+        "prebuild-install": "^7.1.1",
+        "socks": "^2.6.1"
+      },
+      "engines": {
+        "node": ">=12.9.0"
+      },
+      "peerDependencies": {
+        "@aws-sdk/credential-providers": "^3.186.0",
+        "gcp-metadata": "^5.2.0",
+        "mongodb": ">=3.4.0"
+      },
+      "peerDependenciesMeta": {
+        "@aws-sdk/credential-providers": {
+          "optional": true
+        },
+        "gcp-metadata": {
+          "optional": true
+        }
       }
     },
     "packages/shell-api": {
@@ -38126,8 +38185,8 @@
         "@babel/plugin-proposal-class-properties": "^7.8.3",
         "@babel/preset-react": "^7.18.6",
         "@babel/preset-typescript": "^7.18.6",
-        "@mongodb-js/compass-components": "1.8.0",
-        "@mongodb-js/compass-editor": "0.7.0",
+        "@mongodb-js/compass-components": "*",
+        "@mongodb-js/compass-editor": "*",
         "@mongosh/browser-runtime-core": "0.0.0-dev.0",
         "@mongosh/errors": "0.0.0-dev.0",
         "@mongosh/history": "0.0.0-dev.0",
@@ -38457,7 +38516,21 @@
         "bson": "^5.2.0",
         "mongodb": "^5.3.0",
         "mongodb-build-info": "^1.5.0",
-        "mongodb-client-encryption": "^2.7.1"
+        "mongodb-client-encryption": "^2.8.0-alpha.1"
+      },
+      "dependencies": {
+        "mongodb-client-encryption": {
+          "version": "2.8.0-alpha.1",
+          "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-2.8.0-alpha.1.tgz",
+          "integrity": "sha512-7i3ZCkCJL5hbQlX0QjX4jishuuIpzgXd8PkB1oXqTqrp0yLFgIPfmczhxgbc3kHIsWGaeJLXX5w28spJTgNY8w==",
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "node-addon-api": "^4.3.0",
+            "prebuild-install": "^7.1.1",
+            "socks": "^2.6.1"
+          }
+        }
       }
     },
     "@mongosh/service-provider-server": {
@@ -38471,9 +38544,23 @@
         "aws4": "^1.11.0",
         "kerberos": "^2.0.0",
         "mongodb": "^5.3.0",
-        "mongodb-client-encryption": "^2.7.1",
+        "mongodb-client-encryption": "^2.8.0-alpha.1",
         "mongodb-connection-string-url": "^2.6.0",
         "saslprep": "mongodb-js/saslprep#v1.0.4"
+      },
+      "dependencies": {
+        "mongodb-client-encryption": {
+          "version": "2.8.0-alpha.1",
+          "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-2.8.0-alpha.1.tgz",
+          "integrity": "sha512-7i3ZCkCJL5hbQlX0QjX4jishuuIpzgXd8PkB1oXqTqrp0yLFgIPfmczhxgbc3kHIsWGaeJLXX5w28spJTgNY8w==",
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "node-addon-api": "^4.3.0",
+            "prebuild-install": "^7.1.1",
+            "socks": "^2.6.1"
+          }
+        }
       }
     },
     "@mongosh/shell-api": {
@@ -38802,9 +38889,9 @@
           }
         },
         "@octokit/openapi-types": {
-          "version": "16.0.0",
-          "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-16.0.0.tgz",
-          "integrity": "sha512-JbFWOqTJVLHZSUUoF4FzAZKYtqdxWu9Z5m2QQnOyEa04fOFljvyh7D3GYKbfuaSWisqehImiVIMG4eyJeP5VEA==",
+          "version": "17.1.0",
+          "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-17.1.0.tgz",
+          "integrity": "sha512-rnI26BAITDZTo5vqFOmA7oX4xRd18rO+gcK4MiTpJmsRMxAw0JmevNjPsjpry1bb9SVNo56P/0kbiyXXa4QluA==",
           "dev": true,
           "peer": true
         },
@@ -38836,13 +38923,13 @@
           }
         },
         "@octokit/types": {
-          "version": "9.0.0",
-          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.0.0.tgz",
-          "integrity": "sha512-LUewfj94xCMH2rbD5YJ+6AQ4AVjFYTgpp6rboWM5T7N3IsIF65SBEOVcYMGAEzO/kKNiNaW4LoWtoThOhH06gw==",
+          "version": "9.2.0",
+          "resolved": "https://registry.npmjs.org/@octokit/types/-/types-9.2.0.tgz",
+          "integrity": "sha512-xySzJG4noWrIBFyMu4lg4tu9vAgNg9S0aoLRONhAEz6ueyi1evBzb40HitIosaYS4XOexphG305IVcLrIX/30g==",
           "dev": true,
           "peer": true,
           "requires": {
-            "@octokit/openapi-types": "^16.0.0"
+            "@octokit/openapi-types": "^17.1.0"
           }
         }
       }
@@ -49205,6 +49292,7 @@
       "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-2.7.1.tgz",
       "integrity": "sha512-LN1udDf9nZ/paUcuY2AATIVWKf7oGHb2IKMQqGu/7iiqpNlV0M6xjbQix0bxEQvzZZW0T9PG6PN8mYeMR+YDnA==",
       "optional": true,
+      "peer": true,
       "requires": {
         "bindings": "^1.5.0",
         "node-addon-api": "^4.3.0",

--- a/packages/cli-repl/test/e2e-fle.spec.ts
+++ b/packages/cli-repl/test/e2e-fle.spec.ts
@@ -299,9 +299,8 @@ describe('FLE tests', () => {
     expect(compactResult).to.include('The "compactStructuredEncryptionData" command requires Mongo instance configured with auto encryption.');
   });
 
-  context('6.0+', () => {
-    skipIfServerVersion(testServer, '< 6.0'); // Queryable Encryption only available on 6.0+
-    skipIfServerVersion(testServer, '> 6.x'); // TODO(MONGOSH-1410): Queryable Encryption made a breaking change for 7.0
+  context('7.0', () => {
+    skipIfServerVersion(testServer, '< 7.0');
 
     it('allows explicit encryption with bypassQueryAnalysis', async function() {
       if (isMacosTooOldForQE()) {
@@ -502,12 +501,6 @@ describe('FLE tests', () => {
       // Since there is only one field to be encrypted hence there would only be one DEK in our keyvault collection
       expect(parseInt(dekCount.trim(), 10)).to.equal(1);
     });
-  });
-
-  context('6.2+', () => {
-    skipIfServerVersion(testServer, '< 6.2'); // Range QE only available on 6.2+
-    skipIfServerVersion(testServer, '> 6.x'); // TODO(MONGOSH-1410): Queryable Encryption made a breaking change for 7.0
-
     it('allows explicit range encryption with bypassQueryAnalysis', async function() {
       if (isMacosTooOldForQE()) {
         return this.skip();

--- a/packages/cli-repl/test/e2e-fle.spec.ts
+++ b/packages/cli-repl/test/e2e-fle.spec.ts
@@ -299,8 +299,8 @@ describe('FLE tests', () => {
     expect(compactResult).to.include('The "compactStructuredEncryptionData" command requires Mongo instance configured with auto encryption.');
   });
 
-  context('7.0', () => {
-    skipIfServerVersion(testServer, '< 7.0');
+  context('7.0+', () => {
+    skipIfServerVersion(testServer, '< 7.0'); // Queryable Encryption v2 only available on 6.0+
 
     it('allows explicit encryption with bypassQueryAnalysis', async function() {
       if (isMacosTooOldForQE()) {

--- a/packages/cli-repl/test/e2e-fle.spec.ts
+++ b/packages/cli-repl/test/e2e-fle.spec.ts
@@ -300,7 +300,7 @@ describe('FLE tests', () => {
   });
 
   context('7.0+', () => {
-    skipIfServerVersion(testServer, '< 7.0'); // Queryable Encryption v2 only available on 6.0+
+    skipIfServerVersion(testServer, '< 7.0'); // Queryable Encryption v2 only available on 7.0+
 
     it('allows explicit encryption with bypassQueryAnalysis', async function() {
       if (isMacosTooOldForQE()) {

--- a/packages/service-provider-core/package.json
+++ b/packages/service-provider-core/package.json
@@ -40,7 +40,7 @@
     "mongodb-build-info": "^1.5.0"
   },
   "optionalDependencies": {
-    "mongodb-client-encryption": "^2.7.1"
+    "mongodb-client-encryption": "^2.8.0-alpha.1"
   },
   "dependency-check": {
     "entries": [

--- a/packages/service-provider-server/package.json
+++ b/packages/service-provider-server/package.json
@@ -55,7 +55,7 @@
     "saslprep": "mongodb-js/saslprep#v1.0.4"
   },
   "optionalDependencies": {
-    "mongodb-client-encryption": "^2.7.1",
+    "mongodb-client-encryption": "^2.8.0-alpha.1",
     "kerberos": "^2.0.0"
   }
 }


### PR DESCRIPTION
**TODO:**

* [ ] wait for a non-alpha 2.8.0 release and update it here

The QE tests that depend on a server version now require 7.0 and up.

We'll add some tests to make sure data in 6.x versions can be read in https://jira.mongodb.org/browse/MONGOSH-1412