### PR TITLE
chore(deps): use @mongodb-js/saslprep COMPASS-6996

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26194,14 +26194,12 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "node_modules/saslprep": {
-      "version": "1.0.4",
-      "resolved": "git+ssh://git@github.com/mongodb-js/saslprep.git#9813a626d0685f54e4f2fac6160470d6e01d8c96",
-      "license": "MIT",
+      "name": "@mongodb-js/saslprep",
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.0.tgz",
+      "integrity": "sha512-Xfijy7HvfzzqiOAhAepF4SGN5e9leLkMvg/OPOF97XemjfVCYN/oWa75wnkc6mltMSTwY+XlbhWgUOJmkFspSw==",
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
-      },
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/sass": {
@@ -30683,7 +30681,7 @@
         "aws4": "^1.11.0",
         "mongodb": "^5.7.0",
         "mongodb-connection-string-url": "^2.6.0",
-        "saslprep": "mongodb-js/saslprep#v1.0.4"
+        "saslprep": "npm:@mongodb-js/saslprep@^1.1.0"
       },
       "devDependencies": {
         "@mongodb-js/eslint-config-mongosh": "^1.0.0",
@@ -39634,7 +39632,7 @@
         "mongodb-client-encryption": "^2.8.0",
         "mongodb-connection-string-url": "^2.6.0",
         "prettier": "^2.8.8",
-        "saslprep": "mongodb-js/saslprep#v1.0.4"
+        "saslprep": "npm:@mongodb-js/saslprep@^1.1.0"
       }
     },
     "@mongosh/shell-api": {
@@ -52490,8 +52488,9 @@
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="
     },
     "saslprep": {
-      "version": "git+ssh://git@github.com/mongodb-js/saslprep.git#9813a626d0685f54e4f2fac6160470d6e01d8c96",
-      "from": "saslprep@mongodb-js/saslprep#v1.0.4",
+      "version": "npm:@mongodb-js/saslprep@1.1.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.0.tgz",
+      "integrity": "sha512-Xfijy7HvfzzqiOAhAepF4SGN5e9leLkMvg/OPOF97XemjfVCYN/oWa75wnkc6mltMSTwY+XlbhWgUOJmkFspSw==",
       "requires": {
         "sparse-bitfield": "^3.0.3"
       }

--- a/packages/service-provider-server/package.json
+++ b/packages/service-provider-server/package.json
@@ -53,7 +53,7 @@
     "aws4": "^1.11.0",
     "mongodb": "^5.7.0",
     "mongodb-connection-string-url": "^2.6.0",
-    "saslprep": "mongodb-js/saslprep#v1.0.4"
+    "saslprep": "npm:@mongodb-js/saslprep@^1.1.0"
   },
   "optionalDependencies": {
     "kerberos": "^2.0.0",


### PR DESCRIPTION
… until the driver package starts depending directly on it, rather than in an optional dependency.