### PR TITLE
fix(logging): relax ThrottledAnalytics two-session test

### DIFF
--- a/packages/logging/src/analytics-helpers.spec.ts
+++ b/packages/logging/src/analytics-helpers.spec.ts
@@ -219,8 +219,12 @@ describe('analytics helpers', function () {
 
       expect(events).to.have.lengthOf(4);
       expect(
-        events.filter((e) => e[0] === 'track').map((e) => e[1].event)
-      ).to.deep.eq(['hi', 'hi', 'hi']);
+        events
+          .filter((e) => e[0] === 'track')
+          .map((e) => e[1].event)
+          .join(',')
+        // can't be fully sure which instance 'won' the lock because fs operations are inherently subject to race conditions
+      ).to.match(/^(hi,hi,hi|bye,bye,bye)$/);
     });
   });
 });


### PR DESCRIPTION
Because file system operations are not guaranteed to complete in the order in which they were started, this test was previously flaky.

It seems in line with the goals of the test to just allow either session to “win” the lock file, so do that instead.