### PR TITLE
chore: try and make the test aggregation more complicated so it doesn't drop 'stages' from the explain plan  MONGOSH-1635

### DIFF
--- a/packages/shell-api/src/integration.spec.ts
+++ b/packages/shell-api/src/integration.spec.ts
@@ -1199,6 +1199,8 @@ describe('Shell API (integration)', function () {
 
           const cursor = await collection.aggregate(
             [
+              { $match: { x: 0 } },
+              { $project: { x: 1 } },
               {
                 $count: 'count',
               },

--- a/packages/shell-api/src/integration.spec.ts
+++ b/packages/shell-api/src/integration.spec.ts
@@ -1199,8 +1199,7 @@ describe('Shell API (integration)', function () {
 
           const cursor = await collection.aggregate(
             [
-              { $match: { x: 0 } },
-              { $project: { x: 1 } },
+              { $collStats: {} },
               {
                 $count: 'count',
               },


### PR DESCRIPTION
The latest alpha seems to have changed things:

```
[2023/11/06 15:51:29.306]   3) Shell API (integration)
[2023/11/06 15:51:29.306]        collection
[2023/11/06 15:51:29.306]          aggregate
[2023/11/06 15:51:29.306]            runs an explain with explain: queryPlanner:
[2023/11/06 15:51:29.306]       AssertionError: expected { explainVersion: '2', …(5), …(2) } to contain keys 'ok', and 'stages'
[2023/11/06 15:51:29.306]       + expected - actual
[2023/11/06 15:51:29.306]        [
[2023/11/06 15:51:29.306]       -  "command"
[2023/11/06 15:51:29.306]       -  "explainVersion"
[2023/11/06 15:51:29.306]          "ok"
[2023/11/06 15:51:29.306]       -  "queryPlanner"
[2023/11/06 15:51:29.306]       -  "serverInfo"
[2023/11/06 15:51:29.306]       -  "serverParameters"
[2023/11/06 15:51:29.306]       +  "stages"
[2023/11/06 15:51:29.306]        ]
```