### PR TITLE
chore(shell-api): check StaleConfig error codeName in addition to code number

### DIFF
--- a/packages/shell-api/src/collection.ts
+++ b/packages/shell-api/src/collection.ts
@@ -1853,7 +1853,7 @@ export default class Collection extends ShellApiWithMongoClass {
 
       return await this._aggregateAndScaleCollStats(collStats, scale);
     } catch (e: any) {
-      if (e?.code === 13388) {
+      if (e?.codeName === 'StaleConfig' || e?.code === 13388) {
         // Fallback to the deprecated way of fetching that folks can still
         // fetch the stats of sharded timeseries collections. SERVER-72686
         try {


### PR DESCRIPTION
The server team has confirmed that they prefer for downstream teams to check error codeName values rather than (only) code numbers, as the latter may go away when code is being refactored.

(Opened COMPASS-7082 and MONGOSH-1554 to track the other instances of this.)