### PR TITLE
fix(errors): downgrade chalk because the latest versions are esm-only modules, hack old version out of package-lock.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -31781,7 +31781,7 @@
       "version": "0.0.0-dev.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "chalk": "^5.3.0",
+        "chalk": "^4.1.2",
         "handlebars": "^4.7.7",
         "typescript": "^5.0.4"
       },
@@ -31795,17 +31795,6 @@
       },
       "engines": {
         "node": ">=14.15.1"
-      }
-    },
-    "packages/errors/node_modules/chalk": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-      "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w==",
-      "engines": {
-        "node": "^12.17.0 || ^14.13 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
     "packages/history": {
@@ -40867,19 +40856,12 @@
         "@mongodb-js/eslint-config-mongosh": "^1.0.0",
         "@mongodb-js/prettier-config-devtools": "^1.0.1",
         "@mongodb-js/tsconfig-mongosh": "^1.0.0",
-        "chalk": "^5.3.0",
+        "chalk": "^4.1.2",
         "depcheck": "^1.4.3",
         "eslint": "^7.25.0",
         "handlebars": "^4.7.7",
         "prettier": "^2.8.8",
         "typescript": "^5.0.4"
-      },
-      "dependencies": {
-        "chalk": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-5.3.0.tgz",
-          "integrity": "sha512-dLitG79d+GV1Nb/VYcCDFivJeK1hiukt9QjRNVOsUtTy1rR1YJsmpGGTZ3qJos+uw7WmWF4wUwBd9jxjocFC2w=="
-        }
       }
     },
     "@mongosh/history": {

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -33,7 +33,7 @@
     "unitTestsOnly": true
   },
   "dependencies": {
-    "chalk": "^5.3.0",
+    "chalk": "^4.1.2",
     "handlebars": "^4.7.7",
     "typescript": "^5.0.4"
   },


### PR DESCRIPTION
This should fix the "update automatically generated files" action.