### PR TITLE
fix(cli-repl): do not include crypt shared library version in buildInfo MONGOSH-1496

### DIFF
--- a/packages/cli-repl/src/build-info.ts
+++ b/packages/cli-repl/src/build-info.ts
@@ -1,6 +1,5 @@
 import os from 'os';
 import { CliServiceProvider } from '@mongosh/service-provider-server';
-import { getCryptLibraryPaths } from './crypt-library-paths';
 
 export interface BuildInfo {
   version: string;
@@ -16,9 +15,7 @@ export interface BuildInfo {
   opensslVersion: string;
   sharedOpenssl: boolean;
   segmentApiKey?: string;
-  deps: ReturnType<typeof CliServiceProvider.getVersionInformation> & {
-    cryptSharedLibraryVersion?: string;
-  }
+  deps: ReturnType<typeof CliServiceProvider.getVersionInformation>;
 }
 
 function getSystemArch(): typeof process['arch'] {
@@ -40,26 +37,15 @@ function getSystemArch(): typeof process['arch'] {
  * Return an object with information about this mongosh instance,
  * in particular, when it was built and how.
  */
+// eslint-disable-next-line @typescript-eslint/require-await
 export async function buildInfo({
   withSegmentApiKey,
-  withCryptSharedVersionInfo,
 }: {
   withSegmentApiKey?: boolean,
-  withCryptSharedVersionInfo?: boolean,
 } = {}): Promise<BuildInfo> {
   const dependencyVersionInfo: BuildInfo['deps'] = {
     ...CliServiceProvider.getVersionInformation()
   };
-  try {
-    if (withCryptSharedVersionInfo) {
-      const version = (await getCryptLibraryPaths()).expectedVersion?.versionStr;
-      if (version) {
-        dependencyVersionInfo.cryptSharedLibraryVersion = version;
-      }
-    }
-  } catch {
-    /* ignore */
-  }
 
   const runtimeData = {
     nodeVersion: process.version,

--- a/packages/cli-repl/src/cli-repl.ts
+++ b/packages/cli-repl/src/cli-repl.ts
@@ -229,7 +229,7 @@ export class CliRepl implements MongoshIOProvider {
     logger.info('MONGOSH', mongoLogId(1_000_000_000), 'log', 'Starting log', {
       execPath: process.execPath,
       envInfo: redactSensitiveData(this.getLoggedEnvironmentVariables()),
-      ...await buildInfo({ withCryptSharedVersionInfo: true })
+      ...await buildInfo()
     });
 
     let analyticsSetupError: Error | null = null;
@@ -376,7 +376,7 @@ export class CliRepl implements MongoshIOProvider {
   injectReplFunctions(): void {
     const functions = {
       async buildInfo() {
-        return await buildInfo({ withCryptSharedVersionInfo: true });
+        return await buildInfo();
       }
     } as const;
     const { context } = this.mongoshRepl.runtimeState().repl;

--- a/packages/cli-repl/src/run.ts
+++ b/packages/cli-repl/src/run.ts
@@ -77,7 +77,7 @@ import net from 'net';
     }
     if (options.buildInfo) {
       // eslint-disable-next-line no-console
-      console.log(JSON.stringify(await buildInfo({ withCryptSharedVersionInfo: true }), null, '  '));
+      console.log(JSON.stringify(await buildInfo(), null, '  '));
       return;
     }
     if (options.smokeTests) {


### PR DESCRIPTION
Loading the shared library on startup can crash mongosh when it is run on bare-bones x64 systems without additional CPU features, because the shared library uses advanced CPU set features like AVX while its global constructors run. (These features have been required by the server artifacts since 5.0:
https://www.mongodb.com/docs/manual/administration/production-notes/#x86_64)