### PR TITLE
fix(service-provider-server): downgrade kerberos to 2.0.1

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20988,25 +20988,19 @@
       }
     },
     "node_modules/kerberos": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/kerberos/-/kerberos-2.0.2.tgz",
-      "integrity": "sha512-pP1aZ+T9/58joIdvhqTKTAnwLVLe3cnh+fE7UazuuHNCf4BxHUwF+oh5g2KK3yhouTfb3RQMi+mjw3/6vshdOg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/kerberos/-/kerberos-2.0.1.tgz",
+      "integrity": "sha512-O/jIgbdGK566eUhFwIcgalbqirYU/r76MW7/UFw06Fd9x5bSwgyZWL/Vm26aAmezQww/G9KYkmmJBkEkPk5HLw==",
       "hasInstallScript": true,
       "optional": true,
       "dependencies": {
         "bindings": "^1.5.0",
-        "node-addon-api": "^6.1.0",
+        "node-addon-api": "^4.3.0",
         "prebuild-install": "7.1.1"
       },
       "engines": {
         "node": ">=12.9.0"
       }
-    },
-    "node_modules/kerberos/node_modules/node-addon-api": {
-      "version": "6.1.0",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
-      "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==",
-      "optional": true
     },
     "node_modules/keyv": {
       "version": "3.0.0",
@@ -31547,7 +31541,7 @@
         "node": ">=14.15.1"
       },
       "optionalDependencies": {
-        "kerberos": "^2.0.2",
+        "kerberos": "2.0.1",
         "mongodb-client-encryption": "^6.0.0"
       }
     },
@@ -40619,7 +40613,7 @@
         "aws4": "^1.11.0",
         "depcheck": "^1.4.3",
         "eslint": "^7.25.0",
-        "kerberos": "^2.0.2",
+        "kerberos": "2.0.1",
         "mongodb": "^6.0.0",
         "mongodb-client-encryption": "^6.0.0",
         "mongodb-connection-string-url": "^2.6.0",
@@ -49286,22 +49280,14 @@
       }
     },
     "kerberos": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/kerberos/-/kerberos-2.0.2.tgz",
-      "integrity": "sha512-pP1aZ+T9/58joIdvhqTKTAnwLVLe3cnh+fE7UazuuHNCf4BxHUwF+oh5g2KK3yhouTfb3RQMi+mjw3/6vshdOg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/kerberos/-/kerberos-2.0.1.tgz",
+      "integrity": "sha512-O/jIgbdGK566eUhFwIcgalbqirYU/r76MW7/UFw06Fd9x5bSwgyZWL/Vm26aAmezQww/G9KYkmmJBkEkPk5HLw==",
       "optional": true,
       "requires": {
         "bindings": "^1.5.0",
-        "node-addon-api": "^6.1.0",
+        "node-addon-api": "^4.3.0",
         "prebuild-install": "7.1.1"
-      },
-      "dependencies": {
-        "node-addon-api": {
-          "version": "6.1.0",
-          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
-          "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==",
-          "optional": true
-        }
       }
     },
     "keyv": {

--- a/packages/service-provider-server/package.json
+++ b/packages/service-provider-server/package.json
@@ -57,7 +57,7 @@
     "socks": "^2.7.1"
   },
   "optionalDependencies": {
-    "kerberos": "^2.0.2",
+    "kerberos": "2.0.1",
     "mongodb-client-encryption": "^6.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
https://github.com/mongodb-js/kerberos/commit/abaf8d4e32692a889d53a35b05fcaa4df12c280b raised the ABI requirements for prebuilt kerberos binaries, breaking our connectivity tests. Since the 2.0.2 release does not contain critical bug fixes, we can downgrade until this issue is resolved on the Node.js driver side.