### PR TITLE
chore: turn some mocha lint rules back into errors, fix the errors MONGOSH-1508

### DIFF
--- a/configs/eslint-config-mongosh/index.js
+++ b/configs/eslint-config-mongosh/index.js
@@ -12,9 +12,7 @@ const tempRules = {
 
   'mocha/no-exports': 1,
   'mocha/max-top-level-suites': 1,
-  'mocha/no-identical-title': 1,
   'mocha/no-sibling-hooks': 1,
-  'mocha/no-nested-tests': 1,
 
   'filename-rules/match': 1,
 

--- a/packages/autocomplete/src/index.spec.ts
+++ b/packages/autocomplete/src/index.spec.ts
@@ -680,12 +680,12 @@ describe('completer.completer', function () {
   });
 
   context('for shell commands', function () {
-    it('completes partial commands', async function () {
+    it('completes partial commands (sho)', async function () {
       const i = 'sho';
       expect(await completer(noParams, i)).to.deep.equal([['show'], i]);
     });
 
-    it('completes partial commands', async function () {
+    it('completes partial commands (show)', async function () {
       const i = 'show';
       const result = await completer(noParams, i);
       expect(result[0]).to.contain('show databases');

--- a/packages/cli-repl/src/cli-repl.spec.ts
+++ b/packages/cli-repl/src/cli-repl.spec.ts
@@ -1700,7 +1700,7 @@ describe('CliRepl', function () {
         expect(exitCode).to.equal(0);
       });
 
-      it('isInteractive() is true for --eval with --shell', async function () {
+      it('isInteractive() is true for --eval with --shell (eval)', async function () {
         const filename1 = path.resolve(
           __dirname,
           '..',
@@ -1742,7 +1742,7 @@ describe('CliRepl', function () {
         expect(exitCode).to.equal(0);
       });
 
-      it('isInteractive() is true for --eval with --shell', async function () {
+      it('isInteractive() is true for --eval with --shell (filenames)', async function () {
         const filename1 = path.resolve(
           __dirname,
           '..',

--- a/packages/e2e-tests/test/e2e-auth.spec.ts
+++ b/packages/e2e-tests/test/e2e-auth.spec.ts
@@ -630,7 +630,7 @@ describe('Auth e2e', function () {
           expect(output).to.include("role: 'anna2'");
           shell.assertNoErrors();
         });
-        it('getRoles with rolesInfo field', async function () {
+        it('getRoles with rolesInfo field for other db', async function () {
           await shell.executeLine(`use ${dbName}`);
           expect(
             await shell.executeLine(
@@ -639,7 +639,7 @@ describe('Auth e2e', function () {
           ).to.include('roles: []');
           shell.assertNoErrors();
         });
-        it('getRoles with rolesInfo field', async function () {
+        it('getRoles with rolesInfo field for the current db', async function () {
           await shell.executeLine(`use ${dbName}`);
           const output = await shell.executeLine(
             `db.getRoles( {rolesInfo: { db: "${dbName}", role: "anna" } })`

--- a/packages/e2e-tests/test/e2e.spec.ts
+++ b/packages/e2e-tests/test/e2e.spec.ts
@@ -472,22 +472,22 @@ describe('e2e', function () {
       it('number', async function () {
         expect(await shell.executeLine('1')).to.include('1');
         shell.assertNoErrors();
-        it('string', async function () {
-          expect(await shell.executeLine('"string"')).to.include('string');
-          shell.assertNoErrors();
-        });
-        it('undefined', async function () {
-          await shell.executeLine('undefined');
-          shell.assertNoErrors();
-        });
-        it('null', async function () {
-          expect(await shell.executeLine('null')).to.include('null');
-          shell.assertNoErrors();
-        });
-        it('bool', async function () {
-          expect(await shell.executeLine('true')).to.include('true');
-          shell.assertNoErrors();
-        });
+      });
+      it('string', async function () {
+        expect(await shell.executeLine('"string"')).to.include('string');
+        shell.assertNoErrors();
+      });
+      it('undefined', async function () {
+        await shell.executeLine('undefined');
+        shell.assertNoErrors();
+      });
+      it('null', async function () {
+        expect(await shell.executeLine('null')).to.include('null');
+        shell.assertNoErrors();
+      });
+      it('bool', async function () {
+        expect(await shell.executeLine('true')).to.include('true');
+        shell.assertNoErrors();
       });
     });
     it('runs a complete function', async function () {

--- a/packages/editor/src/editor.spec.ts
+++ b/packages/editor/src/editor.spec.ts
@@ -455,7 +455,7 @@ describe('Editor', function () {
       expect(result).to.be.equal('fn = function() { console.log(222); };');
     });
 
-    it('returns an assignment statement for an identifier', function () {
+    it('returns an assignment statement for a statement', function () {
       const result = editor._prepareResult({
         originalCode: '111',
         modifiedCode: '222',

--- a/packages/shell-api/src/collection.spec.ts
+++ b/packages/shell-api/src/collection.spec.ts
@@ -2422,7 +2422,7 @@ describe('Collection', function () {
           collection._name
         );
       });
-      it('calls serviceProvider.watch when given no args', async function () {
+      it('calls serviceProvider.watch when given pipeline and ops args', async function () {
         const pipeline = [{ $match: { operationType: 'insertOne' } }];
         const ops = { batchSize: 1 };
         await collection.watch(pipeline, ops);

--- a/packages/shell-api/src/database.spec.ts
+++ b/packages/shell-api/src/database.spec.ts
@@ -2991,7 +2991,7 @@ describe('Database', function () {
           database._name
         );
       });
-      it('calls serviceProvider.watch when given no args', async function () {
+      it('calls serviceProvider.watch when given pipeline and ops args', async function () {
         const pipeline = [{ $match: { operationType: 'insertOne' } }];
         const ops = { batchSize: 1 };
         await database.watch(pipeline, ops);

--- a/packages/shell-api/src/help.spec.ts
+++ b/packages/shell-api/src/help.spec.ts
@@ -16,9 +16,7 @@ describe('Help', function () {
         (await toShellResult(new Help({ help: 'help' }, { translate }))).type
       ).to.equal('Help');
     });
-  });
 
-  describe('#toShellResult', function () {
     it('returns the Help a plain object', async function () {
       const properties = {
         help: 'help',

--- a/packages/shell-api/src/integration.spec.ts
+++ b/packages/shell-api/src/integration.spec.ts
@@ -409,28 +409,26 @@ describe('Shell API (integration)', function () {
         });
 
         it('returns update result correctly', function () {
-          it('returns update result correctly', function () {
-            const {
-              acknowledged,
-              insertedId,
-              matchedCount,
-              modifiedCount,
-              upsertedCount,
-            } = result;
+          const {
+            acknowledged,
+            insertedId,
+            matchedCount,
+            modifiedCount,
+            upsertedCount,
+          } = result;
 
-            expect({
-              acknowledged,
-              insertedId,
-              matchedCount,
-              modifiedCount,
-              upsertedCount,
-            }).to.deep.equal({
-              acknowledged: 1,
-              insertedId: null,
-              matchedCount: 1,
-              modifiedCount: 1,
-              upsertedCount: 0,
-            });
+          expect({
+            acknowledged,
+            insertedId,
+            matchedCount,
+            modifiedCount,
+            upsertedCount,
+          }).to.deep.equal({
+            acknowledged: 1,
+            insertedId: null,
+            matchedCount: 1,
+            modifiedCount: 1,
+            upsertedCount: 0,
           });
         });
       });

--- a/packages/shell-api/src/integration.spec.ts
+++ b/packages/shell-api/src/integration.spec.ts
@@ -424,7 +424,7 @@ describe('Shell API (integration)', function () {
             modifiedCount,
             upsertedCount,
           }).to.deep.equal({
-            acknowledged: 1,
+            acknowledged: true,
             insertedId: null,
             matchedCount: 1,
             modifiedCount: 1,

--- a/packages/shell-api/src/mongo.spec.ts
+++ b/packages/shell-api/src/mongo.spec.ts
@@ -852,7 +852,7 @@ describe('Mongo', function () {
         await mongo.watch(pipeline);
         expect(serviceProvider.watch).to.have.been.calledWith(pipeline, {});
       });
-      it('calls serviceProvider.watch when given no args', async function () {
+      it('calls serviceProvider.watch when given pipeline and ops args', async function () {
         const pipeline = [{ $match: { operationType: 'insertOne' } }];
         const ops = { batchSize: 1 };
         await mongo.watch(pipeline, ops);

--- a/packages/shell-api/src/shell-bson.spec.ts
+++ b/packages/shell-api/src/shell-bson.spec.ts
@@ -277,7 +277,7 @@ describe('Shell BSON', function () {
       }
       expect.fail('Expecting error, nothing thrown');
     });
-    it('errors for wrong type of arg 1', function () {
+    it('errors for wrong type of arg 2', function () {
       try {
         (shellBson.Code as any)('code', 1);
       } catch (e: any) {

--- a/packages/shell-evaluator/src/shell-evaluator.spec.ts
+++ b/packages/shell-evaluator/src/shell-evaluator.spec.ts
@@ -87,7 +87,7 @@ describe('ShellEvaluator', function () {
       expect(itSpy).to.have.been.calledWith();
     });
 
-    it('forwards the exit/quit command', async function () {
+    it('forwards the exitquit command (exit)', async function () {
       const dontCallEval = () => {
         throw new Error('unreachable');
       };
@@ -95,7 +95,7 @@ describe('ShellEvaluator', function () {
       expect(exitSpy).to.have.been.calledWith();
     });
 
-    it('forwards the exit/quit command', async function () {
+    it('forwards the exit/quit command (quit)', async function () {
       const dontCallEval = () => {
         throw new Error('unreachable');
       };


### PR DESCRIPTION
The are good to reinstate as errors IMHO:
```
'mocha/no-identical-title': 1,
'mocha/no-nested-tests': 1,
```

So I fixed the lines they caught.


I think the following mocha-related overrides make sense to leave as warnings:
```
'mocha/no-exports': 1,
'mocha/max-top-level-suites': 1,
'mocha/no-sibling-hooks': 1,
```

But let me know if others feel differently. I don't feel too strongly about it.