### PR TITLE
fix(cli-repl): keep the raw mode off for the whole duration of the eval MONGOSH-1433

### DIFF
--- a/packages/cli-repl/src/async-repl.spec.ts
+++ b/packages/cli-repl/src/async-repl.spec.ts
@@ -102,6 +102,21 @@ describe('AsyncRepl', () => {
     await expectInStream(output, 'meow');
   });
 
+  it('disables raw mode for input during both sync and async evaluation when async sigint is enabled', async() => {
+    const { input, output, repl } = createDefaultAsyncRepl({ onAsyncSigint: () => false });
+    let isRaw = true;
+    Object.defineProperty(input, 'isRaw', {
+      get() { return isRaw; },
+      enumerable: true
+    });
+    (input as any).setRawMode = (value: boolean) => { isRaw = value; };
+    repl.context.isRawMode = () => isRaw;
+
+    input.write('const before = isRawMode(); new Promise(setImmediate).then(() => ({before, after: isRawMode()}))\n');
+    await expectInStream(output, 'before: false, after: false');
+    expect(isRaw).to.equal(true);
+  });
+
   it('handles asynchronous exceptions well', async() => {
     const { input, output } = createDefaultAsyncRepl();
 

--- a/packages/cli-repl/test/e2e.spec.ts
+++ b/packages/cli-repl/test/e2e.spec.ts
@@ -726,8 +726,7 @@ describe('e2e', function() {
           throw new Error('Waiting for the file to load...');
         });
 
-        // Writing ^C to shell
-        shell.writeInput('\x03');
+        shell.kill('SIGINT');
 
         await eventually(() => {
           if (shell.output.includes('MongoshInterruptedError')) {

--- a/packages/cli-repl/test/e2e.spec.ts
+++ b/packages/cli-repl/test/e2e.spec.ts
@@ -705,47 +705,82 @@ describe('e2e', function() {
       }
     });
 
-    let shell: TestShell;
-    beforeEach(async() => {
-      shell = TestShell.start({ args: [ '--nodb' ], removeSigintListeners: true });
-      await shell.waitForPrompt();
-      shell.assertNoErrors();
+    describe('non-interactive', function() {
+      it('interrupts file execution', async function() {
+        const filename = path.resolve(
+          __dirname,
+          'fixtures',
+          'load',
+          'long-sleep.js'
+        );
+        const shell = TestShell.start({
+          args: ['--nodb', filename],
+          removeSigintListeners: true,
+          forceTerminal: true
+        });
+
+        await eventually(() => {
+          if (shell.output.includes('Long sleep')) {
+            return;
+          }
+          throw new Error('Waiting for the file to load...');
+        });
+
+        // Writing ^C to shell
+        shell.writeInput('\x03');
+
+        await eventually(() => {
+          if (shell.output.includes('MongoshInterruptedError')) {
+            return;
+          }
+          throw new Error('Waiting for the interruption...');
+        });
+      });
     });
 
-    it('interrupts sync execution', async() => {
-      await shell.executeLine('void process.removeAllListeners("SIGINT")');
-      const result = shell.executeLine('while(true);');
-      setTimeout(() => shell.kill('SIGINT'), 1000);
-      await result;
-      shell.assertContainsError('interrupted');
-    });
-    it('interrupts async awaiting', async() => {
-      const result = shell.executeLine('new Promise(() => {});');
-      setTimeout(() => shell.kill('SIGINT'), 3000);
-      await result;
-      shell.assertContainsOutput('Stopping execution...');
-    });
-    it('interrupts load()', async() => {
-      const filename = path.resolve(__dirname, 'fixtures', 'load', 'infinite-loop.js');
-      const result = shell.executeLine(`load(${JSON.stringify(filename)})`);
-      setTimeout(() => shell.kill('SIGINT'), 3000);
-      await result;
-      // The while loop in the script is run as "sync" code
-      shell.assertContainsError('interrupted');
-    });
-    it('behaves normally after an exception', async() => {
-      await shell.executeLine('throw new Error()');
-      await new Promise((resolve) => setTimeout(resolve, 100));
-      shell.kill('SIGINT');
-      await shell.waitForPrompt();
-      await new Promise((resolve) => setTimeout(resolve, 100));
-      shell.assertNotContainsOutput('interrupted');
-      shell.assertNotContainsOutput('Stopping execution');
-    });
-    it('does not trigger MaxListenersExceededWarning', async() => {
-      await shell.executeLine('for (let i = 0; i < 11; i++) { console.log("hi"); }\n');
-      await shell.executeLine('for (let i = 0; i < 20; i++) (async() => { await sleep(0) })()');
-      shell.assertNotContainsOutput('MaxListenersExceededWarning');
+    describe('interactive', function() {
+      let shell: TestShell;
+      beforeEach(async() => {
+        shell = TestShell.start({ args: [ '--nodb' ], removeSigintListeners: true });
+        await shell.waitForPrompt();
+        shell.assertNoErrors();
+      });
+
+      it('interrupts sync execution', async() => {
+        await shell.executeLine('void process.removeAllListeners("SIGINT")');
+        const result = shell.executeLine('while(true);');
+        setTimeout(() => shell.kill('SIGINT'), 1000);
+        await result;
+        shell.assertContainsError('interrupted');
+      });
+      it('interrupts async awaiting', async() => {
+        const result = shell.executeLine('new Promise(() => {});');
+        setTimeout(() => shell.kill('SIGINT'), 3000);
+        await result;
+        shell.assertContainsOutput('Stopping execution...');
+      });
+      it('interrupts load()', async() => {
+        const filename = path.resolve(__dirname, 'fixtures', 'load', 'infinite-loop.js');
+        const result = shell.executeLine(`load(${JSON.stringify(filename)})`);
+        setTimeout(() => shell.kill('SIGINT'), 3000);
+        await result;
+        // The while loop in the script is run as "sync" code
+        shell.assertContainsError('interrupted');
+      });
+      it('behaves normally after an exception', async() => {
+        await shell.executeLine('throw new Error()');
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        shell.kill('SIGINT');
+        await shell.waitForPrompt();
+        await new Promise((resolve) => setTimeout(resolve, 100));
+        shell.assertNotContainsOutput('interrupted');
+        shell.assertNotContainsOutput('Stopping execution');
+      });
+      it('does not trigger MaxListenersExceededWarning', async() => {
+        await shell.executeLine('for (let i = 0; i < 11; i++) { console.log("hi"); }\n');
+        await shell.executeLine('for (let i = 0; i < 20; i++) (async() => { await sleep(0) })()');
+        shell.assertNotContainsOutput('MaxListenersExceededWarning');
+      });
     });
   });
 

--- a/packages/cli-repl/test/fixtures/load/long-sleep.js
+++ b/packages/cli-repl/test/fixtures/load/long-sleep.js
@@ -1,0 +1,5 @@
+/* eslint-disable */
+console.log('Long sleep');
+(async() => {
+  await sleep(1_000_000);
+})();


### PR DESCRIPTION
Fixes Ctrl+C behavior for mongosh running files by making sure that raw mode is disabled for the whole duration of the code evaluation inside `ayncRepl.eval`

TODO: 

- [ ] Add tests. Wanted to open PR already to kick of a CI run to make sure this doesn't break anything unexpectedly (existing cli-repl tests are still passing)