### PR TITLE
chore: fix for node install failing on windows machines

### DIFF
--- a/.evergreen/InstallNode.ps1
+++ b/.evergreen/InstallNode.ps1
@@ -14,7 +14,7 @@ $wc.DownloadFile($url, $node_zip)
 Write-Output "$filename downloaded"
 Write-Output "Time taken: $((Get-Date).Subtract($start_time).Seconds) second(s)"
 
-Expand-Archive $node_zip -OutputPath $PSScriptRoot
+Expand-Archive $node_zip -DestinationPath $PSScriptRoot
 Get-ChildItem -Path $PSScriptRoot
 
 Set-Location -Path $node_dir


### PR DESCRIPTION
Not sure how this was working before but from the documentation of PowerShell, it seems `-OutputPath` has not been there since quite some time. It has always been `-DestinationPath`.

I spawned a host with the same distro (windows-vsCurrent-small) for which we had these tests failing and noticed that the version of Powershell over there is 5.1 which only has `-DestinationPath` as the valid argument.

Here are a few links for Powershell Expand-Archive docs for reference:
- [v5.x docs](https://learn.microsoft.com/en-gb/previous-versions/powershell/module/microsoft.powershell.archive/expand-archive?view=powershell-5.0)
- [v4.x docs](https://learn.microsoft.com/en-gb/previous-versions/powershell/module/microsoft.powershell.archive/expand-archive?view=powershell-7.1&viewFallbackFrom=powershell-4.0)
- [v3.x docs](https://learn.microsoft.com/en-us/previous-versions/powershell/module/microsoft.powershell.archive/expand-archive?view=powershell-7.1&viewFallbackFrom=powershell-3.0)