### PR TITLE
chore: add .git-blame-ignore-revs file

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,4 @@
+# prettier adoption
+7e9ecd99d852e5e5f2a659c4a12b090c370b6a6c
+# eslintrc overhaul
+0f28698459e1c8216df769745170a3a46d3def62


### PR DESCRIPTION
This makes it easier to run `git blame` across the recent bulk source code changes for linting/prettifying.

Enable with:

```
git config blame.ignoreRevsFile .git-blame-ignore-revs
```

(The filename is convention, and e.g. also used by the MongoDB server source repository.)