### PR TITLE
fix(cli-repl): invert and fix passwordless-auth-mechanism check

### DIFF
--- a/packages/cli-repl/src/cli-repl.ts
+++ b/packages/cli-repl/src/cli-repl.ts
@@ -804,11 +804,12 @@ export class CliRepl implements MongoshIOProvider {
    */
   isPasswordMissingURI(cs: ConnectionString): boolean {
     return !!(
-      (
-        cs.username &&
-        !cs.password &&
-        cs.searchParams.get('authMechanism') !== 'GSSAPI'
-      ) // no need for a password for Kerberos
+      cs.username &&
+      !cs.password &&
+      // Only password-based mechanisms require a password, including the default SCRAM-SHA-* ones
+      ['', 'MONGODB-CR', 'PLAIN', 'SCRAM-SHA-1', 'SCRAM-SHA-256'].includes(
+        cs.searchParams.get('authMechanism') ?? ''
+      )
     );
   }
 

--- a/packages/cli-repl/test/e2e-oidc.spec.ts
+++ b/packages/cli-repl/test/e2e-oidc.spec.ts
@@ -144,6 +144,22 @@ describe('OIDC auth e2e', function () {
     shell.assertNoErrors();
   });
 
+  it('can successfully authenticate using OIDC Auth Code Flow when a username is specified', async function () {
+    shell = TestShell.start({
+      args: [
+        await testServer.connectionString(),
+        '--username=testuser',
+        '--authenticationMechanism=MONGODB-OIDC',
+        '--oidcRedirectUri=http://localhost:0/',
+        `--browser=${fetchBrowserFixture}`,
+      ],
+    });
+    await shell.waitForPrompt();
+
+    await verifyUser(shell, 'testuser', 'testServer-group');
+    shell.assertNoErrors();
+  });
+
   it('can successfully authenticate using OIDC Device Auth Flow', async function () {
     shell = TestShell.start({
       args: [


### PR DESCRIPTION
Currently, if a username is specified but no password, mongosh will prompt for a password before connecting.

Kerberos/GSSAPI was made an exception, since it rarely makes use of a password. However, there are other mechanisms where a username can, and often will, be provided without a password (AWS, OIDC, and technically even X.509).

This commit prevents mongosh from prompting for a password for those mechanisms, and inverts the check to explicitly list the mechanisms that *do* require a password (the list of auth mechanisms is unlikely to change soon, but if it does, it likely wouldn’t include a new password-based auth mechanism, so avoiding false positive return values seems like a better choice than avoiding false negative return values).