### PR TITLE
feat: remove free monitoring banner and deprecate related methods MONGOSH-1415

### DIFF
--- a/packages/cli-repl/src/mongosh-repl.ts
+++ b/packages/cli-repl/src/mongosh-repl.ts
@@ -405,7 +405,6 @@ class MongoshNodeRepl implements EvaluationListener {
       const { shellApi } = instanceState;
       const banners = await Promise.all([
         (async() => await shellApi.show('startupWarnings'))(),
-        (async() => await shellApi.show('freeMonitoring'))(),
         (async() => await shellApi.show('automationNotices'))(),
         (async() => await shellApi.show('nonGenuineMongoDBCheck'))()
       ]);

--- a/packages/cli-repl/test/e2e-banners.spec.ts
+++ b/packages/cli-repl/test/e2e-banners.spec.ts
@@ -1,6 +1,3 @@
-import { serialize, Long } from 'bson';
-import { once } from 'events';
-import { createServer } from 'http';
 import { startTestServer, skipIfApiStrict } from '../../../testing/integration-testing-hooks';
 import { TestShell } from './test-shell';
 
@@ -9,30 +6,6 @@ describe('e2e startup banners', () => {
   afterEach(TestShell.cleanup);
 
   const testServer = startTestServer('shared');
-
-  let freeMonitoringHttpServer;
-  before(async() => {
-    freeMonitoringHttpServer = createServer((req, res) => {
-      req.resume().on('end', () => {
-        res.end(serialize({
-          version: new Long(1),
-          haltMetricsUploading: false,
-          id: 'mock123',
-          informationalURL: 'http://www.example.com',
-          message: 'Welcome to the Mock Free Monitoring Endpoint',
-          reportingInterval: new Long(1),
-          userReminder: 'Some user reminder about free monitoring'
-        }));
-      });
-    });
-    freeMonitoringHttpServer.listen(42123);
-    await once(freeMonitoringHttpServer, 'listening');
-  });
-
-  after(() => {
-    // eslint-disable-next-line chai-friendly/no-unused-expressions
-    freeMonitoringHttpServer?.close?.();
-  });
 
   context('without special configuration', () => {
     it('shows startup warnings', async() => {
@@ -63,64 +36,6 @@ describe('e2e startup banners', () => {
       await shell.waitForPrompt();
       shell.assertContainsOutput("This server is managed by automation service 'automation service'.");
       shell.assertNoErrors();
-    });
-  });
-
-  context('with free monitoring', () => {
-    if (
-      !process.env.MONGOSH_SERVER_TEST_VERSION?.includes('community') ||
-      process.env.MONGOSH_SERVER_TEST_VERSION.match(/^4\.[0-3]/) ||
-      process.platform === 'win32'
-    ) {
-      // Enterprise and 4.2/4.0 community servers do not know about the setParameter flags below.
-      // On Windows in CI, this fails as well (for unknown reasons).
-      before(function() { this.skip(); });
-    }
-
-    // Using a non-shared server so we can change the server configuration
-    // in isolation here.
-    const testServer = startTestServer(
-      'not-shared',
-      '--setParameter', 'cloudFreeMonitoringEndpointURL=http://127.0.0.1:42123/',
-      '--setParameter', 'testingDiagnosticsEnabled=true');
-
-    it('shows free monitoring notice by default', async() => {
-      const shell = TestShell.start({ args: [await testServer.connectionString()] });
-      await shell.waitForPrompt();
-      shell.assertContainsOutput('To enable free monitoring, run the following command: db.enableFreeMonitoring()');
-      shell.assertNoErrors();
-    });
-
-    context('with free monitoring explicitly disabled', () => {
-      beforeEach(async() => {
-        const helperShell = TestShell.start({ args: [await testServer.connectionString()] });
-        await helperShell.waitForPrompt();
-        await helperShell.executeLine('db.disableFreeMonitoring()');
-        helperShell.assertNoErrors();
-      });
-
-      it('does not show a free monitoring notice', async() => {
-        const shell = TestShell.start({ args: [await testServer.connectionString()] });
-        await shell.waitForPrompt();
-        shell.assertNotContainsOutput('free monitoring');
-        shell.assertNoErrors();
-      });
-    });
-
-    context('with free monitoring explicitly enabled', () => {
-      beforeEach(async() => {
-        const helperShell = TestShell.start({ args: [await testServer.connectionString()] });
-        await helperShell.waitForPrompt();
-        await helperShell.executeLine('db.enableFreeMonitoring()');
-        helperShell.assertNoErrors();
-      });
-
-      it('does not show a free monitoring notice', async() => {
-        const shell = TestShell.start({ args: [await testServer.connectionString()] });
-        await shell.waitForPrompt();
-        shell.assertContainsOutput('Some user reminder about free monitoring');
-        shell.assertNoErrors();
-      });
     });
   });
 });

--- a/packages/shell-api/src/database.ts
+++ b/packages/shell-api/src/database.ts
@@ -1082,6 +1082,7 @@ export default class Database extends ShellApiWithMongoClass {
 
   @returnsPromise
   @apiVersions([])
+  @deprecated
   async getFreeMonitoringStatus(): Promise<Document> {
     this._emitDatabaseApiCall('getFreeMonitoringStatus', {});
     return await this._runAdminCommand(
@@ -1093,6 +1094,7 @@ export default class Database extends ShellApiWithMongoClass {
 
   @returnsPromise
   @apiVersions([])
+  @deprecated
   async disableFreeMonitoring(): Promise<Document> {
     this._emitDatabaseApiCall('disableFreeMonitoring', {});
     return await this._runAdminCommand(
@@ -1105,6 +1107,7 @@ export default class Database extends ShellApiWithMongoClass {
 
   @returnsPromise
   @apiVersions([])
+  @deprecated
   async enableFreeMonitoring(): Promise<Document | string> {
     this._emitDatabaseApiCall('enableFreeMonitoring', {});
     const helloResult = await this.hello();

--- a/packages/shell-api/src/helpers.ts
+++ b/packages/shell-api/src/helpers.ts
@@ -833,18 +833,6 @@ export function getBadge(collections: Document[], index: number): string {
   return '';
 }
 
-export const FREE_MONITORING_BANNER = `\
-Enable MongoDB's free cloud-based monitoring service, which will then receive and display
-metrics about your deployment (disk utilization, CPU, operation statistics, etc).
-
-The monitoring data will be available on a MongoDB website with a unique URL accessible to you
-and anyone you share the URL with. MongoDB may use this information to make product
-improvements and to suggest MongoDB products and deployment options to you.
-
-To enable free monitoring, run the following command: db.enableFreeMonitoring()
-To permanently disable this reminder, run the following command: db.disableFreeMonitoring()
-`;
-
 export function shallowClone<T>(input: T): T {
   if (!input || typeof input !== 'object') return input;
   return Array.isArray(input) ? ([...input] as unknown as T) : { ...input };

--- a/packages/shell-api/src/mongo.spec.ts
+++ b/packages/shell-api/src/mongo.spec.ts
@@ -363,61 +363,6 @@ describe('Mongo', () => {
         });
       });
 
-      describe('freeMonitoring', () => {
-        it('calls database.adminCommand', async() => {
-          const expectedResult = { ok: 1, state: '' };
-          database.adminCommand.resolves(expectedResult);
-          await mongo.show('freeMonitoring');
-          expect(database.adminCommand).to.have.been.calledWith(
-            { getFreeMonitoringStatus: 1 }
-          );
-        });
-
-        it('returns ShowBannerResult CommandResult (freeMonitoring enabled with notice)', async() => {
-          const expectedResult = {
-            ok: 1,
-            state: 'enabled',
-            userReminder: 'Reminder!'
-          };
-          database.adminCommand.resolves(expectedResult);
-          const result = await mongo.show('freeMonitoring');
-          expect(result.value).to.deep.equal({
-            content: 'Reminder!'
-          });
-          expect(result.type).to.equal('ShowBannerResult');
-        });
-
-        it('returns ShowBannerResult CommandResult (freeMonitoring undecided)', async() => {
-          const expectedResult = {
-            ok: 1,
-            state: 'undecided'
-          };
-          database.adminCommand.resolves(expectedResult);
-          const result = await mongo.show('freeMonitoring');
-          expect((result.value as any).content).to.include('run the following command: db.enableFreeMonitoring');
-          expect(result.type).to.equal('ShowBannerResult');
-        });
-
-        it('returns ShowBannerResult CommandResult (freeMonitoring disabled)', async() => {
-          const expectedResult = {
-            ok: 1,
-            state: 'disabled'
-          };
-          database.adminCommand.resolves(expectedResult);
-          const result = await mongo.show('freeMonitoring');
-          expect(result.value).to.equal(null);
-          expect(result.type).to.equal('ShowBannerResult');
-        });
-
-        it('returns null database.adminCommand rejects', async() => {
-          const expectedError = new Error();
-          database.adminCommand.rejects(expectedError);
-          const result = await mongo.show('freeMonitoring');
-          expect(result.value).to.equal(null);
-          expect(result.type).to.equal('ShowBannerResult');
-        });
-      });
-
       describe('automationNotices', () => {
         it('calls database.hello', async() => {
           const expectedResult = { ok: 1 };

--- a/packages/shell-api/src/mongo.ts
+++ b/packages/shell-api/src/mongo.ts
@@ -53,8 +53,7 @@ import Session from './session';
 import {
   assertArgsDefinedType,
   processFLEOptions,
-  isValidDatabaseName,
-  FREE_MONITORING_BANNER
+  isValidDatabaseName
 } from './helpers';
 import ChangeStreamCursor from './change-stream-cursor';
 import { blockedByDriverMetadata } from './error-codes';
@@ -386,23 +385,6 @@ export default class Mongo extends ShellApiClass {
           header: 'The server generated these startup warnings when booting',
           content: lines.join('\n')
         });
-      }
-      case 'freeMonitoring': {
-        let freemonStatus;
-        try {
-          freemonStatus = await db.adminCommand({ getFreeMonitoringStatus: 1 });
-        } catch (error: any) {
-          this._instanceState.messageBus.emit('mongosh:error', error, 'shell-api');
-          return new CommandResult('ShowBannerResult', null);
-        }
-
-        if (freemonStatus.state === 'enabled' && freemonStatus.userReminder) {
-          return new CommandResult('ShowBannerResult', { content: freemonStatus.userReminder });
-        } else if (freemonStatus.state === 'undecided') {
-          return new CommandResult('ShowBannerResult', { content: FREE_MONITORING_BANNER });
-        }
-
-        return new CommandResult('ShowBannerResult', null);
       }
       case 'automationNotices': {
         let helloResult;

--- a/packages/shell-api/src/shell-api.ts
+++ b/packages/shell-api/src/shell-api.ts
@@ -114,7 +114,7 @@ async function showCompleter(params: ShellCommandAutocompleteParameters, args: s
   }
   const candidates = [
     'databases', 'dbs', 'collections', 'tables', 'profile', 'users', 'roles', 'log', 'logs',
-    'startupWarnings', 'freeMonitoring', 'automationNotices', 'nonGenuineMongoDBCheck'
+    'startupWarnings', 'automationNotices', 'nonGenuineMongoDBCheck'
   ];
   return candidates.filter(str => str.startsWith(args[1] ?? ''));
 }


### PR DESCRIPTION
There are currently related tests failing on 6.0.6 because free monitoring was disabled in it. We want to remove the support for this anyway, so let's just get rid of the code and its tests rather than adding an extra version check for the next two weeks.