### PR TITLE
fix: use queryPlanner to keep conventions with other explain methods MONGOSH-1317

### DIFF
--- a/packages/shell-api/src/aggregate-or-find-cursor.ts
+++ b/packages/shell-api/src/aggregate-or-find-cursor.ts
@@ -41,9 +41,7 @@ export abstract class AggregateOrFindCursor<
     // TODO: @maurizio we should probably move this in the Explain class?
     // NOTE: the node driver always returns the full explain plan
     // for Cursor and the queryPlanner explain for AggregationCursor.
-    if (verbosity !== undefined) {
-      verbosity = validateExplainableVerbosity(verbosity);
-    }
+    verbosity = validateExplainableVerbosity(verbosity);
     const fullExplain: any = await this._cursor.explain(verbosity);
 
     const explain: any = {

--- a/packages/shell-api/src/helpers.spec.ts
+++ b/packages/shell-api/src/helpers.spec.ts
@@ -5,6 +5,7 @@ import {
   getPrintableShardStatus,
   scaleIndividualShardStatistics,
   tsToSeconds,
+  validateExplainableVerbosity,
 } from './helpers';
 import { Database, Mongo, ShellInstanceState } from './index';
 import constructShellBson from './shell-bson';
@@ -37,6 +38,28 @@ describe('dataFormat', function () {
     expect(dataFormat(4096 * 4096)).to.equal('16MiB');
     expect(dataFormat(4096 * 4096 * 4096)).to.equal('64GiB');
     expect(dataFormat(4096 * 4096 * 4096 * 1000)).to.equal('64000GiB');
+  });
+});
+
+describe('validateExplainableVerbosity', function () {
+  const legacyMappings = [
+    { input: true, expected: 'allPlansExecution' },
+    { input: false, expected: 'queryPlanner' },
+    { input: undefined, expected: 'queryPlanner' },
+  ];
+
+  describe('legacy mappings', function () {
+    for (const { input, expected } of legacyMappings) {
+      it(`maps ${input} to ${expected}`, function () {
+        expect(validateExplainableVerbosity(input)).to.be.equal(expected);
+      });
+    }
+  });
+
+  it('keeps the provided verbosity if a mapping does not apply', function () {
+    expect(validateExplainableVerbosity('allPlansExecution')).to.be.equal(
+      'allPlansExecution'
+    );
   });
 });
 

--- a/packages/shell-api/src/helpers.ts
+++ b/packages/shell-api/src/helpers.ts
@@ -69,12 +69,12 @@ export function adaptAggregateOptions(options: any = {}): {
 }
 
 export function validateExplainableVerbosity(
-  verbosity: ExplainVerbosityLike
+  verbosity?: ExplainVerbosityLike
 ): ExplainVerbosityLike & string {
   // Legacy shell behavior.
   if (verbosity === true) {
     verbosity = 'allPlansExecution';
-  } else if (verbosity === false) {
+  } else if (verbosity === false || verbosity === undefined) {
     verbosity = 'queryPlanner';
   }
 


### PR DESCRIPTION
These are the different ways of doing explain on a cursor or a query:

| Case | Code                                            | Provided Execution Stats | Verbosity         |
|------|-------------------------------------------------|--------------------------|-------------------|
| 1    | db.runCommand({…verbosity:’allPlansExecution’}) | yes                      | allPlansExecution |
| 2    | db.foo.explain(‘allPlansExecution’).agg(…)      | yes                      | allPlansExecution |
| 3    | db.foo.explain().agg(…)                         | no                       | queryPlanner      |
| 4    | db.foo.agg(…).explain()                         | no                       | allPlansExecution |

What are we doing in this PR is aligning case 4, so instead of using `allPlansExecution` by default, it uses `queryPlanner`, as the rest of the cases. The table will look like:

| Case | Code                                            | Provided Execution Stats | Verbosity         |
|------|-------------------------------------------------|--------------------------|-------------------|
| 1    | db.runCommand({…verbosity:’allPlansExecution’}) | yes                      | allPlansExecution |
| 2    | db.foo.explain(‘allPlansExecution’).agg(…)      | yes                      | allPlansExecution |
| 3    | db.foo.explain().agg(…)                         | no                       | queryPlanner      |
| 4    | db.foo.agg(…).explain()                         | no                       | queryPlanner |