### PR TITLE
fix(cli-repl): clear update notification cache when source URL changes

### DIFF
--- a/packages/cli-repl/src/update-notification-manager.spec.ts
+++ b/packages/cli-repl/src/update-notification-manager.spec.ts
@@ -45,7 +45,10 @@ describe('UpdateNotificationManager', function () {
     expect(await manager.getLatestVersionIfMoreRecent('')).to.equal(null);
     expect(reqHandler).to.have.been.calledOnce;
     const fileContents = JSON.parse(await fs.readFile(filename, 'utf-8'));
-    expect(Object.keys(fileContents)).to.deep.equal(['lastChecked']);
+    expect(Object.keys(fileContents)).to.deep.equal([
+      'updateURL',
+      'lastChecked',
+    ]);
     expect(fileContents.lastChecked).to.be.a('number');
   });
 
@@ -54,6 +57,13 @@ describe('UpdateNotificationManager', function () {
     await manager.fetchUpdateMetadata(httpServerUrl, filename);
     await manager.fetchUpdateMetadata(httpServerUrl, filename);
     expect(reqHandler).to.have.been.calledOnce;
+  });
+
+  it('does not re-use existing data if the updateURL value has changed', async function () {
+    const manager = new UpdateNotificationManager();
+    await manager.fetchUpdateMetadata(httpServerUrl, filename);
+    await manager.fetchUpdateMetadata(httpServerUrl + '/?foo=bar', filename);
+    expect(reqHandler).to.have.been.calledTwice;
   });
 
   it('caches 304 responses if the server supports ETag-based caching', async function () {

--- a/packages/cli-repl/src/update-notification-manager.ts
+++ b/packages/cli-repl/src/update-notification-manager.ts
@@ -6,6 +6,7 @@ interface MongoshUpdateLocalFileContents {
   lastChecked?: number;
   latestKnownMongoshVersion?: string;
   etag?: string;
+  updateURL?: string;
 }
 
 // Utility for fetching metadata about potentially available newer versions
@@ -64,6 +65,11 @@ export class UpdateNotificationManager {
         // ignore possibly corrupted file contents
       }
 
+      if (localFileContents?.updateURL !== updateURL) {
+        // Invalidate local cache if the source URL has changed.
+        localFileContents = undefined;
+      }
+
       if (localFileContents?.latestKnownMongoshVersion) {
         this.latestKnownMongoshVersion =
           localFileContents.latestKnownMongoshVersion;
@@ -109,6 +115,7 @@ export class UpdateNotificationManager {
       ?.sort(semver.rcompare)?.[0];
 
     localFileContents = {
+      updateURL,
       lastChecked: Date.now(),
       etag: response.headers.get('etag') ?? undefined,
       latestKnownMongoshVersion: this.latestKnownMongoshVersion,


### PR DESCRIPTION
This should remove flakiness from a recently introduced test and should also just generally be the right thing to do.