### PR TITLE
chore: updates fake mongodb deployment detection using mongodb-build-info@1.6.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22056,9 +22056,9 @@
       }
     },
     "node_modules/mongodb-build-info": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/mongodb-build-info/-/mongodb-build-info-1.5.0.tgz",
-      "integrity": "sha512-D+cXTPet0X7fcMuXBR+Trzqjl9DX7lX7L36v527+5T8mp/wTUP9r/rA/PrmHrQLa9jGknxEbAZOHpC+g/lJ/UQ==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/mongodb-build-info/-/mongodb-build-info-1.6.2.tgz",
+      "integrity": "sha512-kSEu/dJNABTnrrrnyACTyPxsXYa8hfxuhhv1xMYhTi5c9Y0n76levzp/YMHVuFeQ4fE52HeEHBXksKQZfQ6wbw==",
       "dependencies": {
         "mongodb-connection-string-url": "^2.2.0"
       }
@@ -30575,7 +30575,7 @@
         "@mongosh/errors": "0.0.0-dev.0",
         "bson": "^5.3.0",
         "mongodb": "^5.6.0",
-        "mongodb-build-info": "^1.5.0"
+        "mongodb-build-info": "^1.6.2"
       },
       "devDependencies": {
         "@mongodb-js/eslint-config-mongosh": "^1.0.0",
@@ -39520,7 +39520,7 @@
         "depcheck": "^1.4.3",
         "eslint": "^7.25.0",
         "mongodb": "^5.6.0",
-        "mongodb-build-info": "^1.5.0",
+        "mongodb-build-info": "1.6.2",
         "mongodb-client-encryption": "^2.8.0",
         "prettier": "^2.8.8"
       }
@@ -49187,9 +49187,9 @@
       }
     },
     "mongodb-build-info": {
-      "version": "1.5.0",
-      "resolved": "https://registry.npmjs.org/mongodb-build-info/-/mongodb-build-info-1.5.0.tgz",
-      "integrity": "sha512-D+cXTPet0X7fcMuXBR+Trzqjl9DX7lX7L36v527+5T8mp/wTUP9r/rA/PrmHrQLa9jGknxEbAZOHpC+g/lJ/UQ==",
+      "version": "1.6.2",
+      "resolved": "https://registry.npmjs.org/mongodb-build-info/-/mongodb-build-info-1.6.2.tgz",
+      "integrity": "sha512-kSEu/dJNABTnrrrnyACTyPxsXYa8hfxuhhv1xMYhTi5c9Y0n76levzp/YMHVuFeQ4fE52HeEHBXksKQZfQ6wbw==",
       "requires": {
         "mongodb-connection-string-url": "^2.2.0"
       }

--- a/packages/service-provider-core/package.json
+++ b/packages/service-provider-core/package.json
@@ -45,7 +45,7 @@
     "@mongosh/errors": "0.0.0-dev.0",
     "bson": "^5.3.0",
     "mongodb": "^5.6.0",
-    "mongodb-build-info": "^1.5.0"
+    "mongodb-build-info": "^1.6.2"
   },
   "optionalDependencies": {
     "mongodb-client-encryption": "^2.8.0"

--- a/packages/service-provider-core/src/connect-info.spec.ts
+++ b/packages/service-provider-core/src/connect-info.spec.ts
@@ -41,19 +41,6 @@ describe('getConnectInfo', function () {
     ok: 1,
   };
 
-  const CMD_LINE_OPTS = {
-    argv: [
-      '/opt/mongodb-osx-x86_64-enterprise-3.6.3/bin/mongod',
-      '--dbpath=/Users/user/testdata',
-    ],
-    parsed: {
-      storage: {
-        dbPath: '/Users/user/testdata',
-      },
-    },
-    ok: 1,
-  };
-
   const ATLAS_VERSION = {
     atlasVersion: '20210330.0.0.1617063608',
     gitVersion: '8f7e5bdde713391e8123a463895bb7fb660a5ffd',
@@ -98,7 +85,6 @@ describe('getConnectInfo', function () {
         ATLAS_URI,
         '0.0.6',
         BUILD_INFO,
-        CMD_LINE_OPTS,
         ATLAS_VERSION,
         TOPOLOGY_WITH_CREDENTIALS
       )
@@ -129,7 +115,6 @@ describe('getConnectInfo', function () {
         ATLAS_URI,
         '0.0.6',
         BUILD_INFO,
-        CMD_LINE_OPTS,
         ATLAS_VERSION,
         TOPOLOGY_NO_CREDENTIALS
       )
@@ -156,14 +141,7 @@ describe('getConnectInfo', function () {
       uri: '',
     };
     expect(
-      getConnectInfo(
-        '',
-        '0.0.6',
-        BUILD_INFO,
-        CMD_LINE_OPTS,
-        null,
-        TOPOLOGY_WITH_CREDENTIALS
-      )
+      getConnectInfo('', '0.0.6', BUILD_INFO, null, TOPOLOGY_WITH_CREDENTIALS)
     ).to.deep.equal(output);
   });
 
@@ -187,14 +165,7 @@ describe('getConnectInfo', function () {
       uri: '',
     };
     expect(
-      getConnectInfo(
-        '',
-        '0.0.6',
-        null,
-        CMD_LINE_OPTS,
-        null,
-        TOPOLOGY_WITH_CREDENTIALS
-      )
+      getConnectInfo('', '0.0.6', null, null, TOPOLOGY_WITH_CREDENTIALS)
     ).to.deep.equal(output);
   });
 });

--- a/packages/service-provider-core/src/connect-info.ts
+++ b/packages/service-provider-core/src/connect-info.ts
@@ -25,19 +25,16 @@ export default function getConnectInfo(
   uri: string,
   mongoshVersion: string,
   buildInfo: any,
-  cmdLineOpts: any,
   atlasVersion: any,
   topology: any
 ): ConnectInfo {
   buildInfo ??= {}; // We're currently not getting buildInfo with --apiStrict.
   const { isGenuine: is_genuine, serverName: non_genuine_server_name } =
-    getBuildInfo.getGenuineMongoDB(buildInfo, cmdLineOpts);
+    getBuildInfo.getGenuineMongoDB(uri);
   // Atlas Data Lake has been renamed to Atlas Data Federation
   const { isDataLake: is_data_federation, dlVersion: dl_version } =
     getBuildInfo.getDataLake(buildInfo);
 
-  // get this information from topology rather than cmdLineOpts, since not all
-  // connections are able to run getCmdLineOpts command
   const auth_type = topology.s.credentials
     ? topology.s.credentials.mechanism
     : null;

--- a/packages/service-provider-server/src/cli-service-provider.spec.ts
+++ b/packages/service-provider-server/src/cli-service-provider.spec.ts
@@ -961,25 +961,18 @@ describe('CliServiceProvider', function () {
       expect(info.extraInfo.is_atlas).to.equal(false);
       expect(info.extraInfo.is_localhost).to.equal(true);
       expect(info.extraInfo.fcv).to.equal(undefined);
-      expect(dbStub.command).to.have.callCount(4);
+      expect(dbStub.command).to.have.callCount(3);
     });
 
     context('when connected to a DocumentDB deployment', function () {
       it('correctly gathers info on the fake deployment', async function () {
-        dbStub.command.callsFake(
-          (params) =>
-            new Promise((resolve, reject) => {
-              if (params.getCmdLineOpts) {
-                reject({
-                  ok: 0,
-                  code: 303,
-                  message: 'Feature not supported: getCmdLineOpts',
-                  operationTime: Date.now(),
-                });
-              } else {
-                resolve({ ok: 1 });
-              }
-            })
+        const serviceProvider = new CliServiceProvider(
+          clientStub,
+          bus,
+          dummyOptions,
+          new ConnectionString(
+            'mongodb://elastic-docdb-123456789.eu-central-1.docdb-elastic.amazonaws.com:27017'
+          )
         );
 
         const info = await serviceProvider.getConnectionInfo();
@@ -990,13 +983,14 @@ describe('CliServiceProvider', function () {
 
     context('when connected to a CosmosDB deployment', function () {
       it('correctly gathers info on the fake deployment', async function () {
-        // eslint-disable-next-line @typescript-eslint/require-await
-        dbStub.command.callsFake(async (params) => {
-          if (params.buildInfo) {
-            return { ok: 1, _t: 1 };
-          }
-          return { ok: 1 };
-        });
+        const serviceProvider = new CliServiceProvider(
+          clientStub,
+          bus,
+          dummyOptions,
+          new ConnectionString(
+            'mongodb+srv://compass-vcore.mongocluster.cosmos.azure.com'
+          )
+        );
 
         const info = await serviceProvider.getConnectionInfo();
         expect(info.extraInfo.is_genuine).to.be.false;

--- a/packages/service-provider-server/src/cli-service-provider.ts
+++ b/packages/service-provider-server/src/cli-service-provider.ts
@@ -331,49 +331,29 @@ class CliServiceProvider
   async getConnectionInfo(): Promise<ConnectionInfo> {
     const topology = this.getTopology();
     const { version } = require('../package.json');
-    const [
-      buildInfo = null,
-      cmdLineOptsOrServerError = null,
-      atlasVersion = null,
-      fcv = null,
-    ] = await Promise.all([
-      this.runCommandWithCheck(
-        'admin',
-        { buildInfo: 1 },
-        this.baseCmdOptions
-      ).catch(() => {}),
-      this.runCommandWithCheck(
-        'admin',
-        { getCmdLineOpts: 1 },
-        this.baseCmdOptions
-      ).catch((e) => {
-        // mongodb-build-info.getGenuineMongoDB expects either
-        // the successful or failure response from server
-        // Ref: https://github.com/mongodb-js/mongodb-build-info/blob/9247eeba730a905397ad09fe5a377067edc49b34/index.js#L89
-        return {
-          ok: e.ok,
-          code: e.code,
-          errmsg: e.message,
-          operationTime: e.operationTime,
-        };
-      }),
-      this.runCommandWithCheck(
-        'admin',
-        { atlasVersion: 1 },
-        this.baseCmdOptions
-      ).catch(() => {}),
-      this.runCommandWithCheck(
-        'admin',
-        { getParameter: 1, featureCompatibilityVersion: 1 },
-        this.baseCmdOptions
-      ).catch(() => {}),
-    ]);
+    const [buildInfo = null, atlasVersion = null, fcv = null] =
+      await Promise.all([
+        this.runCommandWithCheck(
+          'admin',
+          { buildInfo: 1 },
+          this.baseCmdOptions
+        ).catch(() => {}),
+        this.runCommandWithCheck(
+          'admin',
+          { atlasVersion: 1 },
+          this.baseCmdOptions
+        ).catch(() => {}),
+        this.runCommandWithCheck(
+          'admin',
+          { getParameter: 1, featureCompatibilityVersion: 1 },
+          this.baseCmdOptions
+        ).catch(() => {}),
+      ]);
 
     const extraConnectionInfo = getConnectInfo(
       this.uri?.toString() ?? '',
       version,
       buildInfo,
-      cmdLineOptsOrServerError,
       atlasVersion,
       topology
     );


### PR DESCRIPTION
A follow up of https://github.com/mongodb-js/mongodb-build-info/pull/22, which brings updated logic for fake deployment detection to mongosh.