### PR TITLE
fix(build): more resilient S3 handling for JSON feed MONGOSH-1242

### DIFF
--- a/packages/build/src/index.ts
+++ b/packages/build/src/index.ts
@@ -10,6 +10,8 @@ import type { Config, PackageVariant } from './config';
 export { getArtifactUrl, downloadMongoDb };
 
 if (require.main === module) {
+  Error.stackTraceLimit = 200;
+
   (async () => {
     const command = process.argv[2];
     if (


### PR DESCRIPTION
Account for `NoSuchKey` errors being thrown when downloading files from AWS.

(See the failure from https://spruce.mongodb.com/task/mongosh_draft_publish_release_release_publish_dry_run__v1.10.5_draft.0_23_08_11_15_28_19/logs?execution=0 in the 1.10.5-draft.0 build)