### PR TITLE
chore(shell-api): rename configureQueryAnalyzer option to match server

### DIFF
--- a/packages/shell-api/src/collection.ts
+++ b/packages/shell-api/src/collection.ts
@@ -2036,6 +2036,7 @@ export default class Collection extends ShellApiWithMongoClass {
     return setHideIndex(this, index, false);
   }
 
+  @serverVersions(['7.0.0', ServerVersions.latest])
   @returnsPromise
   @topologies([Topologies.ReplSet, Topologies.Sharded])
   @apiVersions([])
@@ -2048,6 +2049,7 @@ export default class Collection extends ShellApiWithMongoClass {
     });
   }
 
+  @serverVersions(['7.0.0', ServerVersions.latest])
   @returnsPromise
   @topologies([Topologies.ReplSet, Topologies.Sharded])
   @apiVersions([])

--- a/packages/shell-api/src/replica-set.spec.ts
+++ b/packages/shell-api/src/replica-set.spec.ts
@@ -979,16 +979,16 @@ describe('ReplicaSet', () => {
       it('succeeds when running against an unsharded collection on a replicaset', async() => {
         await db.getCollection('test').insertMany(docs);
 
-        const fullResult = await db.getCollection('test').configureQueryAnalyzer({ mode: 'full', sampleRate: 1 });
+        const fullResult = await db.getCollection('test').configureQueryAnalyzer({ mode: 'full', samplesPerSecond: 1 });
         expect(fullResult).to.deep.include({
           ok: 1,
-          newConfiguration: { mode: 'full', sampleRate: 1 }
+          newConfiguration: { mode: 'full', samplesPerSecond: 1 }
         });
 
         const offResult = await db.getCollection('test').configureQueryAnalyzer({ mode: 'off' });
         expect(offResult).to.deep.include({
           ok: 1,
-          oldConfiguration: { mode: 'full', sampleRate: 1 },
+          oldConfiguration: { mode: 'full', samplesPerSecond: 1 },
           newConfiguration: { mode: 'off' }
         });
       });

--- a/packages/shell-api/src/shard.spec.ts
+++ b/packages/shell-api/src/shard.spec.ts
@@ -1832,16 +1832,16 @@ describe('Shard', () => {
       it('succeeds when running against an unsharded collection', async() => {
         await db.getCollection('test').insertMany(docs);
 
-        const fullResult = await db.getCollection('test').configureQueryAnalyzer({ mode: 'full', sampleRate: 1 });
+        const fullResult = await db.getCollection('test').configureQueryAnalyzer({ mode: 'full', samplesPerSecond: 1 });
         expect(fullResult).to.deep.include({
           ok: 1,
-          newConfiguration: { mode: 'full', sampleRate: 1 }
+          newConfiguration: { mode: 'full', samplesPerSecond: 1 }
         });
 
         const offResult = await db.getCollection('test').configureQueryAnalyzer({ mode: 'off' });
         expect(offResult).to.deep.include({
           ok: 1,
-          oldConfiguration: { mode: 'full', sampleRate: 1 },
+          oldConfiguration: { mode: 'full', samplesPerSecond: 1 },
           newConfiguration: { mode: 'off' }
         });
       });
@@ -1850,16 +1850,16 @@ describe('Shard', () => {
         expect((await sh.shardCollection(ns, { key: 1 })).collectionsharded).to.equal(ns);
         await db.getCollection('test').insertMany(docs);
 
-        const fullResult = await db.getCollection('test').configureQueryAnalyzer({ mode: 'full', sampleRate: 1 });
+        const fullResult = await db.getCollection('test').configureQueryAnalyzer({ mode: 'full', samplesPerSecond: 1 });
         expect(fullResult).to.deep.include({
           ok: 1,
-          newConfiguration: { mode: 'full', sampleRate: 1 }
+          newConfiguration: { mode: 'full', samplesPerSecond: 1 }
         });
 
         const offResult = await db.getCollection('test').configureQueryAnalyzer({ mode: 'off' });
         expect(offResult).to.deep.include({
           ok: 1,
-          oldConfiguration: { mode: 'full', sampleRate: 1 },
+          oldConfiguration: { mode: 'full', samplesPerSecond: 1 },
           newConfiguration: { mode: 'off' }
         });
       });


### PR DESCRIPTION
[SERVER-78406](https://jira.mongodb.org/browse/SERVER-78406) renamed the option from `sampleRate` to `samplesPerSecond`. Consequently, we should do the same here.

(This fixes a CI failure on main.)