### PR TITLE
chore: use npm i, not npm ci

### DIFF
--- a/.evergreen/install-npm-deps.sh
+++ b/.evergreen/install-npm-deps.sh
@@ -9,7 +9,10 @@ echo "MONOGDB_DRIVER_VERSION_OVERRIDE:$MONOGDB_DRIVER_VERSION_OVERRIDE"
 if [[ -n "$MONOGDB_DRIVER_VERSION_OVERRIDE" ]]; then
   export REPLACE_PACKAGE="mongodb:$MONOGDB_DRIVER_VERSION_OVERRIDE"
   npm run replace-package
-  npm ci --verbose --force # force because of issues with peer deps and semver pre-releases
+  # force because of issues with peer deps and semver pre-releases,
+  # install rather than ci because `npm ci` can only install packages when your
+  # package.json and package-lock.json or npm-shrinkwrap.json are in sync.
+  npm i --verbose --force
 fi
 
 # if we rewrote this script in javascript using just builtin node modules we could skip the npm ci above


### PR DESCRIPTION
Follow-up to https://github.com/mongodb-js/mongosh/pull/1780

I changed npm i to npm ci at the last minute, after I last tested this manually and it gives an error:
https://spruce.mongodb.com/task/mongosh_linux_unit_compile_ts_659c3bafe3c3310b835871aa_24_01_08_18_15_11/logs?execution=0

```
[2024/01/08 18:17:36.729] npm verb stack Error:
[2024/01/08 18:17:36.729] npm verb stack `npm ci` can only install packages when your package.json and package-lock.json or npm-shrinkwrap.json are in sync. Please update your lock file with `npm install` before continuing.
[2024/01/08 18:17:36.729] npm verb stack
[2024/01/08 18:17:36.729] npm verb stack Invalid: lock file's mongodb@6.3.0 does not satisfy mongodb@6.3.0-dev.20240108.sha.7f3ce0b
```

I was trying to avoid doing install rather than ci because of the `npm run mark-ci-required-optional-dependencies` lower down, but that's probably unavoidable.