### PR TITLE
chore: fixes build failures for s390x and ppc64le archs

### DIFF
--- a/.evergreen/install-node.sh
+++ b/.evergreen/install-node.sh
@@ -43,7 +43,9 @@ else
   fi
 
   npm cache clear --force || true # Try to work around `Cannot read property 'pickAlgorithm' of null` errors in CI
-  npm i -g npm@8.x
+  # Started observing CI failures on RHEL 7.2 (s390x) for installing npm, all
+  # related to network issues hence adding a retry with backoff here.
+  bash "$BASEDIR/retry-with-backoff.sh" npm i -g npm@8.x
 fi
 
 . "$BASEDIR/setup-env.sh"

--- a/.evergreen/retry-with-backoff.sh
+++ b/.evergreen/retry-with-backoff.sh
@@ -1,0 +1,46 @@
+# (Copied over from Compass - https://github.com/mongodb-js/compass/blob/b6fec9cbbb2c6949e9ece3fffe861c3f52e30a4f/.evergreen/retry-with-backoff.sh)
+# Retries a command a with backoff.
+#
+# The retry count is given by ATTEMPTS (default 5), the
+# initial backoff timeout is given by TIMEOUT in seconds
+# (default 1.)
+#
+# Successive backoffs double the timeout.
+#
+#
+# Note: set -e would kill the entire script before retrying
+#
+function retry_with_backoff {
+  local max_attempts=${ATTEMPTS-5}
+  local timeout=${TIMEOUT-1}
+  local attempt=0
+  local exitCode=0
+
+  while [[ $attempt < $max_attempts ]]
+  do
+    attempt_prompt=$(( attempt + 1 ))
+    echo "retry_with_backoff: running '${@}' - attempt n. ${attempt_prompt} ..."
+
+    "$@"
+    exitCode=$?
+
+    if [[ $exitCode == 0 ]]
+    then
+      break
+    fi
+
+    echo "retry_with_backoff: attempt failed! Retrying in ${timeout}.." 1>&2
+    sleep "${timeout}"
+    attempt=$(( attempt + 1 ))
+    timeout=$(( timeout * 2 ))
+  done
+
+  if [[ $exitCode != 0 ]]
+  then
+    echo "retry_with_backoff: All attempts failed" 1>&2
+  fi
+
+  return $exitCode
+}
+
+retry_with_backoff $@

--- a/package-lock.json
+++ b/package-lock.json
@@ -15226,7 +15226,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "devOptional": true,
+      "optional": true,
       "engines": {
         "node": ">=4.0.0"
       }
@@ -15582,7 +15582,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
       "integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==",
-      "devOptional": true,
+      "optional": true,
       "engines": {
         "node": ">=8"
       }
@@ -16840,7 +16840,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
       "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-      "devOptional": true,
+      "optional": true,
       "engines": {
         "node": ">=6"
       }
@@ -17890,7 +17890,7 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-      "devOptional": true
+      "optional": true
     },
     "node_modules/glob": {
       "version": "7.2.0",
@@ -20494,8 +20494,8 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/kerberos/-/kerberos-2.0.1.tgz",
       "integrity": "sha512-O/jIgbdGK566eUhFwIcgalbqirYU/r76MW7/UFw06Fd9x5bSwgyZWL/Vm26aAmezQww/G9KYkmmJBkEkPk5HLw==",
-      "dev": true,
       "hasInstallScript": true,
+      "optional": true,
       "dependencies": {
         "bindings": "^1.5.0",
         "node-addon-api": "^4.3.0",
@@ -22067,8 +22067,8 @@
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-2.8.0.tgz",
       "integrity": "sha512-wIcaETX0Acis9hJkUf2SvtPMq/F1G2gxZXgp8QAe2yJzL+cIUpii8Yv4i3LIeZVwYuYSue8F6/e4pHaE21On7A==",
-      "devOptional": true,
       "hasInstallScript": true,
+      "optional": true,
       "dependencies": {
         "bindings": "^1.5.0",
         "node-addon-api": "^4.3.0",
@@ -22293,7 +22293,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
       "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==",
-      "devOptional": true
+      "optional": true
     },
     "node_modules/natural-compare": {
       "version": "1.4.0",
@@ -22401,7 +22401,7 @@
       "version": "3.33.0",
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.33.0.tgz",
       "integrity": "sha512-7GGVawqyHF4pfd0YFybhv/eM9JwTtPqx0mAanQ146O3FlSh3pA24zf9IRQTOsfTSqXTNzPSP5iagAJ94jjuVog==",
-      "devOptional": true,
+      "optional": true,
       "dependencies": {
         "semver": "^7.3.5"
       },
@@ -24534,7 +24534,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
       "integrity": "sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==",
-      "devOptional": true,
+      "optional": true,
       "dependencies": {
         "detect-libc": "^2.0.0",
         "expand-template": "^2.0.3",
@@ -25042,7 +25042,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "devOptional": true,
+      "optional": true,
       "dependencies": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -25057,7 +25057,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
       "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-      "devOptional": true,
+      "optional": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -26508,27 +26508,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
       "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-      "devOptional": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ]
-    },
-    "node_modules/simple-get": {
-      "version": "4.0.1",
-      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
-      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-      "devOptional": true,
       "funding": [
         {
           "type": "github",
@@ -26543,6 +26522,27 @@
           "url": "https://feross.org/support"
         }
       ],
+      "optional": true
+    },
+    "node_modules/simple-get": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
+      "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "optional": true,
       "dependencies": {
         "decompress-response": "^6.0.0",
         "once": "^1.3.1",
@@ -26553,7 +26553,7 @@
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
       "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-      "devOptional": true,
+      "optional": true,
       "dependencies": {
         "mimic-response": "^3.1.0"
       },
@@ -26568,7 +26568,7 @@
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
       "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-      "devOptional": true,
+      "optional": true,
       "engines": {
         "node": ">=10"
       },
@@ -30665,8 +30665,6 @@
         "@mongodb-js/tsconfig-mongosh": "^1.0.0",
         "depcheck": "^1.4.3",
         "eslint": "^7.25.0",
-        "kerberos": "^2.0.0",
-        "mongodb-client-encryption": "^2.8.0",
         "prettier": "^2.8.8"
       },
       "engines": {
@@ -44003,7 +44001,7 @@
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/deep-extend/-/deep-extend-0.6.0.tgz",
       "integrity": "sha512-LOHxIOaPYdHlJRtCQfDIVZtfw/ufM8+rVj649RIHzcm/vGwQRXFt6OPqIFWsm2XEMrNIEtWR64sY1LEKD2vAOA==",
-      "devOptional": true
+      "optional": true
     },
     "deep-is": {
       "version": "0.1.4",
@@ -44254,7 +44252,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.0.1.tgz",
       "integrity": "sha512-463v3ZeIrcWtdgIg6vI6XUncguvr2TnGl4SzDXinkt9mSLpBJKXT3mW6xT3VQdDN11+WVs29pgvivTc4Lp8v+w==",
-      "devOptional": true
+      "optional": true
     },
     "detect-node": {
       "version": "2.1.0",
@@ -45247,7 +45245,7 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/expand-template/-/expand-template-2.0.3.tgz",
       "integrity": "sha512-XYfuKMvj4O35f/pOXLObndIRvyQ+/+6AhODh+OKWj9S9498pHHn/IMszH+gt0fBCRWMNfk1ZSp5x3AifmnI2vg==",
-      "devOptional": true
+      "optional": true
     },
     "express": {
       "version": "4.18.2",
@@ -46055,7 +46053,7 @@
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
-      "devOptional": true
+      "optional": true
     },
     "glob": {
       "version": "7.2.0",
@@ -48026,7 +48024,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/kerberos/-/kerberos-2.0.1.tgz",
       "integrity": "sha512-O/jIgbdGK566eUhFwIcgalbqirYU/r76MW7/UFw06Fd9x5bSwgyZWL/Vm26aAmezQww/G9KYkmmJBkEkPk5HLw==",
-      "dev": true,
+      "optional": true,
       "requires": {
         "bindings": "^1.5.0",
         "node-addon-api": "^4.3.0",
@@ -49291,7 +49289,7 @@
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-2.8.0.tgz",
       "integrity": "sha512-wIcaETX0Acis9hJkUf2SvtPMq/F1G2gxZXgp8QAe2yJzL+cIUpii8Yv4i3LIeZVwYuYSue8F6/e4pHaE21On7A==",
-      "devOptional": true,
+      "optional": true,
       "requires": {
         "bindings": "^1.5.0",
         "node-addon-api": "^4.3.0",
@@ -49472,7 +49470,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/napi-build-utils/-/napi-build-utils-1.0.2.tgz",
       "integrity": "sha512-ONmRUqK7zj7DWX0D9ADe03wbwOBZxNAfF20PlGfCWQcD3+/MakShIHrMqx9YwPTfxDdF1zLeL+RGZiR9kGMLdg==",
-      "devOptional": true
+      "optional": true
     },
     "natural-compare": {
       "version": "1.4.0",
@@ -49568,7 +49566,7 @@
       "version": "3.33.0",
       "resolved": "https://registry.npmjs.org/node-abi/-/node-abi-3.33.0.tgz",
       "integrity": "sha512-7GGVawqyHF4pfd0YFybhv/eM9JwTtPqx0mAanQ146O3FlSh3pA24zf9IRQTOsfTSqXTNzPSP5iagAJ94jjuVog==",
-      "devOptional": true,
+      "optional": true,
       "requires": {
         "semver": "^7.3.5"
       }
@@ -51212,7 +51210,7 @@
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
       "integrity": "sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==",
-      "devOptional": true,
+      "optional": true,
       "requires": {
         "detect-libc": "^2.0.0",
         "expand-template": "^2.0.3",
@@ -51609,7 +51607,7 @@
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
-      "devOptional": true,
+      "optional": true,
       "requires": {
         "deep-extend": "^0.6.0",
         "ini": "~1.3.0",
@@ -51621,7 +51619,7 @@
           "version": "2.0.1",
           "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
           "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
-          "devOptional": true
+          "optional": true
         }
       }
     },
@@ -52771,13 +52769,13 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/simple-concat/-/simple-concat-1.0.1.tgz",
       "integrity": "sha512-cSFtAPtRhljv69IK0hTVZQ+OfE9nePi/rtJmw5UjHeVyVroEqJXP1sFztKUy1qU+xvz3u/sfYJLa947b7nAN2Q==",
-      "devOptional": true
+      "optional": true
     },
     "simple-get": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/simple-get/-/simple-get-4.0.1.tgz",
       "integrity": "sha512-brv7p5WgH0jmQJr1ZDDfKDOSeWWg+OVypG99A/5vYGPqJ6pxiaHLy8nxtFjBA7oMa01ebA9gfh1uMCFqOuXxvA==",
-      "devOptional": true,
+      "optional": true,
       "requires": {
         "decompress-response": "^6.0.0",
         "once": "^1.3.1",
@@ -52788,7 +52786,7 @@
           "version": "6.0.0",
           "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
           "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
-          "devOptional": true,
+          "optional": true,
           "requires": {
             "mimic-response": "^3.1.0"
           }
@@ -52797,7 +52795,7 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
           "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
-          "devOptional": true
+          "optional": true
         }
       }
     },

--- a/packages/service-provider-server/package.json
+++ b/packages/service-provider-server/package.json
@@ -65,8 +65,6 @@
     "@mongodb-js/tsconfig-mongosh": "^1.0.0",
     "depcheck": "^1.4.3",
     "eslint": "^7.25.0",
-    "kerberos": "^2.0.0",
-    "mongodb-client-encryption": "^2.8.0",
     "prettier": "^2.8.8"
   }
 }


### PR DESCRIPTION
Somehow in the [following commit](https://github.com/mongodb-js/mongosh/pull/1503/commits/74b4834086712754bbe08e276eccbfeb6e6c968e#diff-3f8569b068ef11ea8f1fc5b5682d8ba0c6f494982ca211e549ae2156805f3561R72-R75), mongodb-client-encryption as well as kerberos ended up being `devDependencies` in addition to being `optionalDependencies`.

I looked back in commits before this one and concluded that these have always been `optionalDependencies` so this might have been just a mistake. It can be seen from the [base build of this failed build](https://spruce.mongodb.com/version/64a41f0d5623435ea6d2a7b0/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC&variant=linux_s390x_build) that we always had [the same failure](https://parsley.mongodb.com/evergreen/mongosh_linux_s390x_build_compile_artifact_817467053c0cb21f08e4bd62cd7794be51ae00f0_23_07_03_15_12_54/0/task?bookmarks=0,30277&shareLine=16909) for installing `mongodb-client-encryption` on s390x and ppc64le archs but since they were `optionalDependencies`, our bootstrap did not fail until this change (which marked them non-optional).