### PR TITLE
chore(cli-repl): add startup timing measurement functionality

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12074,9 +12074,9 @@
       "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
     },
     "node_modules/boxednode": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/boxednode/-/boxednode-2.1.2.tgz",
-      "integrity": "sha512-HumFJM1jFkz00vgL0qFNK2d/z2suUgCJWehvztxyTm2BclHilX/97D9ac+vqa25Gz+AcpzvEw/Ko+yaIaCNYSw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/boxednode/-/boxednode-2.2.0.tgz",
+      "integrity": "sha512-09q4Wi2FTpiYb5vGTLW94zeVw90xFsgQ9RkLzd4K/KBJ4nQv4WoZmmOhi9M2BKxqCRGE6WYwDBj5ddHIxRCysw==",
       "dependencies": {
         "@pkgjs/nv": "^0.2.1",
         "chalk": "^4.1.0",
@@ -31039,7 +31039,7 @@
         "@mongodb-js/mongodb-downloader": "^0.2.7",
         "@octokit/rest": "^17.9.0",
         "aws-sdk": "^2.674.0",
-        "boxednode": "^2.1.2",
+        "boxednode": "^2.2.0",
         "command-exists": "^1.2.9",
         "download": "^8.0.0",
         "es-aggregate-error": "^1.0.9",
@@ -38129,7 +38129,7 @@
         "@types/tar-fs": "^2.0.0",
         "@types/tmp": "^0.2.3",
         "aws-sdk": "^2.674.0",
-        "boxednode": "^2.1.2",
+        "boxednode": "^2.2.0",
         "command-exists": "^1.2.9",
         "cross-spawn": "^7.0.3",
         "depcheck": "^1.4.3",
@@ -42198,9 +42198,9 @@
       "integrity": "sha512-AlcaJBi/pqqJBIQ8U9Mcpc9i8Aqxn88Skv5d+xBX006BY5u8N3mGLHa5Lgppa7L/HfwgwLgZ6NYs+Ag6uUmJRA=="
     },
     "boxednode": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/boxednode/-/boxednode-2.1.2.tgz",
-      "integrity": "sha512-HumFJM1jFkz00vgL0qFNK2d/z2suUgCJWehvztxyTm2BclHilX/97D9ac+vqa25Gz+AcpzvEw/Ko+yaIaCNYSw==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/boxednode/-/boxednode-2.2.0.tgz",
+      "integrity": "sha512-09q4Wi2FTpiYb5vGTLW94zeVw90xFsgQ9RkLzd4K/KBJ4nQv4WoZmmOhi9M2BKxqCRGE6WYwDBj5ddHIxRCysw==",
       "requires": {
         "@pkgjs/nv": "^0.2.1",
         "chalk": "^4.1.0",

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -65,7 +65,7 @@
     "@mongodb-js/dl-center": "^1.1.1",
     "@octokit/rest": "^17.9.0",
     "aws-sdk": "^2.674.0",
-    "boxednode": "^2.1.2",
+    "boxednode": "^2.2.0",
     "command-exists": "^1.2.9",
     "download": "^8.0.0",
     "es-aggregate-error": "^1.0.9",

--- a/packages/cli-repl/src/cli-repl.ts
+++ b/packages/cli-repl/src/cli-repl.ts
@@ -42,7 +42,7 @@ import path from 'path';
 import { promisify } from 'util';
 import { getOsInfo } from './get-os-info';
 import { UpdateNotificationManager } from './update-notification-manager';
-import { getTimingData, markTime } from './startup-timing';
+import { markTime } from './startup-timing';
 
 /**
  * Connecting text key.

--- a/packages/cli-repl/src/cli-repl.ts
+++ b/packages/cli-repl/src/cli-repl.ts
@@ -42,6 +42,7 @@ import path from 'path';
 import { promisify } from 'util';
 import { getOsInfo } from './get-os-info';
 import { UpdateNotificationManager } from './update-notification-manager';
+import { getTimingData, markTime } from './startup-timing';
 
 /**
  * Connecting text key.
@@ -226,9 +227,11 @@ export class CliRepl implements MongoshIOProvider {
   ): Promise<void> {
     const { version } = require('../package.json');
     await this.verifyNodeVersion();
+    markTime('verified node version');
 
     this.isContainerizedEnvironment =
       await this.getIsContainerizedEnvironment();
+    markTime('checked containerized environment');
 
     if (!this.cliOptions.nodb) {
       const cs = new ConnectionString(driverUri);
@@ -249,19 +252,23 @@ export class CliRepl implements MongoshIOProvider {
     } catch (err: any) {
       this.warnAboutInaccessibleFile(err);
     }
+    markTime('ensured shell homedir');
 
     await this.logManager.cleanupOldLogfiles();
+    markTime('cleaned up log files');
     const logger = await this.logManager.createLogWriter();
     if (!this.cliOptions.quiet) {
       this.output.write(`Current Mongosh Log ID:\t${logger.logId}\n`);
     }
     this.logWriter = logger;
+    markTime('instantiated log writer');
 
     logger.info('MONGOSH', mongoLogId(1_000_000_000), 'log', 'Starting log', {
       execPath: process.execPath,
       envInfo: redactSensitiveData(this.getLoggedEnvironmentVariables()),
       ...(await buildInfo()),
     });
+    markTime('logged initial message');
 
     let analyticsSetupError: Error | null = null;
     try {
@@ -272,6 +279,7 @@ export class CliRepl implements MongoshIOProvider {
       analyticsSetupError = err;
     }
 
+    markTime('created analytics instance');
     setupLoggerAndTelemetry(
       this.bus,
       logger,
@@ -284,6 +292,7 @@ export class CliRepl implements MongoshIOProvider {
       },
       version
     );
+    markTime('completed telemetry setup');
 
     if (analyticsSetupError) {
       this.bus.emit('mongosh:error', analyticsSetupError, 'analytics');
@@ -298,6 +307,7 @@ export class CliRepl implements MongoshIOProvider {
     }
 
     this.globalConfig = await this.loadGlobalConfigFile();
+    markTime('read global config files');
 
     // Needs to happen after loading the mongosh config file(s)
     void this.fetchMongoshUpdateUrl();
@@ -331,6 +341,7 @@ export class CliRepl implements MongoshIOProvider {
     }
 
     driverOptions = await this.prepareOIDCOptions(driverOptions);
+    markTime('prepared OIDC options');
 
     let initialServiceProvider;
     try {
@@ -346,10 +357,12 @@ export class CliRepl implements MongoshIOProvider {
       }
       throw err;
     }
+    markTime('completed SP setup');
     const initialized = await this.mongoshRepl.initialize(
       initialServiceProvider,
       await this.getMoreRecentMongoshVersion()
     );
+    markTime('initialized mongosh repl');
     this.injectReplFunctions();
 
     const commandLineLoadFiles = this.cliOptions.fileNames ?? [];
@@ -388,6 +401,7 @@ export class CliRepl implements MongoshIOProvider {
         this.mongoshRepl
       ),
     });
+    markTime('set up editor');
 
     if (willExecuteCommandLineScripts) {
       this.mongoshRepl.setIsInteractive(willEnterInteractiveMode);
@@ -425,9 +439,12 @@ export class CliRepl implements MongoshIOProvider {
        * - Programmatic users who really want a dependency on a snippet can use
        *   snippet('load-all') to explicitly load snippets
        */
+      markTime('start load snippets');
       await snippetManager?.loadAllSnippets();
+      markTime('done load snippets');
     }
     await this.loadRcFiles();
+    markTime('loaded rc files');
 
     this.verifyPlatformSupport();
 
@@ -435,6 +452,7 @@ export class CliRepl implements MongoshIOProvider {
     // can disable the telemetry setting.
     this.setTelemetryEnabled(await this.getConfig('enableTelemetry'));
     this.bus.emit('mongosh:start-mongosh-repl', { version });
+    markTime('starting repl');
     await this.mongoshRepl.startRepl(initialized);
   }
 
@@ -514,6 +532,7 @@ export class CliRepl implements MongoshIOProvider {
     let lastEvalResult: any;
     let exitCode = 0;
     try {
+      markTime('start eval scripts');
       for (const script of evalScripts) {
         this.bus.emit('mongosh:eval-cli-script');
         lastEvalResult = await this.mongoshRepl.loadExternalCode(
@@ -521,6 +540,7 @@ export class CliRepl implements MongoshIOProvider {
           '@(shell eval)'
         );
       }
+      markTime('finished eval scripts');
     } catch (err) {
       // We have two distinct flows of control in the exception case;
       // if we are running in --json mode, we treat the error as a
@@ -559,6 +579,7 @@ export class CliRepl implements MongoshIOProvider {
       this.output.write(formattedResult + '\n');
     }
 
+    markTime('wrote eval output, start loading external files');
     for (const file of files) {
       if (!this.cliOptions.quiet) {
         this.output.write(
@@ -567,6 +588,7 @@ export class CliRepl implements MongoshIOProvider {
       }
       await this.mongoshRepl.loadExternalFile(file);
     }
+    markTime('finished external files');
     return exitCode;
   }
 
@@ -951,6 +973,7 @@ export class CliRepl implements MongoshIOProvider {
    * Close all open resources held by this REPL instance.
    */
   async close(): Promise<void> {
+    markTime('start closing');
     if (this.closing) {
       return;
     }
@@ -970,6 +993,7 @@ export class CliRepl implements MongoshIOProvider {
         await new Promise((resolve) => this.output.write('', resolve));
       }
     }
+    markTime('output flushed');
     this.closing = true;
     const analytics = this.toggleableAnalytics;
     let flushError: string | null = null;
@@ -978,6 +1002,7 @@ export class CliRepl implements MongoshIOProvider {
       const flushStart = Date.now();
       try {
         await promisify(analytics.flush.bind(analytics))();
+        markTime('flushed analytics');
       } catch (err: any) {
         flushError = err.message;
       } finally {
@@ -995,6 +1020,7 @@ export class CliRepl implements MongoshIOProvider {
       }
     );
     await this.logWriter?.flush();
+    markTime('flushed log writer');
     this.bus.emit('mongosh:closed');
   }
 

--- a/packages/cli-repl/src/run.ts
+++ b/packages/cli-repl/src/run.ts
@@ -13,6 +13,7 @@ function enableFipsIfRequested() {
 }
 enableFipsIfRequested();
 
+import { markTime } from './startup-timing';
 import { CliRepl } from './cli-repl';
 import { parseCliArgs } from './arg-parser';
 import { runSmokeTests } from './smoke-tests';
@@ -47,6 +48,8 @@ if ((v8 as any)?.startupSnapshot?.isBuildingSnapshot?.()) {
 
   (v8 as any).startupSnapshot.setDeserializeMainFunction(() => {
     enableFipsIfRequested();
+    markTime('loaded pre-snapshot deps');
+
     void main();
   });
 } else {
@@ -55,6 +58,7 @@ if ((v8 as any)?.startupSnapshot?.isBuildingSnapshot?.()) {
 
 // eslint-disable-next-line complexity
 async function main() {
+  markTime('entered main');
   if (process.env.MONGOSH_RUN_NODE_SCRIPT) {
     // For uncompiled mongosh: node /path/to/this/file script ... -> node script ...
     // FOr compiled mongosh: mongosh mongosh script ... -> mongosh script ...
@@ -213,6 +217,7 @@ async function main() {
       shellHomePaths: shellHomePaths,
       globalConfigPaths: globalConfigPaths,
     });
+    markTime('entering repl.start()');
     await repl.start(connectionInfo.connectionString, {
       productName: 'MongoDB Shell',
       productDocsLink: 'https://www.mongodb.com/docs/mongodb-shell/',

--- a/packages/cli-repl/src/startup-timing.ts
+++ b/packages/cli-repl/src/startup-timing.ts
@@ -1,0 +1,50 @@
+const jsTimingEntries: [string, bigint][] = [];
+const timing: {
+  markTime: (label: string) => void;
+  getTimingData: () => [string, number][];
+} = !process.env.MONGOSH_SHOW_TIMING_DATA
+  ? {
+      markTime: () => {
+        /* ignore */
+      },
+      getTimingData: () => [],
+    }
+  : (process as any).boxednode
+  ? {
+      markTime: (process as any).boxednode.markTime,
+      getTimingData: (process as any).boxednode.getTimingData,
+    }
+  : {
+      markTime: (label: string) => {
+        jsTimingEntries.push([label, process.hrtime.bigint()]);
+      },
+      getTimingData: () => {
+        const data = jsTimingEntries.sort((a, b) => Number(a[1] - b[1]));
+        // Adjust times so that process initialization happens at time 0
+        return data.map(([label, time]) => [label, Number(time - data[0][1])]);
+      },
+    };
+
+export const markTime = timing.markTime;
+export const getTimingData = timing.getTimingData;
+
+if (process.env.MONGOSH_SHOW_TIMING_DATA) {
+  process.on('exit', function () {
+    const rawTimingData = getTimingData();
+    if (process.env.MONGOSH_SHOW_TIMING_DATA === 'json') {
+      console.log(JSON.stringify(rawTimingData));
+    } else {
+      console.table(
+        rawTimingData.map(([label, time], i) => [
+          label,
+          `${(time / 1_000_000).toFixed(2)}ms`,
+          i > 0
+            ? `+${((time - rawTimingData[i - 1][1]) / 1_000_000).toFixed(2)}ms`
+            : '',
+        ])
+      );
+    }
+  });
+}
+
+markTime('cli-repl timing initialized');


### PR DESCRIPTION
```
$ time env MONGOSH_SHOW_TIMING_DATA=1 ./dist/mongosh --version
0.0.0-dev.0
┌─────────┬─────────────────────────────────────┬────────────┬─────────────┐
│ (index) │                  0                  │     1      │      2      │
├─────────┼─────────────────────────────────────┼────────────┼─────────────┤
│    0    │      'Process initialization'       │  '0.00ms'  │     ''      │
│    1    │        'Enter BoxednodeMain'        │  '0.09ms'  │  '+0.09ms'  │
│    2    │  'Start InitializeOncePerProcess'   │  '0.09ms'  │  '+0.00ms'  │
│    3    │ 'Finished InitializeOncePerProcess' │  '1.75ms'  │  '+1.67ms'  │
│    4    │          'Initialized V8'           │  '2.42ms'  │  '+0.67ms'  │
│    5    │         'Initialized Loop'          │  '2.51ms'  │  '+0.09ms'  │
│    6    │          'Created Isolate'          │  '5.05ms'  │  '+2.54ms'  │
│    7    │        'Created IsolateData'        │  '5.27ms'  │  '+0.22ms'  │
│    8    │          'Created Context'          │ '12.28ms'  │  '+7.01ms'  │
│    9    │        'Created Environment'        │ '40.49ms'  │ '+28.21ms'  │
│   10    │          'Added bindings'           │ '40.50ms'  │  '+0.01ms'  │
│   11    │        'Calling entrypoint'         │ '58.83ms'  │ '+18.33ms'  │
│   12    │    'cli-repl timing initialized'    │ '61.07ms'  │  '+2.24ms'  │
│   13    │           'entered main'            │ '204.97ms' │ '+143.90ms' │
│   14    │         'Called entrypoint'         │ '208.02ms' │  '+3.04ms'  │
│   15    │ 'Loaded Environment, entering loop' │ '208.34ms' │  '+0.32ms'  │
└─────────┴─────────────────────────────────────┴────────────┴─────────────┘

real	0m0,226s
user	0m0,195s
sys	0m0,052s
```

<details>
<summary>For full `--eval --nodb` roundtrip</summary>

```
$ time env MONGOSH_SHOW_TIMING_DATA=1 ./dist/mongosh --norc --nodb --eval '' --eval '' --quiet
┌─────────┬───────────────────────────────────────────────────┬────────────┬─────────────┐
│ (index) │                         0                         │     1      │      2      │
├─────────┼───────────────────────────────────────────────────┼────────────┼─────────────┤
│    0    │             'Process initialization'              │  '0.00ms'  │     ''      │
│    1    │               'Enter BoxednodeMain'               │  '0.08ms'  │  '+0.08ms'  │
│    2    │         'Start InitializeOncePerProcess'          │  '0.09ms'  │  '+0.00ms'  │
│    3    │        'Finished InitializeOncePerProcess'        │  '1.76ms'  │  '+1.67ms'  │
│    4    │                 'Initialized V8'                  │  '2.49ms'  │  '+0.73ms'  │
│    5    │                'Initialized Loop'                 │  '2.58ms'  │  '+0.09ms'  │
│    6    │                 'Created Isolate'                 │  '5.27ms'  │  '+2.69ms'  │
│    7    │               'Created IsolateData'               │  '5.49ms'  │  '+0.23ms'  │
│    8    │                 'Created Context'                 │ '12.53ms'  │  '+7.04ms'  │
│    9    │               'Created Environment'               │ '41.56ms'  │ '+29.02ms'  │
│   10    │                 'Added bindings'                  │ '41.57ms'  │  '+0.01ms'  │
│   11    │               'Calling entrypoint'                │ '63.89ms'  │ '+22.32ms'  │
│   12    │           'cli-repl timing initialized'           │ '67.12ms'  │  '+3.24ms'  │
│   13    │                  'entered main'                   │ '223.87ms' │ '+156.74ms' │
│   14    │              'entering repl.start()'              │ '228.82ms' │  '+4.95ms'  │
│   15    │                'Called entrypoint'                │ '230.64ms' │  '+1.82ms'  │
│   16    │              'verified node version'              │ '230.88ms' │  '+0.24ms'  │
│   17    │        'Loaded Environment, entering loop'        │ '231.16ms' │  '+0.27ms'  │
│   18    │        'checked containerized environment'        │ '231.87ms' │  '+0.71ms'  │
│   19    │              'ensured shell homedir'              │ '232.21ms' │  '+0.34ms'  │
│   20    │              'cleaned up log files'               │ '237.10ms' │  '+4.90ms'  │
│   21    │             'instantiated log writer'             │ '238.13ms' │  '+1.03ms'  │
│   22    │             'logged initial message'              │ '279.97ms' │ '+41.84ms'  │
│   23    │           'created analytics instance'            │ '283.77ms' │  '+3.80ms'  │
│   24    │            'completed telemetry setup'            │ '320.04ms' │ '+36.27ms'  │
│   25    │            'read global config files'             │ '326.27ms' │  '+6.22ms'  │
│   26    │              'prepared OIDC options'              │ '326.50ms' │  '+0.24ms'  │
│   27    │               'completed SP setup'                │ '335.09ms' │  '+8.59ms'  │
│   28    │             'fetched connection info'             │ '337.24ms' │  '+2.14ms'  │
│   29    │                     'greeted'                     │ '337.33ms' │  '+0.09ms'  │
│   30    │               'fetched config vars'               │ '337.36ms' │  '+0.03ms'  │
│   31    │               'created repl object'               │ '399.91ms' │ '+62.56ms'  │
│   32    │               'set up history file'               │ '402.28ms' │  '+2.37ms'  │
│   33    │             'finished initialization'             │ '402.71ms' │  '+0.43ms'  │
│   34    │            'initialized mongosh repl'             │ '402.72ms' │  '+0.01ms'  │
│   35    │                  'set up editor'                  │ '403.05ms' │  '+0.33ms'  │
│   36    │               'start eval scripts'                │ '403.17ms' │  '+0.12ms'  │
│   37    │                 'start repl eval'                 │ '403.75ms' │  '+0.58ms'  │
│   38    │               'start async rewrite'               │ '403.92ms' │  '+0.17ms'  │
│   39    │               'done async rewrite'                │ '511.44ms' │ '+107.52ms' │
│   40    │       'start runtimeSupportCode processing'       │ '511.59ms' │  '+0.15ms'  │
│   41    │    'done global runtimeSupportCode processing'    │ '512.98ms' │  '+1.39ms'  │
│   42    │       'finished evaluating processed code'        │ '570.66ms' │ '+57.68ms'  │
│   43    │                 'done repl eval'                  │ '570.74ms' │  '+0.08ms'  │
│   44    │                  're-set prompt'                  │ '571.39ms' │  '+0.64ms'  │
│   45    │                 'start repl eval'                 │ '571.67ms' │  '+0.29ms'  │
│   46    │               'start async rewrite'               │ '571.71ms' │  '+0.04ms'  │
│   47    │               'done async rewrite'                │ '591.64ms' │ '+19.92ms'  │
│   48    │       'finished evaluating processed code'        │ '593.22ms' │  '+1.59ms'  │
│   49    │                 'done repl eval'                  │ '593.23ms' │  '+0.01ms'  │
│   50    │                  're-set prompt'                  │ '593.30ms' │  '+0.06ms'  │
│   51    │              'finished eval scripts'              │ '593.35ms' │  '+0.06ms'  │
│   52    │ 'wrote eval output, start loading external files' │ '593.36ms' │  '+0.00ms'  │
│   53    │             'finished external files'             │ '593.36ms' │  '+0.00ms'  │
│   54    │                  'start closing'                  │ '593.51ms' │  '+0.16ms'  │
│   55    │                 'output flushed'                  │ '593.62ms' │  '+0.11ms'  │
│   56    │               'flushed log writer'                │ '594.39ms' │  '+0.77ms'  │
└─────────┴───────────────────────────────────────────────────┴────────────┴─────────────┘
```

real	0m0,625s
user	0m0,774s
sys	0m0,185s
</details>