### PR TITLE
fix(shell-api): use public BulkWriteResult props MONGOSH-1507 COMPASS-7023

### DIFF
--- a/packages/shell-api/src/bulk.spec.ts
+++ b/packages/shell-api/src/bulk.spec.ts
@@ -1,5 +1,8 @@
 import { CommonErrors } from '@mongosh/errors';
-import type { ServiceProvider } from '@mongosh/service-provider-core';
+import type {
+  ServiceProvider,
+  BulkWriteResult as SPBulkWriteResult,
+} from '@mongosh/service-provider-core';
 import { bson } from '@mongosh/service-provider-core';
 import { fail } from 'assert';
 import chai, { expect } from 'chai';
@@ -82,14 +85,14 @@ describe('Bulk API', function () {
           let innerStub: StubbedInstance<any>;
           const bulkWriteResult = {
             ok: 1,
-            nInserted: 1,
+            insertedCount: 1,
             insertedIds: { 0: new bson.ObjectId() },
-            nMatched: 0,
-            nModified: 0,
-            nRemoved: 0,
-            nUpserted: 0,
-            upserted: [],
-          };
+            matchedCount: 0,
+            modifiedCount: 0,
+            deletedCount: 0,
+            upsertedCount: 0,
+            upsertedIds: { 0: new bson.ObjectId() },
+          } satisfies Partial<SPBulkWriteResult>;
           beforeEach(function () {
             bus = stubInterface<EventEmitter>();
             serviceProvider = stubInterface<ServiceProvider>();
@@ -160,12 +163,12 @@ describe('Bulk API', function () {
           });
           describe('execute', function () {
             it('calls innerBulk.execute', async function () {
-              innerStub.execute.returns({ result: bulkWriteResult });
+              innerStub.execute.returns(bulkWriteResult);
               await bulk.execute();
               expect(innerStub.execute).to.have.been.calledWith();
             });
             it('returns new BulkWriteResult', async function () {
-              innerStub.execute.returns({ result: bulkWriteResult });
+              innerStub.execute.returns(bulkWriteResult);
               const res = await bulk.execute();
               expect((await toShellResult(res)).type).to.equal(
                 'BulkWriteResult'
@@ -173,13 +176,13 @@ describe('Bulk API', function () {
               expect(res).to.deep.equal(
                 new BulkWriteResult(
                   !!bulkWriteResult.ok, // acknowledged
-                  bulkWriteResult.nInserted,
+                  bulkWriteResult.insertedCount,
                   bulkWriteResult.insertedIds,
-                  bulkWriteResult.nMatched,
-                  bulkWriteResult.nModified,
-                  bulkWriteResult.nRemoved,
-                  bulkWriteResult.nUpserted,
-                  bulkWriteResult.upserted
+                  bulkWriteResult.matchedCount,
+                  bulkWriteResult.modifiedCount,
+                  bulkWriteResult.deletedCount,
+                  bulkWriteResult.upsertedCount,
+                  bulkWriteResult.upsertedIds
                 )
               );
               expect(bulk._executed).to.equal(true);

--- a/packages/shell-api/src/bulk.ts
+++ b/packages/shell-api/src/bulk.ts
@@ -185,19 +185,18 @@ export default class Bulk extends ShellApiWithMongoClass {
   @returnsPromise
   @apiVersions([1])
   async execute(writeConcern?: WriteConcern): Promise<BulkWriteResult> {
-    // @ts-expect-error TODO(MONGOSH-1507) fix the typing
-    const { result } = await this._serviceProviderBulkOp.execute();
+    const result = await this._serviceProviderBulkOp.execute();
     this._executed = true;
     this._emitBulkApiCall('execute', { writeConcern: writeConcern });
     return new BulkWriteResult(
       !!result.ok, // acknowledged
-      result.nInserted,
+      result.insertedCount,
       result.insertedIds,
-      result.nMatched,
-      result.nModified,
-      result.nRemoved,
-      result.nUpserted,
-      result.upserted
+      result.matchedCount,
+      result.modifiedCount,
+      result.deletedCount,
+      result.upsertedCount,
+      result.upsertedIds
     );
   }
 


### PR DESCRIPTION
This accounts for removal of these legacy getters in the 6.x driver.

The only catch here is that `.result.upserted` is of a different type than `.upsertedIds`, but since the type of the latter matches what our own `BulkWriteResult` class expects (and also matches `.insertedIds`), this is probably closer to a bug fix than proper breakage.