### PR TITLE
fix(async-rewriter): implement custom completion record computation MONGOSH-1579

### DIFF
--- a/packages/async-rewriter2/benchmark/index.ts
+++ b/packages/async-rewriter2/benchmark/index.ts
@@ -3,7 +3,8 @@ import AsyncWriter from '../src/index';
 const RUNS = 10;
 
 const start = process.hrtime.bigint();
-for (let i = 0; i < RUNS; i++) new AsyncWriter().runtimeSupportCode();
+for (let i = 0; i < RUNS; i++)
+  new AsyncWriter().unprocessedRuntimeSupportCode();
 const stop = process.hrtime.bigint();
 
 // eslint-disable-next-line no-console

--- a/packages/async-rewriter2/src/async-writer-babel.spec.ts
+++ b/packages/async-rewriter2/src/async-writer-babel.spec.ts
@@ -238,6 +238,12 @@ describe('AsyncWriter', function () {
         runTranspiledCode('{ var a = new A(); class A {} }')
       ).to.throw();
     });
+
+    it('does not silently remove break; inside switch', function () {
+      expect(
+        runTranspiledCode('switch (1) { case 1: 1; break; case 2: 2; break;}')
+      ).to.equal(1);
+    });
   });
 
   context('implicit awaiting', function () {


### PR DESCRIPTION
In the initial async rewriter step, we wrap the incoming script in an IIFE so that we can then perform all subsequent steps under the assumption that all code is run inside a function.

Part of this step is to look at the completion records of the code and using it as the return value of the generated function.

We use babel’s `path.getCompletionRecords()` method for this; that works nicely, except for fact that, despite its name, it has side effects, and in particular just removes `break;` statements from the AST.
(https://github.com/babel/babel/commit/b577e44d168ed6f38b48880a3d5f42c7079d430b)

I’ve considered a few approaches to this problem, like trying to clone the relevant AST before calling that method (problematic because then the return value of `path.getCompletionRecords()` does not actually point to the right nodes anymore), or keeping track of removed `break` statements and re-inserting them after calling the method.

Ultimately, it seemed like the simplest solution to avoid the method entirely, just look for statements that look like they could potentially contribute to the completion record of the input code, and then assign their results to the variable that we were already using to store that result.