### PR TITLE
chore(ci): expand test matrix MONGOSH-1140 MONGOSH-1142 MONGOSH-1146

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -10435,6 +10435,25 @@ tasks:
         vars:
           node_js_version: "16.20.1"
           dockerfile: debian11-deb
+  - name: pkg_test_docker_deb_x64_debian12_deb
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_deb_x64
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: deb-x64
+      - func: write_preload_script
+      - func: install
+        vars:
+          node_js_version: "16.20.1"
+          npm_deps_mode: cli_build
+      - func: test_artifact_docker
+        vars:
+          node_js_version: "16.20.1"
+          dockerfile: debian12-deb
   - name: pkg_test_docker_rpm_x64_centos7_rpm
     tags: ["smoke-test"]
     depends_on:
@@ -10796,6 +10815,25 @@ tasks:
         vars:
           node_js_version: "16.20.1"
           dockerfile: ubuntu22.04-fips-deb
+  - name: pkg_test_docker_deb_x64_openssl3_debian12_deb
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_deb_x64_openssl3
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: deb-x64-openssl3
+      - func: write_preload_script
+      - func: install
+        vars:
+          node_js_version: "16.20.1"
+          npm_deps_mode: cli_build
+      - func: test_artifact_docker
+        vars:
+          node_js_version: "16.20.1"
+          dockerfile: debian12-deb
   - name: pkg_test_docker_rpm_x64_openssl3_rocky8_epel_rpm
     tags: ["smoke-test"]
     depends_on:
@@ -10986,6 +11024,25 @@ tasks:
         vars:
           node_js_version: "16.20.1"
           dockerfile: debian11-deb
+  - name: pkg_test_docker_deb_arm64_debian12_deb
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_deb_arm64
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: deb-arm64
+      - func: write_preload_script
+      - func: install
+        vars:
+          node_js_version: "16.20.1"
+          npm_deps_mode: cli_build
+      - func: test_artifact_docker
+        vars:
+          node_js_version: "16.20.1"
+          dockerfile: debian12-deb
   - name: pkg_test_docker_rpm_arm64_rocky8_rpm
     tags: ["smoke-test"]
     depends_on:
@@ -11736,6 +11793,11 @@ buildvariants:
     run_on: rhel80-small
     tasks:
       - name: e2e_tests_linux_x64
+  - name: e2e_rhel90_x64
+    display_name: "RHEL 9.0 x64 (E2E Tests)"
+    run_on: rhel90-small
+    tasks:
+      - name: e2e_tests_linux_x64
   - name: e2e_rhel83_x64
     display_name: "RHEL 8.3 x64 (E2E Tests, FIPS-available OS)"
     run_on: rhel83-fips
@@ -11743,6 +11805,13 @@ buildvariants:
       - name: e2e_tests_linux_x64
       - name: e2e_tests_linux_x64_openssl11
       - name: e2e_tests_linux_x64_openssl11_fips
+  - name: e2e_rhel92_x64
+    display_name: "RHEL 9.2 x64 (E2E Tests, FIPS-available OS)"
+    run_on: rhel92-fips
+    tasks:
+      - name: e2e_tests_linux_x64
+      - name: e2e_tests_linux_x64_openssl3
+      - name: e2e_tests_linux_x64_openssl3_fips
   - name: e2e_ubuntu1804_x64
     display_name: "Ubuntu 18.04 x64 (E2E Tests)"
     run_on: ubuntu1804-small
@@ -11754,6 +11823,12 @@ buildvariants:
     tasks:
       - name: e2e_tests_linux_x64
       - name: e2e_tests_linux_x64_openssl11
+  - name: e2e_ubuntu2204_x64
+    display_name: "Ubuntu 22.04 x64 (E2E Tests)"
+    run_on: ubuntu2204-small
+    tasks:
+      - name: e2e_tests_linux_x64
+      - name: e2e_tests_linux_x64_openssl3
   - name: e2e_debian9_x64
     display_name: "Debian 9 x64 (E2E Tests)"
     run_on: debian92-small
@@ -11781,6 +11856,11 @@ buildvariants:
     run_on: amazon2-small
     tasks:
       - name: e2e_tests_linux_x64
+  - name: e2e_amazon2023_x64
+    display_name: "Amazon Linux 2023 x64 (E2E Tests)"
+    run_on: amazon2023.0-small
+    tasks:
+      - name: e2e_tests_linux_x64
   - name: e2e_suse12_x64
     display_name: "SLES 12 x64 (E2E Tests)"
     run_on: suse12-sp5-small
@@ -11802,14 +11882,29 @@ buildvariants:
     tasks:
       - name: e2e_tests_linux_arm64
       - name: e2e_tests_linux_arm64_openssl11
+  - name: e2e_ubuntu2204_arm64
+    display_name: "Ubuntu 22.04 arm64 (E2E Tests)"
+    run_on: ubuntu2204-arm64-small
+    tasks:
+      - name: e2e_tests_linux_arm64
   - name: e2e_amazon2_arm64
     display_name: "Amazon Linux 2 arm64 (E2E Tests)"
     run_on: amazon2-arm64-small
     tasks:
       - name: e2e_tests_linux_arm64
+  - name: e2e_amazon2023_arm64
+    display_name: "Amazon Linux 2023 arm64 (E2E Tests)"
+    run_on: amazon2023.0-arm64-small
+    tasks:
+      - name: e2e_tests_linux_arm64
   - name: e2e_rhel82_arm64
     display_name: "RHEL 8.2 arm64 (E2E Tests)"
     run_on: rhel82-arm64-small
+    tasks:
+      - name: e2e_tests_linux_arm64
+  - name: e2e_rhel90_arm64
+    display_name: "RHEL 9.0 arm64 (E2E Tests)"
+    run_on: rhel90-arm64-small
     tasks:
       - name: e2e_tests_linux_arm64
   - name: e2e_rhel81_ppc64le
@@ -11984,6 +12079,7 @@ buildvariants:
       - name: pkg_test_docker_deb_x64_debian9_deb
       - name: pkg_test_docker_deb_x64_debian10_deb
       - name: pkg_test_docker_deb_x64_debian11_deb
+      - name: pkg_test_docker_deb_x64_debian12_deb
       - name: pkg_test_docker_rpm_x64_centos7_rpm
       - name: pkg_test_docker_rpm_x64_amazonlinux2_rpm
       - name: pkg_test_docker_rpm_x64_amazonlinux2023_rpm
@@ -12003,6 +12099,7 @@ buildvariants:
       - name: pkg_test_docker_rpm_x64_openssl11_fedora34_rpm
       - name: pkg_test_docker_deb_x64_openssl3_ubuntu22_04_deb
       - name: pkg_test_docker_deb_x64_openssl3_ubuntu22_04_fips_deb
+      - name: pkg_test_docker_deb_x64_openssl3_debian12_deb
       - name: pkg_test_docker_rpm_x64_openssl3_rocky8_epel_rpm
       - name: pkg_test_docker_rpm_x64_openssl3_rocky9_rpm
       - name: pkg_test_docker_rpm_x64_openssl3_rocky9_fips_rpm
@@ -12017,6 +12114,7 @@ buildvariants:
       - name: pkg_test_docker_deb_arm64_ubuntu22_04_deb
       - name: pkg_test_docker_deb_arm64_debian10_deb
       - name: pkg_test_docker_deb_arm64_debian11_deb
+      - name: pkg_test_docker_deb_arm64_debian12_deb
       - name: pkg_test_docker_rpm_arm64_rocky8_rpm
       - name: pkg_test_docker_rpm_arm64_rocky9_rpm
       - name: pkg_test_docker_rpm_arm64_fedora34_rpm

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -9222,6 +9222,44 @@ tasks:
           node_js_version: "16.20.1"
           mongosh_server_test_version: "5.0.x-enterprise"
           mongosh_test_e2e_force_fips: ""
+  - name: e2e_tests_darwin_x64_700rc10_fips
+    tags: ["e2e-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: darwin
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.1"
+          npm_deps_mode: cli_build
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: darwin-x64
+      - func: run_e2e_tests
+        vars:
+          node_js_version: "16.20.1"
+          mongosh_server_test_version: "7.0.0-rc10-enterprise"
+          mongosh_test_e2e_force_fips: "1"
+  - name: e2e_tests_darwin_x64_700rc10
+    tags: ["e2e-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: darwin
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.1"
+          npm_deps_mode: cli_build
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: darwin-x64
+      - func: run_e2e_tests
+        vars:
+          node_js_version: "16.20.1"
+          mongosh_server_test_version: "7.0.0-rc10-enterprise"
+          mongosh_test_e2e_force_fips: ""
   - name: e2e_tests_darwin_arm64_fips
     tags: ["e2e-test"]
     depends_on:
@@ -9297,6 +9335,44 @@ tasks:
         vars:
           node_js_version: "16.20.1"
           mongosh_server_test_version: "5.0.x-enterprise"
+          mongosh_test_e2e_force_fips: ""
+  - name: e2e_tests_darwin_arm64_700rc10_fips
+    tags: ["e2e-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: darwin_arm64
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.1"
+          npm_deps_mode: cli_build
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: darwin-arm64
+      - func: run_e2e_tests
+        vars:
+          node_js_version: "16.20.1"
+          mongosh_server_test_version: "7.0.0-rc10-enterprise"
+          mongosh_test_e2e_force_fips: "1"
+  - name: e2e_tests_darwin_arm64_700rc10
+    tags: ["e2e-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: darwin_arm64
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.1"
+          npm_deps_mode: cli_build
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: darwin-arm64
+      - func: run_e2e_tests
+        vars:
+          node_js_version: "16.20.1"
+          mongosh_server_test_version: "7.0.0-rc10-enterprise"
           mongosh_test_e2e_force_fips: ""
   - name: e2e_tests_linux_x64_fips
     tags: ["e2e-test"]
@@ -9374,6 +9450,44 @@ tasks:
           node_js_version: "16.20.1"
           mongosh_server_test_version: "5.0.x-enterprise"
           mongosh_test_e2e_force_fips: ""
+  - name: e2e_tests_linux_x64_700rc10_fips
+    tags: ["e2e-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_x64_build
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.1"
+          npm_deps_mode: cli_build
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-x64
+      - func: run_e2e_tests
+        vars:
+          node_js_version: "16.20.1"
+          mongosh_server_test_version: "7.0.0-rc10-enterprise"
+          mongosh_test_e2e_force_fips: "1"
+  - name: e2e_tests_linux_x64_700rc10
+    tags: ["e2e-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_x64_build
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.1"
+          npm_deps_mode: cli_build
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-x64
+      - func: run_e2e_tests
+        vars:
+          node_js_version: "16.20.1"
+          mongosh_server_test_version: "7.0.0-rc10-enterprise"
+          mongosh_test_e2e_force_fips: ""
   - name: e2e_tests_linux_x64_openssl11_fips
     tags: ["e2e-test"]
     depends_on:
@@ -9449,6 +9563,44 @@ tasks:
         vars:
           node_js_version: "16.20.1"
           mongosh_server_test_version: "5.0.x-enterprise"
+          mongosh_test_e2e_force_fips: ""
+  - name: e2e_tests_linux_x64_openssl11_700rc10_fips
+    tags: ["e2e-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_x64_build_openssl11
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.1"
+          npm_deps_mode: cli_build
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-x64-openssl11
+      - func: run_e2e_tests
+        vars:
+          node_js_version: "16.20.1"
+          mongosh_server_test_version: "7.0.0-rc10-enterprise"
+          mongosh_test_e2e_force_fips: "1"
+  - name: e2e_tests_linux_x64_openssl11_700rc10
+    tags: ["e2e-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_x64_build_openssl11
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.1"
+          npm_deps_mode: cli_build
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-x64-openssl11
+      - func: run_e2e_tests
+        vars:
+          node_js_version: "16.20.1"
+          mongosh_server_test_version: "7.0.0-rc10-enterprise"
           mongosh_test_e2e_force_fips: ""
   - name: e2e_tests_linux_x64_openssl3_fips
     tags: ["e2e-test"]
@@ -9526,6 +9678,44 @@ tasks:
           node_js_version: "16.20.1"
           mongosh_server_test_version: "5.0.x-enterprise"
           mongosh_test_e2e_force_fips: ""
+  - name: e2e_tests_linux_x64_openssl3_700rc10_fips
+    tags: ["e2e-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_x64_build_openssl3
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.1"
+          npm_deps_mode: cli_build
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-x64-openssl3
+      - func: run_e2e_tests
+        vars:
+          node_js_version: "16.20.1"
+          mongosh_server_test_version: "7.0.0-rc10-enterprise"
+          mongosh_test_e2e_force_fips: "1"
+  - name: e2e_tests_linux_x64_openssl3_700rc10
+    tags: ["e2e-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_x64_build_openssl3
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.1"
+          npm_deps_mode: cli_build
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-x64-openssl3
+      - func: run_e2e_tests
+        vars:
+          node_js_version: "16.20.1"
+          mongosh_server_test_version: "7.0.0-rc10-enterprise"
+          mongosh_test_e2e_force_fips: ""
   - name: e2e_tests_linux_arm64_fips
     tags: ["e2e-test"]
     depends_on:
@@ -9601,6 +9791,44 @@ tasks:
         vars:
           node_js_version: "16.20.1"
           mongosh_server_test_version: "5.0.x-enterprise"
+          mongosh_test_e2e_force_fips: ""
+  - name: e2e_tests_linux_arm64_700rc10_fips
+    tags: ["e2e-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_arm64_build
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.1"
+          npm_deps_mode: cli_build
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-arm64
+      - func: run_e2e_tests
+        vars:
+          node_js_version: "16.20.1"
+          mongosh_server_test_version: "7.0.0-rc10-enterprise"
+          mongosh_test_e2e_force_fips: "1"
+  - name: e2e_tests_linux_arm64_700rc10
+    tags: ["e2e-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_arm64_build
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.1"
+          npm_deps_mode: cli_build
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-arm64
+      - func: run_e2e_tests
+        vars:
+          node_js_version: "16.20.1"
+          mongosh_server_test_version: "7.0.0-rc10-enterprise"
           mongosh_test_e2e_force_fips: ""
   - name: e2e_tests_linux_arm64_openssl11_fips
     tags: ["e2e-test"]
@@ -9678,6 +9906,44 @@ tasks:
           node_js_version: "16.20.1"
           mongosh_server_test_version: "5.0.x-enterprise"
           mongosh_test_e2e_force_fips: ""
+  - name: e2e_tests_linux_arm64_openssl11_700rc10_fips
+    tags: ["e2e-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_arm64_build_openssl11
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.1"
+          npm_deps_mode: cli_build
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-arm64-openssl11
+      - func: run_e2e_tests
+        vars:
+          node_js_version: "16.20.1"
+          mongosh_server_test_version: "7.0.0-rc10-enterprise"
+          mongosh_test_e2e_force_fips: "1"
+  - name: e2e_tests_linux_arm64_openssl11_700rc10
+    tags: ["e2e-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_arm64_build_openssl11
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.1"
+          npm_deps_mode: cli_build
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-arm64-openssl11
+      - func: run_e2e_tests
+        vars:
+          node_js_version: "16.20.1"
+          mongosh_server_test_version: "7.0.0-rc10-enterprise"
+          mongosh_test_e2e_force_fips: ""
   - name: e2e_tests_linux_ppc64le_fips
     tags: ["e2e-test"]
     depends_on:
@@ -9753,6 +10019,44 @@ tasks:
         vars:
           node_js_version: "16.20.1"
           mongosh_server_test_version: "5.0.x-enterprise"
+          mongosh_test_e2e_force_fips: ""
+  - name: e2e_tests_linux_ppc64le_700rc10_fips
+    tags: ["e2e-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_ppc64le_build
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.1"
+          npm_deps_mode: cli_build
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-ppc64le
+      - func: run_e2e_tests
+        vars:
+          node_js_version: "16.20.1"
+          mongosh_server_test_version: "7.0.0-rc10-enterprise"
+          mongosh_test_e2e_force_fips: "1"
+  - name: e2e_tests_linux_ppc64le_700rc10
+    tags: ["e2e-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_ppc64le_build
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.1"
+          npm_deps_mode: cli_build
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-ppc64le
+      - func: run_e2e_tests
+        vars:
+          node_js_version: "16.20.1"
+          mongosh_server_test_version: "7.0.0-rc10-enterprise"
           mongosh_test_e2e_force_fips: ""
   - name: e2e_tests_linux_s390x_fips
     tags: ["e2e-test"]
@@ -9830,6 +10134,44 @@ tasks:
           node_js_version: "16.20.1"
           mongosh_server_test_version: "5.0.x-enterprise"
           mongosh_test_e2e_force_fips: ""
+  - name: e2e_tests_linux_s390x_700rc10_fips
+    tags: ["e2e-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_s390x_build
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.1"
+          npm_deps_mode: cli_build
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-s390x
+      - func: run_e2e_tests
+        vars:
+          node_js_version: "16.20.1"
+          mongosh_server_test_version: "7.0.0-rc10-enterprise"
+          mongosh_test_e2e_force_fips: "1"
+  - name: e2e_tests_linux_s390x_700rc10
+    tags: ["e2e-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_s390x_build
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.1"
+          npm_deps_mode: cli_build
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-s390x
+      - func: run_e2e_tests
+        vars:
+          node_js_version: "16.20.1"
+          mongosh_server_test_version: "7.0.0-rc10-enterprise"
+          mongosh_test_e2e_force_fips: ""
   - name: e2e_tests_win32_fips
     tags: ["e2e-test"]
     depends_on:
@@ -9905,6 +10247,44 @@ tasks:
         vars:
           node_js_version: "16.20.1"
           mongosh_server_test_version: "5.0.x-enterprise"
+          mongosh_test_e2e_force_fips: ""
+  - name: e2e_tests_win32_700rc10_fips
+    tags: ["e2e-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: win32_build
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.1"
+          npm_deps_mode: cli_build
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: win32
+      - func: run_e2e_tests
+        vars:
+          node_js_version: "16.20.1"
+          mongosh_server_test_version: "7.0.0-rc10-enterprise"
+          mongosh_test_e2e_force_fips: "1"
+  - name: e2e_tests_win32_700rc10
+    tags: ["e2e-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: win32_build
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.1"
+          npm_deps_mode: cli_build
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: win32
+      - func: run_e2e_tests
+        vars:
+          node_js_version: "16.20.1"
+          mongosh_server_test_version: "7.0.0-rc10-enterprise"
           mongosh_test_e2e_force_fips: ""
 
   ###
@@ -11860,7 +12240,7 @@ buildvariants:
     display_name: "Amazon Linux 2023 x64 (E2E Tests)"
     run_on: amazon2023.0-small
     tasks:
-      - name: e2e_tests_linux_x64
+      - name: e2e_tests_linux_x64_700rc10
   - name: e2e_suse12_x64
     display_name: "SLES 12 x64 (E2E Tests)"
     run_on: suse12-sp5-small
@@ -11896,7 +12276,7 @@ buildvariants:
     display_name: "Amazon Linux 2023 arm64 (E2E Tests)"
     run_on: amazon2023.0-arm64-small
     tasks:
-      - name: e2e_tests_linux_arm64
+      - name: e2e_tests_linux_arm64_700rc10
   - name: e2e_rhel82_arm64
     display_name: "RHEL 8.2 arm64 (E2E Tests)"
     run_on: rhel82-arm64-small

--- a/.evergreen/evergreen.yml.in
+++ b/.evergreen/evergreen.yml.in
@@ -844,10 +844,11 @@ tasks:
   # E2E TESTS
   ###
   <% for (const { executableOsId, compileBuildVariant } of RELEASE_PACKAGE_MATRIX) {
-    for (const mVersion of ['stable', '5.0.x']) {
+    // TODO(MONGOSH-1548): Account for 7.0.0 GA release when it happens
+    for (const mVersion of ['stable', '5.0.x', '7.0.0-rc10']) {
       for (const fipsVariant of ['fips', 'nofips']) {
     %>
-  - name: e2e_tests_<% out(executableOsId.replace(/-/g, '_')) %><% out(mVersion === 'stable' ? '' : '_50x') %><% out(fipsVariant === 'fips' ? '_fips' : '') %>
+  - name: e2e_tests_<% out(executableOsId.replace(/-/g, '_')) %><% out(mVersion === 'stable' ? '' : '_' + mVersion.replace(/[^a-zA-Z0-9]/g, '')) %><% out(fipsVariant === 'fips' ? '_fips' : '') %>
     tags: ["e2e-test"]
     depends_on:
       - name: compile_artifact
@@ -1194,7 +1195,7 @@ buildvariants:
     display_name: "Amazon Linux 2023 x64 (E2E Tests)"
     run_on: amazon2023.0-small
     tasks:
-      - name: e2e_tests_linux_x64
+      - name: e2e_tests_linux_x64_700rc10
   - name: e2e_suse12_x64
     display_name: "SLES 12 x64 (E2E Tests)"
     run_on: suse12-sp5-small
@@ -1230,7 +1231,7 @@ buildvariants:
     display_name: "Amazon Linux 2023 arm64 (E2E Tests)"
     run_on: amazon2023.0-arm64-small
     tasks:
-      - name: e2e_tests_linux_arm64
+      - name: e2e_tests_linux_arm64_700rc10
   - name: e2e_rhel82_arm64
     display_name: "RHEL 8.2 arm64 (E2E Tests)"
     run_on: rhel82-arm64-small

--- a/.evergreen/evergreen.yml.in
+++ b/.evergreen/evergreen.yml.in
@@ -1127,6 +1127,11 @@ buildvariants:
     run_on: rhel80-small
     tasks:
       - name: e2e_tests_linux_x64
+  - name: e2e_rhel90_x64
+    display_name: "RHEL 9.0 x64 (E2E Tests)"
+    run_on: rhel90-small
+    tasks:
+      - name: e2e_tests_linux_x64
   - name: e2e_rhel83_x64
     display_name: "RHEL 8.3 x64 (E2E Tests, FIPS-available OS)"
     run_on: rhel83-fips
@@ -1134,6 +1139,13 @@ buildvariants:
       - name: e2e_tests_linux_x64
       - name: e2e_tests_linux_x64_openssl11
       - name: e2e_tests_linux_x64_openssl11_fips
+  - name: e2e_rhel92_x64
+    display_name: "RHEL 9.2 x64 (E2E Tests, FIPS-available OS)"
+    run_on: rhel92-fips
+    tasks:
+      - name: e2e_tests_linux_x64
+      - name: e2e_tests_linux_x64_openssl3
+      - name: e2e_tests_linux_x64_openssl3_fips
   - name: e2e_ubuntu1804_x64
     display_name: "Ubuntu 18.04 x64 (E2E Tests)"
     run_on: ubuntu1804-small
@@ -1145,6 +1157,12 @@ buildvariants:
     tasks:
       - name: e2e_tests_linux_x64
       - name: e2e_tests_linux_x64_openssl11
+  - name: e2e_ubuntu2204_x64
+    display_name: "Ubuntu 22.04 x64 (E2E Tests)"
+    run_on: ubuntu2204-small
+    tasks:
+      - name: e2e_tests_linux_x64
+      - name: e2e_tests_linux_x64_openssl3
   - name: e2e_debian9_x64
     display_name: "Debian 9 x64 (E2E Tests)"
     run_on: debian92-small
@@ -1172,6 +1190,11 @@ buildvariants:
     run_on: amazon2-small
     tasks:
       - name: e2e_tests_linux_x64
+  - name: e2e_amazon2023_x64
+    display_name: "Amazon Linux 2023 x64 (E2E Tests)"
+    run_on: amazon2023.0-small
+    tasks:
+      - name: e2e_tests_linux_x64
   - name: e2e_suse12_x64
     display_name: "SLES 12 x64 (E2E Tests)"
     run_on: suse12-sp5-small
@@ -1193,14 +1216,29 @@ buildvariants:
     tasks:
       - name: e2e_tests_linux_arm64
       - name: e2e_tests_linux_arm64_openssl11
+  - name: e2e_ubuntu2204_arm64
+    display_name: "Ubuntu 22.04 arm64 (E2E Tests)"
+    run_on: ubuntu2204-arm64-small
+    tasks:
+      - name: e2e_tests_linux_arm64
   - name: e2e_amazon2_arm64
     display_name: "Amazon Linux 2 arm64 (E2E Tests)"
     run_on: amazon2-arm64-small
     tasks:
       - name: e2e_tests_linux_arm64
+  - name: e2e_amazon2023_arm64
+    display_name: "Amazon Linux 2023 arm64 (E2E Tests)"
+    run_on: amazon2023.0-arm64-small
+    tasks:
+      - name: e2e_tests_linux_arm64
   - name: e2e_rhel82_arm64
     display_name: "RHEL 8.2 arm64 (E2E Tests)"
     run_on: rhel82-arm64-small
+    tasks:
+      - name: e2e_tests_linux_arm64
+  - name: e2e_rhel90_arm64
+    display_name: "RHEL 9.0 arm64 (E2E Tests)"
+    run_on: rhel90-arm64-small
     tasks:
       - name: e2e_tests_linux_arm64
   - name: e2e_rhel81_ppc64le

--- a/config/release-package-matrix.js
+++ b/config/release-package-matrix.js
@@ -20,7 +20,7 @@ exports.RELEASE_PACKAGE_MATRIX = [
     compileBuildVariant: 'linux_x64_build',
     packages: [
       { name: 'linux-x64', description: 'Linux Tarball 64-bit', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['ubuntu20.04-tgz'] },
-      { name: 'deb-x64', description: 'Debian / Ubuntu 64-bit', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['ubuntu18.04-deb', 'ubuntu20.04-deb', 'ubuntu22.04-deb', 'ubuntu22.04-nohome-deb', 'debian9-deb', 'debian10-deb', 'debian11-deb'] },
+      { name: 'deb-x64', description: 'Debian / Ubuntu 64-bit', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['ubuntu18.04-deb', 'ubuntu20.04-deb', 'ubuntu22.04-deb', 'ubuntu22.04-nohome-deb', 'debian9-deb', 'debian10-deb', 'debian11-deb', 'debian12-deb'] },
       { name: 'rpm-x64', description: 'RHEL / CentOS / Fedora / Suse 64-bit', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['centos7-rpm', 'amazonlinux2-rpm', 'amazonlinux2023-rpm', 'rocky8-rpm', 'rocky9-rpm', 'fedora34-rpm', 'suse12-rpm', 'suse15-rpm', 'amazonlinux1-rpm'] }
     ]
   },
@@ -38,7 +38,7 @@ exports.RELEASE_PACKAGE_MATRIX = [
     compileBuildVariant: 'linux_x64_build_openssl3',
     packages: [
       { name: 'linux-x64-openssl3', description: 'Linux Tarball 64-bit (shared OpenSSL 3)', packageOn: 'linux_package', smokeTestKind: 'none' },
-      { name: 'deb-x64-openssl3', description: 'Debian / Ubuntu 64-bit (shared OpenSSL 3)', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['ubuntu22.04-deb', 'ubuntu22.04-fips-deb'] },
+      { name: 'deb-x64-openssl3', description: 'Debian / Ubuntu 64-bit (shared OpenSSL 3)', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['ubuntu22.04-deb', 'ubuntu22.04-fips-deb', 'debian12-deb'] },
       { name: 'rpm-x64-openssl3', description: 'RHEL / CentOS 64-bit (shared OpenSSL 3)', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['rocky8-epel-rpm', 'rocky9-rpm', 'rocky9-fips-rpm', 'amazonlinux2023-rpm'] }
     ]
   },
@@ -47,7 +47,7 @@ exports.RELEASE_PACKAGE_MATRIX = [
     compileBuildVariant: 'linux_arm64_build',
     packages: [
       { name: 'linux-arm64', description: 'Linux Tarball arm64', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['ubuntu20.04-tgz'] },
-      { name: 'deb-arm64', description: 'Debian / Ubuntu arm64', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['ubuntu18.04-deb', 'ubuntu20.04-deb', 'ubuntu22.04-deb', 'debian10-deb', 'debian11-deb'] },
+      { name: 'deb-arm64', description: 'Debian / Ubuntu arm64', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['ubuntu18.04-deb', 'ubuntu20.04-deb', 'ubuntu22.04-deb', 'debian10-deb', 'debian11-deb', 'debian12-deb'] },
       { name: 'rpm-arm64', description: 'RHEL / CentOS arm64', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['rocky8-rpm', 'rocky9-rpm', 'fedora34-rpm', 'amazonlinux2-rpm', 'amazonlinux2023-rpm'] }
     ]
   },

--- a/package-lock.json
+++ b/package-lock.json
@@ -22143,9 +22143,9 @@
       }
     },
     "node_modules/mongodb-download-url": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/mongodb-download-url/-/mongodb-download-url-1.3.0.tgz",
-      "integrity": "sha512-N7mRi3/LIAHCeTa+JtJVrVno4BNHVYF+6/WUamVFsbvCxtljDmQA1n9FSQxV4dfdiknR9zaoFcXAmd1gtg3Elg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/mongodb-download-url/-/mongodb-download-url-1.4.0.tgz",
+      "integrity": "sha512-1ukzOgMINkU4pLOYNAM+khuX6qezzgIKF7Eog3gk5hT4fcskFExjswgbebLWqVW7sIQwMsSa/gq/yTMN78lu/g==",
       "dependencies": {
         "debug": "^4.1.1",
         "minimist": "^1.2.3",
@@ -49321,9 +49321,9 @@
       }
     },
     "mongodb-download-url": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/mongodb-download-url/-/mongodb-download-url-1.3.0.tgz",
-      "integrity": "sha512-N7mRi3/LIAHCeTa+JtJVrVno4BNHVYF+6/WUamVFsbvCxtljDmQA1n9FSQxV4dfdiknR9zaoFcXAmd1gtg3Elg==",
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/mongodb-download-url/-/mongodb-download-url-1.4.0.tgz",
+      "integrity": "sha512-1ukzOgMINkU4pLOYNAM+khuX6qezzgIKF7Eog3gk5hT4fcskFExjswgbebLWqVW7sIQwMsSa/gq/yTMN78lu/g==",
       "requires": {
         "debug": "^4.1.1",
         "minimist": "^1.2.3",

--- a/packages/cli-repl/test/e2e-oidc.spec.ts
+++ b/packages/cli-repl/test/e2e-oidc.spec.ts
@@ -235,9 +235,10 @@ describe('OIDC auth e2e', function () {
     await verifyUser(shell, 'testuser', 'testServer-group');
     await shell.executeLine('db.getMongo().setReadPref("primaryPreferred");');
     await verifyUser(shell, 'testuser', 'testServer-group');
-    await shell.executeLine(
-      `db = connect(${JSON.stringify(cs + '/?authMechanism=MONGODB-OIDC')})`
-    );
+    const cs2 = await testServer.connectionString({
+      authMechanism: 'MONGODB-OIDC',
+    });
+    await shell.executeLine(`db = connect(${JSON.stringify(cs2)})`);
     await verifyUser(shell, 'testuser', 'testServer-group');
     shell.assertNoErrors();
     expect(tokenFetches).to.equal(1);
@@ -255,8 +256,9 @@ describe('OIDC auth e2e', function () {
     await shell.waitForPrompt();
 
     await verifyUser(shell, 'testuser', 'testServer-group');
-    const cs2 =
-      (await testServer2.connectionString()) + '/?authMechanism=MONGODB-OIDC';
+    const cs2 = await testServer2.connectionString({
+      authMechanism: 'MONGODB-OIDC',
+    });
     await shell.executeLine(`db = connect(${JSON.stringify(cs2)})`);
     await verifyUser(shell, 'testuser', 'testServer2-group');
     shell.assertNoErrors();

--- a/packages/cli-repl/test/e2e-snippet.spec.ts
+++ b/packages/cli-repl/test/e2e-snippet.spec.ts
@@ -12,6 +12,12 @@ describe('snippet integration tests', function () {
   let shell: TestShell;
   let makeTestShell: () => TestShell;
   beforeEach(async function () {
+    if (process.env.DISTRO_ID === 'rhel92-fips') {
+      // TODO: The HTTPS requests we are making for snippet support do not work
+      // with the FIPS configuration on the RHEL 9.2 FIPS-enabled machines.
+      return this.skip();
+    }
+
     makeTestShell = () =>
       TestShell.start({
         args: ['--nodb'],

--- a/scripts/docker/debian12-deb.Dockerfile
+++ b/scripts/docker/debian12-deb.Dockerfile
@@ -1,0 +1,12 @@
+FROM debian:12
+
+ARG artifact_url=""
+ADD ${artifact_url} /tmp
+ADD node_modules /usr/share/mongodb-crypt-library-version/node_modules
+RUN apt-get update
+RUN apt-get install -y man-db
+RUN apt-get install -y /tmp/*mongosh*.deb
+RUN /usr/bin/mongosh --build-info
+RUN env MONGOSH_RUN_NODE_SCRIPT=1 mongosh /usr/share/mongodb-crypt-library-version/node_modules/.bin/mongodb-crypt-library-version /usr/lib/mongosh_crypt_v1.so | grep -Eq '^mongo_(crypt|csfle)_v1-'
+RUN man mongosh | grep -q tlsAllowInvalidCertificates
+ENTRYPOINT [ "mongosh" ]


### PR DESCRIPTION
Add docker-based smoke tests for Debian 12 and e2e tests for RHEL9 and Ubuntu 22.04.