### PR TITLE
fix(shell-api): try running convertShardKeyToHashed agg against empty db

### DIFF
--- a/packages/shell-api/src/mongo.ts
+++ b/packages/shell-api/src/mongo.ts
@@ -687,7 +687,9 @@ export default class Mongo extends ShellApiClass {
       // If that fails, try using $collStats for local.oplog.rs.
       () => this.getDB('local').getCollection('oplog.rs').aggregate([ { $collStats: {} }, ...pipeline ])
     ]) {
-      result = await (await approach()).next();
+      try {
+        result = await (await approach()).next();
+      } catch { continue; }
       if (result) break;
     }
     if (!result) {

--- a/packages/shell-api/src/mongo.ts
+++ b/packages/shell-api/src/mongo.ts
@@ -678,19 +678,17 @@ export default class Mongo extends ShellApiClass {
       { $project: { _id: { $toHashedIndexKey: { $literal: value } } } }
     ];
     let result;
-    try {
-      // Try $documents if available.
-      result = await (await this.getDB('admin').aggregate([ { $documents: [{}] }, ...pipeline ])).next();
-    } catch {
-      try {
-        // If that fails, try a default collection like admin.system.version.
-        result = await (await this.getDB('admin').getCollection('system.version').aggregate(pipeline)).next();
-      } catch {
-        // If that fails, try using $collStats for local.oplog.rs.
-        try {
-          result = await (await this.getDB('local').getCollection('oplog.rs').aggregate([ { $collStats: {} }, ...pipeline ])).next();
-        } catch { /* throw exception below */ }
-      }
+    for (const approach of [
+      // Try $documents if available (NB: running $documents on an empty db requires SERVER-63811 i.e. 6.0.3+).
+      () => this.getDB('_fakeDbForMongoshCSKTH').aggregate([ { $documents: [{}] }, ...pipeline ]),
+      () => this.getDB('admin').aggregate([ { $documents: [{}] }, ...pipeline ]),
+      // If that fails, try a default collection like admin.system.version.
+      () => this.getDB('admin').getCollection('system.version').aggregate(pipeline),
+      // If that fails, try using $collStats for local.oplog.rs.
+      () => this.getDB('local').getCollection('oplog.rs').aggregate([ { $collStats: {} }, ...pipeline ])
+    ]) {
+      result = await (await approach()).next();
+      if (result) break;
     }
     if (!result) {
       throw new MongoshRuntimeError(


### PR DESCRIPTION
Recently, our serverless connectivity tests have been failing in CI because none of the approaches in the `convertShardKeyToHashed()` were working anymore.

However, our serverless test instance is now running MongoDB 6.3.1, which contains the fix for SERVER-63811; adding a new variant that runs the pipeline against a fake/empty database seems to work now, and is probably the most preferable approach anyway.