### PR TITLE
feat(cli-repl): add --eject [WIP] [Skunkworks]

### DIFF
--- a/packages/arg-parser/src/cli-options.ts
+++ b/packages/arg-parser/src/cli-options.ts
@@ -54,4 +54,5 @@ export interface CliOptions {
   oidcRedirectUri?: string;
   oidcTrustedEndpoint?: boolean;
   browser?: string | false;
+  eject?: boolean;
 }

--- a/packages/cli-repl/README.md
+++ b/packages/cli-repl/README.md
@@ -18,6 +18,7 @@ CLI interface for [MongoDB Shell][mongosh], an extension to Node.js REPL with Mo
         --version                              Show version information
         --quiet                                Silence output from the shell during the connection process
         --shell                                Run the shell after executing files
+        --eject                                Execute a script rather than entering a REPL
         --nodb                                 Don't connect to mongod on startup - no 'db address' [arg] expected
         --norc                                 Will not run the '.mongoshrc.js' file on start up
         --eval [arg]                           Evaluate javascript

--- a/packages/cli-repl/src/arg-parser.ts
+++ b/packages/cli-repl/src/arg-parser.ts
@@ -57,6 +57,7 @@ const OPTIONS = {
     'apiDeprecationErrors',
     'apiStrict',
     'buildInfo',
+    'eject',
     'help',
     'ipv6',
     'nodb',

--- a/packages/cli-repl/src/constants.ts
+++ b/packages/cli-repl/src/constants.ts
@@ -33,6 +33,7 @@ export const USAGE = `
         )}
         --quiet                                ${i18n.__('cli-repl.args.quiet')}
         --shell                                ${i18n.__('cli-repl.args.shell')}
+        --eject                                ${i18n.__('cli-repl.args.eject')}
         --nodb                                 ${i18n.__('cli-repl.args.nodb')}
         --norc                                 ${i18n.__('cli-repl.args.norc')}
         --eval [arg]                           ${i18n.__('cli-repl.args.eval')}

--- a/packages/i18n/src/locales/en_US.ts
+++ b/packages/i18n/src/locales/en_US.ts
@@ -19,6 +19,7 @@ const translations: Catalog = {
       version: 'Show version information',
       quiet: 'Silence output from the shell during the connection process',
       shell: 'Run the shell after executing files',
+      eject: 'Execute a script rather than entering the REPL',
       nodb: "Don't connect to mongod on startup - no 'db address' [arg] expected",
       norc: "Will not run the '.mongoshrc.js' file on start up",
       eval: 'Evaluate javascript',


### PR DESCRIPTION
Total hack.

```bash
node bin/mongosh.js "mongodb://127.0.0.1:60170/" --eject /Users/leroux.bodenstein/mongo/my-scripts/test.ts
Current Mongosh Log ID:	6536625732f72d1e99d5bc83
Connecting to:		mongodb://127.0.0.1:60170/?directConnection=true&serverSelectionTimeoutMS=2000&appName=mongosh+0.0.0-dev.0
executing /Users/leroux.bodenstein/mongo/my-scripts/test.ts...
{
  db: 'test',
  collections: 0,
  views: 0,
  objects: 0,
  avgObjSize: 0,
  dataSize: 0,
  storageSize: 0,
  indexes: 0,
  indexSize: 0,
  totalSize: 0,
  scaleFactor: 1,
  fsUsedSize: 0,
  fsTotalSize: 0,
  ok: 1
}
```

```typescript
// test.ts
import { MongoClient } from 'mongodb';

export async function run({client }: { client: MongoClient }) {
  console.log(await client.db().command({ dbStats: 1 }));
}
```

I have a package.json next to test.ts that depends on mongodb just for types.
