### PR TITLE
feat(cli-repl): do not show MDB version for SPI STREAMS-576

### DIFF
--- a/packages/cli-repl/src/mongosh-repl.spec.ts
+++ b/packages/cli-repl/src/mongosh-repl.spec.ts
@@ -1309,4 +1309,28 @@ describe('MongoshNodeRepl', function () {
       expect(output).to.not.match(/Using MongoDB/);
     });
   });
+
+  context('with is_stream: true', function () {
+    beforeEach(async function () {
+      sp.getConnectionInfo.resolves({
+        extraInfo: {
+          uri: 'mongodb://localhost:27017/test',
+          is_localhost: true,
+          is_stream: true,
+        },
+        buildInfo: {
+          version: '4.4.1',
+        },
+      });
+      mongoshReplOptions.shellCliOptions = {
+        nodb: false,
+      };
+      mongoshRepl = new MongoshNodeRepl(mongoshReplOptions);
+      await mongoshRepl.initialize(serviceProvider);
+    });
+
+    it('shows Atlas Stream Processing', function () {
+      expect(output).to.match(/Using MongoDB:\t\tAtlas Stream Processing/);
+    });
+  });
 });

--- a/packages/cli-repl/src/mongosh-repl.ts
+++ b/packages/cli-repl/src/mongosh-repl.ts
@@ -177,13 +177,11 @@ class MongoshNodeRepl implements EvaluationListener {
     let mongodVersion = extraInfo?.is_stream
       ? 'Atlas Stream Processing'
       : buildInfo?.version;
-    if (!extraInfo?.is_stream) {
-      const apiVersion = serviceProvider.getRawClient()?.serverApi?.version;
-      if (apiVersion) {
-        mongodVersion =
-          (mongodVersion ? mongodVersion + ' ' : '') +
-          `(API Version ${apiVersion})`;
-      }
+    const apiVersion = serviceProvider.getRawClient()?.serverApi?.version;
+    if (apiVersion) {
+      mongodVersion =
+        (mongodVersion ? mongodVersion + ' ' : '') +
+        `(API Version ${apiVersion})`;
     }
     await this.greet(mongodVersion, moreRecentMongoshVersion);
     await this.printBasicConnectivityWarning(instanceState);
@@ -461,7 +459,7 @@ class MongoshNodeRepl implements EvaluationListener {
    * The greeting for the shell, showing server and shell version.
    */
   async greet(
-    mongodVersion?: string,
+    mongodVersion: string,
     moreRecentMongoshVersion?: string | null
   ): Promise<void> {
     if (this.shellCliOptions.quiet) {
@@ -469,7 +467,7 @@ class MongoshNodeRepl implements EvaluationListener {
     }
     const { version } = require('../package.json');
     let text = '';
-    if (mongodVersion && !this.shellCliOptions.nodb) {
+    if (!this.shellCliOptions.nodb) {
       text += `Using MongoDB:\t\t${mongodVersion}\n`;
     }
     text += `${this.clr(


### PR DESCRIPTION
Currently, MongoDB version will be printed as part of the greeting message. We'd like to not show it when connecting to a streams processing instance as that info is not very relevant. 