### PR TITLE
fix(build): fix list of files expected to be unchanged for releases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ dist.tgz
 compiled-ts.tgz
 mongocryptd.pid
 .sbom
+.nvm

--- a/packages/build/src/npm-packages/list.spec.ts
+++ b/packages/build/src/npm-packages/list.spec.ts
@@ -26,12 +26,13 @@ describe('npm-packages list', function () {
     beforeEach(function () {
       expectedFiles = [
         path.resolve(__dirname, '..', '..', '..', '..', 'lerna.json'),
+        path.resolve(__dirname, '..', '..', '..', '..', 'package.json'),
+        path.resolve(__dirname, '..', '..', '..', '..', 'package-lock.json'),
       ];
       packages = listNpmPackages();
-      packages.forEach(({ location }) => {
+      for (const { location } of packages) {
         expectedFiles.push(path.resolve(location, 'package.json'));
-        expectedFiles.push(path.resolve(location, 'package-lock.json'));
-      });
+      }
 
       spawnSync = sinon.stub();
     });

--- a/packages/build/src/npm-packages/publish.ts
+++ b/packages/build/src/npm-packages/publish.ts
@@ -61,13 +61,16 @@ export function markBumpedFilesAsAssumeUnchanged(
   assumeUnchanged: boolean,
   spawnSyncFn: typeof spawnSync = spawnSync
 ): void {
-  const filesToAssume = [path.resolve(PROJECT_ROOT, 'lerna.json')];
-  packages.forEach(({ location }) => {
+  const filesToAssume = [
+    path.resolve(PROJECT_ROOT, 'lerna.json'),
+    path.resolve(PROJECT_ROOT, 'package.json'),
+    path.resolve(PROJECT_ROOT, 'package-lock.json'),
+  ];
+  for (const { location } of packages) {
     filesToAssume.push(path.resolve(location, 'package.json'));
-    filesToAssume.push(path.resolve(location, 'package-lock.json'));
-  });
+  }
 
-  filesToAssume.forEach((f) => {
+  for (const f of filesToAssume) {
     spawnSyncFn(
       'git',
       [
@@ -85,5 +88,5 @@ export function markBumpedFilesAsAssumeUnchanged(
     console.info(
       `File ${f} is now ${assumeUnchanged ? '' : 'NOT '}assumed to be unchanged`
     );
-  });
+  }
 }


### PR DESCRIPTION
Before publishing to npm, lerna ensures that the working tree is in a clean state (no unchanged or uncommitted files).

Our logic to make `git` assume that files were unchanged was broken for a few files, in particular the top-level package.json and the `.nvm` directory that we now place under the `.evergreen/` folder in the repository rather than a temporary path.