### PR TITLE
fix(ci): do not use mongodbtoolchain v4 to compile mongosh MONGOSH-1604

### DIFF
--- a/.evergreen/setup-env.sh
+++ b/.evergreen/setup-env.sh
@@ -1,7 +1,7 @@
 set -e
 set -x
 export BASEDIR="$PWD/.evergreen"
-export PATH="/cygdrive/c/python/Python311/Scripts:/cygdrive/c/python/Python311:/cygdrive/c/Python311/Scripts:/cygdrive/c/Python311:/opt/python/3.6/bin:$BASEDIR/mingit/cmd:$BASEDIR/mingit/mingw64/libexec/git-core:$BASEDIR/git-2:$BASEDIR/npm-9/node_modules/.bin:$BASEDIR/node-v$NODE_JS_VERSION-win-x64:/opt/java/jdk16/bin:/opt/chefdk/gitbin:/cygdrive/c/cmake/bin:/opt/mongodbtoolchain/v4/bin:/opt/mongodbtoolchain/v3/bin:$PATH"
+export PATH="/cygdrive/c/python/Python311/Scripts:/cygdrive/c/python/Python311:/cygdrive/c/Python311/Scripts:/cygdrive/c/Python311:/opt/python/3.6/bin:$BASEDIR/mingit/cmd:$BASEDIR/mingit/mingw64/libexec/git-core:$BASEDIR/git-2:$BASEDIR/npm-9/node_modules/.bin:$BASEDIR/node-v$NODE_JS_VERSION-win-x64:/opt/java/jdk16/bin:/opt/chefdk/gitbin:/cygdrive/c/cmake/bin:/opt/mongodbtoolchain/v3/bin:$PATH"
 export IS_MONGOSH_EVERGREEN_CI=1
 export DEBUG="mongodb*,$DEBUG"
 


### PR DESCRIPTION
On x64 Linux, the v4 mongodbtoolchain gcc is configured with `--with-arch=sandybridge`, raising the minimum CPU requirements to that level. In particular, availability of the AVX CPU feature is made a prerequisite for the generated executables to run.

It is possible to override this default for the v4 mongodbtoolchain when compiling a specific executable. However, another quirk of this toolchain (and reason why we want to migrate away from it) is that it statically links in the C++ standard library, which has unfortunately been compiled using the compiler's defaults.

On the server side, 5.0+ uses AVX as a minimum hardware requirement, but since mongosh 2.x is intended to support both 4.2 and 4.4, we should stick to the requirements of these older versions.

So, for now, just switch back to the v3 mongodbtoolchain, which seems to work fine in terms of compiling mongosh. The Node.js configure script *does* warn that the gcc version (8.5.0) in this toolchain is no longer officially supported, so that underlines the importance of switching away from the server’s toolchain in the near future (MONGOSH-864).

We “test” this by inspecting the generated binary and looking at the instructions it contains, rather than trying to emulate older hardware.