### PR TITLE
fix(build): keep using 6.0.x RHEL7.2 crypt_shared library on s390x

### DIFF
--- a/packages/build/src/packaging/download-crypt-library.ts
+++ b/packages/build/src/packaging/download-crypt-library.ts
@@ -31,9 +31,13 @@ export async function downloadCryptLibrary(
   );
   // Download mongodb for latest server version, including rapid releases
   // (for the platforms that they exist for, i.e. for ppc64le/s390x only pick stable releases).
-  const versionSpec = /ppc64|s390x/.exec(opts.arch || process.arch)
-    ? 'stable'
-    : 'continuous';
+  let versionSpec = 'continuous';
+  if (/ppc64/.test(opts.arch || process.arch)) {
+    versionSpec = 'stable';
+  }
+  if (/s390x/.test(opts.arch || process.arch)) {
+    versionSpec = '6.0.x'; // The 7.x+ server releases don't have RHEL7-compatible crypt_shared libraries
+  }
   const libdir = await downloadMongoDb(cryptTmpTargetDir, versionSpec, opts);
   const cryptLibrary = path.join(
     libdir,


### PR DESCRIPTION
The server team just release 7.0.0, which does not provide a crypt_shared library for RHEL7 on s390x. To keep things as they are currently working, we continue to use the 6.0.x shared library instead. We may want to switch to the RHEL8 7.x-server library at some point in the future when there are new QE features that require an updated shared library.