### PR TITLE
chore(logging): add throttling to the telemetry helper MONGOSH-1423

### DIFF
--- a/packages/cli-repl/src/cli-repl.spec.ts
+++ b/packages/cli-repl/src/cli-repl.spec.ts
@@ -1146,6 +1146,19 @@ describe('CliRepl', () => {
           expect(requests).to.have.lengthOf(0);
         });
 
+        it('throttles telemetry beyond a certain rage', async() => {
+          await cliRepl.start(await testServer.connectionString(), {});
+          for (let i = 0; i < 60; i++) {
+            input.write('db.hello()\n');
+          }
+          input.write('exit\n');
+          await waitBus(cliRepl.bus, 'mongosh:closed');
+          const events = requests.flatMap((req) => {
+            return JSON.parse(req.body).batch;
+          });
+          expect(events).to.have.lengthOf(30);
+        });
+
         context('with a 5.0+ server', () => {
           skipIfServerVersion(testServer, '<= 4.4');
 

--- a/packages/cli-repl/src/cli-repl.ts
+++ b/packages/cli-repl/src/cli-repl.ts
@@ -733,15 +733,13 @@ export class CliRepl implements MongoshIOProvider {
       }
     }
     this.closing = true;
-    const analytics = this.segmentAnalytics;
+    const analytics = this.toggleableAnalytics;
     let flushError: string | null = null;
     let flushDuration: number | null = null;
     if (analytics) {
       const flushStart = Date.now();
       try {
-        await promisify(
-          this.toggleableAnalytics.flush.bind(this.toggleableAnalytics)
-        )();
+        await promisify(analytics.flush.bind(analytics))();
       } catch (err: any) {
         flushError = err.message;
       } finally {

--- a/packages/cli-repl/src/cli-repl.ts
+++ b/packages/cli-repl/src/cli-repl.ts
@@ -22,7 +22,7 @@ import type { CryptLibraryPathResult } from './crypt-library-paths';
 import { formatForJSONOutput } from './format-json';
 import { MongoLogManager, MongoLogWriter, mongoLogId } from 'mongodb-log-writer';
 import MongoshNodeRepl, { MongoshNodeReplOptions, MongoshIOProvider } from './mongosh-repl';
-import { setupLoggerAndTelemetry, ToggleableAnalytics } from '@mongosh/logging';
+import { setupLoggerAndTelemetry, ToggleableAnalytics, ThrottledAnalytics } from '@mongosh/logging';
 import { MongoshBus, CliUserConfig, CliUserConfigValidator } from '@mongosh/types';
 import { promises as fs } from 'fs';
 import path from 'path';
@@ -391,7 +391,15 @@ export class CliRepl implements MongoshIOProvider {
         axiosRetryConfig: { retries: 0 }
       } as any /* axiosConfig and axiosRetryConfig are existing options, but don't have type definitions */
     );
-    this.toggleableAnalytics = new ToggleableAnalytics(this.segmentAnalytics);
+    this.toggleableAnalytics = new ToggleableAnalytics(
+      new ThrottledAnalytics({
+        target: this.segmentAnalytics,
+        throttle: {
+          rate: 30,
+          metadataPath: this.shellHomeDirectory.paths.shellLocalDataPath
+        }
+      })
+    );
   }
 
   setTelemetryEnabled(enabled: boolean): void {
@@ -731,7 +739,9 @@ export class CliRepl implements MongoshIOProvider {
     if (analytics) {
       const flushStart = Date.now();
       try {
-        await promisify(analytics.flush.bind(analytics))();
+        await promisify(
+          this.toggleableAnalytics.flush.bind(this.toggleableAnalytics)
+        )();
       } catch (err: any) {
         flushError = err.message;
       } finally {

--- a/packages/logging/src/analytics-helpers.ts
+++ b/packages/logging/src/analytics-helpers.ts
@@ -169,7 +169,7 @@ type ThrottledAnalyticsOptions = {
   throttle: {
     /** Allowed events per timeframe number */
     rate: number;
-    /** Timeframe for throttling (default: 60_000ms) */
+    /** Timeframe for throttling in milliseconds (default: 60_000ms) */
     timeframe?: number;
     /** Path to persist rpm value to be able to track them between sessions */
     metadataPath: string;
@@ -257,8 +257,7 @@ export class ThrottledAnalytics implements MongoshAnalytics {
     if (!this.throttleOptions) {
       return true;
     }
-    // If throttle minute window passed, reset throttle state and allow to emit
-    // event
+    // If throttle window passed, reset throttle state and allow to emit event
     if (
       Date.now() - this.throttleState.timestamp >
       (this.throttleOptions.timeframe ?? 60_000)

--- a/packages/logging/src/analytics-helpers.ts
+++ b/packages/logging/src/analytics-helpers.ts
@@ -1,25 +1,77 @@
-export type MongoshAnalyticsIdentity = {
-  userId: string;
-} | {
-  anonymousId: string;
+import fs from 'fs';
+import path from 'path';
+
+export type MongoshAnalyticsIdentity =
+  | {
+      userId: string;
+      anonymousId?: never;
+    }
+  | {
+      userId?: never;
+      anonymousId: string;
+    };
+
+type AnalyticsIdentifyMessage = MongoshAnalyticsIdentity & {
+  traits: { platform: string };
+};
+
+type AnalyticsTrackMessage = MongoshAnalyticsIdentity & {
+  event: string;
+  properties: {
+    // eslint-disable-next-line camelcase
+    mongosh_version: string;
+    [key: string]: any;
+  };
 };
 
 /**
  * General interface for an Analytics provider that mongosh can use.
  */
 export interface MongoshAnalytics {
-  identify(message: MongoshAnalyticsIdentity & {
-    traits: { platform: string }
-  }): void;
+  identify(message: AnalyticsIdentifyMessage): void;
 
-  track(message: MongoshAnalyticsIdentity & {
-    event: string,
-    properties: {
-      // eslint-disable-next-line camelcase
-      mongosh_version: string,
-      [key: string]: any;
+  track(message: AnalyticsTrackMessage): void;
+
+  // NB: Callback and not a promise to match segment analytics interface so it's
+  // easier to pass it to the helpers constructor
+  flush(callback: (err?: Error) => void): void;
+}
+
+class Queue<T> {
+  private queue: T[] = [];
+  private state: 'paused' | 'enabled' | 'disabled' = 'paused';
+  constructor(private applyFn: (val: T) => void) {}
+  push(val: T) {
+    switch (this.state) {
+      case 'paused':
+        this.queue.push(val);
+        return;
+      case 'enabled':
+        this.applyFn(val);
+        return;
+      case 'disabled':
+      default:
+        return;
     }
-  }): void;
+  }
+  enable() {
+    this.state = 'enabled';
+    const queue = this.queue;
+    this.queue = [];
+    queue.forEach((val) => {
+      this.applyFn(val);
+    });
+  }
+  disable() {
+    this.state = 'disabled';
+    this.queue = [];
+  }
+  pause() {
+    this.state = 'paused';
+  }
+  isPaused() {
+    return this.state === 'paused';
+  }
 }
 
 /**
@@ -30,15 +82,28 @@ export interface MongoshAnalytics {
 export class NoopAnalytics implements MongoshAnalytics {
   identify(_info: any): void {} // eslint-disable-line @typescript-eslint/no-unused-vars
   track(_info: any): void {} // eslint-disable-line @typescript-eslint/no-unused-vars
+  flush(cb: () => void) {
+    cb();
+  }
 }
+
+type AnalyticsEventsQueueItem =
+  | ['identify', Parameters<MongoshAnalytics['identify']>]
+  | ['track', Parameters<MongoshAnalytics['track']>];
 
 /**
  * An implementation of MongoshAnalytics that forwards to another implementation
  * and can be enabled/paused/disabled.
  */
 export class ToggleableAnalytics implements MongoshAnalytics {
-  _queue: Array<['identify', Parameters<MongoshAnalytics['identify']>] | ['track', Parameters<MongoshAnalytics['track']>]> = [];
-  _state: 'enabled' | 'disabled' | 'paused' = 'paused';
+  _queue = new Queue<AnalyticsEventsQueueItem>((item) => {
+    if (item[0] === 'identify') {
+      this._target.identify(...item[1]);
+    }
+    if (item[0] === 'track') {
+      this._target.track(...item[1]);
+    }
+  });
   _target: MongoshAnalytics;
   _pendingError?: Error;
 
@@ -48,53 +113,28 @@ export class ToggleableAnalytics implements MongoshAnalytics {
 
   identify(...args: Parameters<MongoshAnalytics['identify']>): void {
     this._validateArgs(args);
-    switch (this._state) {
-      case 'enabled':
-        this._target.identify(...args);
-        break;
-      case 'paused':
-        this._queue.push(['identify', args]);
-        break;
-      default:
-        break;
-    }
+    this._queue.push(['identify', args]);
   }
 
   track(...args: Parameters<MongoshAnalytics['track']>): void {
     this._validateArgs(args);
-    switch (this._state) {
-      case 'enabled':
-        this._target.track(...args);
-        break;
-      case 'paused':
-        this._queue.push(['track', args]);
-        break;
-      default:
-        break;
-    }
+    this._queue.push(['track', args]);
   }
 
   enable() {
     if (this._pendingError) {
       throw this._pendingError;
     }
-    this._state = 'enabled';
-    const queue = this._queue;
-    this._queue = [];
-    for (const entry of queue) {
-      if (entry[0] === 'identify') this.identify(...entry[1]);
-      if (entry[0] === 'track') this.track(...entry[1]);
-    }
+    this._queue.enable();
   }
 
   disable() {
-    this._state = 'disabled';
     this._pendingError = undefined;
-    this._queue = [];
+    this._queue.disable();
   }
 
   pause() {
-    this._state = 'paused';
+    this._queue.pause();
   }
 
   _validateArgs([firstArg]: [MongoshAnalyticsIdentity]): void {
@@ -108,15 +148,153 @@ export class ToggleableAnalytics implements MongoshAnalytics {
     if (!('userId' in firstArg && firstArg.userId) &&
         !('anonymousId' in firstArg && firstArg.anonymousId)) {
       const err = new Error('Telemetry setup is missing userId or anonymousId');
-      switch (this._state) {
-        case 'enabled':
-          throw err;
-        case 'paused':
-          this._pendingError ??= err;
-          break;
-        default:
-          break;
+      if (this._queue.isPaused()) {
+        this._pendingError ??= err;
+      } else {
+        throw err;
       }
     }
+  }
+
+  flush(callback: (err?: Error | undefined) => void): void {
+    return this._target.flush(callback);
+  }
+}
+
+type ThrottledAnalyticsOptions = {
+  target: MongoshAnalytics;
+  /**
+   * Throttling options. If not provided, throttling is disabled (default: null)
+   */
+  throttle: {
+    /** Allowed events per timeframe number */
+    rate: number;
+    /** Timeframe for throttling (default: 60_000ms) */
+    timeframe?: number;
+    /** Path to persist rpm value to be able to track them between sessions */
+    metadataPath: string;
+  } | null;
+};
+
+export class ThrottledAnalytics implements MongoshAnalytics {
+  private trackQueue = new Queue<AnalyticsTrackMessage>((message) => {
+    if (this.shouldEmitAnalyticsEvent()) {
+      this.target.track(message);
+      this.throttleState.count++;
+    }
+  });
+  private target: ThrottledAnalyticsOptions['target'] = new NoopAnalytics();
+  private currentUserId: string | null = null;
+  private throttleOptions: ThrottledAnalyticsOptions['throttle'] = null;
+  private throttleState = { count: 0, timestamp: Date.now() };
+  private restorePromise: Promise<void> = Promise.resolve();
+
+  constructor({ target, throttle }: Partial<ThrottledAnalyticsOptions> = {}) {
+    this.target = target ?? this.target;
+    this.throttleOptions = throttle ?? this.throttleOptions;
+  }
+
+  get metadataPath() {
+    if (!this.throttleOptions) {
+      throw new Error(
+        'Metadata path is not avaialble if throttling is disabled'
+      );
+    }
+
+    if (!this.currentUserId) {
+      throw new Error('Metadata path is not avaialble if userId is not set');
+    }
+
+    const {
+      throttleOptions: { metadataPath },
+      currentUserId: userId
+    } = this;
+
+    return path.resolve(metadataPath, `am-${userId}.json`);
+  }
+
+  identify(message: AnalyticsIdentifyMessage): void {
+    if (this.currentUserId) {
+      throw new Error('Identify can only be called once per user session');
+    }
+    this.currentUserId = message.userId ?? message.anonymousId;
+    this.restorePromise = this.restoreThrottleState().then(() => {
+      if (this.shouldEmitAnalyticsEvent()) {
+        this.target.identify(message);
+        this.throttleState.count++;
+      }
+      this.trackQueue.enable();
+    });
+  }
+
+  track(message: AnalyticsTrackMessage): void {
+    this.trackQueue.push(message);
+  }
+
+  private async restoreThrottleState() {
+    if (!this.throttleOptions) {
+      return;
+    }
+
+    if (!this.currentUserId) {
+      throw new Error('Trying to restore throttle state before userId is set');
+    }
+
+    try {
+      this.throttleState = JSON.parse(
+        await fs.promises.readFile(this.metadataPath, 'utf8')
+      );
+    } catch (e) {
+      if ((e as any).code === 'ENOENT') {
+        return;
+      }
+      throw e;
+    }
+  }
+
+  private shouldEmitAnalyticsEvent() {
+    // No throttle options indicate that throttling is disabled
+    if (!this.throttleOptions) {
+      return true;
+    }
+    // If throttle minute window passed, reset throttle state and allow to emit
+    // event
+    if (
+      Date.now() - this.throttleState.timestamp >
+      (this.throttleOptions.timeframe ?? 60_000)
+    ) {
+      this.throttleState.timestamp = Date.now();
+      this.throttleState.count = 0;
+      return true;
+    }
+    // Otherwise only allow if the count below the allowed rate
+    return this.throttleState.count < this.throttleOptions.rate;
+  }
+
+  flush(callback: (err?: Error | undefined) => void): void {
+    if (!this.throttleOptions) {
+      this.target.flush(callback);
+      return;
+    }
+
+    if (!this.currentUserId) {
+      callback(
+        new Error('Trying to persist throttle state before userId is set')
+      );
+      return;
+    }
+
+    this.restorePromise.finally(() => {
+      fs.writeFile(
+        this.metadataPath,
+        JSON.stringify(this.throttleState),
+        (err) => {
+          if (err) {
+            return callback(err);
+          }
+          this.target.flush(callback);
+        }
+      );
+    });
   }
 }

--- a/packages/logging/src/analytics-helpers.ts
+++ b/packages/logging/src/analytics-helpers.ts
@@ -266,7 +266,6 @@ export class ThrottledAnalytics implements MongoshAnalytics {
       throw new Error('Identify can only be called once per user session');
     }
     this.currentUserId = message.userId ?? message.anonymousId;
-    console.log(this.currentUserId);
     this.restorePromise = this.restoreThrottleState().then((enabled) => {
       if (!enabled) {
         this.trackQueue.disable();

--- a/packages/logging/src/analytics-helpers.ts
+++ b/packages/logging/src/analytics-helpers.ts
@@ -309,7 +309,10 @@ export class ThrottledAnalytics implements MongoshAnalytics {
       );
     } catch (e) {
       if ((e as any).code !== 'ENOENT') {
-        throw e;
+        // Any error except ENOENT means that we failed to restore state for
+        // some unknown / unexpected reason, ignore the error and assume that it
+        // is not safe to enable telemetry in that case
+        return false;
       }
     }
 

--- a/packages/logging/src/analytics-helpers.ts
+++ b/packages/logging/src/analytics-helpers.ts
@@ -283,6 +283,10 @@ export class ThrottledAnalytics implements MongoshAnalytics {
     this.trackQueue.push(message);
   }
 
+  // Tries to restore persisted throttle state and returns `true` if telemetry can
+  // be enabled on restore. This method must not throw exceptions, since there
+  // is nothing to handle them. If the error is unexpected, this method should
+  // return `false` to disable telemetry
   private async restoreThrottleState(): Promise<boolean> {
     if (!this.throttleOptions) {
       return true;

--- a/packages/logging/src/index.ts
+++ b/packages/logging/src/index.ts
@@ -1,2 +1,7 @@
 export { setupLoggerAndTelemetry } from './setup-logger-and-telemetry';
-export { MongoshAnalytics, ToggleableAnalytics, NoopAnalytics } from './analytics-helpers';
+export {
+  MongoshAnalytics,
+  ToggleableAnalytics,
+  NoopAnalytics,
+  ThrottledAnalytics
+} from './analytics-helpers';

--- a/packages/logging/src/setup-logger-and-telemetry.spec.ts
+++ b/packages/logging/src/setup-logger-and-telemetry.spec.ts
@@ -19,7 +19,8 @@ describe('setupLoggerAndTelemetry', () => {
   } as any);
   const analytics = {
     identify(info: any) { analyticsOutput.push(['identify', info]); },
-    track(info: any) { analyticsOutput.push(['track', info]); }
+    track(info: any) { analyticsOutput.push(['track', info]); },
+    flush() {}
   };
 
   beforeEach(() => {


### PR DESCRIPTION
This patch adds throttling to the telemetry tracking that is persisted across user sessions for the same userId. The implementation is ready and unit tests in logging are done, but a bunch of e2e tests seem to fail now because of the throttling, so I'm opening it as a draft to see what else is failing that I'm maybe not catching locally.