### PR TITLE
fix(ci): also skip java-shell tests on 4.2.x enterprise server

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -3054,20 +3054,6 @@ functions:
       params:
         aws_key: ${aws_key}
         aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux_unit-m42xe_n20_java_shell.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m42xe_n20_java_shell.tgz
-        bucket: mciuploads
-    - command: shell.exec
-      params:
-        working_dir: src
-        shell: bash
-        script: |
-          set -e
-          tar xvzf nyc-output-linux_unit-m42xe_n20_java_shell.tgz
-    - command: s3.get
-      params:
-        aws_key: ${aws_key}
-        aws_secret: ${aws_secret}
         local_file: src/nyc-output-linux_unit-m44xc_n20_java_shell.tgz
         remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m44xc_n20_java_shell.tgz
         bucket: mciuploads
@@ -3204,20 +3190,6 @@ functions:
         script: |
           set -e
           tar xvzf nyc-output-linux_unit-m42xc_n16_java_shell.tgz
-    - command: s3.get
-      params:
-        aws_key: ${aws_key}
-        aws_secret: ${aws_secret}
-        local_file: src/nyc-output-linux_unit-m42xe_n16_java_shell.tgz
-        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m42xe_n16_java_shell.tgz
-        bucket: mciuploads
-    - command: shell.exec
-      params:
-        working_dir: src
-        shell: bash
-        script: |
-          set -e
-          tar xvzf nyc-output-linux_unit-m42xe_n16_java_shell.tgz
     - command: s3.get
       params:
         aws_key: ${aws_key}
@@ -12873,7 +12845,6 @@ buildvariants:
       - name: test_n20_i18n
       - name: test_n16_i18n
       - name: test_m42xc_n20_java_shell
-      - name: test_m42xe_n20_java_shell
       - name: test_m44xc_n20_java_shell
       - name: test_m44xe_n20_java_shell
       - name: test_m50xc_n20_java_shell
@@ -12884,7 +12855,6 @@ buildvariants:
       - name: test_m70xe_n20_java_shell
       - name: test_mlatest_n20_java_shell
       - name: test_m42xc_n16_java_shell
-      - name: test_m42xe_n16_java_shell
       - name: test_m44xc_n16_java_shell
       - name: test_m44xe_n16_java_shell
       - name: test_m50xc_n16_java_shell

--- a/.evergreen/evergreen.yml.in
+++ b/.evergreen/evergreen.yml.in
@@ -47,15 +47,16 @@ for (const packageInfo of MONGOSH_PACKAGES) {
       });
     } else {
       for (const { shortName: mShort, versionSpec: mVersion } of MONGODB_VERSIONS) {
-        const defaultVariantsForMdbServerTest = (mShort === '42xe') ?
+        let variants = packageInfo.variants ?? defaultVariants;
+        variants = (mShort === '42xe') ?
           // The MongoDB 4.2 enterprise server does not work on Ubuntu 20.04
-          defaultVariants.filter(v => v !== 'linux') :
-          defaultVariants;
+          variants.filter(v => v !== 'linux') :
+          variants;
         const id = `m${mShort}_n${nShort}_${packageInfo.name.replace(/-/g, '_')}`;
         ALL_UNIT_TESTS.push({
           id, nShort, nVersion, mShort, mVersion, skipNodeVersionCheck,
           packageName: packageInfo.name,
-          variants: packageInfo.variants ?? defaultVariantsForMdbServerTest
+          variants
         });
       }
     }


### PR DESCRIPTION
Missed this in def7f1c5c9a0466269aa1546.