### PR TITLE
fix(deps): build kerberos in RTLD mode for Linux executables MONGOSH-1628

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -6394,6 +6394,8 @@ functions:
         shell: bash
         env:
           NODE_JS_VERSION: ${node_js_version}
+          TEST_MONGOSH_EXECUTABLE: ${test_mongosh_executable|}
+          KERBEROS_JUMPHOST_DOCKERFILE: ${kerberos_jumphost_dockerfile|}
         script: |
           set -e
           {
@@ -6464,6 +6466,13 @@ functions:
         local_file: src/dist.tgz
         remote_file: mongosh/binaries/${revision}/${revision_order_id}/mongosh-${executable_os_id}${extra_upload_tag}.tgz
         bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf dist.tgz
 
   ###
   # E2E TEST EXECUTION
@@ -11070,6 +11079,370 @@ tasks:
           disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
 
   ###
+  # EXECUTABLE CONNECTIVITY TESTS
+  ###
+  - name: executable_connectivity_test_linux_x64_rocky8
+    tags: ["connectivity-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_x64_build
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-x64
+      - func: test_connectivity
+        vars:
+          node_js_version: "20.9.0"
+          test_mongosh_executable: dist/mongosh
+          kerberos_jumphost_dockerfile: "Dockerfile.rocky8"
+  - name: executable_connectivity_test_linux_x64_ubuntu2004
+    tags: ["connectivity-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_x64_build
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-x64
+      - func: test_connectivity
+        vars:
+          node_js_version: "20.9.0"
+          test_mongosh_executable: dist/mongosh
+          kerberos_jumphost_dockerfile: "Dockerfile.ubuntu2004"
+  - name: executable_connectivity_test_linux_x64_node20
+    tags: ["connectivity-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_x64_build
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-x64
+      - func: test_connectivity
+        vars:
+          node_js_version: "20.9.0"
+          test_mongosh_executable: dist/mongosh
+          kerberos_jumphost_dockerfile: "Dockerfile.node20"
+  - name: executable_connectivity_test_linux_x64_rocky9
+    tags: ["connectivity-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_x64_build
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-x64
+      - func: test_connectivity
+        vars:
+          node_js_version: "20.9.0"
+          test_mongosh_executable: dist/mongosh
+          kerberos_jumphost_dockerfile: "Dockerfile.rocky9"
+  - name: executable_connectivity_test_linux_x64_ubuntu2204
+    tags: ["connectivity-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_x64_build
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-x64
+      - func: test_connectivity
+        vars:
+          node_js_version: "20.9.0"
+          test_mongosh_executable: dist/mongosh
+          kerberos_jumphost_dockerfile: "Dockerfile.ubuntu2204"
+  - name: executable_connectivity_test_linux_x64_openssl11_rocky8
+    tags: ["connectivity-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_x64_build_openssl11
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-x64-openssl11
+      - func: test_connectivity
+        vars:
+          node_js_version: "20.9.0"
+          test_mongosh_executable: dist/mongosh
+          kerberos_jumphost_dockerfile: "Dockerfile.rocky8"
+  - name: executable_connectivity_test_linux_x64_openssl11_ubuntu2004
+    tags: ["connectivity-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_x64_build_openssl11
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-x64-openssl11
+      - func: test_connectivity
+        vars:
+          node_js_version: "20.9.0"
+          test_mongosh_executable: dist/mongosh
+          kerberos_jumphost_dockerfile: "Dockerfile.ubuntu2004"
+  - name: executable_connectivity_test_linux_x64_openssl3_node20
+    tags: ["connectivity-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_x64_build_openssl3
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-x64-openssl3
+      - func: test_connectivity
+        vars:
+          node_js_version: "20.9.0"
+          test_mongosh_executable: dist/mongosh
+          kerberos_jumphost_dockerfile: "Dockerfile.node20"
+  - name: executable_connectivity_test_linux_x64_openssl3_rocky9
+    tags: ["connectivity-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_x64_build_openssl3
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-x64-openssl3
+      - func: test_connectivity
+        vars:
+          node_js_version: "20.9.0"
+          test_mongosh_executable: dist/mongosh
+          kerberos_jumphost_dockerfile: "Dockerfile.rocky9"
+  - name: executable_connectivity_test_linux_x64_openssl3_ubuntu2204
+    tags: ["connectivity-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_x64_build_openssl3
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-x64-openssl3
+      - func: test_connectivity
+        vars:
+          node_js_version: "20.9.0"
+          test_mongosh_executable: dist/mongosh
+          kerberos_jumphost_dockerfile: "Dockerfile.ubuntu2204"
+  - name: executable_connectivity_test_linux_arm64_rocky8
+    tags: ["connectivity-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_arm64_build
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-arm64
+      - func: test_connectivity
+        vars:
+          node_js_version: "20.9.0"
+          test_mongosh_executable: dist/mongosh
+          kerberos_jumphost_dockerfile: "Dockerfile.rocky8"
+  - name: executable_connectivity_test_linux_arm64_ubuntu2004
+    tags: ["connectivity-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_arm64_build
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-arm64
+      - func: test_connectivity
+        vars:
+          node_js_version: "20.9.0"
+          test_mongosh_executable: dist/mongosh
+          kerberos_jumphost_dockerfile: "Dockerfile.ubuntu2004"
+  - name: executable_connectivity_test_linux_arm64_node20
+    tags: ["connectivity-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_arm64_build
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-arm64
+      - func: test_connectivity
+        vars:
+          node_js_version: "20.9.0"
+          test_mongosh_executable: dist/mongosh
+          kerberos_jumphost_dockerfile: "Dockerfile.node20"
+  - name: executable_connectivity_test_linux_arm64_rocky9
+    tags: ["connectivity-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_arm64_build
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-arm64
+      - func: test_connectivity
+        vars:
+          node_js_version: "20.9.0"
+          test_mongosh_executable: dist/mongosh
+          kerberos_jumphost_dockerfile: "Dockerfile.rocky9"
+  - name: executable_connectivity_test_linux_arm64_ubuntu2204
+    tags: ["connectivity-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_arm64_build
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-arm64
+      - func: test_connectivity
+        vars:
+          node_js_version: "20.9.0"
+          test_mongosh_executable: dist/mongosh
+          kerberos_jumphost_dockerfile: "Dockerfile.ubuntu2204"
+  - name: executable_connectivity_test_linux_arm64_openssl11_rocky8
+    tags: ["connectivity-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_arm64_build_openssl11
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-arm64-openssl11
+      - func: test_connectivity
+        vars:
+          node_js_version: "20.9.0"
+          test_mongosh_executable: dist/mongosh
+          kerberos_jumphost_dockerfile: "Dockerfile.rocky8"
+  - name: executable_connectivity_test_linux_arm64_openssl11_ubuntu2004
+    tags: ["connectivity-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_arm64_build_openssl11
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-arm64-openssl11
+      - func: test_connectivity
+        vars:
+          node_js_version: "20.9.0"
+          test_mongosh_executable: dist/mongosh
+          kerberos_jumphost_dockerfile: "Dockerfile.ubuntu2004"
+  - name: executable_connectivity_test_linux_arm64_openssl3_node20
+    tags: ["connectivity-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_arm64_build_openssl3
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-arm64-openssl3
+      - func: test_connectivity
+        vars:
+          node_js_version: "20.9.0"
+          test_mongosh_executable: dist/mongosh
+          kerberos_jumphost_dockerfile: "Dockerfile.node20"
+  - name: executable_connectivity_test_linux_arm64_openssl3_rocky9
+    tags: ["connectivity-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_arm64_build_openssl3
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-arm64-openssl3
+      - func: test_connectivity
+        vars:
+          node_js_version: "20.9.0"
+          test_mongosh_executable: dist/mongosh
+          kerberos_jumphost_dockerfile: "Dockerfile.rocky9"
+  - name: executable_connectivity_test_linux_arm64_openssl3_ubuntu2204
+    tags: ["connectivity-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_arm64_build_openssl3
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-arm64-openssl3
+      - func: test_connectivity
+        vars:
+          node_js_version: "20.9.0"
+          test_mongosh_executable: dist/mongosh
+          kerberos_jumphost_dockerfile: "Dockerfile.ubuntu2204"
+
+  ###
   # PACKAGING
   ###
   - name: package_and_upload_artifact_darwin_x64
@@ -12565,6 +12938,8 @@ tasks:
         variant: "*"
       - name: ".e2e-test"
         variant: "*"
+      - name: ".connectivity-test"
+        variant: "*"
       - name: check
         variant: "*"
       - name: ".unit-test"
@@ -13366,7 +13741,7 @@ buildvariants:
       - name: compile_artifact
 
   - name: pkg_smoke_tests_docker_x64
-    display_name: "package smoke tests (x64 Docker)"
+    display_name: "package smoke (x64 Docker)"
     run_on: ubuntu2004-small
     tasks:
       - name: pkg_test_docker_linux_x64_ubuntu20_04_tgz
@@ -13401,7 +13776,7 @@ buildvariants:
       - name: pkg_test_docker_rpm_x64_openssl3_rocky9_fips_rpm
       - name: pkg_test_docker_rpm_x64_openssl3_amazonlinux2023_rpm
   - name: pkg_smoke_tests_docker_arm64
-    display_name: "package smoke tests (arm64 Docker)"
+    display_name: "package smoke (arm64 Docker)"
     run_on: ubuntu2004-arm64-small
     tasks:
       - name: pkg_test_docker_linux_arm64_ubuntu20_04_tgz
@@ -13430,6 +13805,53 @@ buildvariants:
       - name: pkg_test_docker_rpm_arm64_openssl3_rocky9_rpm
       - name: pkg_test_docker_rpm_arm64_openssl3_rocky9_fips_rpm
       - name: pkg_test_docker_rpm_arm64_openssl3_amazonlinux2023_rpm
+  - name: exec_connectitivty_tests_docker_x64_openssl11
+    display_name: "executable connectivity tests (x64 Docker for OpenSSL 1.1 base OS)"
+    run_on: ubuntu2004-small
+    tasks:
+      - name: executable_connectivity_test_linux_x64_rocky8
+      - name: executable_connectivity_test_linux_x64_ubuntu2004
+      - name: executable_connectivity_test_linux_x64_node20
+      - name: executable_connectivity_test_linux_x64_rocky9
+      - name: executable_connectivity_test_linux_x64_ubuntu2204
+      - name: executable_connectivity_test_linux_x64_openssl11_rocky8
+      - name: executable_connectivity_test_linux_x64_openssl11_ubuntu2004
+  - name: exec_connectitivty_tests_docker_arm64_openssl11
+    display_name: "executable connectivity tests (arm64 Docker for OpenSSL 1.1 base OS)"
+    run_on: ubuntu2004-arm64-small
+    tasks:
+      - name: executable_connectivity_test_linux_arm64_rocky8
+      - name: executable_connectivity_test_linux_arm64_ubuntu2004
+      - name: executable_connectivity_test_linux_arm64_node20
+      - name: executable_connectivity_test_linux_arm64_rocky9
+      - name: executable_connectivity_test_linux_arm64_ubuntu2204
+      - name: executable_connectivity_test_linux_arm64_openssl11_rocky8
+      - name: executable_connectivity_test_linux_arm64_openssl11_ubuntu2004
+  - name: exec_connectitivty_tests_docker_x64_openssl3
+    display_name: "executable connectivity tests (x64 Docker for OpenSSL 3 base OS)"
+    run_on: ubuntu2204-small
+    tasks:
+      - name: executable_connectivity_test_linux_x64_rocky8
+      - name: executable_connectivity_test_linux_x64_ubuntu2004
+      - name: executable_connectivity_test_linux_x64_node20
+      - name: executable_connectivity_test_linux_x64_rocky9
+      - name: executable_connectivity_test_linux_x64_ubuntu2204
+      - name: executable_connectivity_test_linux_x64_openssl3_node20
+      - name: executable_connectivity_test_linux_x64_openssl3_rocky9
+      - name: executable_connectivity_test_linux_x64_openssl3_ubuntu2204
+  # TODO: Re-enable after docker-compose is available on an arm64 distro
+  #- name: exec_connectitivty_tests_docker_arm64_openssl3
+  #  display_name: "executable connectivity tests (arm64 Docker for OpenSSL 3 base OS)"
+  #  run_on: ubuntu2204-arm64-small
+  #  tasks:
+  #    - name: executable_connectivity_test_linux_arm64_rocky8
+  #    - name: executable_connectivity_test_linux_arm64_ubuntu2004
+  #    - name: executable_connectivity_test_linux_arm64_node20
+  #    - name: executable_connectivity_test_linux_arm64_rocky9
+  #    - name: executable_connectivity_test_linux_arm64_ubuntu2204
+  #    - name: executable_connectivity_test_linux_arm64_openssl3_node20
+  #    - name: executable_connectivity_test_linux_arm64_openssl3_rocky9
+  #    - name: executable_connectivity_test_linux_arm64_openssl3_ubuntu2204
   - name: pkg_smoke_tests_win32
     display_name: "package smoke tests (win32)"
     run_on: ubuntu2004-small

--- a/.evergreen/evergreen.yml.in
+++ b/.evergreen/evergreen.yml.in
@@ -346,6 +346,8 @@ functions:
         shell: bash
         env:
           NODE_JS_VERSION: ${node_js_version}
+          TEST_MONGOSH_EXECUTABLE: ${test_mongosh_executable|}
+          KERBEROS_JUMPHOST_DOCKERFILE: ${kerberos_jumphost_dockerfile|}
         script: |
           set -e
           {
@@ -416,6 +418,13 @@ functions:
         local_file: src/dist.tgz
         remote_file: mongosh/binaries/${revision}/${revision_order_id}/mongosh-${executable_os_id}${extra_upload_tag}.tgz
         bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf dist.tgz
 
   ###
   # E2E TEST EXECUTION
@@ -999,6 +1008,35 @@ tasks:
   <% } } } %>
 
   ###
+  # EXECUTABLE CONNECTIVITY TESTS
+  ###
+  <% const executableConnectivityTests = [];
+  for (const { executableOsId, compileBuildVariant, kerberosConnectivityTestDockerfiles = [] } of RELEASE_PACKAGE_MATRIX) {
+    for (const dockerFile of kerberosConnectivityTestDockerfiles) {
+      const taskName = `executable_connectivity_test_${executableOsId.replace(/-/g, '_')}_${dockerFile.replace(/-/g, '_')}`;
+      executableConnectivityTests.push({ executableOsId, taskName });
+    %>
+  - name: <% out(taskName) %>
+    tags: ["connectivity-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: <% out(compileBuildVariant) %>
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "<% out(NODE_JS_VERSION_20) %>"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: <% out(executableOsId) %>
+      - func: test_connectivity
+        vars:
+          node_js_version: "<% out(NODE_JS_VERSION_20) %>"
+          test_mongosh_executable: dist/mongosh
+          kerberos_jumphost_dockerfile: "Dockerfile.<% out(dockerFile) %>"
+  <% } } %>
+
+  ###
   # PACKAGING
   ###
   <% for (const { executableOsId, compileBuildVariant, packages } of RELEASE_PACKAGE_MATRIX) {
@@ -1022,10 +1060,14 @@ tasks:
   ###
   # SMOKE TESTS
   ###
-  <% for (const { packages } of RELEASE_PACKAGE_MATRIX) {
+  <%
+  const packageSmokeTestTasks = [];
+  for (const { packages, executableOsId } of RELEASE_PACKAGE_MATRIX) {
        for (const { name, packageOn, smokeTestKind, smokeTestDockerfiles } of packages) if (smokeTestKind !== 'none') {
-        for (const dockerfile of smokeTestDockerfiles || ['']) { %>
-  - name: pkg_test_<% out(`${smokeTestKind}_${name}${dockerfile ? `_${dockerfile}` : ''}`.replace(/[-.]/g, '_')) %>
+        for (const dockerfile of smokeTestDockerfiles || ['']) {
+          const taskName = `pkg_test_${smokeTestKind}_${name}${dockerfile ? `_${dockerfile}` : ''}`.replace(/[-.]/g, '_');
+          packageSmokeTestTasks.push({taskName, executableOsId}); %>
+  - name: <% out(taskName) %>
     tags: ["smoke-test"]
     depends_on:
       - name: package_and_upload_artifact_<% out(name.replace(/-/g, '_')) %>
@@ -1079,6 +1121,8 @@ tasks:
       - name: ".extra-integration-test"
         variant: "*"
       - name: ".e2e-test"
+        variant: "*"
+      - name: ".connectivity-test"
         variant: "*"
       - name: check
         variant: "*"
@@ -1435,25 +1479,54 @@ buildvariants:
       - name: compile_artifact
 
   - name: pkg_smoke_tests_docker_x64
-    display_name: "package smoke tests (x64 Docker)"
+    display_name: "package smoke (x64 Docker)"
     run_on: ubuntu2004-small
     tasks:
-  <% for (const { packages, executableOsId } of RELEASE_PACKAGE_MATRIX) {
-      if (executableOsId.includes('linux-x64')) {
-       for (const { name, smokeTestKind, smokeTestDockerfiles } of packages) if (smokeTestKind !== 'none') {
-        for (const dockerfile of smokeTestDockerfiles || []) { %>
-      - name: pkg_test_<% out(`${smokeTestKind}_${name}${dockerfile ? `_${dockerfile}` : ''}`.replace(/[-.]/g, '_')) %>
-  <% } } } } %>
+  <% for (const { taskName, executableOsId } of packageSmokeTestTasks) {
+      if (executableOsId.includes('linux-x64')) { %>
+      - name: <% out(taskName) %>
+  <% } } %>
   - name: pkg_smoke_tests_docker_arm64
-    display_name: "package smoke tests (arm64 Docker)"
+    display_name: "package smoke (arm64 Docker)"
     run_on: ubuntu2004-arm64-small
     tasks:
-  <% for (const { packages, executableOsId } of RELEASE_PACKAGE_MATRIX) {
-      if (executableOsId.includes('linux-arm64')) {
-       for (const { name, smokeTestKind, smokeTestDockerfiles } of packages) if (smokeTestKind !== 'none') {
-        for (const dockerfile of smokeTestDockerfiles || []) { %>
-      - name: pkg_test_<% out(`${smokeTestKind}_${name}${dockerfile ? `_${dockerfile}` : ''}`.replace(/[-.]/g, '_')) %>
-  <% } } } } %>
+  <% for (const { taskName, executableOsId } of packageSmokeTestTasks) {
+      if (executableOsId.includes('linux-arm64')) { %>
+      - name: <% out(taskName) %>
+  <% } } %>
+  - name: exec_connectitivty_tests_docker_x64_openssl11
+    display_name: "executable connectivity tests (x64 Docker for OpenSSL 1.1 base OS)"
+    run_on: ubuntu2004-small
+    tasks:
+  <% for (const { taskName, executableOsId } of executableConnectivityTests) {
+      if (executableOsId.includes('linux-x64') && !taskName.includes('openssl3')) { %>
+      - name: <% out(taskName) %>
+  <% } } %>
+  - name: exec_connectitivty_tests_docker_arm64_openssl11
+    display_name: "executable connectivity tests (arm64 Docker for OpenSSL 1.1 base OS)"
+    run_on: ubuntu2004-arm64-small
+    tasks:
+  <% for (const { taskName, executableOsId } of executableConnectivityTests) {
+      if (executableOsId.includes('linux-arm64') && !taskName.includes('openssl3')) { %>
+      - name: <% out(taskName) %>
+  <% } } %>
+  - name: exec_connectitivty_tests_docker_x64_openssl3
+    display_name: "executable connectivity tests (x64 Docker for OpenSSL 3 base OS)"
+    run_on: ubuntu2204-small
+    tasks:
+  <% for (const { taskName, executableOsId } of executableConnectivityTests) {
+      if (executableOsId.includes('linux-x64') && !taskName.includes('openssl11')) { %>
+      - name: <% out(taskName) %>
+  <% } } %>
+  # TODO: Re-enable after docker-compose is available on an arm64 distro
+  #- name: exec_connectitivty_tests_docker_arm64_openssl3
+  #  display_name: "executable connectivity tests (arm64 Docker for OpenSSL 3 base OS)"
+  #  run_on: ubuntu2204-arm64-small
+  #  tasks:
+  <% for (const { taskName, executableOsId } of executableConnectivityTests) {
+      if (executableOsId.includes('linux-arm64') && !taskName.includes('openssl11')) { %>
+  #    - name: <% out(taskName) %>
+  <% } } %>
   - name: pkg_smoke_tests_win32
     display_name: "package smoke tests (win32)"
     run_on: ubuntu2004-small

--- a/.evergreen/run-e2e-tests.sh
+++ b/.evergreen/run-e2e-tests.sh
@@ -12,7 +12,6 @@ if [[ "$DISABLE_OPENSSL_SHARED_CONFIG_FOR_BUNDLED_OPENSSL" == "true" ]] && [[ ! 
 fi
 
 source .evergreen/setup-env.sh
-tar xvzf dist.tgz
 dist/mongosh --version
 
 export MONGOSH_TEST_EXECUTABLE_PATH="$(pwd)/dist/mongosh"

--- a/config/build.conf.js
+++ b/config/build.conf.js
@@ -165,10 +165,11 @@ module.exports = {
               []
           )
         ],
-        debDepends: 'libc6 (>= 2.17), libgssapi-krb5-2' + (
+        debDepends: 'libc6 (>= 2.17)' + (
           SHARED_OPENSSL_TAG === 'openssl11' ? ', libssl1.1' :
             SHARED_OPENSSL_TAG === 'openssl3' ? ', libssl3' : ''
         ),
+        debRecommends: 'libgssapi-krb5-2',
         fullName: 'MongoDB Shell',
         version: CLI_REPL_PACKAGE_JSON.version,
         description: CLI_REPL_PACKAGE_JSON.description,

--- a/config/release-package-matrix.d.ts
+++ b/config/release-package-matrix.d.ts
@@ -1,6 +1,7 @@
 export interface ExecutablePackageInformation {
   executableOsId: string;
   compileBuildVariant: string;
+  kerberosConnectivityTestDockerfiles?: string[];
   packages: PackageInformation[];
 }
 

--- a/config/release-package-matrix.js
+++ b/config/release-package-matrix.js
@@ -24,6 +24,9 @@ const publicDescriptions = {
   win32_x64: 'Windows x64 (10+)'
 };
 
+const krbConnTestsOpenSSL11 = ['rocky8', 'ubuntu2004'];
+const krbConnTestsOpenSSL3 = ['node20', 'rocky9', 'ubuntu2204'];
+
 exports.RELEASE_PACKAGE_MATRIX = [
   {
     executableOsId: 'darwin-x64',
@@ -42,6 +45,7 @@ exports.RELEASE_PACKAGE_MATRIX = [
   {
     executableOsId: 'linux-x64',
     compileBuildVariant: 'linux_x64_build',
+    kerberosConnectivityTestDockerfiles: [...krbConnTestsOpenSSL11, ...krbConnTestsOpenSSL3],
     packages: [
       { name: 'linux-x64', description: publicDescriptions.linux_x64, packageType: 'tgz', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['ubuntu20.04-tgz'], serverLikeTargetList: [...allLinux] },
       { name: 'deb-x64', description: publicDescriptions.debian_x64, packageType: 'deb', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['ubuntu18.04-deb', 'ubuntu20.04-deb', 'ubuntu22.04-deb', 'ubuntu22.04-nohome-deb', 'debian10-deb', 'debian11-deb', 'debian12-deb'], serverLikeTargetList: [...ubuntu1804AndAboveAndDebBased] },
@@ -51,6 +55,7 @@ exports.RELEASE_PACKAGE_MATRIX = [
   {
     executableOsId: 'linux-x64-openssl11',
     compileBuildVariant: 'linux_x64_build_openssl11',
+    kerberosConnectivityTestDockerfiles: [...krbConnTestsOpenSSL11],
     packages: [
       { name: 'linux-x64-openssl11', description: publicDescriptions.linux_x64, packageType: 'tgz with shared OpenSSL 1.1', packageOn: 'linux_package', smokeTestKind: 'none', serverLikeTargetList: [...allLinux] },
       { name: 'deb-x64-openssl11', description: publicDescriptions.debian_x64, packageType: 'deb with shared OpenSSL 1.1', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['ubuntu20.04-deb', 'debian10-deb', 'debian11-deb'], serverLikeTargetList: [...ubuntu1804AndAboveAndDebBased] },
@@ -60,6 +65,7 @@ exports.RELEASE_PACKAGE_MATRIX = [
   {
     executableOsId: 'linux-x64-openssl3',
     compileBuildVariant: 'linux_x64_build_openssl3',
+    kerberosConnectivityTestDockerfiles: [...krbConnTestsOpenSSL3],
     packages: [
       { name: 'linux-x64-openssl3', description: publicDescriptions.linux_x64, packageType: 'tgz with shared OpenSSL 3', packageOn: 'linux_package', smokeTestKind: 'none', serverLikeTargetList: [...allLinux] },
       { name: 'deb-x64-openssl3', description: publicDescriptions.debian_x64, packageType: 'deb with shared OpenSSL 1.1', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['ubuntu22.04-deb', 'ubuntu22.04-fips-deb', 'debian12-deb'], serverLikeTargetList: [...ubuntu1804AndAboveAndDebBased] },
@@ -69,6 +75,7 @@ exports.RELEASE_PACKAGE_MATRIX = [
   {
     executableOsId: 'linux-arm64',
     compileBuildVariant: 'linux_arm64_build',
+    kerberosConnectivityTestDockerfiles: [...krbConnTestsOpenSSL11, ...krbConnTestsOpenSSL3],
     packages: [
       { name: 'linux-arm64', description: publicDescriptions.linux_arm64, packageType: 'tgz', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['ubuntu20.04-tgz'], serverLikeTargetList: [...al2AndAbove] },
       { name: 'deb-arm64', description: publicDescriptions.debian_arm64, packageType: 'deb', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['ubuntu18.04-deb', 'ubuntu20.04-deb', 'ubuntu22.04-deb', 'debian10-deb', 'debian11-deb', 'debian12-deb'], serverLikeTargetList: [...ubuntu1804AndAboveAndDebBased] },
@@ -78,6 +85,7 @@ exports.RELEASE_PACKAGE_MATRIX = [
   {
     executableOsId: 'linux-arm64-openssl11',
     compileBuildVariant: 'linux_arm64_build_openssl11',
+    kerberosConnectivityTestDockerfiles: [...krbConnTestsOpenSSL11],
     packages: [
       { name: 'linux-arm64-openssl11', description: publicDescriptions.linux_arm64, packageType: 'tgz with shared OpenSSL 1.1', packageOn: 'linux_package', smokeTestKind: 'none', serverLikeTargetList: [...al2AndAbove] },
       { name: 'deb-arm64-openssl11', description: publicDescriptions.debian_arm64, packageType: 'deb with shared OpenSSL 1.1', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['ubuntu20.04-deb', 'debian10-deb', 'debian11-deb'], serverLikeTargetList: [...ubuntu1804AndAboveAndDebBased] },
@@ -87,6 +95,7 @@ exports.RELEASE_PACKAGE_MATRIX = [
   {
     executableOsId: 'linux-arm64-openssl3',
     compileBuildVariant: 'linux_arm64_build_openssl3',
+    kerberosConnectivityTestDockerfiles: [...krbConnTestsOpenSSL3],
     packages: [
       { name: 'linux-arm64-openssl3', description: publicDescriptions.linux_arm64, packageType: 'tgz with shared OpenSSL 3', packageOn: 'linux_package', smokeTestKind: 'none', serverLikeTargetList: [...al2AndAbove] },
       { name: 'deb-arm64-openssl3', description: publicDescriptions.debian_arm64, packageType: 'deb with shared OpenSSL 3', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['ubuntu22.04-deb', 'ubuntu22.04-fips-deb', 'debian12-deb'], serverLikeTargetList: [...ubuntu1804AndAboveAndDebBased] },

--- a/package-lock.json
+++ b/package-lock.json
@@ -19484,9 +19484,9 @@
       }
     },
     "node_modules/kerberos": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/kerberos/-/kerberos-2.0.3.tgz",
-      "integrity": "sha512-p2EgcmKCdFyGbvReS3+YZMDss7e4xYE4H6KYKzk0Vd9zj0nUt02I9DpD/+cMBsOcPHoqlHr1tm6RWY/SHCQVtw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/kerberos/-/kerberos-2.1.0.tgz",
+      "integrity": "sha512-HvOl6O6cyEN/8Z4CAocHe/sekJtvt5UrxUdCuu7bXDZ2Hnsy6OpsQbISW+lpm03vrbO2ir+1QQ5Sx/vMEhHnog==",
       "hasInstallScript": true,
       "optional": true,
       "dependencies": {
@@ -31536,7 +31536,7 @@
         "node": ">=14.15.1"
       },
       "optionalDependencies": {
-        "kerberos": "^2.0.3",
+        "kerberos": "^2.1.0",
         "mongodb-client-encryption": "^6.0.0"
       }
     },
@@ -38313,7 +38313,7 @@
         "aws4": "^1.11.0",
         "depcheck": "^1.4.3",
         "eslint": "^7.25.0",
-        "kerberos": "^2.0.3",
+        "kerberos": "^2.1.0",
         "mongodb": "^6.3.0",
         "mongodb-client-encryption": "^6.0.0",
         "mongodb-connection-string-url": "^3.0.0",
@@ -47645,9 +47645,9 @@
       }
     },
     "kerberos": {
-      "version": "2.0.3",
-      "resolved": "https://registry.npmjs.org/kerberos/-/kerberos-2.0.3.tgz",
-      "integrity": "sha512-p2EgcmKCdFyGbvReS3+YZMDss7e4xYE4H6KYKzk0Vd9zj0nUt02I9DpD/+cMBsOcPHoqlHr1tm6RWY/SHCQVtw==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/kerberos/-/kerberos-2.1.0.tgz",
+      "integrity": "sha512-HvOl6O6cyEN/8Z4CAocHe/sekJtvt5UrxUdCuu7bXDZ2Hnsy6OpsQbISW+lpm03vrbO2ir+1QQ5Sx/vMEhHnog==",
       "optional": true,
       "requires": {
         "bindings": "^1.5.0",

--- a/packages/build/src/compile/signable-compiler.ts
+++ b/packages/build/src/compile/signable-compiler.ts
@@ -168,6 +168,10 @@ export class SignableCompiler {
         // Custom env vars for sccache:
         AWS_ACCESS_KEY_ID: process.env.DEVTOOLS_CI_AWS_KEY,
         AWS_SECRET_ACCESS_KEY: process.env.DEVTOOLS_CI_AWS_SECRET,
+        // https://jira.mongodb.org/browse/MONGOSH-1628
+        ...(process.platform === 'linux' && {
+          GYP_DEFINES: 'kerberos_use_rtld=true',
+        }),
       },
       addons: [fleAddon, osDnsAddon, kerberosAddon, cryptLibraryVersionAddon]
         .concat(winCAAddon ? [winCAAddon] : [])

--- a/packages/connectivity-tests/test/all.sh
+++ b/packages/connectivity-tests/test/all.sh
@@ -11,10 +11,16 @@ mkdir -p "$TEST_TMPDIR"
 cd "$TEST_TMPDIR"
 export TEST_TMPDIR="$PWD"
 
+if [[ -z "$TEST_MONGOSH_EXECUTABLE" ]]; then
+  export MONGOSH=mongosh
+else
+  export MONGOSH="${MONGOSH_ROOT_DIR}/${TEST_MONGOSH_EXECUTABLE}"
+fi
+
 git clone git@github.com:mongodb-js/devtools-docker-test-envs.git test-envs
 cd test-envs
 
-git checkout f029f9e3a9cc006a6aeb60d941b4f8d87ae4bc95
+git checkout ca4bacd23e6f7ea07618c303b20556e3e4c9c2e6
 
 "$CONNECTIVITY_TEST_SOURCE_DIR/ldap.sh"
 "$CONNECTIVITY_TEST_SOURCE_DIR/localhost.sh"

--- a/packages/connectivity-tests/test/atlas.sh
+++ b/packages/connectivity-tests/test/atlas.sh
@@ -58,7 +58,7 @@ function test_connection_string() {
 
   CONNECTION_STRING="mongodb+srv://${ATLAS_USERNAME}:${ATLAS_PASSWORD}@${ATLAS_HOSTNAME}/admin"
 
-  echo "${CONNECTION_STATUS_COMMAND}" | mongosh "${CONNECTION_STRING}" |
+  echo "${CONNECTION_STATUS_COMMAND}" | "${MONGOSH}" "${CONNECTION_STRING}" |
     grep -Fq "${CONNECTION_STATUS_CHECK_STRING}" ||
     FAILED="Can't connect to Atlas using connection string with username and password"
 
@@ -69,7 +69,7 @@ function test_atlas_in_logs() {
   printf "test_atlas_in_logs ... "
 
   CONNECTION_STRING="mongodb+srv://${ATLAS_USERNAME}:${ATLAS_PASSWORD}@${ATLAS_HOSTNAME}/admin"
-  LOG_ID=$(echo "exit" | mongosh "${CONNECTION_STRING}" | sed -n -e 's/Current Mongosh Log ID:\t//p')
+  LOG_ID=$(echo "exit" | "${MONGOSH}" "${CONNECTION_STRING}" | sed -n -e 's/Current Mongosh Log ID:\t//p')
   LOG_PATH="${HOME}/.mongodb/mongosh/${LOG_ID}_log"
 
   cat "${LOG_PATH}" | grep -Fq '"is_atlas":true' ||
@@ -84,7 +84,7 @@ function test_credentials_masking() {
   CONNECTION_STRING="mongodb+srv://${ATLAS_USERNAME}:${ATLAS_PASSWORD}@${ATLAS_HOSTNAME}/admin"
   MASKED_CREDENTIALS_STRING="mongodb+srv://<credentials>@${ATLAS_HOSTNAME}/admin"
 
-  echo "${CONNECTION_STATUS_COMMAND}" | mongosh "${CONNECTION_STRING}" |
+  echo "${CONNECTION_STATUS_COMMAND}" | "${MONGOSH}" "${CONNECTION_STRING}" |
     grep -Fq "${MASKED_CREDENTIALS_STRING}" ||
     FAILED="When connecting, credentials are not masked in the connection string"
 
@@ -97,7 +97,7 @@ function test_cli_args() {
   CONNECTION_STRING="mongodb+srv://${ATLAS_HOSTNAME}/admin"
 
   echo "${CONNECTION_STATUS_COMMAND}" |
-    mongosh "${CONNECTION_STRING}" --username "${ATLAS_USERNAME}" --password "${ATLAS_PASSWORD}" |
+    "${MONGOSH}" "${CONNECTION_STRING}" --username "${ATLAS_USERNAME}" --password "${ATLAS_PASSWORD}" |
     grep -Fq "${CONNECTION_STATUS_CHECK_STRING}" ||
     FAILED="Can't connect to Atlas using connection string and username and password arguments"
 
@@ -110,7 +110,7 @@ function test_password_prompt() {
   CONNECTION_STRING="mongodb+srv://${ATLAS_HOSTNAME}/admin"
 
   echo -e "${ATLAS_PASSWORD}\n${CONNECTION_STATUS_COMMAND}" |
-    mongosh "${CONNECTION_STRING}" --username "${ATLAS_USERNAME}" |
+    "${MONGOSH}" "${CONNECTION_STRING}" --username "${ATLAS_USERNAME}" |
     grep -Fq "${CONNECTION_STATUS_CHECK_STRING}" ||
     FAILED="Can't connect to Atlas using password prompt"
 
@@ -123,7 +123,7 @@ function test_data_lake() {
   CONNECTION_STRING="mongodb://${ATLAS_DATA_LAKE_HOSTNAME}/admin"
 
   echo "${CONNECTION_STATUS_COMMAND}" |
-    mongosh "${CONNECTION_STRING}" \
+    "${MONGOSH}" "${CONNECTION_STRING}" \
       --tls \
       --authenticationDatabase admin \
       --username "${ATLAS_USERNAME}" \
@@ -140,7 +140,7 @@ function test_serverless() {
   CONNECTION_STRING="mongodb+srv://${ATLAS_SERVERLESS_HOSTNAME}/admin"
 
   echo "${CONNECTION_STATUS_COMMAND}" |
-    mongosh "${CONNECTION_STRING}" \
+    "${MONGOSH}" "${CONNECTION_STRING}" \
       --username "${ATLAS_USERNAME}" \
       --password "${ATLAS_PASSWORD}" |
     grep -Fq "${CONNECTION_STATUS_CHECK_STRING}" ||
@@ -154,7 +154,7 @@ function test_srv_without_nodejs_dns() {
 
   CONNECTION_STRING="mongodb+srv://${ATLAS_USERNAME}:${ATLAS_PASSWORD}@${ATLAS_HOSTNAME}/admin"
 
-  echo "${CONNECTION_STATUS_COMMAND}" | NODE_OPTIONS="-r ${MONGOSH_ROOT_DIR}/testing/disable-dns-srv.js" mongosh "${CONNECTION_STRING}" |
+  echo "${CONNECTION_STATUS_COMMAND}" | NODE_OPTIONS="-r ${MONGOSH_ROOT_DIR}/testing/disable-dns-srv.js" "${MONGOSH}" "${CONNECTION_STRING}" |
     grep -Fq "${CONNECTION_STATUS_CHECK_STRING}" ||
     FAILED="Can't connect to Atlas using connection string without Node.js SRV/TXT DNS support"
 

--- a/packages/connectivity-tests/test/kerberos.sh
+++ b/packages/connectivity-tests/test/kerberos.sh
@@ -2,12 +2,14 @@
 set -e
 set -x
 
+export KERBEROS_JUMPHOST_DOCKERFILE=${KERBEROS_JUMPHOST_DOCKERFILE:-Dockerfile.node20}
+
 FAILED=no
 docker-compose \
   -f "$TEST_TMPDIR/test-envs/docker/kerberos/docker-compose.yaml" \
   -f "$CONNECTIVITY_TEST_SOURCE_DIR/kerberos/docker-compose.kerberos.yaml" \
   --no-ansi \
-  up --exit-code-from kerberos_jumphost --abort-on-container-exit || FAILED=yes
+  up --build --exit-code-from kerberos_jumphost --abort-on-container-exit || FAILED=yes
 
 docker-compose \
   -f "$TEST_TMPDIR/test-envs/docker/kerberos/docker-compose.yaml" \

--- a/packages/connectivity-tests/test/kerberos/Dockerfile.node20
+++ b/packages/connectivity-tests/test/kerberos/Dockerfile.node20
@@ -1,0 +1,10 @@
+FROM node:20
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update
+RUN apt-get install -y krb5-user
+
+COPY krb5.conf /etc/krb5.conf
+COPY kerberos-run.sh /tmp/kerberos-run.sh
+
+CMD [ "/tmp/kerberos-run.sh" ]

--- a/packages/connectivity-tests/test/kerberos/Dockerfile.rocky8
+++ b/packages/connectivity-tests/test/kerberos/Dockerfile.rocky8
@@ -1,0 +1,8 @@
+FROM rockylinux:8
+RUN yum repolist
+RUN yum install -y krb5-workstation krb5-libs
+
+COPY krb5.conf /etc/krb5.conf
+COPY kerberos-run.sh /tmp/kerberos-run.sh
+
+CMD [ "/tmp/kerberos-run.sh" ]

--- a/packages/connectivity-tests/test/kerberos/Dockerfile.rocky9
+++ b/packages/connectivity-tests/test/kerberos/Dockerfile.rocky9
@@ -1,0 +1,8 @@
+FROM rockylinux:9
+RUN yum repolist
+RUN yum install -y krb5-workstation krb5-libs
+
+COPY krb5.conf /etc/krb5.conf
+COPY kerberos-run.sh /tmp/kerberos-run.sh
+
+CMD [ "/tmp/kerberos-run.sh" ]

--- a/packages/connectivity-tests/test/kerberos/Dockerfile.ubuntu2004
+++ b/packages/connectivity-tests/test/kerberos/Dockerfile.ubuntu2004
@@ -1,4 +1,4 @@
-FROM node:16
+FROM ubuntu:20.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 RUN apt-get update

--- a/packages/connectivity-tests/test/kerberos/Dockerfile.ubuntu2204
+++ b/packages/connectivity-tests/test/kerberos/Dockerfile.ubuntu2204
@@ -1,0 +1,10 @@
+FROM ubuntu:22.04
+
+ENV DEBIAN_FRONTEND=noninteractive
+RUN apt-get update
+RUN apt-get install -y krb5-user
+
+COPY krb5.conf /etc/krb5.conf
+COPY kerberos-run.sh /tmp/kerberos-run.sh
+
+CMD [ "/tmp/kerberos-run.sh" ]

--- a/packages/connectivity-tests/test/kerberos/docker-compose.kerberos.yaml
+++ b/packages/connectivity-tests/test/kerberos/docker-compose.kerberos.yaml
@@ -3,7 +3,10 @@ services:
   kerberos_jumphost:
     build:
       context: $CONNECTIVITY_TEST_SOURCE_DIR/kerberos
-    depends_on: 
+      dockerfile: $KERBEROS_JUMPHOST_DOCKERFILE
+    environment:
+      - TEST_MONGOSH_EXECUTABLE
+    depends_on:
       - kdc-kadmin
       - kdc-kadmin2
       - mongodb1

--- a/packages/connectivity-tests/test/kerberos/kerberos-run.sh
+++ b/packages/connectivity-tests/test/kerberos/kerberos-run.sh
@@ -5,7 +5,7 @@ set -x
 CONNECTION_STATUS_COMMAND='db.runCommand({ connectionStatus: 1 }).authInfo.authenticatedUsers'
 CONNECTION_STATUS_CHECK_STRING="user: 'mongodb.user@EXAMPLE.COM"
 
-MONGOSH=/tmp/mongosh/packages/mongosh/bin/mongosh.js
+MONGOSH=/tmp/mongosh/${TEST_MONGOSH_EXECUTABLE:-packages/mongosh/bin/mongosh.js}
 
 FAILED=no
 ANY_FAILED=no

--- a/packages/connectivity-tests/test/kerberos/krb5.conf
+++ b/packages/connectivity-tests/test/kerberos/krb5.conf
@@ -1,5 +1,8 @@
 [libdefaults]
   default_realm = EXAMPLE.COM
+  dns_canonicalize_hostname = false
+  dns_lookup_kdc = false
+  dns_lookup_realm = false
 
 [realms]
   EXAMPLE.COM = {

--- a/packages/connectivity-tests/test/ldap.sh
+++ b/packages/connectivity-tests/test/ldap.sh
@@ -4,7 +4,7 @@ set -x
 
 function try_connect_explicit() {
   echo 'db.runCommand({ connectionStatus: 1 }).authInfo.authenticatedUsers' |
-    (mongosh \
+    ("${MONGOSH}" \
       --host localhost \
       --port 30017 \
       --username "$1" \
@@ -16,7 +16,7 @@ function try_connect_explicit() {
 
 function try_connect_connection_string() {
   echo 'db.runCommand({ connectionStatus: 1 }).authInfo.authenticatedUsers' |
-    (mongosh "$1" | grep -Fq "$2" && echo 'no') || echo 'yes'
+    ("${MONGOSH}" "$1" | grep -Fq "$2" && echo 'no') || echo 'yes'
 }
 
 function test_for_version() {

--- a/packages/connectivity-tests/test/localhost.sh
+++ b/packages/connectivity-tests/test/localhost.sh
@@ -4,12 +4,12 @@ set -x
 
 function try_connect_explicit() {
   echo 'db.runCommand({ connectionStatus: 1 })' |
-    (mongosh --host localhost --port 27021 | grep -Fq authenticatedUsers && echo 'no') || echo 'yes'
+    ("${MONGOSH}" --host localhost --port 27021 | grep -Fq authenticatedUsers && echo 'no') || echo 'yes'
 }
 
 function try_connect_connection_string() {
   echo 'db.runCommand({ connectionStatus: 1 })' |
-    (mongosh "mongodb://localhost:27021/" | grep -Fq authenticatedUsers && echo 'no') || echo 'yes'
+    ("${MONGOSH}" "mongodb://localhost:27021/" | grep -Fq authenticatedUsers && echo 'no') || echo 'yes'
 }
 
 function test_for_version() {
@@ -36,11 +36,18 @@ function test_for_version() {
 # Note that this test only has limited significance right now,
 # as we aren't testing the Node.js versions affected here anywhere in CI.
 function try_connect_ipv4only_dualstackhostname() {
+  if [[ "${MONGOSH}" = "mongosh" ]]; then
+    INNER_MONGOSH=mongosh
+  else
+    INNER_MONGOSH="/host/${MONGOSH}"
+  fi
   MONGODB_VERSION="5.0" docker-compose -f docker/enterprise/docker-compose.yaml up -d
 
+  DOCKER_BASE_IMG=ubuntu:$("${MONGOSH}" --quiet --nodb --eval 'b = buildInfo(); b.sharedOpenssl && b.opensslVersion.startsWith("1.") ? "20.04" : "22.04"')
   # Use a second docker container to be able to modify /etc/hosts easily
-  cat <<EOF | docker run -i --rm --network host -v /:/host ubuntu:22.04 bash && FAILED=no || FAILED=yes
+  cat <<EOF | docker run -i --rm --network host -v /:/host "${DOCKER_BASE_IMG}" bash && FAILED=no || FAILED=yes
 export PATH=/host$(echo "$PATH" | sed 's~:~:/host~g'):\$PATH
+apt update && apt -y install openssl # necessary on Ubuntu 20.04
 
 set -e
 set -x
@@ -48,7 +55,7 @@ set -x
 echo -e '::1 dualstackhost\n127.0.0.1 dualstackhost\n' > /etc/hosts
 
 echo 'db.runCommand({ connectionStatus: 1 })' | \
-  mongosh "mongodb://dualstackhost:27021/?serverSelectionTimeoutMS=2000" | \
+  "${INNER_MONGOSH}" "mongodb://dualstackhost:27021/?serverSelectionTimeoutMS=2000" | \
   grep -Fq authenticatedUsers
 EOF
   if [ $FAILED = yes ]; then

--- a/packages/service-provider-server/package.json
+++ b/packages/service-provider-server/package.json
@@ -59,7 +59,7 @@
     "socks": "^2.7.1"
   },
   "optionalDependencies": {
-    "kerberos": "^2.0.3",
+    "kerberos": "^2.1.0",
     "mongodb-client-encryption": "^6.0.0"
   },
   "devDependencies": {

--- a/packaging/deb-template/DEBIAN/control
+++ b/packaging/deb-template/DEBIAN/control
@@ -9,3 +9,4 @@ Maintainer: {{maintainer}}
 Homepage: {{homepage}}
 Description: {{description}}
 Depends: {{debDepends}}
+Recommends: {{debRecommends}}


### PR DESCRIPTION
##### fix(deps): build kerberos in RTLD mode for Linux executables MONGOSH-1628

- Update the Kerberos addon to the latest version (2.1.0).
- Build the Kerberos addon using RTLD for Linux mongosh executables
  (i.e. opening the system Kerberos libraries using `dlopen()` to avoid
  the symbol conflict with OpenSSL 3 on RHEL8).
- Update the `.deb` definitions to account for the fact that the
  Kerberos system libraries are no longer a strict dependency
  of mongosh.
- Include the Kerberos version in the `--build-info` output.
- Make sure that if loading the Kerberos addon fails during a
  connection attempt, a meaningful error message gets passed
  to the user, instead of the driver’s default one (which
  swallows all information about the root cause).
- As a drive-by, also do that for mongodb-client-encryption; we
  occasionally receive bug reports about CSFLE/QE not working on
  homebrew installations, and this may help with that.

##### fixup: add connectivity tests running against compiled executable
