### PR TITLE
chore: Remove keyVault single-Document wrapping methods MONGOSH-1556 

### DIFF
--- a/packages/shell-api/src/field-level-encryption.spec.ts
+++ b/packages/shell-api/src/field-level-encryption.spec.ts
@@ -450,34 +450,12 @@ describe('Field Level Encryption', function () {
         } as any;
         sp.find.returns(c);
         const result = await keyVault.getKey(KEY_ID);
-        expect(sp.find).to.have.been.calledTwice;
+        expect(sp.find).to.have.been.calledOnce;
         expect(sp.find).to.have.been.calledWith(DB, COLL, { _id: KEY_ID }, {});
-        expect(result._cursor).to.deep.equal(c);
-        expect(result._id).to.equal(1);
-        expect(await result.next()).to.deep.equal({ _id: 1 });
+        expect(result).to.deep.equal({ _id: 1 });
       });
-      it('avoids running .find() twice if the cursor supports rewinding', async function () {
-        const c = {
-          next() {
-            return { _id: 1 };
-          },
-          limit() {},
-          rewind: sinon.stub(),
-        } as any;
-        sp.find.returns(c);
-        const result = await keyVault.getKey(KEY_ID);
-        expect(sp.find).to.have.been.calledOnceWithExactly(
-          DB,
-          COLL,
-          { _id: KEY_ID },
-          {}
-        );
-        expect(c.rewind).to.have.been.calledOnceWithExactly();
-        expect(result._cursor).to.deep.equal(c);
-        expect(result._id).to.equal(1);
-        expect(await result.next()).to.deep.equal({ _id: 1 });
-      });
-      it('works when no result is returned', async function () {
+
+      it('returns null when no result is returned', async function () {
         const c = {
           next() {
             return null;
@@ -486,14 +464,9 @@ describe('Field Level Encryption', function () {
         } as any;
         sp.find.returns(c);
         const result = await keyVault.getKey(KEY_ID);
-        expect(sp.find).to.have.been.calledTwice;
+        expect(sp.find).to.have.been.calledOnce;
         expect(sp.find).to.have.been.calledWith(DB, COLL, { _id: KEY_ID }, {});
-        expect(result._cursor).to.deep.equal(c);
-        expect(result._id).to.equal(undefined);
-        expect(inspect(result)).to.include(
-          'no result -- will return `null` in future mongosh versions'
-        );
-        expect(await result.next()).to.deep.equal(null);
+        expect(result).to.equal(null);
       });
     });
     describe('getKeyByAltName', function () {
@@ -507,16 +480,14 @@ describe('Field Level Encryption', function () {
         const keyaltname = 'abc';
         sp.find.returns(c);
         const result = await keyVault.getKeyByAltName(keyaltname);
-        expect(sp.find).to.have.been.calledTwice;
+        expect(sp.find).to.have.been.calledOnce;
         expect(sp.find).to.have.been.calledWith(
           DB,
           COLL,
           { keyAltNames: keyaltname },
           {}
         );
-        expect(result._cursor).to.deep.equal(c);
-        expect(result._id).to.equal(1);
-        expect(await result.next()).to.deep.equal({ _id: 1 });
+        expect(result).to.deep.equal({ _id: 1 });
       });
     });
     describe('getKeys', function () {

--- a/packages/shell-api/src/field-level-encryption.ts
+++ b/packages/shell-api/src/field-level-encryption.ts
@@ -97,79 +97,6 @@ const isMasterKey = (
   );
 };
 
-// The KeyVault.getKey() and KeyVault.getKeyByAltName() are special because:
-// - the legacy shell and mongosh versions up to 1.5.4 return a *cursor* (that returns at most one document)
-// - drivers implementing the key management API return a *document* (or null)
-// The driver API design is the right choice here. While we are migrating to it, to keep
-// backwards compatibility with previous mongosh versions, we return a Proxy object
-// that returns the document but provides access to cursor methods, either by
-// rewinding the cursor from which we retrieved the result document (if possible)
-// or re-creating the cursor altogether.
-// Unfortunately, we cannot return a Proxy for `null` in the no-result case, so
-// we return a Proxy for a dummy object in that case.
-const NO_RESULT_PLACEHOLDER_DOC = Object.freeze({
-  // A bit hacky but probably as good as it gets.
-  [Symbol('no result -- will return `null` in future mongosh versions')]: true,
-});
-async function makeSingleDocReturnValue(
-  makeCursor: () => Promise<Cursor>,
-  method: string,
-  instanceState: ShellInstanceState
-): Promise<Document> {
-  let cursor = await makeCursor();
-  let doc: Document | null = null;
-  try {
-    doc = await cursor.limit(1).next();
-  } catch {
-    /* ignore */
-  } finally {
-    if (typeof cursor._cursor.rewind === 'function') {
-      cursor._cursor.rewind();
-    } else {
-      // Not all service providers provide a .rewind() function,
-      // fall back to just re-creating the cursor.
-      cursor = await makeCursor();
-    }
-  }
-
-  const warn = () => {
-    void instanceState.printDeprecationWarning(
-      `${method} returns a single document and will stop providing cursor methods in future versions of mongosh.`
-    );
-  };
-  return new Proxy(doc ?? NO_RESULT_PLACEHOLDER_DOC, {
-    get(target, property, receiver) {
-      if (property === shellApiType) {
-        return 'Document';
-      }
-      if (property === asPrintable) {
-        return;
-      }
-      if (property in target) {
-        return Reflect.get(target, property, receiver);
-      }
-      if (typeof property !== 'symbol' && property in cursor) {
-        warn();
-      }
-      return Reflect.get(cursor, property);
-    },
-
-    getOwnPropertyDescriptor(target, property) {
-      if (property in target) {
-        return Reflect.getOwnPropertyDescriptor(target, property);
-      }
-      if (typeof property !== 'symbol' && property in cursor) {
-        warn();
-      }
-      return Reflect.getOwnPropertyDescriptor(cursor, property);
-    },
-
-    has(target, property) {
-      return property in target || property in cursor;
-    },
-  });
-}
-
 @shellApiClassDefault
 @classPlatforms(['CLI'])
 export class ClientEncryption extends ShellApiWithMongoClass {
@@ -459,28 +386,20 @@ export class KeyVault extends ShellApiWithMongoClass {
     );
   }
 
-  @returnType('Cursor')
   @apiVersions([1])
   @returnsPromise
-  async getKey(keyId: BinaryType): Promise<Document> {
+  async getKey(keyId: BinaryType): Promise<Document | null> {
     assertArgsDefinedType([keyId], [true], 'KeyVault.getKey');
-    return await makeSingleDocReturnValue(
-      () => this._keyColl.find({ _id: keyId }),
-      'KeyVault.getKey',
-      this._instanceState
-    );
+    const cursor = await this._keyColl.find({ _id: keyId });
+    return await cursor.limit(1).next();
   }
 
-  @returnType('Cursor')
   @apiVersions([1])
   @returnsPromise
-  async getKeyByAltName(keyAltName: string): Promise<Document> {
+  async getKeyByAltName(keyAltName: string): Promise<Document | null> {
     assertArgsDefinedType([keyAltName], ['string'], 'KeyVault.getKeyByAltName');
-    return await makeSingleDocReturnValue(
-      () => this._keyColl.find({ keyAltNames: keyAltName }),
-      'KeyVault.getKeyByAltName',
-      this._instanceState
-    );
+    const cursor = await this._keyColl.find({ keyAltNames: keyAltName });
+    return await cursor.limit(1).next();
   }
 
   // eslint-disable-next-line @typescript-eslint/require-await


### PR DESCRIPTION
Currently, as in https://jira.mongodb.org/browse/MONGOSH-1266, we are wrapping the KeyVault `getKey` and `getKeyByAltName` return values into a proxy that acts both as a document and a cursor. In mongosh 2.0, we are dropping the proxy and returning either a Document or null if the key doesn't exist, mimicking the driver's behaviour.

This PR implements https://jira.mongodb.org/browse/MONGOSH-1556, that removes the wrapper proxy and simplifies a bit the code base.