### PR TITLE
fix: install nvm in task local directory instead of home

### DIFF
--- a/.evergreen/install-node.sh
+++ b/.evergreen/install-node.sh
@@ -23,7 +23,8 @@ else
       sed -i "$HOME/.npmrc" -e 's/^prefix=.*$//'
     fi
   fi
-  export NVM_DIR="$HOME/.nvm"
+  export NVM_DIR="$BASEDIR/.nvm"
+  mkdir -p "${NVM_DIR}"
 
   curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.38.0/install.sh | bash
 

--- a/.evergreen/setup-env.sh
+++ b/.evergreen/setup-env.sh
@@ -9,7 +9,7 @@ if [ "$OS" != "Windows_NT" ]; then
   if which realpath; then # No realpath on macOS, but also not needed there
     export HOME="$(realpath "$HOME")" # Needed to de-confuse nvm when /home is a symlink
   fi
-  export NVM_DIR="$HOME/.nvm"
+  export NVM_DIR="$BASEDIR/.nvm"
   echo "Setting NVM environment home: $NVM_DIR"
   [ -s "$NVM_DIR/nvm.sh" ] && \. "$NVM_DIR/nvm.sh"
   set +x # nvm is very verbose


### PR DESCRIPTION
A few runners are reporting nvm already installed in HOME directory and that is breaking our installation scripts. This PR will change the install location to project directory.