### PR TITLE
chore: bump the driver to 6.2.0 MONGOSH-1528

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -55,7 +55,7 @@
         "find-up": "^5.0.0",
         "husky": "^8.0.3",
         "mocha": "^10.2.0",
-        "mongodb": "^6.0.0",
+        "mongodb": "^6.2.0",
         "mongodb-runner": "^5.4.4",
         "node-gyp": "^9.0.0",
         "nyc": "^15.1.0",
@@ -22652,12 +22652,12 @@
       }
     },
     "node_modules/mongodb": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.0.0.tgz",
-      "integrity": "sha512-wUIYesF4DTyDccm0noE5TwGi9ISdXUAi9T2cQ4xPc+EUBZG44bfMVt2ecOG5Ypca7eCz3oRpJm6YI6c7jAnuNw==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.2.0.tgz",
+      "integrity": "sha512-d7OSuGjGWDZ5usZPqfvb36laQ9CPhnWkAGHT61x5P95p/8nMVeH8asloMwW6GcYFeB0Vj4CB/1wOTDG2RA9BFA==",
       "dependencies": {
         "@mongodb-js/saslprep": "^1.1.0",
-        "bson": "^6.0.0",
+        "bson": "^6.2.0",
         "mongodb-connection-string-url": "^2.6.0"
       },
       "engines": {
@@ -30727,7 +30727,7 @@
         "@mongodb-js/tsconfig-mongosh": "^1.0.0",
         "depcheck": "^1.4.3",
         "eslint": "^7.25.0",
-        "mongodb": "^6.0.0",
+        "mongodb": "^6.2.0",
         "prettier": "^2.8.8"
       },
       "engines": {
@@ -31160,7 +31160,7 @@
         "eslint": "^7.25.0",
         "lodash": "^4.17.21",
         "moment": "^2.29.1",
-        "mongodb": "^6.0.0",
+        "mongodb": "^6.2.0",
         "node-fetch": "^2.6.1",
         "prettier": "^2.8.8",
         "rimraf": "^3.0.2"
@@ -31446,7 +31446,7 @@
         "@aws-sdk/credential-providers": "^3.347.1",
         "@mongosh/errors": "0.0.0-dev.0",
         "bson": "^6.2.0",
-        "mongodb": "^6.0.0",
+        "mongodb": "^6.2.0",
         "mongodb-build-info": "^1.6.2"
       },
       "devDependencies": {
@@ -31476,7 +31476,7 @@
         "@mongosh/types": "0.0.0-dev.0",
         "@types/sinon-chai": "^3.2.4",
         "aws4": "^1.11.0",
-        "mongodb": "^6.0.0",
+        "mongodb": "^6.2.0",
         "mongodb-connection-string-url": "^2.6.0",
         "socks": "^2.7.1"
       },
@@ -31516,7 +31516,7 @@
         "bson": "^6.2.0",
         "depcheck": "^1.4.3",
         "eslint": "^7.25.0",
-        "mongodb": "^6.0.0",
+        "mongodb": "^6.2.0",
         "prettier": "^2.8.8",
         "semver": "^7.5.3"
       },
@@ -31590,7 +31590,7 @@
         "@mongodb-js/tsconfig-mongosh": "^1.0.0",
         "depcheck": "^1.4.3",
         "eslint": "^7.25.0",
-        "mongodb": "^6.0.0",
+        "mongodb": "^6.2.0",
         "prettier": "^2.8.8"
       },
       "engines": {
@@ -37720,7 +37720,7 @@
         "@mongosh/i18n": "0.0.0-dev.0",
         "depcheck": "^1.4.3",
         "eslint": "^7.25.0",
-        "mongodb": "^6.0.0",
+        "mongodb": "^6.2.0",
         "mongodb-connection-string-url": "^2.6.0",
         "prettier": "^2.8.8"
       }
@@ -38057,7 +38057,7 @@
         "eslint": "^7.25.0",
         "lodash": "^4.17.21",
         "moment": "^2.29.1",
-        "mongodb": "^6.0.0",
+        "mongodb": "^6.2.0",
         "node-fetch": "^2.6.1",
         "prettier": "^2.8.8",
         "rimraf": "^3.0.2",
@@ -38248,7 +38248,7 @@
         "bson": "^6.2.0",
         "depcheck": "^1.4.3",
         "eslint": "^7.25.0",
-        "mongodb": "^6.0.0",
+        "mongodb": "^6.2.0",
         "mongodb-build-info": "^1.6.2",
         "mongodb-client-encryption": "^6.0.0",
         "prettier": "^2.8.8"
@@ -38270,7 +38270,7 @@
         "depcheck": "^1.4.3",
         "eslint": "^7.25.0",
         "kerberos": "^2.0.3",
-        "mongodb": "^6.0.0",
+        "mongodb": "^6.2.0",
         "mongodb-client-encryption": "^6.0.0",
         "mongodb-connection-string-url": "^2.6.0",
         "prettier": "^2.8.8",
@@ -38292,7 +38292,7 @@
         "bson": "^6.2.0",
         "depcheck": "^1.4.3",
         "eslint": "^7.25.0",
-        "mongodb": "^6.0.0",
+        "mongodb": "^6.2.0",
         "mongodb-redact": "^0.2.2",
         "prettier": "^2.8.8",
         "semver": "^7.5.3"
@@ -38346,7 +38346,7 @@
         "@mongodb-js/tsconfig-mongosh": "^1.0.0",
         "depcheck": "^1.4.3",
         "eslint": "^7.25.0",
-        "mongodb": "^6.0.0",
+        "mongodb": "^6.2.0",
         "prettier": "^2.8.8"
       }
     },
@@ -50076,12 +50076,12 @@
       "dev": true
     },
     "mongodb": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.0.0.tgz",
-      "integrity": "sha512-wUIYesF4DTyDccm0noE5TwGi9ISdXUAi9T2cQ4xPc+EUBZG44bfMVt2ecOG5Ypca7eCz3oRpJm6YI6c7jAnuNw==",
+      "version": "6.2.0",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-6.2.0.tgz",
+      "integrity": "sha512-d7OSuGjGWDZ5usZPqfvb36laQ9CPhnWkAGHT61x5P95p/8nMVeH8asloMwW6GcYFeB0Vj4CB/1wOTDG2RA9BFA==",
       "requires": {
         "@mongodb-js/saslprep": "^1.1.0",
-        "bson": "^6.0.0",
+        "bson": "^6.2.0",
         "mongodb-connection-string-url": "^2.6.0"
       }
     },

--- a/package.json
+++ b/package.json
@@ -102,7 +102,7 @@
     "find-up": "^5.0.0",
     "husky": "^8.0.3",
     "mocha": "^10.2.0",
-    "mongodb": "^6.0.0",
+    "mongodb": "^6.2.0",
     "mongodb-runner": "^5.4.4",
     "node-gyp": "^9.0.0",
     "nyc": "^15.1.0",

--- a/packages/arg-parser/package.json
+++ b/packages/arg-parser/package.json
@@ -46,7 +46,7 @@
     "@mongodb-js/tsconfig-mongosh": "^1.0.0",
     "depcheck": "^1.4.3",
     "eslint": "^7.25.0",
-    "mongodb": "^6.0.0",
+    "mongodb": "^6.2.0",
     "prettier": "^2.8.8"
   }
 }

--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -42,7 +42,7 @@
     "eslint": "^7.25.0",
     "lodash": "^4.17.21",
     "moment": "^2.29.1",
-    "mongodb": "^6.0.0",
+    "mongodb": "^6.2.0",
     "node-fetch": "^2.6.1",
     "prettier": "^2.8.8",
     "rimraf": "^3.0.2"

--- a/packages/service-provider-core/package.json
+++ b/packages/service-provider-core/package.json
@@ -46,7 +46,7 @@
     "@aws-sdk/credential-providers": "^3.347.1",
     "@mongosh/errors": "0.0.0-dev.0",
     "bson": "^6.2.0",
-    "mongodb": "^6.0.0",
+    "mongodb": "^6.2.0",
     "mongodb-build-info": "^1.6.2"
   },
   "optionalDependencies": {

--- a/packages/service-provider-server/package.json
+++ b/packages/service-provider-server/package.json
@@ -54,7 +54,7 @@
     "@mongosh/types": "0.0.0-dev.0",
     "@types/sinon-chai": "^3.2.4",
     "aws4": "^1.11.0",
-    "mongodb": "^6.0.0",
+    "mongodb": "^6.2.0",
     "mongodb-connection-string-url": "^2.6.0",
     "socks": "^2.7.1"
   },

--- a/packages/shell-api/package.json
+++ b/packages/shell-api/package.json
@@ -55,7 +55,7 @@
     "bson": "^6.2.0",
     "depcheck": "^1.4.3",
     "eslint": "^7.25.0",
-    "mongodb": "^6.0.0",
+    "mongodb": "^6.2.0",
     "prettier": "^2.8.8",
     "semver": "^7.5.3"
   }

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -46,7 +46,7 @@
     "@mongodb-js/tsconfig-mongosh": "^1.0.0",
     "depcheck": "^1.4.3",
     "eslint": "^7.25.0",
-    "mongodb": "^6.0.0",
+    "mongodb": "^6.2.0",
     "prettier": "^2.8.8"
   }
 }


### PR DESCRIPTION
https://jira.mongodb.org/browse/MONGOSH-1528 should be fixed by https://jira.mongodb.org/browse/NODE-5496 which is in 6.2.0.