### PR TITLE
chore: add a config for running CI against the nightly driver MONGOSH-1473

### DIFF
--- a/.evergreen-nightly-driver.yml
+++ b/.evergreen-nightly-driver.yml
@@ -1,3 +1,4 @@
+# https://github.com/evergreen-ci/evergreen/blob/main/docs/Project-Configuration/Parameterized-Builds.md#project-config
 parameters:
   - key: mongodb_version_override
     value: nightly

--- a/.evergreen-nightly-driver.yml
+++ b/.evergreen-nightly-driver.yml
@@ -1,0 +1,6 @@
+parameters:
+  - key: mongodb_version_override
+    value: nightly
+
+include:
+  - filename: .evergreen.yml

--- a/.evergreen-nightly-driver.yml
+++ b/.evergreen-nightly-driver.yml
@@ -1,6 +1,6 @@
 # https://github.com/evergreen-ci/evergreen/blob/main/docs/Project-Configuration/Parameterized-Builds.md#project-config
 parameters:
-  - key: mongodb_version_override
+  - key: mongodb_driver_version_override
     value: nightly
 
 include:

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -78,6 +78,7 @@ functions:
         env:
           NODE_JS_VERSION: ${node_js_version}
           DISTRO_ID: ${distro_id}
+          MONOGDB_VERSION_OVERRIDE: ${mongodb_version_override}
         script: |
           source .evergreen/install-node.sh
           source .evergreen/install-npm-deps.sh
@@ -114,6 +115,7 @@ functions:
         env:
           NODE_JS_VERSION: ${node_js_version}
           DISTRO_ID: ${distro_id}
+          MONOGDB_VERSION_OVERRIDE: ${mongodb_version_override}
         script: |
           source .evergreen/install-node.sh
           source .evergreen/install-npm-deps.sh

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -78,7 +78,7 @@ functions:
         env:
           NODE_JS_VERSION: ${node_js_version}
           DISTRO_ID: ${distro_id}
-          MONOGDB_VERSION_OVERRIDE: ${mongodb_version_override}
+          MONOGDB_DRIVER_VERSION_OVERRIDE: ${mongodb_driver_version_override}
         script: |
           source .evergreen/install-node.sh
           source .evergreen/install-npm-deps.sh
@@ -115,7 +115,7 @@ functions:
         env:
           NODE_JS_VERSION: ${node_js_version}
           DISTRO_ID: ${distro_id}
-          MONOGDB_VERSION_OVERRIDE: ${mongodb_version_override}
+          MONOGDB_DRIVER_VERSION_OVERRIDE: ${mongodb_driver_version_override}
         script: |
           source .evergreen/install-node.sh
           source .evergreen/install-npm-deps.sh

--- a/.evergreen/evergreen.yml.in
+++ b/.evergreen/evergreen.yml.in
@@ -145,6 +145,7 @@ functions:
         env:
           NODE_JS_VERSION: ${node_js_version}
           DISTRO_ID: ${distro_id}
+          MONOGDB_VERSION_OVERRIDE: ${mongodb_version_override}
         script: |
           source .evergreen/install-node.sh
           source .evergreen/install-npm-deps.sh
@@ -181,6 +182,7 @@ functions:
         env:
           NODE_JS_VERSION: ${node_js_version}
           DISTRO_ID: ${distro_id}
+          MONOGDB_VERSION_OVERRIDE: ${mongodb_version_override}
         script: |
           source .evergreen/install-node.sh
           source .evergreen/install-npm-deps.sh

--- a/.evergreen/evergreen.yml.in
+++ b/.evergreen/evergreen.yml.in
@@ -145,7 +145,7 @@ functions:
         env:
           NODE_JS_VERSION: ${node_js_version}
           DISTRO_ID: ${distro_id}
-          MONOGDB_VERSION_OVERRIDE: ${mongodb_version_override}
+          MONOGDB_DRIVER_VERSION_OVERRIDE: ${mongodb_driver_version_override}
         script: |
           source .evergreen/install-node.sh
           source .evergreen/install-npm-deps.sh
@@ -182,7 +182,7 @@ functions:
         env:
           NODE_JS_VERSION: ${node_js_version}
           DISTRO_ID: ${distro_id}
-          MONOGDB_VERSION_OVERRIDE: ${mongodb_version_override}
+          MONOGDB_DRIVER_VERSION_OVERRIDE: ${mongodb_driver_version_override}
         script: |
           source .evergreen/install-node.sh
           source .evergreen/install-npm-deps.sh

--- a/.evergreen/install-npm-deps.sh
+++ b/.evergreen/install-npm-deps.sh
@@ -3,11 +3,11 @@ set -x
 
 npm ci --verbose
 
-echo "MONOGDB_VERSION_OVERRIDE:$MONOGDB_VERSION_OVERRIDE"
+echo "MONOGDB_DRIVER_VERSION_OVERRIDE:$MONOGDB_DRIVER_VERSION_OVERRIDE"
 
-# if MONOGDB_VERSION_OVERRIDE is set, then we want to replace the package version
-if [[ -n "$MONOGDB_VERSION_OVERRIDE" ]]; then
-  export REPLACE_PACKAGE="mongodb:$MONOGDB_VERSION_OVERRIDE"
+# if MONOGDB_DRIVER_VERSION_OVERRIDE is set, then we want to replace the package version
+if [[ -n "$MONOGDB_DRIVER_VERSION_OVERRIDE" ]]; then
+  export REPLACE_PACKAGE="mongodb:$MONOGDB_DRIVER_VERSION_OVERRIDE"
   npm run replace-package
 fi
 

--- a/.evergreen/install-npm-deps.sh
+++ b/.evergreen/install-npm-deps.sh
@@ -9,6 +9,7 @@ echo "MONOGDB_DRIVER_VERSION_OVERRIDE:$MONOGDB_DRIVER_VERSION_OVERRIDE"
 if [[ -n "$MONOGDB_DRIVER_VERSION_OVERRIDE" ]]; then
   export REPLACE_PACKAGE="mongodb:$MONOGDB_DRIVER_VERSION_OVERRIDE"
   npm run replace-package
+  npm ci --verbose --force # force because of issues with peer deps and semver pre-releases
 fi
 
 # if we rewrote this script in javascript using just builtin node modules we could skip the npm ci above

--- a/.evergreen/install-npm-deps.sh
+++ b/.evergreen/install-npm-deps.sh
@@ -3,6 +3,8 @@ set -x
 
 npm ci --verbose
 
+echo "MONOGDB_VERSION_OVERRIDE:$MONOGDB_VERSION_OVERRIDE"
+
 # if MONOGDB_VERSION_OVERRIDE is set, then we want to replace the package version
 if [[ -n "$MONOGDB_VERSION_OVERRIDE" ]]; then
   export REPLACE_PACKAGE="mongodb:$MONOGDB_VERSION_OVERRIDE"

--- a/.evergreen/install-npm-deps.sh
+++ b/.evergreen/install-npm-deps.sh
@@ -3,6 +3,12 @@ set -x
 
 npm ci --verbose
 
+# if MONOGDB_VERSION_OVERRIDE is set, then we want to replace the package version
+if [[ -n "$MONOGDB_VERSION_OVERRIDE" ]]; then
+  export REPLACE_PACKAGE="mongodb:$MONOGDB_VERSION_OVERRIDE"
+  npm run replace-package
+fi
+
 # if we rewrote this script in javascript using just builtin node modules we could skip the npm ci above
 npm run mark-ci-required-optional-dependencies
 

--- a/scripts/replace-package.js
+++ b/scripts/replace-package.js
@@ -17,7 +17,7 @@ if (!parsed || !parsed.groups.from || !parsed.groups.to) {
 }
 
 function resolveTag(from, to) {
-  return execSync(`npm dist-tag ls ${from}@${to} | awk -F ': ' '/^${to}/ {print \$2}'`).toString().trim();
+  return execSync(`npm dist-tag ls '${from}@${to}' | awk -F ': ' '/^${to}/ {print \$2}'`).toString().trim();
 }
 
 const { from, to: _to } = parsed.groups;

--- a/scripts/replace-package.js
+++ b/scripts/replace-package.js
@@ -1,12 +1,10 @@
-// Replace a package with symlinks to a specific directory.
 // Example:
-// REPLACE_PACKAGE=mongodb:/home/src/node-mongodb-native node scripts/replace-package.js
-// will make 'mongodb' point to '/home/src/node-mongodb-native' in the root
-// directory and all lerna packages.
+// REPLACE_PACKAGE=mongodb:latest node scripts/replace-package.js
+// will replace the 'mongodb' dep's version with latest in the root directory
+// and all packages.
 'use strict';
 const fs = require('fs');
 const path = require('path');
-const { pathToFileURL } = require('url');
 
 const replacement = process.env.REPLACE_PACKAGE;
 if (!replacement) {
@@ -21,7 +19,6 @@ const { from, to } = parsed.groups;
 for (const dir of ['.', ...fs.readdirSync('packages').map(dir => path.join('packages', dir))]) {
   const packageJson = path.join(dir, 'package.json');
   if (fs.existsSync(packageJson)) {
-    const target = pathToFileURL(path.resolve(to)).href;
     const contents = JSON.parse(fs.readFileSync(packageJson));
     for (const deps of [
       contents.dependencies,
@@ -29,7 +26,7 @@ for (const dir of ['.', ...fs.readdirSync('packages').map(dir => path.join('pack
       contents.optionalDependencies
     ]) {
       if (deps && deps[from]) {
-        console.info('Replacing', from, 'in', dir, 'with', target);
+        console.info(`Replacing deps[${from}]: ${deps[from]} with ${to}`);
         deps[from] = to;
       }
     }


### PR DESCRIPTION
For use with https://spruce.mongodb.com/project/mongosh/settings/periodic-builds. Or any other way that you can specify an evergreen config file other than the default one.
