### PR TITLE
feat: add atlas streams support MONGOSH-1514

### DIFF
--- a/packages/cli-repl/src/format-output.ts
+++ b/packages/cli-repl/src/format-output.ts
@@ -82,6 +82,14 @@ export default function formatOutput(
     return formatListCommands(value, options);
   }
 
+  if (type === 'ListStreamProcessorsResult') {
+    return inspect(value, {
+      ...options,
+      depth: Infinity,
+      maxArrayLength: Infinity,
+    });
+  }
+
   if (type === 'ShowProfileResult') {
     if (value.count === 0) {
       return clr(

--- a/packages/cli-repl/src/format-output.ts
+++ b/packages/cli-repl/src/format-output.ts
@@ -82,7 +82,7 @@ export default function formatOutput(
     return formatListCommands(value, options);
   }
 
-  if (type === 'ListStreamProcessorsResult') {
+  if (type === 'StreamsListResult') {
     return inspect(value, {
       ...options,
       depth: Infinity,

--- a/packages/i18n/src/locales/en_US.ts
+++ b/packages/i18n/src/locales/en_US.ts
@@ -2682,6 +2682,54 @@ const translations: Catalog = {
           },
         },
       },
+      Streams: {
+        help: {
+          description: 'Streams',
+          attributes: {
+            process: {
+              description:
+                'Allows a user to process streams of data in the shell interactively and quickly iterate building a stream processor as they go.',
+            },
+            createStreamProcessor: {
+              description: 'Create a named stream processor.',
+            },
+            getProcessor: {
+              description: 'Get a stream processor with specified name.',
+            },
+            listStreamProcessors: {
+              description: 'Show a list of all the named stream processors.',
+            },
+            listConnections: {
+              description:
+                'Show a list of all the named connections for this instance from the Connection Registry.',
+            },
+          },
+        },
+      },
+      StreamProcessor: {
+        help: {
+          description: 'Stream processor',
+          attributes: {
+            start: {
+              description: 'Start a named stream processor.',
+            },
+            stop: {
+              description: 'Stop a named stream processor.',
+            },
+            drop: {
+              description: 'Drop a named stream processor.',
+            },
+            sample: {
+              description:
+                'Return a sample of the results from a named stream processor.',
+            },
+            stats: {
+              description:
+                'Return stats captured from a named stream processor.',
+            },
+          },
+        },
+      },
     },
   },
   'transport-browser': {

--- a/packages/service-provider-core/src/connect-info.spec.ts
+++ b/packages/service-provider-core/src/connect-info.spec.ts
@@ -71,6 +71,7 @@ describe('getConnectInfo', function () {
       is_enterprise: true,
       auth_type: 'LDAP',
       is_data_federation: false,
+      is_stream: false,
       dl_version: null,
       atlas_version: '20210330.0.0.1617063608',
       is_genuine: true,
@@ -101,6 +102,7 @@ describe('getConnectInfo', function () {
       is_enterprise: true,
       auth_type: null,
       is_data_federation: false,
+      is_stream: false,
       dl_version: null,
       atlas_version: '20210330.0.0.1617063608',
       is_genuine: true,
@@ -121,6 +123,39 @@ describe('getConnectInfo', function () {
     ).to.deep.equal(output);
   });
 
+  it('reports correct information when a stream uri is passed', function () {
+    const streamUri =
+      'mongodb://atlas-stream-67b8e1cd6d60357be377be7b-1dekw.virginia-usa.a.query.mongodb-dev.net/';
+    const output = {
+      is_atlas: true,
+      is_localhost: false,
+      is_do: false,
+      server_version: '3.2.0-rc2',
+      mongosh_version: '0.0.6',
+      is_enterprise: true,
+      auth_type: 'LDAP',
+      is_data_federation: false,
+      is_stream: true,
+      dl_version: null,
+      atlas_version: null,
+      is_genuine: true,
+      non_genuine_server_name: 'mongodb',
+      server_arch: 'x86_64',
+      node_version: process.version,
+      server_os: 'osx',
+      uri: streamUri,
+    };
+    expect(
+      getConnectInfo(
+        streamUri,
+        '0.0.6',
+        BUILD_INFO,
+        null,
+        TOPOLOGY_WITH_CREDENTIALS
+      )
+    ).to.deep.equal(output);
+  });
+
   it('reports correct information when an empty uri is passed', function () {
     const output = {
       is_atlas: false,
@@ -131,6 +166,7 @@ describe('getConnectInfo', function () {
       is_enterprise: true,
       auth_type: 'LDAP',
       is_data_federation: false,
+      is_stream: false,
       dl_version: null,
       atlas_version: null,
       is_genuine: true,
@@ -155,6 +191,7 @@ describe('getConnectInfo', function () {
       is_enterprise: false,
       auth_type: 'LDAP',
       is_data_federation: false,
+      is_stream: false,
       dl_version: null,
       atlas_version: null,
       is_genuine: true,

--- a/packages/service-provider-core/src/connect-info.ts
+++ b/packages/service-provider-core/src/connect-info.ts
@@ -55,22 +55,10 @@ export default function getConnectInfo(
     is_enterprise: getBuildInfo.isEnterprise(buildInfo),
     auth_type,
     is_data_federation,
-    is_stream: isStream(uri),
+    is_stream: getBuildInfo.isAtlasStream(uri),
     dl_version,
     atlas_version: atlasVersion?.atlasVersion ?? null,
     is_genuine,
     non_genuine_server_name,
   };
-}
-
-function isStream(uri: string): boolean {
-  try {
-    return (
-      getBuildInfo.isAtlas(uri) &&
-      !!/^atlas-stream-.+/.exec(new URL(uri).hostname)
-    );
-  } catch {
-    // invalid uri
-  }
-  return false;
 }

--- a/packages/service-provider-core/src/connect-info.ts
+++ b/packages/service-provider-core/src/connect-info.ts
@@ -13,6 +13,7 @@ export interface ConnectInfo {
   is_enterprise: boolean;
   auth_type?: string;
   is_data_federation: boolean;
+  is_stream: boolean;
   dl_version?: string;
   atlas_version?: string;
   is_genuine: boolean;
@@ -54,9 +55,22 @@ export default function getConnectInfo(
     is_enterprise: getBuildInfo.isEnterprise(buildInfo),
     auth_type,
     is_data_federation,
+    is_stream: isStream(uri),
     dl_version,
     atlas_version: atlasVersion?.atlasVersion ?? null,
     is_genuine,
     non_genuine_server_name,
   };
+}
+
+function isStream(uri: string): boolean {
+  try {
+    return (
+      getBuildInfo.isAtlas(uri) &&
+      !!/^atlas-stream-.+/.exec(new URL(uri).hostname)
+    );
+  } catch {
+    // invalid uri
+  }
+  return false;
 }

--- a/packages/shell-api/src/index.ts
+++ b/packages/shell-api/src/index.ts
@@ -33,6 +33,7 @@ import {
   TypeSignature,
 } from './decorators';
 import { Topologies, ServerVersions } from './enums';
+import { InterruptFlag } from './interruptor';
 
 export {
   AggregationCursor,
@@ -68,4 +69,5 @@ export {
   TypeSignature,
   OnLoadResult,
   ShellPlugin,
+  InterruptFlag,
 };

--- a/packages/shell-api/src/interruptor.spec.ts
+++ b/packages/shell-api/src/interruptor.spec.ts
@@ -28,13 +28,13 @@ describe('interruptor', function () {
           interruptError = e;
         });
         expect(interruptError).to.be.undefined;
-        interruptFlag.set();
+        await interruptFlag.set();
         await promisify(process.nextTick)();
         expect(interruptError).to.be.instanceOf(MongoshInterruptedError);
       });
 
       it('rejects immediately if the interrupt happened before', async function () {
-        interruptFlag.set();
+        await interruptFlag.set();
 
         interruptPromise = interruptFlag.asPromise();
         let interruptError: MongoshInterruptedError | undefined;
@@ -74,7 +74,7 @@ describe('interruptor', function () {
     });
 
     it('causes an interrupt error to be thrown on entry', async function () {
-      instanceState.interrupted.set();
+      await instanceState.interrupted.set();
       try {
         await database.runCommand({ some: 1 });
       } catch (e: any) {
@@ -87,7 +87,7 @@ describe('interruptor', function () {
     });
 
     it('causes an interrupt error to be thrown on exit', async function () {
-      let resolveCall: (result: any) => void;
+      let resolveCall!: (result: any) => void;
       serviceProvider.runCommandWithCheck.resolves(
         new Promise((resolve) => {
           resolveCall = resolve;
@@ -97,7 +97,7 @@ describe('interruptor', function () {
       const runCommand = database.runCommand({ some: 1 });
       await new Promise(setImmediate);
       await new Promise(setImmediate); // ticks due to db._baseOptions() being async
-      instanceState.interrupted.set();
+      await instanceState.interrupted.set();
       resolveCall({ ok: 1 });
 
       try {

--- a/packages/shell-api/src/shell-instance-state.spec.ts
+++ b/packages/shell-api/src/shell-instance-state.spec.ts
@@ -108,6 +108,19 @@ describe('ShellInstanceState', function () {
       expect(prompt).to.equal('> ');
     });
 
+    it('returns correct prompt for stream', async function () {
+      serviceProvider.getConnectionInfo.resolves({
+        extraInfo: {
+          uri: 'mongodb://atlas-stream-65a5f1cd6d50457be377be7b-1dekw.virginia-usa.a.query.mongodb-dev.net/',
+          is_stream: true,
+        },
+      });
+
+      await instanceState.fetchConnectionInfo();
+      const prompt = await instanceState.getDefaultPrompt();
+      expect(prompt).to.equal('AtlasStreamProcessing> ');
+    });
+
     describe('Atlas Data Lake prefix', function () {
       it('inferred from extraInfo', async function () {
         serviceProvider.getConnectionInfo.resolves({

--- a/packages/shell-api/src/shell-instance-state.ts
+++ b/packages/shell-api/src/shell-instance-state.ts
@@ -33,6 +33,7 @@ import { TransformMongoErrorPlugin } from './mongo-errors';
 import NoDatabase from './no-db';
 import type { ShellBson } from './shell-bson';
 import constructShellBson from './shell-bson';
+import { Streams } from './streams';
 
 /**
  * The subset of CLI options that is relevant for the shell API's behavior itself.
@@ -299,6 +300,11 @@ export default class ShellInstanceState {
         configurable: true,
         set: setFunc,
         get: () => this.currentDb,
+      });
+      // add the global "sp" for stream processing
+      const streams = Streams.newInstance(this);
+      Object.defineProperty(contextObject, 'sp', {
+        get: () => streams,
       });
     }
 

--- a/packages/shell-api/src/shell-instance-state.ts
+++ b/packages/shell-api/src/shell-instance-state.ts
@@ -227,6 +227,7 @@ export default class ShellInstanceState {
     this.currentDb = newDb;
     this.context.rs = new ReplicaSet(this.currentDb);
     this.context.sh = new Shard(this.currentDb);
+    this.context.sp = Streams.newInstance(this.currentDb);
     this.fetchConnectionInfo().catch((err) =>
       this.messageBus.emit('mongosh:error', err, 'shell-api')
     );
@@ -282,6 +283,7 @@ export default class ShellInstanceState {
 
     contextObject.rs = new ReplicaSet(this.currentDb);
     contextObject.sh = new Shard(this.currentDb);
+    contextObject.sp = Streams.newInstance(this.currentDb);
 
     const setFunc = (newDb: any): Database => {
       if (getShellApiType(newDb) !== 'Database') {
@@ -300,11 +302,6 @@ export default class ShellInstanceState {
         configurable: true,
         set: setFunc,
         get: () => this.currentDb,
-      });
-      // add the global "sp" for stream processing
-      const streams = Streams.newInstance(this);
-      Object.defineProperty(contextObject, 'sp', {
-        get: () => streams,
       });
     }
 

--- a/packages/shell-api/src/shell-instance-state.ts
+++ b/packages/shell-api/src/shell-instance-state.ts
@@ -481,6 +481,10 @@ export default class ShellInstanceState {
 
   // eslint-disable-next-line @typescript-eslint/require-await
   async getDefaultPrompt(): Promise<string> {
+    if (this.connectionInfo?.extraInfo?.is_stream) {
+      return 'AtlasStreamProcessing> ';
+    }
+
     const prefix = this.getDefaultPromptPrefix();
     const topologyInfo = this.getTopologySpecificPrompt();
     let dbname = '';

--- a/packages/shell-api/src/shell-instance-state.ts
+++ b/packages/shell-api/src/shell-instance-state.ts
@@ -437,7 +437,7 @@ export default class ShellInstanceState {
   }
 
   async onInterruptExecution(): Promise<boolean> {
-    this.interrupted.set();
+    await this.interrupted.set();
     this.currentCursor = null;
 
     this.resumeMongosAfterInterrupt = await Promise.all(

--- a/packages/shell-api/src/stream-processor.ts
+++ b/packages/shell-api/src/stream-processor.ts
@@ -71,7 +71,7 @@ export default class StreamProcessor extends ShellApiWithMongoClass {
   async _sampleFrom(cursorId: number) {
     let currentCursorId = cursorId;
     // keep pulling until end of stream
-    while (currentCursorId !== 0) {
+    while (String(currentCursorId) !== '0') {
       const res = await this._streams._runStreamCommand({
         getMoreSampleStreamProcessor: this.name,
         cursorId: currentCursorId,

--- a/packages/shell-api/src/stream-processor.ts
+++ b/packages/shell-api/src/stream-processor.ts
@@ -74,7 +74,7 @@ export default class StreamProcessor extends ShellApiWithMongoClass {
     while (currentCursorId !== 0) {
       const res = await this._streams._runStreamCommand({
         getMoreSampleStreamProcessor: this.name,
-        cursorID: currentCursorId,
+        cursorId: currentCursorId,
       });
 
       if (res.ok !== 1) {

--- a/packages/shell-api/src/stream-processor.ts
+++ b/packages/shell-api/src/stream-processor.ts
@@ -40,6 +40,10 @@ export default class StreamProcessor extends ShellApiWithMongoClass {
 
   @returnsPromise
   async drop() {
+    return this._drop();
+  }
+
+  async _drop() {
     return await this._streams._runStreamCommand({
       dropStreamProcessor: this.name,
     });
@@ -67,7 +71,6 @@ export default class StreamProcessor extends ShellApiWithMongoClass {
     return this._sampleFrom(r.cursorId as number);
   }
 
-  @returnsPromise
   async _sampleFrom(cursorId: number) {
     let currentCursorId = cursorId;
     // keep pulling until end of stream

--- a/packages/shell-api/src/stream-processor.ts
+++ b/packages/shell-api/src/stream-processor.ts
@@ -1,0 +1,114 @@
+import { promisify } from 'util';
+
+import type { Document } from '@mongosh/service-provider-core';
+
+import type Mongo from './mongo';
+import { asPrintable } from './enums';
+import {
+  ShellApiWithMongoClass,
+  returnsPromise,
+  shellApiClassDefault,
+} from './decorators';
+
+import type { Streams } from './streams';
+
+const sleep = promisify(setTimeout);
+
+@shellApiClassDefault
+export default class StreamProcessor extends ShellApiWithMongoClass {
+  constructor(public _streams: Streams, public name: string) {
+    super();
+  }
+
+  get _mongo(): Mongo {
+    return this._streams._mongo;
+  }
+
+  [asPrintable]() {
+    return `Atlas Stream Processor: ${this.name}`;
+  }
+
+  @returnsPromise
+  async start() {
+    const result = await this._streams._runCommand({
+      startStreamProcessor: this.name,
+    });
+    return result;
+  }
+
+  @returnsPromise
+  async stop() {
+    const result = await this._streams._runCommand({
+      stopStreamProcessor: this.name,
+    });
+    return result;
+  }
+
+  @returnsPromise
+  async drop() {
+    const result = await this._streams._runCommand({
+      dropStreamProcessor: this.name,
+    });
+    return result;
+  }
+
+  @returnsPromise
+  async stats(options: Document = {}) {
+    return this._streams._runCommand({
+      getStreamProcessorStats: this.name,
+      ...options,
+    });
+  }
+
+  @returnsPromise
+  async sample(options: Document = {}) {
+    const r = await this._streams._runCommand({
+      startSampleStreamProcessor: this.name,
+      ...options,
+    });
+
+    if (r.ok !== 1) {
+      return r;
+    }
+
+    return this._sampleFrom(r.cursorId as number);
+  }
+
+  @returnsPromise
+  async _sampleFrom(cursorId: number) {
+    let currentCursorId = cursorId;
+    // keep pulling until end of stream
+    while (currentCursorId !== 0) {
+      const res = await this._streams._runCommand({
+        getMoreSampleStreamProcessor: this.name,
+        cursorID: currentCursorId,
+      });
+
+      if (res.ok !== 1) {
+        return res;
+      }
+
+      currentCursorId = res.cursorId;
+
+      // print fetched documents
+      for (const doc of res.messages) {
+        await this._instanceState.shellApi.printjson(doc);
+      }
+
+      // wait before pulling again if no result in this batch
+      if (!res.messages.length) {
+        const interruptable = this._instanceState.interrupted.asPromise();
+        try {
+          await Promise.race([
+            sleep(1000), // wait 1 second
+            interruptable.promise, // unless interruppted
+          ]);
+        } finally {
+          interruptable.destroy();
+        }
+      }
+    }
+
+    return;
+  }
+}

--- a/packages/shell-api/src/streams.spec.ts
+++ b/packages/shell-api/src/streams.spec.ts
@@ -1,0 +1,165 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import type Mongo from './mongo';
+import Database from './database';
+import { Streams } from './streams';
+import { InterruptFlag, MongoshInterruptedError } from './interruptor';
+
+describe('Streams', function () {
+  let mongo: Mongo;
+  let streams: Streams;
+  const identity = (a: unknown) => a;
+
+  beforeEach(function () {
+    mongo = {
+      _instanceState: {
+        interrupted: new InterruptFlag(),
+        shellApi: { printjson: identity },
+        transformError: identity,
+      },
+      _serviceProvider: {
+        runCommand: identity,
+      },
+    } as unknown as Mongo;
+    streams = new Streams(new Database(mongo, 'testDb'));
+  });
+
+  describe('createStreamProcessor', function () {
+    it('throws when name is empty', async function () {
+      const caught = await streams
+        .createStreamProcessor('', [])
+        .catch((e) => e);
+      expect(caught.message).to.contain(
+        '[COMMON-10001] Invalid processor name'
+      );
+    });
+
+    it('throws when pipeline is empty', async function () {
+      const caught = await streams
+        .createStreamProcessor('spm', [])
+        .catch((e) => e);
+      expect(caught.message).to.contain('[COMMON-10001] Invalid pipeline');
+    });
+
+    it('returns error when creation fails', async function () {
+      const error = { ok: Date.now() };
+      sinon.stub(mongo._serviceProvider, 'runCommand').resolves(error);
+
+      const pipeline = [{ $match: { foo: 'bar' } }];
+      const result = await streams.createStreamProcessor('spm', pipeline);
+      expect(result).to.eql(error);
+    });
+
+    it('returns newly created processor', async function () {
+      const runCmdStub = sinon
+        .stub(mongo._serviceProvider, 'runCommand')
+        .resolves({ ok: 1 });
+
+      const pipeline = [{ $match: { foo: 'bar' } }];
+      const result = await streams.createStreamProcessor('spm', pipeline);
+      expect(result).to.eql(streams.getProcessor('spm'));
+
+      const cmd = { createStreamProcessor: 'spm', pipeline };
+      expect(runCmdStub.calledOnceWithExactly('admin', cmd, {})).to.be.true;
+    });
+  });
+
+  describe('process', function () {
+    it('throws when pipeline is empty', async function () {
+      const caught = await streams.process([]).catch((e) => e);
+      expect(caught.message).to.contain('[COMMON-10001] Invalid pipeline');
+    });
+
+    it('returns if process cmd errors', async function () {
+      const error = { ok: Date.now() };
+      sinon.stub(mongo._serviceProvider, 'runCommand').resolves(error);
+
+      const pipeline = [{ $match: { foo: 'bar' } }];
+      const result = await streams.process(pipeline);
+      expect(result).to.eql(error);
+    });
+
+    it('prints received sample documents until the end', async function () {
+      const pipeline = [{ $match: { foo: 'bar' } }];
+      const spmName = 'testSpm';
+      const cursorId = Date.now();
+
+      const runCmdStub = sinon.stub(mongo._serviceProvider, 'runCommand');
+      runCmdStub
+        .withArgs('admin', { processStreamProcessor: pipeline }, {})
+        .resolves({ ok: 1, name: spmName, cursorId });
+      runCmdStub
+        .withArgs(
+          'admin',
+          { getMoreSampleStreamProcessor: spmName, cursorId },
+          {}
+        )
+        .resolves({
+          ok: 1,
+          messages: [{ msg: '1st' }],
+          cursorId: cursorId - 1,
+        });
+      runCmdStub
+        .withArgs(
+          'admin',
+          { getMoreSampleStreamProcessor: spmName, cursorId: cursorId - 1 },
+          {}
+        )
+        .resolves({ ok: 1, messages: [{ msg: '2nd' }], cursorId: 0 });
+
+      const printSub = sinon.stub(mongo._instanceState.shellApi, 'printjson');
+
+      await streams.process(pipeline);
+
+      expect(printSub.firstCall.args).to.eql([{ msg: '1st' }]);
+      expect(printSub.secondCall.args).to.eql([{ msg: '2nd' }]);
+      expect(
+        runCmdStub.calledWithExactly(
+          'admin',
+          { dropStreamProcessor: spmName },
+          {}
+        )
+      ).to.be.true;
+    });
+
+    it('drops the processor and then stops on interruption', async function () {
+      const pipeline = [{ $match: { foo: 'bar' } }];
+      const spmName = 'testSpm';
+      const cursorId = Date.now();
+
+      let getMoreResolve;
+      const getMoreCalled = new Promise((r) => (getMoreResolve = r));
+
+      const runCmdStub = sinon.stub(mongo._serviceProvider, 'runCommand');
+      runCmdStub
+        .withArgs('admin', { processStreamProcessor: pipeline }, {})
+        .resolves({ ok: 1, name: spmName, cursorId });
+      runCmdStub
+        .withArgs(
+          'admin',
+          { getMoreSampleStreamProcessor: spmName, cursorId },
+          {}
+        )
+        .callsFake(() => {
+          getMoreResolve();
+          return new Promise(identity);
+        });
+
+      const processPromise = streams.process(pipeline).catch((e) => e);
+
+      await getMoreCalled;
+
+      await mongo._instanceState.interrupted.set();
+
+      expect(await processPromise).to.be.instanceOf(MongoshInterruptedError);
+      expect(
+        runCmdStub.calledWithExactly(
+          'admin',
+          { dropStreamProcessor: spmName },
+          {}
+        )
+      ).to.be.true;
+    });
+  });
+});

--- a/packages/shell-api/src/streams.ts
+++ b/packages/shell-api/src/streams.ts
@@ -48,7 +48,7 @@ export class Streams extends ShellApiWithMongoClass {
   }
 
   @returnsPromise
-  async process(pipeline: Document[], options: Document = {}) {
+  async process(pipeline: Document[], options?: Document) {
     if (!Array.isArray(pipeline) || !pipeline.length) {
       throw new MongoshInvalidInputError(
         'Invalid pipeline',
@@ -57,9 +57,8 @@ export class Streams extends ShellApiWithMongoClass {
       );
     }
     const result = await this._runStreamCommand({
-      processStreamProcessor: 1,
-      pipeline,
-      options,
+      processStreamProcessor: pipeline,
+      ...(options ? { options } : {}),
     });
 
     if (result.ok !== 1) {

--- a/packages/shell-api/src/streams.ts
+++ b/packages/shell-api/src/streams.ts
@@ -1,0 +1,172 @@
+import type { Document } from 'bson';
+import { CommonErrors, MongoshInvalidInputError } from '@mongosh/errors';
+
+import { MongoshInterruptedError } from './interruptor';
+import {
+  ShellApiWithMongoClass,
+  returnsPromise,
+  shellApiClassDefault,
+} from './decorators';
+import type ShellInstanceState from './shell-instance-state';
+import StreamProcessor from './stream-processor';
+import { ADMIN_DB, asPrintable } from './enums';
+import type Mongo from './mongo';
+
+@shellApiClassDefault
+export class Streams extends ShellApiWithMongoClass {
+  public static newInstance(instanceState: ShellInstanceState) {
+    return new Proxy(new Streams(instanceState), {
+      get(target, prop) {
+        const v = (target as any)[prop];
+        if (v !== undefined) {
+          return v;
+        }
+        if (typeof prop === 'string') {
+          return target.getProcessor(prop);
+        }
+      },
+    });
+  }
+
+  constructor(private instanceState: ShellInstanceState) {
+    super();
+  }
+
+  get _mongo(): Mongo {
+    return this.instanceState.currentDb._mongo;
+  }
+
+  [asPrintable](): string {
+    return 'Atlas Stream Processing';
+  }
+
+  getProcessor(name: string) {
+    return new StreamProcessor(this, name);
+  }
+
+  @returnsPromise
+  async process(pipeline: Document[], options: Document = {}) {
+    if (!Array.isArray(pipeline) || !pipeline.length) {
+      throw new MongoshInvalidInputError(
+        'Invalid pipeline',
+        CommonErrors.InvalidArgument,
+        pipeline
+      );
+    }
+    const result = await this._runCommand({
+      processStreamProcessor: 1,
+      pipeline,
+      options,
+    });
+
+    if (result.ok !== 1) {
+      return result;
+    }
+
+    const { name, cursorId } = result as {
+      name: string;
+      limit: number;
+      cursorId: number;
+    };
+    const sp = this.getProcessor(name);
+
+    const stopAndDrop = () => {
+      sp.stop()
+        .then(() => sp.drop())
+        .catch(() => {
+          /* ignore */
+        });
+    };
+
+    try {
+      await sp._sampleFrom(cursorId);
+    } catch (err) {
+      // try to stop and drop the temp processor when interrupted
+      if (err instanceof MongoshInterruptedError) {
+        this._instanceState.messageBus.once(
+          'mongosh:interrupt-complete',
+          stopAndDrop
+        );
+      }
+
+      throw err;
+    }
+
+    // stop and drop the temp processor if reached the end of sample
+    return stopAndDrop();
+  }
+
+  @returnsPromise
+  async createStreamProcessor(
+    name: string,
+    pipeline: Document[],
+    options: Document
+  ) {
+    if (typeof name !== 'string' || name.trim() === '') {
+      throw new MongoshInvalidInputError(
+        `Invalid processor name: ${name}`,
+        CommonErrors.InvalidArgument
+      );
+    }
+    if (!Array.isArray(pipeline) || !pipeline.length) {
+      throw new MongoshInvalidInputError(
+        'Invalid pipeline',
+        CommonErrors.InvalidArgument,
+        pipeline
+      );
+    }
+    const result = await this._runCommand({
+      createStreamProcessor: name,
+      pipeline,
+      options,
+    });
+
+    if (result.ok !== 1) {
+      return result;
+    }
+
+    return this.getProcessor(name);
+  }
+
+  @returnsPromise
+  async listStreamProcessors(filter: Document) {
+    const result = await this._runCommand({
+      listStreamProcessors: 1,
+      filter,
+    });
+    if (result.ok !== 1) {
+      return result;
+    }
+    const processors = result.streamProcessors;
+    const sps = processors.map((sp: StreamProcessor) =>
+      this.getProcessor(sp.name)
+    );
+    return Object.defineProperty(sps, asPrintable, {
+      value() {
+        return JSON.stringify(processors, null, 2);
+      },
+    });
+  }
+
+  @returnsPromise
+  listConnections(filter: Document) {
+    return this._runCommand({
+      listStreamConnections: 1,
+      filter,
+    });
+  }
+
+  async _runCommand(cmd: Document, options: Document = {}) {
+    const { _mongo, _instanceState } = this;
+    const interruptable = _instanceState.interrupted.asPromise();
+    try {
+      const result = await Promise.race([
+        _mongo._serviceProvider.runCommand(ADMIN_DB, cmd, options), // run cmd
+        interruptable.promise, // unless interruppted
+      ]);
+      return result;
+    } finally {
+      interruptable.destroy();
+    }
+  }
+}


### PR DESCRIPTION
This PR adds Atlas Stream Processing support to the mongosh:
- adds a new flag `is_stream` to the `ConnectInfo` type
- changes default prompt to `AtlasStreamProcessing> ` when `is_stream` is `true`
- adds a new global object `sp` for doing streams related operations