### PR TITLE
fix: adopt dns result order changes VSCODE-458

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9485,25 +9485,6 @@
         "react": "^17.0.2"
       }
     },
-    "node_modules/@mongodb-js/devtools-connect": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-connect/-/devtools-connect-2.2.1.tgz",
-      "integrity": "sha512-u/gFNrPAvikNJg43K6YUgldVhngW/oK+aqmzXOkyi3Y6rsH8tDBcISWUtv626ajczAFXB2hebQtAVNdrbZpVpA==",
-      "dependencies": {
-        "lodash.merge": "^4.6.2",
-        "mongodb-connection-string-url": "^2.6.0",
-        "system-ca": "^1.0.2"
-      },
-      "optionalDependencies": {
-        "os-dns-native": "^1.2.0",
-        "resolve-mongodb-srv": "^1.1.1"
-      },
-      "peerDependencies": {
-        "@mongodb-js/oidc-plugin": "^0.2.4",
-        "mongodb": "^5.4.0",
-        "mongodb-log-writer": "^1.2.0"
-      }
-    },
     "node_modules/@mongodb-js/devtools-github-repo": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-github-repo/-/devtools-github-repo-1.2.0.tgz",
@@ -9769,51 +9750,6 @@
       "resolved": "https://registry.npmjs.org/@mongodb-js/oidc-mock-provider/-/oidc-mock-provider-0.3.0.tgz",
       "integrity": "sha512-tW5JSMzJkx0qmzkrXaKOXF62RnsWLj4kozYtGeC7W29aNdMeaAdhA28KPHH3gfN95qdFqQ04pb4NE8uqa62+rQ==",
       "dev": true
-    },
-    "node_modules/@mongodb-js/oidc-plugin": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/oidc-plugin/-/oidc-plugin-0.2.4.tgz",
-      "integrity": "sha512-rh9zed1EOy1hbB7U+C/Jt74jtGJLa9wohX+xChKzbAtHRyIR7zj1jLWV9J/l2IuhBSPvnTw/T8ta9clbNT0JTg==",
-      "peer": true,
-      "dependencies": {
-        "abort-controller": "^3.0.0",
-        "express": "^4.18.2",
-        "open": "^9.1.0",
-        "openid-client": "^5.4.0"
-      },
-      "engines": {
-        "node": ">= 14.18.0"
-      }
-    },
-    "node_modules/@mongodb-js/oidc-plugin/node_modules/define-lazy-prop": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
-      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
-      "peer": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@mongodb-js/oidc-plugin/node_modules/open": {
-      "version": "9.1.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-9.1.0.tgz",
-      "integrity": "sha512-OS+QTnw1/4vrf+9hh1jc1jnYjzSG4ttTBB8UxOwAnInG3Uo4ssetzC1ihqaIHjLJnA5GGlRl6QlZXOTQhRBUvg==",
-      "peer": true,
-      "dependencies": {
-        "default-browser": "^4.0.0",
-        "define-lazy-prop": "^3.0.0",
-        "is-inside-container": "^1.0.0",
-        "is-wsl": "^2.2.0"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
     },
     "node_modules/@mongodb-js/prettier-config-devtools": {
       "version": "1.0.1",
@@ -29948,7 +29884,7 @@
         "mongodb-connection-string-url": "^2.6.0"
       },
       "devDependencies": {
-        "@mongodb-js/devtools-connect": "^2.2.1",
+        "@mongodb-js/devtools-connect": "^2.3.1",
         "@mongodb-js/eslint-config-mongosh": "^1.0.0",
         "@mongodb-js/prettier-config-devtools": "^1.0.1",
         "@mongodb-js/tsconfig-mongosh": "^1.0.0",
@@ -29959,6 +29895,74 @@
       },
       "engines": {
         "node": ">=14.15.1"
+      }
+    },
+    "packages/arg-parser/node_modules/@mongodb-js/devtools-connect": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-connect/-/devtools-connect-2.3.1.tgz",
+      "integrity": "sha512-kdcJj6ao5jCeVbnndDJQIMD0HWBEhU7JB7Vcz7atnmJKA9cRgpSptvkAwfCAXXAYp4a+T2XcyP6BD6msM2jTJg==",
+      "dev": true,
+      "dependencies": {
+        "lodash.merge": "^4.6.2",
+        "mongodb-connection-string-url": "^2.6.0",
+        "system-ca": "^1.0.2"
+      },
+      "optionalDependencies": {
+        "os-dns-native": "^1.2.0",
+        "resolve-mongodb-srv": "^1.1.1"
+      },
+      "peerDependencies": {
+        "@mongodb-js/oidc-plugin": "^0.3.0",
+        "mongodb": "^5.4.0",
+        "mongodb-log-writer": "^1.2.0"
+      }
+    },
+    "packages/arg-parser/node_modules/@mongodb-js/oidc-plugin": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/oidc-plugin/-/oidc-plugin-0.3.0.tgz",
+      "integrity": "sha512-XIriu5WYwBJWiHFpIpiXz7FkeA0+jUyGB4KBs6v0U8JGlkkoAJY9lWuzBt0surjcl/dBWvpsZYun6492fMb2kw==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "express": "^4.18.2",
+        "open": "^9.1.0",
+        "openid-client": "^5.4.0"
+      },
+      "engines": {
+        "node": ">= 14.18.0"
+      }
+    },
+    "packages/arg-parser/node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "dev": true,
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/arg-parser/node_modules/open": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-9.1.0.tgz",
+      "integrity": "sha512-OS+QTnw1/4vrf+9hh1jc1jnYjzSG4ttTBB8UxOwAnInG3Uo4ssetzC1ihqaIHjLJnA5GGlRl6QlZXOTQhRBUvg==",
+      "dev": true,
+      "peer": true,
+      "dependencies": {
+        "default-browser": "^4.0.0",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "packages/async-rewriter2": {
@@ -30581,7 +30585,7 @@
       "version": "0.0.0-dev.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@mongodb-js/devtools-connect": "^2.2.1",
+        "@mongodb-js/devtools-connect": "^2.3.1",
         "@mongosh/errors": "0.0.0-dev.0",
         "@mongosh/history": "0.0.0-dev.0",
         "@mongosh/types": "0.0.0-dev.0",
@@ -30598,6 +30602,70 @@
       },
       "engines": {
         "node": ">=14.15.1"
+      }
+    },
+    "packages/logging/node_modules/@mongodb-js/devtools-connect": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-connect/-/devtools-connect-2.3.1.tgz",
+      "integrity": "sha512-kdcJj6ao5jCeVbnndDJQIMD0HWBEhU7JB7Vcz7atnmJKA9cRgpSptvkAwfCAXXAYp4a+T2XcyP6BD6msM2jTJg==",
+      "dependencies": {
+        "lodash.merge": "^4.6.2",
+        "mongodb-connection-string-url": "^2.6.0",
+        "system-ca": "^1.0.2"
+      },
+      "optionalDependencies": {
+        "os-dns-native": "^1.2.0",
+        "resolve-mongodb-srv": "^1.1.1"
+      },
+      "peerDependencies": {
+        "@mongodb-js/oidc-plugin": "^0.3.0",
+        "mongodb": "^5.4.0",
+        "mongodb-log-writer": "^1.2.0"
+      }
+    },
+    "packages/logging/node_modules/@mongodb-js/oidc-plugin": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/oidc-plugin/-/oidc-plugin-0.3.0.tgz",
+      "integrity": "sha512-XIriu5WYwBJWiHFpIpiXz7FkeA0+jUyGB4KBs6v0U8JGlkkoAJY9lWuzBt0surjcl/dBWvpsZYun6492fMb2kw==",
+      "peer": true,
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "express": "^4.18.2",
+        "open": "^9.1.0",
+        "openid-client": "^5.4.0"
+      },
+      "engines": {
+        "node": ">= 14.18.0"
+      }
+    },
+    "packages/logging/node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/logging/node_modules/open": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-9.1.0.tgz",
+      "integrity": "sha512-OS+QTnw1/4vrf+9hh1jc1jnYjzSG4ttTBB8UxOwAnInG3Uo4ssetzC1ihqaIHjLJnA5GGlRl6QlZXOTQhRBUvg==",
+      "peer": true,
+      "dependencies": {
+        "default-browser": "^4.0.0",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "packages/mongosh": {
@@ -30673,7 +30741,7 @@
       "version": "0.0.0-dev.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@mongodb-js/devtools-connect": "^2.2.1",
+        "@mongodb-js/devtools-connect": "^2.3.1",
         "@mongosh/errors": "0.0.0-dev.0",
         "@mongosh/service-provider-core": "0.0.0-dev.0",
         "@mongosh/types": "0.0.0-dev.0",
@@ -30697,6 +30765,70 @@
       "optionalDependencies": {
         "kerberos": "^2.0.0",
         "mongodb-client-encryption": "^2.8.0"
+      }
+    },
+    "packages/service-provider-server/node_modules/@mongodb-js/devtools-connect": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-connect/-/devtools-connect-2.3.1.tgz",
+      "integrity": "sha512-kdcJj6ao5jCeVbnndDJQIMD0HWBEhU7JB7Vcz7atnmJKA9cRgpSptvkAwfCAXXAYp4a+T2XcyP6BD6msM2jTJg==",
+      "dependencies": {
+        "lodash.merge": "^4.6.2",
+        "mongodb-connection-string-url": "^2.6.0",
+        "system-ca": "^1.0.2"
+      },
+      "optionalDependencies": {
+        "os-dns-native": "^1.2.0",
+        "resolve-mongodb-srv": "^1.1.1"
+      },
+      "peerDependencies": {
+        "@mongodb-js/oidc-plugin": "^0.3.0",
+        "mongodb": "^5.4.0",
+        "mongodb-log-writer": "^1.2.0"
+      }
+    },
+    "packages/service-provider-server/node_modules/@mongodb-js/oidc-plugin": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/oidc-plugin/-/oidc-plugin-0.3.0.tgz",
+      "integrity": "sha512-XIriu5WYwBJWiHFpIpiXz7FkeA0+jUyGB4KBs6v0U8JGlkkoAJY9lWuzBt0surjcl/dBWvpsZYun6492fMb2kw==",
+      "peer": true,
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "express": "^4.18.2",
+        "open": "^9.1.0",
+        "openid-client": "^5.4.0"
+      },
+      "engines": {
+        "node": ">= 14.18.0"
+      }
+    },
+    "packages/service-provider-server/node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/service-provider-server/node_modules/open": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-9.1.0.tgz",
+      "integrity": "sha512-OS+QTnw1/4vrf+9hh1jc1jnYjzSG4ttTBB8UxOwAnInG3Uo4ssetzC1ihqaIHjLJnA5GGlRl6QlZXOTQhRBUvg==",
+      "peer": true,
+      "dependencies": {
+        "default-browser": "^4.0.0",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "packages/shell-api": {
@@ -30785,7 +30917,7 @@
       "version": "0.0.0-dev.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@mongodb-js/devtools-connect": "^2.2.1"
+        "@mongodb-js/devtools-connect": "^2.3.1"
       },
       "devDependencies": {
         "@mongodb-js/eslint-config-mongosh": "^1.0.0",
@@ -30798,6 +30930,70 @@
       },
       "engines": {
         "node": ">=14.15.1"
+      }
+    },
+    "packages/types/node_modules/@mongodb-js/devtools-connect": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-connect/-/devtools-connect-2.3.1.tgz",
+      "integrity": "sha512-kdcJj6ao5jCeVbnndDJQIMD0HWBEhU7JB7Vcz7atnmJKA9cRgpSptvkAwfCAXXAYp4a+T2XcyP6BD6msM2jTJg==",
+      "dependencies": {
+        "lodash.merge": "^4.6.2",
+        "mongodb-connection-string-url": "^2.6.0",
+        "system-ca": "^1.0.2"
+      },
+      "optionalDependencies": {
+        "os-dns-native": "^1.2.0",
+        "resolve-mongodb-srv": "^1.1.1"
+      },
+      "peerDependencies": {
+        "@mongodb-js/oidc-plugin": "^0.3.0",
+        "mongodb": "^5.4.0",
+        "mongodb-log-writer": "^1.2.0"
+      }
+    },
+    "packages/types/node_modules/@mongodb-js/oidc-plugin": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/oidc-plugin/-/oidc-plugin-0.3.0.tgz",
+      "integrity": "sha512-XIriu5WYwBJWiHFpIpiXz7FkeA0+jUyGB4KBs6v0U8JGlkkoAJY9lWuzBt0surjcl/dBWvpsZYun6492fMb2kw==",
+      "peer": true,
+      "dependencies": {
+        "abort-controller": "^3.0.0",
+        "express": "^4.18.2",
+        "open": "^9.1.0",
+        "openid-client": "^5.4.0"
+      },
+      "engines": {
+        "node": ">= 14.18.0"
+      }
+    },
+    "packages/types/node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "peer": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/types/node_modules/open": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-9.1.0.tgz",
+      "integrity": "sha512-OS+QTnw1/4vrf+9hh1jc1jnYjzSG4ttTBB8UxOwAnInG3Uo4ssetzC1ihqaIHjLJnA5GGlRl6QlZXOTQhRBUvg==",
+      "peer": true,
+      "dependencies": {
+        "default-browser": "^4.0.0",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "scripts/docker": {
@@ -38763,18 +38959,6 @@
         "semver": "^7.3.8"
       }
     },
-    "@mongodb-js/devtools-connect": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-connect/-/devtools-connect-2.2.1.tgz",
-      "integrity": "sha512-u/gFNrPAvikNJg43K6YUgldVhngW/oK+aqmzXOkyi3Y6rsH8tDBcISWUtv626ajczAFXB2hebQtAVNdrbZpVpA==",
-      "requires": {
-        "lodash.merge": "^4.6.2",
-        "mongodb-connection-string-url": "^2.6.0",
-        "os-dns-native": "^1.2.0",
-        "resolve-mongodb-srv": "^1.1.1",
-        "system-ca": "^1.0.2"
-      }
-    },
     "@mongodb-js/devtools-github-repo": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-github-repo/-/devtools-github-repo-1.2.0.tgz",
@@ -38983,38 +39167,6 @@
       "integrity": "sha512-tW5JSMzJkx0qmzkrXaKOXF62RnsWLj4kozYtGeC7W29aNdMeaAdhA28KPHH3gfN95qdFqQ04pb4NE8uqa62+rQ==",
       "dev": true
     },
-    "@mongodb-js/oidc-plugin": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/oidc-plugin/-/oidc-plugin-0.2.4.tgz",
-      "integrity": "sha512-rh9zed1EOy1hbB7U+C/Jt74jtGJLa9wohX+xChKzbAtHRyIR7zj1jLWV9J/l2IuhBSPvnTw/T8ta9clbNT0JTg==",
-      "peer": true,
-      "requires": {
-        "abort-controller": "^3.0.0",
-        "express": "^4.18.2",
-        "open": "^9.1.0",
-        "openid-client": "^5.4.0"
-      },
-      "dependencies": {
-        "define-lazy-prop": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
-          "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
-          "peer": true
-        },
-        "open": {
-          "version": "9.1.0",
-          "resolved": "https://registry.npmjs.org/open/-/open-9.1.0.tgz",
-          "integrity": "sha512-OS+QTnw1/4vrf+9hh1jc1jnYjzSG4ttTBB8UxOwAnInG3Uo4ssetzC1ihqaIHjLJnA5GGlRl6QlZXOTQhRBUvg==",
-          "peer": true,
-          "requires": {
-            "default-browser": "^4.0.0",
-            "define-lazy-prop": "^3.0.0",
-            "is-inside-container": "^1.0.0",
-            "is-wsl": "^2.2.0"
-          }
-        }
-      }
-    },
     "@mongodb-js/prettier-config-devtools": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/@mongodb-js/prettier-config-devtools/-/prettier-config-devtools-1.0.1.tgz",
@@ -39094,7 +39246,7 @@
     "@mongosh/arg-parser": {
       "version": "file:packages/arg-parser",
       "requires": {
-        "@mongodb-js/devtools-connect": "^2.2.1",
+        "@mongodb-js/devtools-connect": "^2.3.1",
         "@mongodb-js/eslint-config-mongosh": "^1.0.0",
         "@mongodb-js/prettier-config-devtools": "^1.0.1",
         "@mongodb-js/tsconfig-mongosh": "^1.0.0",
@@ -39105,6 +39257,54 @@
         "mongodb": "^5.7.0",
         "mongodb-connection-string-url": "^2.6.0",
         "prettier": "^2.8.8"
+      },
+      "dependencies": {
+        "@mongodb-js/devtools-connect": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-connect/-/devtools-connect-2.3.1.tgz",
+          "integrity": "sha512-kdcJj6ao5jCeVbnndDJQIMD0HWBEhU7JB7Vcz7atnmJKA9cRgpSptvkAwfCAXXAYp4a+T2XcyP6BD6msM2jTJg==",
+          "dev": true,
+          "requires": {
+            "lodash.merge": "^4.6.2",
+            "mongodb-connection-string-url": "^2.6.0",
+            "os-dns-native": "^1.2.0",
+            "resolve-mongodb-srv": "^1.1.1",
+            "system-ca": "^1.0.2"
+          }
+        },
+        "@mongodb-js/oidc-plugin": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/@mongodb-js/oidc-plugin/-/oidc-plugin-0.3.0.tgz",
+          "integrity": "sha512-XIriu5WYwBJWiHFpIpiXz7FkeA0+jUyGB4KBs6v0U8JGlkkoAJY9lWuzBt0surjcl/dBWvpsZYun6492fMb2kw==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "express": "^4.18.2",
+            "open": "^9.1.0",
+            "openid-client": "^5.4.0"
+          }
+        },
+        "define-lazy-prop": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+          "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+          "dev": true,
+          "peer": true
+        },
+        "open": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/open/-/open-9.1.0.tgz",
+          "integrity": "sha512-OS+QTnw1/4vrf+9hh1jc1jnYjzSG4ttTBB8UxOwAnInG3Uo4ssetzC1ihqaIHjLJnA5GGlRl6QlZXOTQhRBUvg==",
+          "dev": true,
+          "peer": true,
+          "requires": {
+            "default-browser": "^4.0.0",
+            "define-lazy-prop": "^3.0.0",
+            "is-inside-container": "^1.0.0",
+            "is-wsl": "^2.2.0"
+          }
+        }
       }
     },
     "@mongosh/async-rewriter2": {
@@ -39560,7 +39760,7 @@
     "@mongosh/logging": {
       "version": "file:packages/logging",
       "requires": {
-        "@mongodb-js/devtools-connect": "^2.2.1",
+        "@mongodb-js/devtools-connect": "^2.3.1",
         "@mongodb-js/eslint-config-mongosh": "^1.0.0",
         "@mongodb-js/prettier-config-devtools": "^1.0.1",
         "@mongodb-js/tsconfig-mongosh": "^1.0.0",
@@ -39572,6 +39772,50 @@
         "mongodb-log-writer": "^1.3.0",
         "mongodb-redact": "^0.2.2",
         "prettier": "^2.8.8"
+      },
+      "dependencies": {
+        "@mongodb-js/devtools-connect": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-connect/-/devtools-connect-2.3.1.tgz",
+          "integrity": "sha512-kdcJj6ao5jCeVbnndDJQIMD0HWBEhU7JB7Vcz7atnmJKA9cRgpSptvkAwfCAXXAYp4a+T2XcyP6BD6msM2jTJg==",
+          "requires": {
+            "lodash.merge": "^4.6.2",
+            "mongodb-connection-string-url": "^2.6.0",
+            "os-dns-native": "^1.2.0",
+            "resolve-mongodb-srv": "^1.1.1",
+            "system-ca": "^1.0.2"
+          }
+        },
+        "@mongodb-js/oidc-plugin": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/@mongodb-js/oidc-plugin/-/oidc-plugin-0.3.0.tgz",
+          "integrity": "sha512-XIriu5WYwBJWiHFpIpiXz7FkeA0+jUyGB4KBs6v0U8JGlkkoAJY9lWuzBt0surjcl/dBWvpsZYun6492fMb2kw==",
+          "peer": true,
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "express": "^4.18.2",
+            "open": "^9.1.0",
+            "openid-client": "^5.4.0"
+          }
+        },
+        "define-lazy-prop": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+          "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+          "peer": true
+        },
+        "open": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/open/-/open-9.1.0.tgz",
+          "integrity": "sha512-OS+QTnw1/4vrf+9hh1jc1jnYjzSG4ttTBB8UxOwAnInG3Uo4ssetzC1ihqaIHjLJnA5GGlRl6QlZXOTQhRBUvg==",
+          "peer": true,
+          "requires": {
+            "default-browser": "^4.0.0",
+            "define-lazy-prop": "^3.0.0",
+            "is-inside-container": "^1.0.0",
+            "is-wsl": "^2.2.0"
+          }
+        }
       }
     },
     "@mongosh/node-runtime-worker-thread": {
@@ -39616,7 +39860,7 @@
     "@mongosh/service-provider-server": {
       "version": "file:packages/service-provider-server",
       "requires": {
-        "@mongodb-js/devtools-connect": "^2.2.1",
+        "@mongodb-js/devtools-connect": "^2.3.1",
         "@mongodb-js/eslint-config-mongosh": "^1.0.0",
         "@mongodb-js/prettier-config-devtools": "^1.0.1",
         "@mongodb-js/tsconfig-mongosh": "^1.0.0",
@@ -39633,6 +39877,50 @@
         "mongodb-connection-string-url": "^2.6.0",
         "prettier": "^2.8.8",
         "saslprep": "npm:@mongodb-js/saslprep@^1.1.0"
+      },
+      "dependencies": {
+        "@mongodb-js/devtools-connect": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-connect/-/devtools-connect-2.3.1.tgz",
+          "integrity": "sha512-kdcJj6ao5jCeVbnndDJQIMD0HWBEhU7JB7Vcz7atnmJKA9cRgpSptvkAwfCAXXAYp4a+T2XcyP6BD6msM2jTJg==",
+          "requires": {
+            "lodash.merge": "^4.6.2",
+            "mongodb-connection-string-url": "^2.6.0",
+            "os-dns-native": "^1.2.0",
+            "resolve-mongodb-srv": "^1.1.1",
+            "system-ca": "^1.0.2"
+          }
+        },
+        "@mongodb-js/oidc-plugin": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/@mongodb-js/oidc-plugin/-/oidc-plugin-0.3.0.tgz",
+          "integrity": "sha512-XIriu5WYwBJWiHFpIpiXz7FkeA0+jUyGB4KBs6v0U8JGlkkoAJY9lWuzBt0surjcl/dBWvpsZYun6492fMb2kw==",
+          "peer": true,
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "express": "^4.18.2",
+            "open": "^9.1.0",
+            "openid-client": "^5.4.0"
+          }
+        },
+        "define-lazy-prop": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+          "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+          "peer": true
+        },
+        "open": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/open/-/open-9.1.0.tgz",
+          "integrity": "sha512-OS+QTnw1/4vrf+9hh1jc1jnYjzSG4ttTBB8UxOwAnInG3Uo4ssetzC1ihqaIHjLJnA5GGlRl6QlZXOTQhRBUvg==",
+          "peer": true,
+          "requires": {
+            "default-browser": "^4.0.0",
+            "define-lazy-prop": "^3.0.0",
+            "is-inside-container": "^1.0.0",
+            "is-wsl": "^2.2.0"
+          }
+        }
       }
     },
     "@mongosh/shell-api": {
@@ -39698,7 +39986,7 @@
     "@mongosh/types": {
       "version": "file:packages/types",
       "requires": {
-        "@mongodb-js/devtools-connect": "^2.2.1",
+        "@mongodb-js/devtools-connect": "^2.3.1",
         "@mongodb-js/eslint-config-mongosh": "^1.0.0",
         "@mongodb-js/prettier-config-devtools": "^1.0.1",
         "@mongodb-js/tsconfig-mongosh": "^1.0.0",
@@ -39706,6 +39994,50 @@
         "eslint": "^7.25.0",
         "mongodb": "^5.7.0",
         "prettier": "^2.8.8"
+      },
+      "dependencies": {
+        "@mongodb-js/devtools-connect": {
+          "version": "2.3.1",
+          "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-connect/-/devtools-connect-2.3.1.tgz",
+          "integrity": "sha512-kdcJj6ao5jCeVbnndDJQIMD0HWBEhU7JB7Vcz7atnmJKA9cRgpSptvkAwfCAXXAYp4a+T2XcyP6BD6msM2jTJg==",
+          "requires": {
+            "lodash.merge": "^4.6.2",
+            "mongodb-connection-string-url": "^2.6.0",
+            "os-dns-native": "^1.2.0",
+            "resolve-mongodb-srv": "^1.1.1",
+            "system-ca": "^1.0.2"
+          }
+        },
+        "@mongodb-js/oidc-plugin": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/@mongodb-js/oidc-plugin/-/oidc-plugin-0.3.0.tgz",
+          "integrity": "sha512-XIriu5WYwBJWiHFpIpiXz7FkeA0+jUyGB4KBs6v0U8JGlkkoAJY9lWuzBt0surjcl/dBWvpsZYun6492fMb2kw==",
+          "peer": true,
+          "requires": {
+            "abort-controller": "^3.0.0",
+            "express": "^4.18.2",
+            "open": "^9.1.0",
+            "openid-client": "^5.4.0"
+          }
+        },
+        "define-lazy-prop": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+          "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+          "peer": true
+        },
+        "open": {
+          "version": "9.1.0",
+          "resolved": "https://registry.npmjs.org/open/-/open-9.1.0.tgz",
+          "integrity": "sha512-OS+QTnw1/4vrf+9hh1jc1jnYjzSG4ttTBB8UxOwAnInG3Uo4ssetzC1ihqaIHjLJnA5GGlRl6QlZXOTQhRBUvg==",
+          "peer": true,
+          "requires": {
+            "default-browser": "^4.0.0",
+            "define-lazy-prop": "^3.0.0",
+            "is-inside-container": "^1.0.0",
+            "is-wsl": "^2.2.0"
+          }
+        }
       }
     },
     "@nicolo-ribaudo/eslint-scope-5-internals": {

--- a/packages/arg-parser/package.json
+++ b/packages/arg-parser/package.json
@@ -38,7 +38,7 @@
     "mongodb-connection-string-url": "^2.6.0"
   },
   "devDependencies": {
-    "@mongodb-js/devtools-connect": "^2.2.1",
+    "@mongodb-js/devtools-connect": "^2.3.1",
     "@mongodb-js/eslint-config-mongosh": "^1.0.0",
     "@mongodb-js/prettier-config-devtools": "^1.0.1",
     "@mongodb-js/tsconfig-mongosh": "^1.0.0",

--- a/packages/logging/package.json
+++ b/packages/logging/package.json
@@ -17,7 +17,7 @@
     "node": ">=14.15.1"
   },
   "dependencies": {
-    "@mongodb-js/devtools-connect": "^2.2.1",
+    "@mongodb-js/devtools-connect": "^2.3.1",
     "@mongosh/errors": "0.0.0-dev.0",
     "@mongosh/history": "0.0.0-dev.0",
     "@mongosh/types": "0.0.0-dev.0",

--- a/packages/service-provider-server/package.json
+++ b/packages/service-provider-server/package.json
@@ -45,7 +45,7 @@
     }
   },
   "dependencies": {
-    "@mongodb-js/devtools-connect": "^2.2.1",
+    "@mongodb-js/devtools-connect": "^2.3.1",
     "@mongosh/errors": "0.0.0-dev.0",
     "@mongosh/service-provider-core": "0.0.0-dev.0",
     "@mongosh/types": "0.0.0-dev.0",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -36,7 +36,7 @@
     "unitTestsOnly": true
   },
   "dependencies": {
-    "@mongodb-js/devtools-connect": "^2.2.1"
+    "@mongodb-js/devtools-connect": "^2.3.1"
   },
   "devDependencies": {
     "@mongodb-js/eslint-config-mongosh": "^1.0.0",


### PR DESCRIPTION
Adopt DNS result order changes with Node v18 and VSCode 1.82.0-insider updates that affected the VSCode extension.