### PR TITLE
fix: do not attempt to publish e2e-tests package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13169,7 +13169,7 @@
       "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
       "dev": true
     },
-    "node_modules/connectivity-tests": {
+    "node_modules/@mongosh/connectivity-tests": {
       "resolved": "packages/connectivity-tests",
       "link": true
     },
@@ -31027,6 +31027,7 @@
       }
     },
     "packages/connectivity-tests": {
+      "name": "@mongosh/connectivity-tests",
       "version": "0.0.0-dev.0",
       "license": "Apache-2.0",
       "devDependencies": {

--- a/packages/build/src/npm-packages/publish.spec.ts
+++ b/packages/build/src/npm-packages/publish.spec.ts
@@ -85,6 +85,7 @@ describe('npm-packages publishNpmPackages', function () {
       [
         'publish',
         'from-package',
+        '--no-private',
         '--no-changelog',
         '--no-push',
         '--exact',

--- a/packages/build/src/npm-packages/publish.ts
+++ b/packages/build/src/npm-packages/publish.ts
@@ -33,6 +33,7 @@ export function publishNpmPackages(
       [
         'publish',
         'from-package',
+        '--no-private',
         '--no-changelog',
         '--no-push',
         '--exact',

--- a/packages/connectivity-tests/package.json
+++ b/packages/connectivity-tests/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "connectivity-tests",
+  "name": "@mongosh/connectivity-tests",
   "version": "0.0.0-dev.0",
   "private": true,
   "license": "Apache-2.0",

--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@mongosh/e2e-tests",
   "version": "0.0.0-dev.0",
+  "private": true,
   "description": "MongoDB Shell E2E Tests Package",
   "homepage": "https://github.com/mongodb-js/mongosh",
   "author": "Compass Team <compass@mongodb.com>",
@@ -16,7 +17,6 @@
     "lint": "npm run eslint . && npm run prettier -- --check .",
     "check": "npm run lint && npm run depcheck",
     "depcheck": "depcheck",
-    "prepublish": "npm run compile",
     "prettier": "prettier",
     "reformat": "npm run prettier -- --write . && npm run eslint --fix"
   },


### PR DESCRIPTION
The publishing step would currently fail on the `e2e-tests` package because it defined a broken `prepublish` script.

We should not be trying to publish the package at all; mark it `private`.