### PR TITLE
chore: only run the driver nightly on x64 linux, npm i --force MONGOSH-1473

### DIFF
--- a/.evergreen-nightly-driver.yml
+++ b/.evergreen-nightly-driver.yml
@@ -1,7 +1,13970 @@
+# Regenerate using `npm run update-evergreen-config`
+# https://jira.mongodb.org/browse/EVG-20276
+unset_function_vars: true
+
 # https://github.com/evergreen-ci/evergreen/blob/main/docs/Project-Configuration/Parameterized-Builds.md#project-config
 parameters:
   - key: mongodb_driver_version_override
     value: nightly
+exec_timeout_secs: 10800
 
-include:
-  - filename: .evergreen.yml
+post_error_fails_task: true
+post:
+  - command: shell.exec
+    params:
+      shell: bash
+      script: |
+        mkdir -p npm-logs
+        tar cvzf npm-logs.tgz npm-logs
+
+        if [ -d "src/tmp/mongodb-runner/logs" ]; then
+            tar cvzf mongodb-runner-logs.tgz -C src/tmp/mongodb-runner logs
+        else
+            echo "Directory src/tmp/logs does not exist. Skipping."
+        fi
+  - command: s3.put
+    params:
+      aws_key: ${aws_key}
+      aws_secret: ${aws_secret}
+      local_file: npm-logs.tgz
+      remote_file: mongosh/binaries/${revision}/${revision_order_id}/npm-logs-${build_variant}-${task_name}-${task_id}.tgz
+      bucket: mciuploads
+      permissions: private
+      visibility: signed
+      content_type: application/x-gzip
+  - command: s3.put
+    params:
+      aws_key: ${aws_key}
+      aws_secret: ${aws_secret}
+      local_file: mongodb-runner-logs.tgz
+      remote_file: mongosh/binaries/${revision}/${revision_order_id}/mongodb-runner-logs-${build_variant}-${task_name}-${task_id}.tgz
+      bucket: mciuploads
+      permissions: private
+      visibility: signed
+      content_type: application/x-gzip
+      optional: true
+
+
+# Functions are any command that can be run.
+#
+# Current functions:
+#   checkout - Checks out the project from git.
+#   compile_ts - Installs Node and all dependencies, and run all prepublish scripts.
+#   install - Installs Node and all dependencies, and download the result of running all prepublish scripts.
+#   check - Performs linter and dependency checks.
+#   test - Runs all tests for a specific package.
+#   test_vscode - Clones the vscode extension repository and runs its tests.
+#   test_connectivity - Runs extra connectivity tests.
+#   test_apistrict - Runs shell API and CLI tests with --apiStrict --apiDeprecationErrors.
+#   compile_artifact - Compile the release binary.
+#   package_and_upload_artifact - Upload the release binary to S3.
+#   test_linux_artifact - Test that the built artifact works where we expect it to.
+#                         We use this to verify that e.g. the Ubuntu-built release
+#                         binary also works on RHEL and Debian.
+#   generate_license_and_vulnerability_report - Generates a report of vulnerabilities affecting the bundled application.
+#   release_publish - Publishes the npm packages and uploads the tarballs.
+functions:
+  checkout:
+    - command: git.get_project
+      type: system
+      params:
+        directory: src
+  compile_ts:
+    - command: expansions.write
+      type: system
+      params:
+        file: tmp/expansions.yaml
+        redacted: true
+    - command: shell.exec
+      type: setup
+      params:
+        working_dir: src
+        shell: bash
+        env:
+          NODE_JS_VERSION: ${node_js_version}
+          DISTRO_ID: ${distro_id}
+          MONOGDB_DRIVER_VERSION_OVERRIDE: ${mongodb_driver_version_override}
+        script: |
+          source .evergreen/install-node.sh
+          source .evergreen/install-npm-deps.sh
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        env:
+          NODE_JS_VERSION: ${node_js_version}
+        script: |
+          source .evergreen/setup-env.sh
+          npm run compile
+          tar cvzf compiled-ts.tgz packages/*/{lib,dist}
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/compiled-ts.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/compiled-ts.tgz
+        bucket: mciuploads
+        permissions: public-read
+        content_type: application/x-gzip
+  install:
+    - command: expansions.write
+      type: system
+      params:
+        file: tmp/expansions.yaml
+        redacted: true
+    - command: shell.exec
+      type: setup
+      params:
+        working_dir: src
+        shell: bash
+        env:
+          NODE_JS_VERSION: ${node_js_version}
+          DISTRO_ID: ${distro_id}
+          MONOGDB_DRIVER_VERSION_OVERRIDE: ${mongodb_driver_version_override}
+        script: |
+          source .evergreen/install-node.sh
+          source .evergreen/install-npm-deps.sh
+    - command: s3.get
+      type: setup
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/compiled-ts.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/compiled-ts.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      type: setup
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          tar xvzf compiled-ts.tgz
+  check:
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        env:
+          NODE_JS_VERSION: ${node_js_version}
+        script: |
+          set -e
+          {
+          source .evergreen/setup-env.sh
+          npm run check-ci
+          }
+  test:
+    - command: expansions.write
+      type: system
+      params:
+        file: tmp/expansions.yaml
+        redacted: true
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          {
+          source .evergreen/setup-env.sh
+          npm run test-ci
+          echo "Archiving current coverage result..."
+          tar cvzf nyc-output.tgz .nyc_output
+          }
+        env:
+          NODE_JS_VERSION: ${node_js_version}
+          MONGOSH_RUN_ONLY_IN_PACKAGE: ${mongosh_run_only_in_package}
+          AWS_AUTH_IAM_ACCESS_KEY_ID: ${devtools_ci_aws_key}
+          AWS_AUTH_IAM_SECRET_ACCESS_KEY: ${devtools_ci_aws_secret}
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-${build_variant}-${mongosh_test_id}.tgz
+        bucket: mciuploads
+        permissions: private
+        visibility: signed
+        content_type: application/x-gzip
+
+  check_coverage:
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-n20_arg_parser.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-n20_arg_parser.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-n20_arg_parser.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-n16_arg_parser.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-n16_arg_parser.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-n16_arg_parser.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-n20_async_rewriter2.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-n20_async_rewriter2.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-n20_async_rewriter2.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-n16_async_rewriter2.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-n16_async_rewriter2.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-n16_async_rewriter2.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-n20_autocomplete.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-n20_autocomplete.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-n20_autocomplete.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-n16_autocomplete.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-n16_autocomplete.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-n16_autocomplete.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-n20_browser_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-n20_browser_repl.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-n20_browser_repl.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-n16_browser_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-n16_browser_repl.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-n16_browser_repl.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-n20_browser_runtime_core.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-n20_browser_runtime_core.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-n20_browser_runtime_core.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-n16_browser_runtime_core.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-n16_browser_runtime_core.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-n16_browser_runtime_core.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-n20_browser_runtime_electron.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-n20_browser_runtime_electron.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-n20_browser_runtime_electron.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-n16_browser_runtime_electron.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-n16_browser_runtime_electron.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-n16_browser_runtime_electron.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-n20_build.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-n20_build.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-n20_build.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-n16_build.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-n16_build.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-n16_build.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m42xc_n20_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m42xc_n20_cli_repl.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m42xc_n20_cli_repl.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m42xe_n20_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m42xe_n20_cli_repl.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m42xe_n20_cli_repl.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m44xc_n20_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m44xc_n20_cli_repl.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m44xc_n20_cli_repl.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m44xe_n20_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m44xe_n20_cli_repl.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m44xe_n20_cli_repl.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m50xc_n20_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m50xc_n20_cli_repl.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m50xc_n20_cli_repl.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m50xe_n20_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m50xe_n20_cli_repl.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m50xe_n20_cli_repl.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m60xc_n20_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m60xc_n20_cli_repl.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m60xc_n20_cli_repl.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m60xe_n20_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m60xe_n20_cli_repl.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m60xe_n20_cli_repl.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m70xc_n20_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m70xc_n20_cli_repl.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m70xc_n20_cli_repl.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m70xe_n20_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m70xe_n20_cli_repl.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m70xe_n20_cli_repl.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-mlatest_n20_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-mlatest_n20_cli_repl.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-mlatest_n20_cli_repl.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m42xc_n16_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m42xc_n16_cli_repl.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m42xc_n16_cli_repl.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m42xe_n16_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m42xe_n16_cli_repl.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m42xe_n16_cli_repl.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m44xc_n16_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m44xc_n16_cli_repl.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m44xc_n16_cli_repl.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m44xe_n16_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m44xe_n16_cli_repl.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m44xe_n16_cli_repl.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m50xc_n16_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m50xc_n16_cli_repl.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m50xc_n16_cli_repl.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m50xe_n16_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m50xe_n16_cli_repl.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m50xe_n16_cli_repl.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m60xc_n16_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m60xc_n16_cli_repl.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m60xc_n16_cli_repl.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m60xe_n16_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m60xe_n16_cli_repl.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m60xe_n16_cli_repl.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m70xc_n16_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m70xc_n16_cli_repl.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m70xc_n16_cli_repl.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m70xe_n16_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m70xe_n16_cli_repl.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m70xe_n16_cli_repl.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-mlatest_n16_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-mlatest_n16_cli_repl.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-mlatest_n16_cli_repl.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m42xc_n20_e2e_tests.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m42xc_n20_e2e_tests.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m42xc_n20_e2e_tests.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m42xe_n20_e2e_tests.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m42xe_n20_e2e_tests.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m42xe_n20_e2e_tests.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m44xc_n20_e2e_tests.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m44xc_n20_e2e_tests.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m44xc_n20_e2e_tests.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m44xe_n20_e2e_tests.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m44xe_n20_e2e_tests.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m44xe_n20_e2e_tests.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m50xc_n20_e2e_tests.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m50xc_n20_e2e_tests.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m50xc_n20_e2e_tests.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m50xe_n20_e2e_tests.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m50xe_n20_e2e_tests.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m50xe_n20_e2e_tests.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m60xc_n20_e2e_tests.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m60xc_n20_e2e_tests.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m60xc_n20_e2e_tests.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m60xe_n20_e2e_tests.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m60xe_n20_e2e_tests.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m60xe_n20_e2e_tests.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m70xc_n20_e2e_tests.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m70xc_n20_e2e_tests.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m70xc_n20_e2e_tests.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m70xe_n20_e2e_tests.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m70xe_n20_e2e_tests.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m70xe_n20_e2e_tests.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-mlatest_n20_e2e_tests.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-mlatest_n20_e2e_tests.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-mlatest_n20_e2e_tests.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m42xc_n16_e2e_tests.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m42xc_n16_e2e_tests.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m42xc_n16_e2e_tests.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m42xe_n16_e2e_tests.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m42xe_n16_e2e_tests.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m42xe_n16_e2e_tests.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m44xc_n16_e2e_tests.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m44xc_n16_e2e_tests.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m44xc_n16_e2e_tests.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m44xe_n16_e2e_tests.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m44xe_n16_e2e_tests.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m44xe_n16_e2e_tests.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m50xc_n16_e2e_tests.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m50xc_n16_e2e_tests.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m50xc_n16_e2e_tests.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m50xe_n16_e2e_tests.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m50xe_n16_e2e_tests.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m50xe_n16_e2e_tests.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m60xc_n16_e2e_tests.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m60xc_n16_e2e_tests.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m60xc_n16_e2e_tests.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m60xe_n16_e2e_tests.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m60xe_n16_e2e_tests.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m60xe_n16_e2e_tests.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m70xc_n16_e2e_tests.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m70xc_n16_e2e_tests.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m70xc_n16_e2e_tests.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m70xe_n16_e2e_tests.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m70xe_n16_e2e_tests.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m70xe_n16_e2e_tests.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-mlatest_n16_e2e_tests.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-mlatest_n16_e2e_tests.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-mlatest_n16_e2e_tests.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-n20_editor.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-n20_editor.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-n20_editor.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-n16_editor.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-n16_editor.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-n16_editor.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-n20_errors.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-n20_errors.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-n20_errors.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-n16_errors.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-n16_errors.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-n16_errors.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-n20_history.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-n20_history.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-n20_history.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-n16_history.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-n16_history.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-n16_history.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-n20_i18n.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-n20_i18n.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-n20_i18n.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-n16_i18n.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-n16_i18n.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-n16_i18n.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-n20_js_multiline_to_singleline.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-n20_js_multiline_to_singleline.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-n20_js_multiline_to_singleline.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-n16_js_multiline_to_singleline.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-n16_js_multiline_to_singleline.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-n16_js_multiline_to_singleline.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-n20_logging.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-n20_logging.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-n20_logging.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-n16_logging.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-n16_logging.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-n16_logging.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m42xc_n20_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m42xc_n20_node_runtime_worker_thread.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m42xc_n20_node_runtime_worker_thread.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m42xe_n20_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m42xe_n20_node_runtime_worker_thread.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m42xe_n20_node_runtime_worker_thread.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m44xc_n20_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m44xc_n20_node_runtime_worker_thread.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m44xc_n20_node_runtime_worker_thread.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m44xe_n20_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m44xe_n20_node_runtime_worker_thread.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m44xe_n20_node_runtime_worker_thread.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m50xc_n20_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m50xc_n20_node_runtime_worker_thread.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m50xc_n20_node_runtime_worker_thread.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m50xe_n20_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m50xe_n20_node_runtime_worker_thread.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m50xe_n20_node_runtime_worker_thread.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m60xc_n20_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m60xc_n20_node_runtime_worker_thread.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m60xc_n20_node_runtime_worker_thread.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m60xe_n20_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m60xe_n20_node_runtime_worker_thread.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m60xe_n20_node_runtime_worker_thread.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m70xc_n20_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m70xc_n20_node_runtime_worker_thread.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m70xc_n20_node_runtime_worker_thread.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m70xe_n20_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m70xe_n20_node_runtime_worker_thread.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m70xe_n20_node_runtime_worker_thread.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-mlatest_n20_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-mlatest_n20_node_runtime_worker_thread.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-mlatest_n20_node_runtime_worker_thread.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m42xc_n16_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m42xc_n16_node_runtime_worker_thread.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m42xc_n16_node_runtime_worker_thread.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m42xe_n16_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m42xe_n16_node_runtime_worker_thread.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m42xe_n16_node_runtime_worker_thread.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m44xc_n16_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m44xc_n16_node_runtime_worker_thread.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m44xc_n16_node_runtime_worker_thread.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m44xe_n16_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m44xe_n16_node_runtime_worker_thread.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m44xe_n16_node_runtime_worker_thread.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m50xc_n16_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m50xc_n16_node_runtime_worker_thread.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m50xc_n16_node_runtime_worker_thread.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m50xe_n16_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m50xe_n16_node_runtime_worker_thread.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m50xe_n16_node_runtime_worker_thread.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m60xc_n16_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m60xc_n16_node_runtime_worker_thread.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m60xc_n16_node_runtime_worker_thread.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m60xe_n16_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m60xe_n16_node_runtime_worker_thread.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m60xe_n16_node_runtime_worker_thread.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m70xc_n16_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m70xc_n16_node_runtime_worker_thread.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m70xc_n16_node_runtime_worker_thread.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m70xe_n16_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m70xe_n16_node_runtime_worker_thread.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m70xe_n16_node_runtime_worker_thread.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-mlatest_n16_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-mlatest_n16_node_runtime_worker_thread.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-mlatest_n16_node_runtime_worker_thread.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-n20_service_provider_core.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-n20_service_provider_core.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-n20_service_provider_core.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-n16_service_provider_core.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-n16_service_provider_core.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-n16_service_provider_core.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m42xc_n20_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m42xc_n20_service_provider_server.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m42xc_n20_service_provider_server.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m42xe_n20_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m42xe_n20_service_provider_server.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m42xe_n20_service_provider_server.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m44xc_n20_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m44xc_n20_service_provider_server.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m44xc_n20_service_provider_server.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m44xe_n20_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m44xe_n20_service_provider_server.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m44xe_n20_service_provider_server.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m50xc_n20_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m50xc_n20_service_provider_server.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m50xc_n20_service_provider_server.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m50xe_n20_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m50xe_n20_service_provider_server.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m50xe_n20_service_provider_server.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m60xc_n20_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m60xc_n20_service_provider_server.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m60xc_n20_service_provider_server.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m60xe_n20_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m60xe_n20_service_provider_server.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m60xe_n20_service_provider_server.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m70xc_n20_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m70xc_n20_service_provider_server.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m70xc_n20_service_provider_server.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m70xe_n20_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m70xe_n20_service_provider_server.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m70xe_n20_service_provider_server.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-mlatest_n20_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-mlatest_n20_service_provider_server.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-mlatest_n20_service_provider_server.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m42xc_n16_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m42xc_n16_service_provider_server.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m42xc_n16_service_provider_server.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m42xe_n16_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m42xe_n16_service_provider_server.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m42xe_n16_service_provider_server.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m44xc_n16_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m44xc_n16_service_provider_server.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m44xc_n16_service_provider_server.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m44xe_n16_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m44xe_n16_service_provider_server.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m44xe_n16_service_provider_server.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m50xc_n16_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m50xc_n16_service_provider_server.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m50xc_n16_service_provider_server.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m50xe_n16_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m50xe_n16_service_provider_server.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m50xe_n16_service_provider_server.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m60xc_n16_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m60xc_n16_service_provider_server.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m60xc_n16_service_provider_server.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m60xe_n16_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m60xe_n16_service_provider_server.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m60xe_n16_service_provider_server.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m70xc_n16_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m70xc_n16_service_provider_server.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m70xc_n16_service_provider_server.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m70xe_n16_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m70xe_n16_service_provider_server.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m70xe_n16_service_provider_server.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-mlatest_n16_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-mlatest_n16_service_provider_server.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-mlatest_n16_service_provider_server.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m42xc_n20_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m42xc_n20_shell_api.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m42xc_n20_shell_api.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m42xe_n20_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m42xe_n20_shell_api.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m42xe_n20_shell_api.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m44xc_n20_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m44xc_n20_shell_api.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m44xc_n20_shell_api.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m44xe_n20_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m44xe_n20_shell_api.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m44xe_n20_shell_api.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m50xc_n20_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m50xc_n20_shell_api.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m50xc_n20_shell_api.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m50xe_n20_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m50xe_n20_shell_api.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m50xe_n20_shell_api.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m60xc_n20_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m60xc_n20_shell_api.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m60xc_n20_shell_api.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m60xe_n20_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m60xe_n20_shell_api.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m60xe_n20_shell_api.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m70xc_n20_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m70xc_n20_shell_api.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m70xc_n20_shell_api.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m70xe_n20_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m70xe_n20_shell_api.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m70xe_n20_shell_api.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-mlatest_n20_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-mlatest_n20_shell_api.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-mlatest_n20_shell_api.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m42xc_n16_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m42xc_n16_shell_api.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m42xc_n16_shell_api.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m42xe_n16_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m42xe_n16_shell_api.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m42xe_n16_shell_api.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m44xc_n16_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m44xc_n16_shell_api.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m44xc_n16_shell_api.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m44xe_n16_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m44xe_n16_shell_api.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m44xe_n16_shell_api.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m50xc_n16_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m50xc_n16_shell_api.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m50xc_n16_shell_api.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m50xe_n16_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m50xe_n16_shell_api.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m50xe_n16_shell_api.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m60xc_n16_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m60xc_n16_shell_api.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m60xc_n16_shell_api.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m60xe_n16_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m60xe_n16_shell_api.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m60xe_n16_shell_api.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m70xc_n16_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m70xc_n16_shell_api.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m70xc_n16_shell_api.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-m70xe_n16_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-m70xe_n16_shell_api.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-m70xe_n16_shell_api.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-mlatest_n16_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-mlatest_n16_shell_api.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-mlatest_n16_shell_api.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-n20_shell_evaluator.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-n20_shell_evaluator.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-n20_shell_evaluator.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-n16_shell_evaluator.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-n16_shell_evaluator.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-n16_shell_evaluator.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-n20_snippet_manager.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-n20_snippet_manager.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-n20_snippet_manager.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-n16_snippet_manager.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-n16_snippet_manager.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-n16_snippet_manager.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-n20_types.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-n20_types.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-n20_types.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-darwin_unit-n16_types.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-darwin_unit-n16_types.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-darwin_unit-n16_types.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-n20_arg_parser.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-n20_arg_parser.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-n20_arg_parser.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-n16_arg_parser.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-n16_arg_parser.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-n16_arg_parser.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-n20_async_rewriter2.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-n20_async_rewriter2.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-n20_async_rewriter2.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-n16_async_rewriter2.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-n16_async_rewriter2.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-n16_async_rewriter2.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-n20_autocomplete.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-n20_autocomplete.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-n20_autocomplete.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-n16_autocomplete.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-n16_autocomplete.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-n16_autocomplete.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-n20_browser_runtime_core.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-n20_browser_runtime_core.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-n20_browser_runtime_core.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-n16_browser_runtime_core.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-n16_browser_runtime_core.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-n16_browser_runtime_core.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-n20_browser_runtime_electron.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-n20_browser_runtime_electron.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-n20_browser_runtime_electron.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-n16_browser_runtime_electron.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-n16_browser_runtime_electron.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-n16_browser_runtime_electron.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-n20_build.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-n20_build.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-n20_build.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-n16_build.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-n16_build.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-n16_build.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m42xc_n20_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m42xc_n20_cli_repl.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m42xc_n20_cli_repl.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m44xc_n20_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m44xc_n20_cli_repl.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m44xc_n20_cli_repl.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m44xe_n20_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m44xe_n20_cli_repl.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m44xe_n20_cli_repl.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m50xc_n20_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m50xc_n20_cli_repl.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m50xc_n20_cli_repl.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m50xe_n20_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m50xe_n20_cli_repl.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m50xe_n20_cli_repl.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m60xc_n20_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m60xc_n20_cli_repl.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m60xc_n20_cli_repl.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m60xe_n20_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m60xe_n20_cli_repl.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m60xe_n20_cli_repl.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m70xc_n20_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m70xc_n20_cli_repl.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m70xc_n20_cli_repl.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m70xe_n20_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m70xe_n20_cli_repl.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m70xe_n20_cli_repl.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-mlatest_n20_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-mlatest_n20_cli_repl.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-mlatest_n20_cli_repl.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m42xc_n16_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m42xc_n16_cli_repl.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m42xc_n16_cli_repl.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m44xc_n16_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m44xc_n16_cli_repl.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m44xc_n16_cli_repl.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m44xe_n16_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m44xe_n16_cli_repl.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m44xe_n16_cli_repl.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m50xc_n16_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m50xc_n16_cli_repl.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m50xc_n16_cli_repl.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m50xe_n16_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m50xe_n16_cli_repl.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m50xe_n16_cli_repl.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m60xc_n16_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m60xc_n16_cli_repl.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m60xc_n16_cli_repl.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m60xe_n16_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m60xe_n16_cli_repl.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m60xe_n16_cli_repl.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m70xc_n16_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m70xc_n16_cli_repl.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m70xc_n16_cli_repl.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m70xe_n16_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m70xe_n16_cli_repl.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m70xe_n16_cli_repl.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-mlatest_n16_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-mlatest_n16_cli_repl.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-mlatest_n16_cli_repl.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m42xc_n20_e2e_tests.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m42xc_n20_e2e_tests.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m42xc_n20_e2e_tests.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m44xc_n20_e2e_tests.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m44xc_n20_e2e_tests.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m44xc_n20_e2e_tests.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m44xe_n20_e2e_tests.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m44xe_n20_e2e_tests.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m44xe_n20_e2e_tests.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m50xc_n20_e2e_tests.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m50xc_n20_e2e_tests.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m50xc_n20_e2e_tests.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m50xe_n20_e2e_tests.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m50xe_n20_e2e_tests.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m50xe_n20_e2e_tests.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m60xc_n20_e2e_tests.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m60xc_n20_e2e_tests.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m60xc_n20_e2e_tests.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m60xe_n20_e2e_tests.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m60xe_n20_e2e_tests.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m60xe_n20_e2e_tests.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m70xc_n20_e2e_tests.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m70xc_n20_e2e_tests.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m70xc_n20_e2e_tests.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m70xe_n20_e2e_tests.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m70xe_n20_e2e_tests.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m70xe_n20_e2e_tests.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-mlatest_n20_e2e_tests.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-mlatest_n20_e2e_tests.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-mlatest_n20_e2e_tests.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m42xc_n16_e2e_tests.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m42xc_n16_e2e_tests.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m42xc_n16_e2e_tests.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m44xc_n16_e2e_tests.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m44xc_n16_e2e_tests.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m44xc_n16_e2e_tests.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m44xe_n16_e2e_tests.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m44xe_n16_e2e_tests.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m44xe_n16_e2e_tests.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m50xc_n16_e2e_tests.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m50xc_n16_e2e_tests.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m50xc_n16_e2e_tests.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m50xe_n16_e2e_tests.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m50xe_n16_e2e_tests.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m50xe_n16_e2e_tests.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m60xc_n16_e2e_tests.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m60xc_n16_e2e_tests.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m60xc_n16_e2e_tests.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m60xe_n16_e2e_tests.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m60xe_n16_e2e_tests.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m60xe_n16_e2e_tests.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m70xc_n16_e2e_tests.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m70xc_n16_e2e_tests.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m70xc_n16_e2e_tests.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m70xe_n16_e2e_tests.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m70xe_n16_e2e_tests.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m70xe_n16_e2e_tests.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-mlatest_n16_e2e_tests.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-mlatest_n16_e2e_tests.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-mlatest_n16_e2e_tests.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-n20_editor.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-n20_editor.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-n20_editor.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-n16_editor.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-n16_editor.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-n16_editor.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-n20_errors.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-n20_errors.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-n20_errors.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-n16_errors.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-n16_errors.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-n16_errors.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-n20_history.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-n20_history.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-n20_history.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-n16_history.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-n16_history.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-n16_history.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-n20_i18n.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-n20_i18n.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-n20_i18n.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-n16_i18n.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-n16_i18n.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-n16_i18n.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m42xc_n20_java_shell.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m42xc_n20_java_shell.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m42xc_n20_java_shell.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m44xc_n20_java_shell.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m44xc_n20_java_shell.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m44xc_n20_java_shell.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m44xe_n20_java_shell.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m44xe_n20_java_shell.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m44xe_n20_java_shell.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m50xc_n20_java_shell.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m50xc_n20_java_shell.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m50xc_n20_java_shell.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m50xe_n20_java_shell.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m50xe_n20_java_shell.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m50xe_n20_java_shell.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m60xc_n20_java_shell.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m60xc_n20_java_shell.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m60xc_n20_java_shell.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m60xe_n20_java_shell.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m60xe_n20_java_shell.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m60xe_n20_java_shell.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m70xc_n20_java_shell.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m70xc_n20_java_shell.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m70xc_n20_java_shell.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m70xe_n20_java_shell.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m70xe_n20_java_shell.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m70xe_n20_java_shell.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-mlatest_n20_java_shell.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-mlatest_n20_java_shell.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-mlatest_n20_java_shell.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m42xc_n16_java_shell.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m42xc_n16_java_shell.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m42xc_n16_java_shell.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m44xc_n16_java_shell.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m44xc_n16_java_shell.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m44xc_n16_java_shell.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m44xe_n16_java_shell.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m44xe_n16_java_shell.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m44xe_n16_java_shell.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m50xc_n16_java_shell.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m50xc_n16_java_shell.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m50xc_n16_java_shell.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m50xe_n16_java_shell.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m50xe_n16_java_shell.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m50xe_n16_java_shell.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m60xc_n16_java_shell.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m60xc_n16_java_shell.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m60xc_n16_java_shell.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m60xe_n16_java_shell.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m60xe_n16_java_shell.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m60xe_n16_java_shell.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m70xc_n16_java_shell.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m70xc_n16_java_shell.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m70xc_n16_java_shell.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m70xe_n16_java_shell.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m70xe_n16_java_shell.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m70xe_n16_java_shell.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-mlatest_n16_java_shell.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-mlatest_n16_java_shell.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-mlatest_n16_java_shell.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-n20_js_multiline_to_singleline.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-n20_js_multiline_to_singleline.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-n20_js_multiline_to_singleline.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-n16_js_multiline_to_singleline.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-n16_js_multiline_to_singleline.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-n16_js_multiline_to_singleline.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-n20_logging.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-n20_logging.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-n20_logging.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-n16_logging.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-n16_logging.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-n16_logging.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m42xc_n20_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m42xc_n20_node_runtime_worker_thread.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m42xc_n20_node_runtime_worker_thread.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m44xc_n20_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m44xc_n20_node_runtime_worker_thread.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m44xc_n20_node_runtime_worker_thread.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m44xe_n20_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m44xe_n20_node_runtime_worker_thread.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m44xe_n20_node_runtime_worker_thread.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m50xc_n20_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m50xc_n20_node_runtime_worker_thread.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m50xc_n20_node_runtime_worker_thread.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m50xe_n20_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m50xe_n20_node_runtime_worker_thread.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m50xe_n20_node_runtime_worker_thread.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m60xc_n20_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m60xc_n20_node_runtime_worker_thread.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m60xc_n20_node_runtime_worker_thread.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m60xe_n20_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m60xe_n20_node_runtime_worker_thread.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m60xe_n20_node_runtime_worker_thread.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m70xc_n20_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m70xc_n20_node_runtime_worker_thread.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m70xc_n20_node_runtime_worker_thread.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m70xe_n20_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m70xe_n20_node_runtime_worker_thread.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m70xe_n20_node_runtime_worker_thread.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-mlatest_n20_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-mlatest_n20_node_runtime_worker_thread.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-mlatest_n20_node_runtime_worker_thread.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m42xc_n16_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m42xc_n16_node_runtime_worker_thread.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m42xc_n16_node_runtime_worker_thread.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m44xc_n16_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m44xc_n16_node_runtime_worker_thread.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m44xc_n16_node_runtime_worker_thread.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m44xe_n16_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m44xe_n16_node_runtime_worker_thread.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m44xe_n16_node_runtime_worker_thread.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m50xc_n16_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m50xc_n16_node_runtime_worker_thread.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m50xc_n16_node_runtime_worker_thread.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m50xe_n16_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m50xe_n16_node_runtime_worker_thread.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m50xe_n16_node_runtime_worker_thread.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m60xc_n16_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m60xc_n16_node_runtime_worker_thread.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m60xc_n16_node_runtime_worker_thread.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m60xe_n16_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m60xe_n16_node_runtime_worker_thread.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m60xe_n16_node_runtime_worker_thread.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m70xc_n16_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m70xc_n16_node_runtime_worker_thread.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m70xc_n16_node_runtime_worker_thread.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m70xe_n16_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m70xe_n16_node_runtime_worker_thread.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m70xe_n16_node_runtime_worker_thread.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-mlatest_n16_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-mlatest_n16_node_runtime_worker_thread.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-mlatest_n16_node_runtime_worker_thread.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-n20_service_provider_core.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-n20_service_provider_core.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-n20_service_provider_core.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-n16_service_provider_core.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-n16_service_provider_core.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-n16_service_provider_core.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m42xc_n20_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m42xc_n20_service_provider_server.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m42xc_n20_service_provider_server.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m44xc_n20_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m44xc_n20_service_provider_server.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m44xc_n20_service_provider_server.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m44xe_n20_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m44xe_n20_service_provider_server.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m44xe_n20_service_provider_server.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m50xc_n20_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m50xc_n20_service_provider_server.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m50xc_n20_service_provider_server.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m50xe_n20_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m50xe_n20_service_provider_server.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m50xe_n20_service_provider_server.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m60xc_n20_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m60xc_n20_service_provider_server.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m60xc_n20_service_provider_server.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m60xe_n20_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m60xe_n20_service_provider_server.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m60xe_n20_service_provider_server.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m70xc_n20_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m70xc_n20_service_provider_server.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m70xc_n20_service_provider_server.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m70xe_n20_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m70xe_n20_service_provider_server.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m70xe_n20_service_provider_server.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-mlatest_n20_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-mlatest_n20_service_provider_server.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-mlatest_n20_service_provider_server.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m42xc_n16_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m42xc_n16_service_provider_server.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m42xc_n16_service_provider_server.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m44xc_n16_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m44xc_n16_service_provider_server.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m44xc_n16_service_provider_server.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m44xe_n16_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m44xe_n16_service_provider_server.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m44xe_n16_service_provider_server.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m50xc_n16_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m50xc_n16_service_provider_server.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m50xc_n16_service_provider_server.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m50xe_n16_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m50xe_n16_service_provider_server.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m50xe_n16_service_provider_server.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m60xc_n16_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m60xc_n16_service_provider_server.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m60xc_n16_service_provider_server.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m60xe_n16_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m60xe_n16_service_provider_server.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m60xe_n16_service_provider_server.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m70xc_n16_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m70xc_n16_service_provider_server.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m70xc_n16_service_provider_server.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m70xe_n16_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m70xe_n16_service_provider_server.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m70xe_n16_service_provider_server.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-mlatest_n16_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-mlatest_n16_service_provider_server.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-mlatest_n16_service_provider_server.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m42xc_n20_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m42xc_n20_shell_api.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m42xc_n20_shell_api.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m44xc_n20_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m44xc_n20_shell_api.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m44xc_n20_shell_api.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m44xe_n20_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m44xe_n20_shell_api.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m44xe_n20_shell_api.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m50xc_n20_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m50xc_n20_shell_api.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m50xc_n20_shell_api.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m50xe_n20_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m50xe_n20_shell_api.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m50xe_n20_shell_api.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m60xc_n20_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m60xc_n20_shell_api.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m60xc_n20_shell_api.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m60xe_n20_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m60xe_n20_shell_api.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m60xe_n20_shell_api.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m70xc_n20_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m70xc_n20_shell_api.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m70xc_n20_shell_api.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m70xe_n20_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m70xe_n20_shell_api.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m70xe_n20_shell_api.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-mlatest_n20_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-mlatest_n20_shell_api.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-mlatest_n20_shell_api.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m42xc_n16_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m42xc_n16_shell_api.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m42xc_n16_shell_api.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m44xc_n16_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m44xc_n16_shell_api.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m44xc_n16_shell_api.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m44xe_n16_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m44xe_n16_shell_api.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m44xe_n16_shell_api.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m50xc_n16_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m50xc_n16_shell_api.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m50xc_n16_shell_api.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m50xe_n16_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m50xe_n16_shell_api.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m50xe_n16_shell_api.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m60xc_n16_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m60xc_n16_shell_api.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m60xc_n16_shell_api.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m60xe_n16_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m60xe_n16_shell_api.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m60xe_n16_shell_api.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m70xc_n16_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m70xc_n16_shell_api.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m70xc_n16_shell_api.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-m70xe_n16_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-m70xe_n16_shell_api.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-m70xe_n16_shell_api.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-mlatest_n16_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-mlatest_n16_shell_api.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-mlatest_n16_shell_api.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-n20_shell_evaluator.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-n20_shell_evaluator.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-n20_shell_evaluator.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-n16_shell_evaluator.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-n16_shell_evaluator.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-n16_shell_evaluator.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-n20_snippet_manager.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-n20_snippet_manager.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-n20_snippet_manager.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-n16_snippet_manager.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-n16_snippet_manager.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-n16_snippet_manager.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-n20_types.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-n20_types.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-n20_types.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-linux_unit-n16_types.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-linux_unit-n16_types.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-linux_unit-n16_types.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-n20_arg_parser.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-n20_arg_parser.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-n20_arg_parser.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-n16_arg_parser.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-n16_arg_parser.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-n16_arg_parser.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-n20_async_rewriter2.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-n20_async_rewriter2.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-n20_async_rewriter2.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-n16_async_rewriter2.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-n16_async_rewriter2.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-n16_async_rewriter2.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-n20_autocomplete.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-n20_autocomplete.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-n20_autocomplete.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-n16_autocomplete.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-n16_autocomplete.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-n16_autocomplete.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-n20_browser_runtime_core.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-n20_browser_runtime_core.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-n20_browser_runtime_core.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-n16_browser_runtime_core.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-n16_browser_runtime_core.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-n16_browser_runtime_core.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-n20_browser_runtime_electron.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-n20_browser_runtime_electron.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-n20_browser_runtime_electron.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-n16_browser_runtime_electron.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-n16_browser_runtime_electron.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-n16_browser_runtime_electron.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-n20_build.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-n20_build.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-n20_build.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-n16_build.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-n16_build.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-n16_build.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m42xc_n20_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m42xc_n20_cli_repl.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m42xc_n20_cli_repl.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m42xe_n20_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m42xe_n20_cli_repl.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m42xe_n20_cli_repl.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m44xc_n20_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m44xc_n20_cli_repl.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m44xc_n20_cli_repl.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m44xe_n20_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m44xe_n20_cli_repl.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m44xe_n20_cli_repl.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m50xc_n20_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m50xc_n20_cli_repl.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m50xc_n20_cli_repl.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m50xe_n20_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m50xe_n20_cli_repl.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m50xe_n20_cli_repl.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m60xc_n20_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m60xc_n20_cli_repl.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m60xc_n20_cli_repl.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m60xe_n20_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m60xe_n20_cli_repl.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m60xe_n20_cli_repl.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m70xc_n20_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m70xc_n20_cli_repl.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m70xc_n20_cli_repl.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m70xe_n20_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m70xe_n20_cli_repl.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m70xe_n20_cli_repl.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-mlatest_n20_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-mlatest_n20_cli_repl.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-mlatest_n20_cli_repl.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m42xc_n16_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m42xc_n16_cli_repl.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m42xc_n16_cli_repl.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m42xe_n16_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m42xe_n16_cli_repl.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m42xe_n16_cli_repl.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m44xc_n16_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m44xc_n16_cli_repl.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m44xc_n16_cli_repl.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m44xe_n16_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m44xe_n16_cli_repl.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m44xe_n16_cli_repl.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m50xc_n16_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m50xc_n16_cli_repl.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m50xc_n16_cli_repl.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m50xe_n16_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m50xe_n16_cli_repl.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m50xe_n16_cli_repl.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m60xc_n16_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m60xc_n16_cli_repl.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m60xc_n16_cli_repl.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m60xe_n16_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m60xe_n16_cli_repl.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m60xe_n16_cli_repl.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m70xc_n16_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m70xc_n16_cli_repl.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m70xc_n16_cli_repl.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m70xe_n16_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m70xe_n16_cli_repl.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m70xe_n16_cli_repl.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-mlatest_n16_cli_repl.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-mlatest_n16_cli_repl.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-mlatest_n16_cli_repl.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m42xc_n20_e2e_tests.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m42xc_n20_e2e_tests.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m42xc_n20_e2e_tests.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m42xe_n20_e2e_tests.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m42xe_n20_e2e_tests.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m42xe_n20_e2e_tests.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m44xc_n20_e2e_tests.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m44xc_n20_e2e_tests.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m44xc_n20_e2e_tests.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m44xe_n20_e2e_tests.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m44xe_n20_e2e_tests.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m44xe_n20_e2e_tests.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m50xc_n20_e2e_tests.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m50xc_n20_e2e_tests.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m50xc_n20_e2e_tests.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m50xe_n20_e2e_tests.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m50xe_n20_e2e_tests.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m50xe_n20_e2e_tests.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m60xc_n20_e2e_tests.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m60xc_n20_e2e_tests.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m60xc_n20_e2e_tests.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m60xe_n20_e2e_tests.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m60xe_n20_e2e_tests.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m60xe_n20_e2e_tests.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m70xc_n20_e2e_tests.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m70xc_n20_e2e_tests.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m70xc_n20_e2e_tests.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m70xe_n20_e2e_tests.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m70xe_n20_e2e_tests.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m70xe_n20_e2e_tests.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-mlatest_n20_e2e_tests.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-mlatest_n20_e2e_tests.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-mlatest_n20_e2e_tests.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m42xc_n16_e2e_tests.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m42xc_n16_e2e_tests.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m42xc_n16_e2e_tests.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m42xe_n16_e2e_tests.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m42xe_n16_e2e_tests.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m42xe_n16_e2e_tests.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m44xc_n16_e2e_tests.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m44xc_n16_e2e_tests.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m44xc_n16_e2e_tests.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m44xe_n16_e2e_tests.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m44xe_n16_e2e_tests.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m44xe_n16_e2e_tests.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m50xc_n16_e2e_tests.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m50xc_n16_e2e_tests.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m50xc_n16_e2e_tests.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m50xe_n16_e2e_tests.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m50xe_n16_e2e_tests.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m50xe_n16_e2e_tests.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m60xc_n16_e2e_tests.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m60xc_n16_e2e_tests.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m60xc_n16_e2e_tests.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m60xe_n16_e2e_tests.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m60xe_n16_e2e_tests.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m60xe_n16_e2e_tests.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m70xc_n16_e2e_tests.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m70xc_n16_e2e_tests.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m70xc_n16_e2e_tests.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m70xe_n16_e2e_tests.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m70xe_n16_e2e_tests.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m70xe_n16_e2e_tests.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-mlatest_n16_e2e_tests.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-mlatest_n16_e2e_tests.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-mlatest_n16_e2e_tests.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-n20_editor.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-n20_editor.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-n20_editor.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-n16_editor.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-n16_editor.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-n16_editor.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-n20_errors.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-n20_errors.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-n20_errors.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-n16_errors.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-n16_errors.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-n16_errors.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-n20_history.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-n20_history.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-n20_history.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-n16_history.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-n16_history.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-n16_history.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-n20_i18n.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-n20_i18n.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-n20_i18n.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-n16_i18n.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-n16_i18n.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-n16_i18n.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-n20_js_multiline_to_singleline.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-n20_js_multiline_to_singleline.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-n20_js_multiline_to_singleline.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-n16_js_multiline_to_singleline.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-n16_js_multiline_to_singleline.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-n16_js_multiline_to_singleline.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-n20_logging.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-n20_logging.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-n20_logging.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-n16_logging.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-n16_logging.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-n16_logging.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m42xc_n20_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m42xc_n20_node_runtime_worker_thread.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m42xc_n20_node_runtime_worker_thread.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m42xe_n20_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m42xe_n20_node_runtime_worker_thread.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m42xe_n20_node_runtime_worker_thread.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m44xc_n20_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m44xc_n20_node_runtime_worker_thread.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m44xc_n20_node_runtime_worker_thread.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m44xe_n20_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m44xe_n20_node_runtime_worker_thread.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m44xe_n20_node_runtime_worker_thread.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m50xc_n20_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m50xc_n20_node_runtime_worker_thread.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m50xc_n20_node_runtime_worker_thread.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m50xe_n20_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m50xe_n20_node_runtime_worker_thread.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m50xe_n20_node_runtime_worker_thread.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m60xc_n20_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m60xc_n20_node_runtime_worker_thread.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m60xc_n20_node_runtime_worker_thread.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m60xe_n20_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m60xe_n20_node_runtime_worker_thread.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m60xe_n20_node_runtime_worker_thread.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m70xc_n20_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m70xc_n20_node_runtime_worker_thread.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m70xc_n20_node_runtime_worker_thread.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m70xe_n20_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m70xe_n20_node_runtime_worker_thread.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m70xe_n20_node_runtime_worker_thread.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-mlatest_n20_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-mlatest_n20_node_runtime_worker_thread.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-mlatest_n20_node_runtime_worker_thread.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m42xc_n16_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m42xc_n16_node_runtime_worker_thread.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m42xc_n16_node_runtime_worker_thread.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m42xe_n16_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m42xe_n16_node_runtime_worker_thread.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m42xe_n16_node_runtime_worker_thread.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m44xc_n16_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m44xc_n16_node_runtime_worker_thread.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m44xc_n16_node_runtime_worker_thread.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m44xe_n16_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m44xe_n16_node_runtime_worker_thread.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m44xe_n16_node_runtime_worker_thread.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m50xc_n16_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m50xc_n16_node_runtime_worker_thread.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m50xc_n16_node_runtime_worker_thread.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m50xe_n16_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m50xe_n16_node_runtime_worker_thread.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m50xe_n16_node_runtime_worker_thread.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m60xc_n16_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m60xc_n16_node_runtime_worker_thread.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m60xc_n16_node_runtime_worker_thread.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m60xe_n16_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m60xe_n16_node_runtime_worker_thread.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m60xe_n16_node_runtime_worker_thread.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m70xc_n16_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m70xc_n16_node_runtime_worker_thread.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m70xc_n16_node_runtime_worker_thread.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m70xe_n16_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m70xe_n16_node_runtime_worker_thread.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m70xe_n16_node_runtime_worker_thread.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-mlatest_n16_node_runtime_worker_thread.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-mlatest_n16_node_runtime_worker_thread.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-mlatest_n16_node_runtime_worker_thread.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-n20_service_provider_core.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-n20_service_provider_core.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-n20_service_provider_core.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-n16_service_provider_core.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-n16_service_provider_core.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-n16_service_provider_core.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m42xc_n20_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m42xc_n20_service_provider_server.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m42xc_n20_service_provider_server.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m42xe_n20_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m42xe_n20_service_provider_server.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m42xe_n20_service_provider_server.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m44xc_n20_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m44xc_n20_service_provider_server.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m44xc_n20_service_provider_server.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m44xe_n20_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m44xe_n20_service_provider_server.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m44xe_n20_service_provider_server.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m50xc_n20_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m50xc_n20_service_provider_server.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m50xc_n20_service_provider_server.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m50xe_n20_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m50xe_n20_service_provider_server.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m50xe_n20_service_provider_server.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m60xc_n20_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m60xc_n20_service_provider_server.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m60xc_n20_service_provider_server.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m60xe_n20_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m60xe_n20_service_provider_server.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m60xe_n20_service_provider_server.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m70xc_n20_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m70xc_n20_service_provider_server.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m70xc_n20_service_provider_server.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m70xe_n20_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m70xe_n20_service_provider_server.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m70xe_n20_service_provider_server.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-mlatest_n20_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-mlatest_n20_service_provider_server.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-mlatest_n20_service_provider_server.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m42xc_n16_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m42xc_n16_service_provider_server.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m42xc_n16_service_provider_server.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m42xe_n16_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m42xe_n16_service_provider_server.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m42xe_n16_service_provider_server.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m44xc_n16_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m44xc_n16_service_provider_server.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m44xc_n16_service_provider_server.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m44xe_n16_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m44xe_n16_service_provider_server.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m44xe_n16_service_provider_server.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m50xc_n16_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m50xc_n16_service_provider_server.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m50xc_n16_service_provider_server.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m50xe_n16_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m50xe_n16_service_provider_server.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m50xe_n16_service_provider_server.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m60xc_n16_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m60xc_n16_service_provider_server.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m60xc_n16_service_provider_server.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m60xe_n16_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m60xe_n16_service_provider_server.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m60xe_n16_service_provider_server.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m70xc_n16_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m70xc_n16_service_provider_server.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m70xc_n16_service_provider_server.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m70xe_n16_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m70xe_n16_service_provider_server.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m70xe_n16_service_provider_server.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-mlatest_n16_service_provider_server.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-mlatest_n16_service_provider_server.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-mlatest_n16_service_provider_server.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m42xc_n20_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m42xc_n20_shell_api.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m42xc_n20_shell_api.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m42xe_n20_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m42xe_n20_shell_api.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m42xe_n20_shell_api.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m44xc_n20_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m44xc_n20_shell_api.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m44xc_n20_shell_api.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m44xe_n20_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m44xe_n20_shell_api.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m44xe_n20_shell_api.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m50xc_n20_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m50xc_n20_shell_api.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m50xc_n20_shell_api.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m50xe_n20_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m50xe_n20_shell_api.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m50xe_n20_shell_api.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m60xc_n20_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m60xc_n20_shell_api.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m60xc_n20_shell_api.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m60xe_n20_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m60xe_n20_shell_api.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m60xe_n20_shell_api.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m70xc_n20_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m70xc_n20_shell_api.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m70xc_n20_shell_api.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m70xe_n20_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m70xe_n20_shell_api.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m70xe_n20_shell_api.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-mlatest_n20_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-mlatest_n20_shell_api.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-mlatest_n20_shell_api.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m42xc_n16_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m42xc_n16_shell_api.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m42xc_n16_shell_api.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m42xe_n16_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m42xe_n16_shell_api.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m42xe_n16_shell_api.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m44xc_n16_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m44xc_n16_shell_api.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m44xc_n16_shell_api.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m44xe_n16_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m44xe_n16_shell_api.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m44xe_n16_shell_api.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m50xc_n16_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m50xc_n16_shell_api.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m50xc_n16_shell_api.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m50xe_n16_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m50xe_n16_shell_api.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m50xe_n16_shell_api.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m60xc_n16_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m60xc_n16_shell_api.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m60xc_n16_shell_api.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m60xe_n16_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m60xe_n16_shell_api.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m60xe_n16_shell_api.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m70xc_n16_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m70xc_n16_shell_api.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m70xc_n16_shell_api.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-m70xe_n16_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-m70xe_n16_shell_api.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-m70xe_n16_shell_api.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-mlatest_n16_shell_api.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-mlatest_n16_shell_api.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-mlatest_n16_shell_api.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-n20_shell_evaluator.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-n20_shell_evaluator.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-n20_shell_evaluator.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-n16_shell_evaluator.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-n16_shell_evaluator.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-n16_shell_evaluator.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-n20_snippet_manager.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-n20_snippet_manager.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-n20_snippet_manager.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-n16_snippet_manager.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-n16_snippet_manager.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-n16_snippet_manager.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-n20_types.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-n20_types.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-n20_types.tgz
+    - command: s3.get
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/nyc-output-win32_unit-n16_types.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/nyc-output-win32_unit-n16_types.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf nyc-output-win32_unit-n16_types.tgz
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar cvzf full-nyc-output.tgz .nyc_output
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/full-nyc-output.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/full-nyc-output.tgz
+        bucket: mciuploads
+        permissions: private
+        visibility: signed
+        content_type: application/x-gzip
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        env:
+          NODE_JS_VERSION: ${node_js_version}
+        script: |
+          set -e
+          {
+          source .evergreen/setup-env.sh
+          npm run report-coverage-ci
+          echo "Creating coverage tarball..."
+          tar cvzf coverage.tgz coverage
+          }
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/coverage.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/coverage.tgz
+        bucket: mciuploads
+        permissions: private
+        visibility: signed
+        content_type: application/x-gzip
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        env:
+          NODE_JS_VERSION: ${node_js_version}
+        script: |
+          set -e
+          {
+          source .evergreen/setup-env.sh
+          npm run check-coverage
+          }
+
+  test_vscode:
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        env:
+          NODE_JS_VERSION: ${node_js_version}
+        script: |
+          set -e
+          {
+          source .evergreen/setup-env.sh
+          (cd scripts/docker && docker build -t ubuntu22.04-xvfb -f ubuntu22.04-xvfb.Dockerfile .)
+          docker run \
+            --rm -v $PWD:/tmp/build ubuntu22.04-xvfb \
+            -c 'cd /tmp/build && ./testing/test-vscode.sh'
+          }
+  test_connectivity:
+    - command: expansions.write
+      type: system
+      params:
+        file: tmp/expansions.yaml
+        redacted: true
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        env:
+          NODE_JS_VERSION: ${node_js_version}
+          TEST_MONGOSH_EXECUTABLE: ${test_mongosh_executable|}
+          KERBEROS_JUMPHOST_DOCKERFILE: ${kerberos_jumphost_dockerfile|}
+        script: |
+          set -e
+          {
+          source .evergreen/setup-env.sh
+          npm run test-connectivity
+          }
+  test_apistrict:
+    - command: expansions.write
+      type: system
+      params:
+        file: tmp/expansions.yaml
+        redacted: true
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        env:
+          NODE_JS_VERSION: ${node_js_version}
+        script: |
+          set -e
+          {
+          source .evergreen/setup-env.sh
+          npm run test-apistrict-ci
+          }
+
+  ###
+  # ARTIFACT COMPILATION
+  #
+  # compile_artifact generates the executable binary and uploads it as TGZ to S3 for later use.
+  # Use download_compiled_artifact to download the TGZ from S3.
+  #
+  # Both functions expect the following arguments:
+  # - executable_os_id
+  ###
+  compile_artifact:
+    - command: expansions.write
+      type: system
+      params:
+        file: tmp/expansions.yaml
+        redacted: true
+    - command: subprocess.exec
+      params:
+        working_dir: src
+        binary: bash .evergreen/compile-artifact.sh
+        env:
+          DISTRO_ID: ${distro_id}
+          NODE_JS_VERSION: ${node_js_version}
+          MONGOSH_SHARED_OPENSSL: ${mongosh_shared_openssl}
+    - command: expansions.update
+      params:
+        ignore_missing_file: false
+        file: tmp/compiling-context.yml
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/dist.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/mongosh-${executable_os_id}${extra_upload_tag}.tgz
+        bucket: mciuploads
+        permissions: public-read
+        content_type: application/x-gzip
+  download_compiled_artifact:
+    - command: s3.get
+      type: setup
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/dist.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/mongosh-${executable_os_id}${extra_upload_tag}.tgz
+        bucket: mciuploads
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          tar xvzf dist.tgz
+
+  ###
+  # E2E TEST EXECUTION
+  #
+  # Runs the E2E tests against the compiled artifact, i.e. expects the compiled artifact to be already present.
+  ###
+  run_e2e_tests:
+    - command: expansions.write
+      type: system
+      params:
+        file: tmp/expansions.yaml
+        redacted: true
+    - command: subprocess.exec
+      params:
+        working_dir: src
+        binary: bash .evergreen/run-e2e-tests.sh
+        env:
+          NODE_JS_VERSION: ${node_js_version}
+          AWS_AUTH_IAM_ACCESS_KEY_ID: ${devtools_ci_aws_key}
+          AWS_AUTH_IAM_SECRET_ACCESS_KEY: ${devtools_ci_aws_secret}
+          DISABLE_OPENSSL_SHARED_CONFIG_FOR_BUNDLED_OPENSSL: ${disable_openssl_shared_config_for_bundled_openssl}
+          E2E_TASK_NAME: ${task_name}
+
+  ###
+  # PACKAGING AND UPLOADING
+  #
+  # package_and_upload_artifact generates a distributable package out of the compiled artifact,
+  # i.e. it expects it to have been downloaded already. The distributable package will be uploaded
+  # to a specifc Evergreen S3 bucket for later use.
+  #
+  # The URL to download the distributable package can be retrieved by get_artifact_url.
+  #
+  # package_and_upload_artifact expects the following arguments:
+  # - distro_id
+  # - package_variant
+  # - executable_os_id
+  #
+  # get_artifact_url expects the following arguments:
+  # - package_variant
+  ###
+  package_and_upload_artifact:
+    - command: expansions.write
+      type: setup
+      params:
+        file: tmp/expansions.yaml
+        redacted: true
+        # TODO: REPLACE WITH CALLING download_compiled_artifact BEFORE
+    - command: s3.get
+      type: setup
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/dist.tgz
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/mongosh-${executable_os_id}.tgz
+        bucket: mciuploads
+    - command: subprocess.exec
+      params:
+        working_dir: src
+        binary: bash .evergreen/package-and-upload-artifact.sh
+        env:
+          NODE_JS_VERSION: ${node_js_version}
+          DISTRO_ID_OVERRIDE: ${distro_id}
+          PACKAGE_VARIANT: ${package_variant}
+          MACOS_NOTARY_KEY: ${macos_notary_key}
+          MACOS_NOTARY_SECRET: ${macos_notary_secret}
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/artifact-url.txt
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/artifact-url-${package_variant}.txt
+        bucket: mciuploads
+        permissions: public-read
+        content_type: application/x-gzip
+  get_artifact_url:
+    - command: s3.get
+      type: setup
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: artifact-url.txt
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/artifact-url-${source_package_variant}.txt
+        bucket: mciuploads
+
+  write_preload_script:
+    - command: shell.exec
+      type: setup
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          set +x
+          cat <<PRELOAD_SCRIPT > preload.sh
+          echo "Preload script starting"
+          set -e
+          set -x
+          export ARTIFACT_URL=$(cat ../artifact-url.txt)
+          export IS_CI=1
+          set +x
+          export MONGOSH_SMOKE_TEST_SERVER="mongodb+srv://${connectivity_test_atlas_username}:${connectivity_test_atlas_password}@${connectivity_test_atlas_hostname}/"
+          echo "Preload script done"
+          set -x
+          PRELOAD_SCRIPT
+  spawn_host:
+    - command: host.create
+      type: setup
+      params:
+        provider: ec2
+        distro: ${distro}
+        security_group_ids:
+          - sg-097bff6dd0d1d31d0 # Magic string that's needed for SSH'ing.
+    - command: host.list
+      type: setup
+      params:
+        num_hosts: 1
+        path: buildhosts.yml # Write the host information to disk.
+        timeout_seconds: 1200
+        wait: true
+  run_pkg_tests_through_ssh:
+    - command: shell.exec
+      type: setup
+      params:
+        shell: bash
+        script: |
+          set -e
+          {
+          set +x
+          echo '${__project_aws_ssh_key_value}' > ~/.ssh/mcipacker.pem
+          chmod 0600 ~/.ssh/mcipacker.pem
+          set -x
+          }
+    - command: subprocess.exec
+      params:
+        working_dir: src
+        binary: bash .evergreen/run-on-ssh-host.sh
+        env:
+          ADMIN_USER_NAME: ${admin_user_name}
+          ONHOST_SCRIPT_PATH: ${onhost_script_path}
+          PRELOAD_SCRIPT_PATH: ${preload_script_path}
+  test_artifact_docker:
+    - command: shell.exec
+      type: setup
+      params:
+        working_dir: src
+        shell: bash
+        env:
+          NODE_JS_VERSION: ${node_js_version}
+        script: |
+          set -e
+          set -x
+          {
+          . .evergreen/setup-env.sh
+          . preload.sh
+          ./scripts/docker/build.sh ${dockerfile}
+          }
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        env:
+          NODE_JS_VERSION: ${node_js_version}
+        script: |
+          set -e
+          set -x
+          {
+          . .evergreen/setup-env.sh
+          . preload.sh
+          ./scripts/docker/run.sh ${dockerfile} --smokeTests
+          }
+  test_artifact_macos:
+    - command: shell.exec
+      type: setup
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          set -x
+          {
+          . preload.sh
+          curl -sSfL "$ARTIFACT_URL" > mongosh.zip
+          unzip mongosh.zip
+          }
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          set -x
+          {
+          system_profiler SPSoftwareDataType # for debugging
+          . preload.sh
+          ./mongosh-*/bin/mongosh --smokeTests
+          }
+  test_artifact_rpmextract:
+    - command: shell.exec
+      type: setup
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          set -x
+          {
+          . preload.sh
+          curl -sSfL "$ARTIFACT_URL" > mongosh.rpm
+          rpm2cpio mongosh.rpm | cpio -idmv
+          }
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          set -x
+          {
+          . preload.sh
+          ./usr/bin/mongosh --smokeTests
+          }
+  test_artifact_debextract:
+    - command: shell.exec
+      type: setup
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          set -x
+          {
+          . preload.sh
+          curl -sSfL "$ARTIFACT_URL" > mongosh.deb
+          dpkg -x mongosh.deb .
+          }
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          set -x
+          {
+          . preload.sh
+          ./usr/bin/mongosh --smokeTests
+          }
+
+  generate_license_and_vulnerability_report:
+    - command: expansions.write
+      type: system
+      params:
+        file: tmp/expansions.yaml
+        redacted: true
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        env:
+          NODE_JS_VERSION: ${node_js_version}
+          EVERGREEN_IS_PATCH: ${is_patch}
+          SNYK_TOKEN: ${snyk_token}
+          EVERGREEN_TASK_URL: https://evergreen.mongodb.com/task/${task_id}
+          JIRA_API_TOKEN: ${jira_api_token}
+        script: |
+          set -e
+          export NODE_JS_VERSION=${node_js_version}
+          source .evergreen/setup-env.sh
+
+          # validate licenses, we first remove THIRD_PARTY_NOTICES.md, so we are sure
+          # that we would only upload the newly generated file in case of success.
+          rm THIRD_PARTY_NOTICES.md
+          npm run update-third-party-notices
+
+          # generate vulnerability report
+          set +e
+          npm run generate-vulnerability-report
+          return_code=$?
+          set -e
+
+          # if on main and not triggered by a tag, also create a ticket for each vulnerability found
+          if [[ "${requester}" == "commit" ]]; then
+            export JIRA_BASE_URL="https://jira.mongodb.org"
+            export JIRA_PROJECT="MONGOSH"
+            export JIRA_VULNERABILITY_BUILD_INFO="- [Evergreen task|$EVERGREEN_TASK_URL]"
+            npm run create-vulnerability-tickets
+          else
+            cat .sbom/vulnerability-report.md
+          fi
+
+          # Fails if the report failed and is not a patch, including during releases:
+          if [[ "${is_patch}" != "true" ]]; then
+            exit $return_code
+          fi
+
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        bucket: mciuploads
+        permissions: private
+        visibility: signed
+        local_file: src/.sbom/dependencies.json
+        remote_file: ${project}/${revision}_${revision_order_id}/dependencies.json
+        content_type: application/json
+        optional: true
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        bucket: mciuploads
+        permissions: private
+        visibility: signed
+        local_file: src/.sbom/snyk-test-result.json
+        remote_file: ${project}/${revision}_${revision_order_id}/snyk-test-result.json
+        content_type: application/json
+        optional: true
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        bucket: mciuploads
+        permissions: private
+        visibility: signed
+        local_file: src/.sbom/snyk-test-result.html
+        remote_file: ${project}/${revision}_${revision_order_id}/snyk-test-result.html
+        content_type: text/html
+        optional: true
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        bucket: mciuploads
+        permissions: private
+        visibility: signed
+        local_file: src/.sbom/vulnerability-report.md
+        remote_file: ${project}/${revision}_${revision_order_id}/vulnerability-report.md
+        content_type: text/markdown
+        optional: true
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        bucket: mciuploads
+        permissions: private
+        visibility: signed
+        local_file: src/THIRD_PARTY_NOTICES.md
+        remote_file: ${project}/${revision}_${revision_order_id}/THIRD_PARTY_NOTICES.md
+        content_type: text/markdown
+        optional: true
+
+  release_draft:
+    - command: expansions.write
+      type: system
+      params:
+        file: tmp/expansions.yaml
+        redacted: true
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          {
+          export NODE_JS_VERSION=${node_js_version}
+          source .evergreen/setup-env.sh
+          export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD="true"
+          npm run evergreen-release draft
+          }
+
+  release_publish_dry_run:
+    - command: expansions.write
+      type: system
+      params:
+        file: tmp/expansions.yaml
+        redacted: true
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          {
+          echo "//registry.npmjs.org/:_authToken=${devtoolsbot_npm_token}" > .npmrc
+          export NODE_JS_VERSION=${node_js_version}
+          source .evergreen/setup-env.sh
+          export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD="true"
+          npm run evergreen-release publish -- --dry-run
+          }
+
+  release_publish:
+    - command: expansions.write
+      type: system
+      params:
+        file: tmp/expansions.yaml
+        redacted: true
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        script: |
+          set -e
+          {
+          echo "//registry.npmjs.org/:_authToken=${devtoolsbot_npm_token}" > .npmrc
+          export NODE_JS_VERSION=${node_js_version}
+          source .evergreen/setup-env.sh
+          export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD="true"
+          npm run evergreen-release publish
+          }
+
+# Tasks will show up as the individual blocks in the Evergreen UI that can
+# pass or fail.
+#
+# Current tasks:
+#   compile_ts - Do the initial compilation of TS sources.
+#   check - Performs linter and dependency checks.
+#   check_coverage - Performs coverage check by merging all NYC outputs first
+#   test_{version} - Runs all tests, against a specified mongod version.
+#   test_vscode - Run the vscode extension integration tests.
+#   test_connectivity - Runs extra connectivity tests.
+#   test_apistrict - Runs shell API and CLI tests with --apiStrict --apiDeprecationErrors.
+#   compile_artifact - Compile the release binary.
+#   package_and_upload_artifact - Upload the release binary to S3.
+#   test_linux_artifact - Test that the built artifact works where we expect it to.
+#   release_publish - Publishes the npm packages and uploads the tarballs.
+#   generate_license_and_vulnerability_report - Generates a report of vulnerabilities affecting the bundled application.
+#   pkg_test_* - Run tests on the release packages
+tasks:
+  - name: compile_ts
+    commands:
+      - func: checkout
+      - func: compile_ts
+        vars:
+          node_js_version: "20.9.0"
+
+  - name: check
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: check
+        vars:
+          node_js_version: "20.9.0"
+
+  - name: check_coverage
+    depends_on:
+      - name: ".unit-test"
+        variant: "*"
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: check_coverage
+        vars:
+          node_js_version: "20.9.0"
+
+  ###
+  # UNIT TESTS
+  # E.g. test_m60xc_n16 stands for mongod 6.0.x, community edition, Node.js 16
+  ###
+  - name: test_n20_arg_parser
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: ""
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "n20_arg_parser"
+          mongosh_run_only_in_package: "arg-parser"
+  - name: test_n16_arg_parser
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: ""
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "n16_arg_parser"
+          mongosh_run_only_in_package: "arg-parser"
+  - name: test_n20_async_rewriter2
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: ""
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "n20_async_rewriter2"
+          mongosh_run_only_in_package: "async-rewriter2"
+  - name: test_n16_async_rewriter2
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: ""
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "n16_async_rewriter2"
+          mongosh_run_only_in_package: "async-rewriter2"
+  - name: test_n20_autocomplete
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: ""
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "n20_autocomplete"
+          mongosh_run_only_in_package: "autocomplete"
+  - name: test_n16_autocomplete
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: ""
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "n16_autocomplete"
+          mongosh_run_only_in_package: "autocomplete"
+  - name: test_n20_browser_repl
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: ""
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "n20_browser_repl"
+          mongosh_run_only_in_package: "browser-repl"
+  - name: test_n16_browser_repl
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: ""
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "n16_browser_repl"
+          mongosh_run_only_in_package: "browser-repl"
+  - name: test_n20_browser_runtime_core
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: ""
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "n20_browser_runtime_core"
+          mongosh_run_only_in_package: "browser-runtime-core"
+  - name: test_n16_browser_runtime_core
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: ""
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "n16_browser_runtime_core"
+          mongosh_run_only_in_package: "browser-runtime-core"
+  - name: test_n20_browser_runtime_electron
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: ""
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "n20_browser_runtime_electron"
+          mongosh_run_only_in_package: "browser-runtime-electron"
+  - name: test_n16_browser_runtime_electron
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: ""
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "n16_browser_runtime_electron"
+          mongosh_run_only_in_package: "browser-runtime-electron"
+  - name: test_n20_build
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: ""
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "n20_build"
+          mongosh_run_only_in_package: "build"
+  - name: test_n16_build
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: ""
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "n16_build"
+          mongosh_run_only_in_package: "build"
+  - name: test_m42xc_n20_cli_repl
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "4.2.x"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m42xc_n20_cli_repl"
+          mongosh_run_only_in_package: "cli-repl"
+  - name: test_m42xe_n20_cli_repl
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "4.2.x-enterprise"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m42xe_n20_cli_repl"
+          mongosh_run_only_in_package: "cli-repl"
+  - name: test_m44xc_n20_cli_repl
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "4.4.x"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m44xc_n20_cli_repl"
+          mongosh_run_only_in_package: "cli-repl"
+  - name: test_m44xe_n20_cli_repl
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "4.4.x-enterprise"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m44xe_n20_cli_repl"
+          mongosh_run_only_in_package: "cli-repl"
+  - name: test_m50xc_n20_cli_repl
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "5.0.x"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m50xc_n20_cli_repl"
+          mongosh_run_only_in_package: "cli-repl"
+  - name: test_m50xe_n20_cli_repl
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "5.0.x-enterprise"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m50xe_n20_cli_repl"
+          mongosh_run_only_in_package: "cli-repl"
+  - name: test_m60xc_n20_cli_repl
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "6.0.x"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m60xc_n20_cli_repl"
+          mongosh_run_only_in_package: "cli-repl"
+  - name: test_m60xe_n20_cli_repl
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "6.0.x-enterprise"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m60xe_n20_cli_repl"
+          mongosh_run_only_in_package: "cli-repl"
+  - name: test_m70xc_n20_cli_repl
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "7.0.x"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m70xc_n20_cli_repl"
+          mongosh_run_only_in_package: "cli-repl"
+  - name: test_m70xe_n20_cli_repl
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "7.0.x-enterprise"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m70xe_n20_cli_repl"
+          mongosh_run_only_in_package: "cli-repl"
+  - name: test_mlatest_n20_cli_repl
+    tags: ["unit-test","mlatest"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "latest-alpha-enterprise"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "mlatest_n20_cli_repl"
+          mongosh_run_only_in_package: "cli-repl"
+  - name: test_m42xc_n16_cli_repl
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "4.2.x"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m42xc_n16_cli_repl"
+          mongosh_run_only_in_package: "cli-repl"
+  - name: test_m42xe_n16_cli_repl
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "4.2.x-enterprise"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m42xe_n16_cli_repl"
+          mongosh_run_only_in_package: "cli-repl"
+  - name: test_m44xc_n16_cli_repl
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "4.4.x"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m44xc_n16_cli_repl"
+          mongosh_run_only_in_package: "cli-repl"
+  - name: test_m44xe_n16_cli_repl
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "4.4.x-enterprise"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m44xe_n16_cli_repl"
+          mongosh_run_only_in_package: "cli-repl"
+  - name: test_m50xc_n16_cli_repl
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "5.0.x"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m50xc_n16_cli_repl"
+          mongosh_run_only_in_package: "cli-repl"
+  - name: test_m50xe_n16_cli_repl
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "5.0.x-enterprise"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m50xe_n16_cli_repl"
+          mongosh_run_only_in_package: "cli-repl"
+  - name: test_m60xc_n16_cli_repl
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "6.0.x"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m60xc_n16_cli_repl"
+          mongosh_run_only_in_package: "cli-repl"
+  - name: test_m60xe_n16_cli_repl
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "6.0.x-enterprise"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m60xe_n16_cli_repl"
+          mongosh_run_only_in_package: "cli-repl"
+  - name: test_m70xc_n16_cli_repl
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "7.0.x"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m70xc_n16_cli_repl"
+          mongosh_run_only_in_package: "cli-repl"
+  - name: test_m70xe_n16_cli_repl
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "7.0.x-enterprise"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m70xe_n16_cli_repl"
+          mongosh_run_only_in_package: "cli-repl"
+  - name: test_mlatest_n16_cli_repl
+    tags: ["unit-test","mlatest"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "latest-alpha-enterprise"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "mlatest_n16_cli_repl"
+          mongosh_run_only_in_package: "cli-repl"
+  - name: test_n20_connectivity_tests
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: ""
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "n20_connectivity_tests"
+          mongosh_run_only_in_package: "connectivity-tests"
+  - name: test_n16_connectivity_tests
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: ""
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "n16_connectivity_tests"
+          mongosh_run_only_in_package: "connectivity-tests"
+  - name: test_m42xc_n20_e2e_tests
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "4.2.x"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m42xc_n20_e2e_tests"
+          mongosh_run_only_in_package: "e2e-tests"
+  - name: test_m42xe_n20_e2e_tests
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "4.2.x-enterprise"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m42xe_n20_e2e_tests"
+          mongosh_run_only_in_package: "e2e-tests"
+  - name: test_m44xc_n20_e2e_tests
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "4.4.x"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m44xc_n20_e2e_tests"
+          mongosh_run_only_in_package: "e2e-tests"
+  - name: test_m44xe_n20_e2e_tests
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "4.4.x-enterprise"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m44xe_n20_e2e_tests"
+          mongosh_run_only_in_package: "e2e-tests"
+  - name: test_m50xc_n20_e2e_tests
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "5.0.x"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m50xc_n20_e2e_tests"
+          mongosh_run_only_in_package: "e2e-tests"
+  - name: test_m50xe_n20_e2e_tests
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "5.0.x-enterprise"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m50xe_n20_e2e_tests"
+          mongosh_run_only_in_package: "e2e-tests"
+  - name: test_m60xc_n20_e2e_tests
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "6.0.x"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m60xc_n20_e2e_tests"
+          mongosh_run_only_in_package: "e2e-tests"
+  - name: test_m60xe_n20_e2e_tests
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "6.0.x-enterprise"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m60xe_n20_e2e_tests"
+          mongosh_run_only_in_package: "e2e-tests"
+  - name: test_m70xc_n20_e2e_tests
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "7.0.x"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m70xc_n20_e2e_tests"
+          mongosh_run_only_in_package: "e2e-tests"
+  - name: test_m70xe_n20_e2e_tests
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "7.0.x-enterprise"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m70xe_n20_e2e_tests"
+          mongosh_run_only_in_package: "e2e-tests"
+  - name: test_mlatest_n20_e2e_tests
+    tags: ["unit-test","mlatest"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "latest-alpha-enterprise"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "mlatest_n20_e2e_tests"
+          mongosh_run_only_in_package: "e2e-tests"
+  - name: test_m42xc_n16_e2e_tests
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "4.2.x"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m42xc_n16_e2e_tests"
+          mongosh_run_only_in_package: "e2e-tests"
+  - name: test_m42xe_n16_e2e_tests
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "4.2.x-enterprise"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m42xe_n16_e2e_tests"
+          mongosh_run_only_in_package: "e2e-tests"
+  - name: test_m44xc_n16_e2e_tests
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "4.4.x"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m44xc_n16_e2e_tests"
+          mongosh_run_only_in_package: "e2e-tests"
+  - name: test_m44xe_n16_e2e_tests
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "4.4.x-enterprise"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m44xe_n16_e2e_tests"
+          mongosh_run_only_in_package: "e2e-tests"
+  - name: test_m50xc_n16_e2e_tests
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "5.0.x"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m50xc_n16_e2e_tests"
+          mongosh_run_only_in_package: "e2e-tests"
+  - name: test_m50xe_n16_e2e_tests
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "5.0.x-enterprise"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m50xe_n16_e2e_tests"
+          mongosh_run_only_in_package: "e2e-tests"
+  - name: test_m60xc_n16_e2e_tests
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "6.0.x"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m60xc_n16_e2e_tests"
+          mongosh_run_only_in_package: "e2e-tests"
+  - name: test_m60xe_n16_e2e_tests
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "6.0.x-enterprise"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m60xe_n16_e2e_tests"
+          mongosh_run_only_in_package: "e2e-tests"
+  - name: test_m70xc_n16_e2e_tests
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "7.0.x"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m70xc_n16_e2e_tests"
+          mongosh_run_only_in_package: "e2e-tests"
+  - name: test_m70xe_n16_e2e_tests
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "7.0.x-enterprise"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m70xe_n16_e2e_tests"
+          mongosh_run_only_in_package: "e2e-tests"
+  - name: test_mlatest_n16_e2e_tests
+    tags: ["unit-test","mlatest"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "latest-alpha-enterprise"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "mlatest_n16_e2e_tests"
+          mongosh_run_only_in_package: "e2e-tests"
+  - name: test_n20_editor
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: ""
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "n20_editor"
+          mongosh_run_only_in_package: "editor"
+  - name: test_n16_editor
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: ""
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "n16_editor"
+          mongosh_run_only_in_package: "editor"
+  - name: test_n20_errors
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: ""
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "n20_errors"
+          mongosh_run_only_in_package: "errors"
+  - name: test_n16_errors
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: ""
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "n16_errors"
+          mongosh_run_only_in_package: "errors"
+  - name: test_n20_history
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: ""
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "n20_history"
+          mongosh_run_only_in_package: "history"
+  - name: test_n16_history
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: ""
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "n16_history"
+          mongosh_run_only_in_package: "history"
+  - name: test_n20_i18n
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: ""
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "n20_i18n"
+          mongosh_run_only_in_package: "i18n"
+  - name: test_n16_i18n
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: ""
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "n16_i18n"
+          mongosh_run_only_in_package: "i18n"
+  - name: test_m42xc_n20_java_shell
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "4.2.x"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m42xc_n20_java_shell"
+          mongosh_run_only_in_package: "java-shell"
+  - name: test_m42xe_n20_java_shell
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "4.2.x-enterprise"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m42xe_n20_java_shell"
+          mongosh_run_only_in_package: "java-shell"
+  - name: test_m44xc_n20_java_shell
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "4.4.x"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m44xc_n20_java_shell"
+          mongosh_run_only_in_package: "java-shell"
+  - name: test_m44xe_n20_java_shell
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "4.4.x-enterprise"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m44xe_n20_java_shell"
+          mongosh_run_only_in_package: "java-shell"
+  - name: test_m50xc_n20_java_shell
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "5.0.x"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m50xc_n20_java_shell"
+          mongosh_run_only_in_package: "java-shell"
+  - name: test_m50xe_n20_java_shell
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "5.0.x-enterprise"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m50xe_n20_java_shell"
+          mongosh_run_only_in_package: "java-shell"
+  - name: test_m60xc_n20_java_shell
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "6.0.x"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m60xc_n20_java_shell"
+          mongosh_run_only_in_package: "java-shell"
+  - name: test_m60xe_n20_java_shell
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "6.0.x-enterprise"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m60xe_n20_java_shell"
+          mongosh_run_only_in_package: "java-shell"
+  - name: test_m70xc_n20_java_shell
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "7.0.x"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m70xc_n20_java_shell"
+          mongosh_run_only_in_package: "java-shell"
+  - name: test_m70xe_n20_java_shell
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "7.0.x-enterprise"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m70xe_n20_java_shell"
+          mongosh_run_only_in_package: "java-shell"
+  - name: test_mlatest_n20_java_shell
+    tags: ["unit-test","mlatest"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "latest-alpha-enterprise"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "mlatest_n20_java_shell"
+          mongosh_run_only_in_package: "java-shell"
+  - name: test_m42xc_n16_java_shell
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "4.2.x"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m42xc_n16_java_shell"
+          mongosh_run_only_in_package: "java-shell"
+  - name: test_m42xe_n16_java_shell
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "4.2.x-enterprise"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m42xe_n16_java_shell"
+          mongosh_run_only_in_package: "java-shell"
+  - name: test_m44xc_n16_java_shell
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "4.4.x"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m44xc_n16_java_shell"
+          mongosh_run_only_in_package: "java-shell"
+  - name: test_m44xe_n16_java_shell
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "4.4.x-enterprise"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m44xe_n16_java_shell"
+          mongosh_run_only_in_package: "java-shell"
+  - name: test_m50xc_n16_java_shell
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "5.0.x"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m50xc_n16_java_shell"
+          mongosh_run_only_in_package: "java-shell"
+  - name: test_m50xe_n16_java_shell
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "5.0.x-enterprise"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m50xe_n16_java_shell"
+          mongosh_run_only_in_package: "java-shell"
+  - name: test_m60xc_n16_java_shell
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "6.0.x"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m60xc_n16_java_shell"
+          mongosh_run_only_in_package: "java-shell"
+  - name: test_m60xe_n16_java_shell
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "6.0.x-enterprise"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m60xe_n16_java_shell"
+          mongosh_run_only_in_package: "java-shell"
+  - name: test_m70xc_n16_java_shell
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "7.0.x"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m70xc_n16_java_shell"
+          mongosh_run_only_in_package: "java-shell"
+  - name: test_m70xe_n16_java_shell
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "7.0.x-enterprise"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m70xe_n16_java_shell"
+          mongosh_run_only_in_package: "java-shell"
+  - name: test_mlatest_n16_java_shell
+    tags: ["unit-test","mlatest"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "latest-alpha-enterprise"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "mlatest_n16_java_shell"
+          mongosh_run_only_in_package: "java-shell"
+  - name: test_n20_js_multiline_to_singleline
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: ""
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "n20_js_multiline_to_singleline"
+          mongosh_run_only_in_package: "js-multiline-to-singleline"
+  - name: test_n16_js_multiline_to_singleline
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: ""
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "n16_js_multiline_to_singleline"
+          mongosh_run_only_in_package: "js-multiline-to-singleline"
+  - name: test_n20_logging
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: ""
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "n20_logging"
+          mongosh_run_only_in_package: "logging"
+  - name: test_n16_logging
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: ""
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "n16_logging"
+          mongosh_run_only_in_package: "logging"
+  - name: test_m42xc_n20_mongosh
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "4.2.x"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m42xc_n20_mongosh"
+          mongosh_run_only_in_package: "mongosh"
+  - name: test_m42xe_n20_mongosh
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "4.2.x-enterprise"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m42xe_n20_mongosh"
+          mongosh_run_only_in_package: "mongosh"
+  - name: test_m44xc_n20_mongosh
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "4.4.x"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m44xc_n20_mongosh"
+          mongosh_run_only_in_package: "mongosh"
+  - name: test_m44xe_n20_mongosh
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "4.4.x-enterprise"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m44xe_n20_mongosh"
+          mongosh_run_only_in_package: "mongosh"
+  - name: test_m50xc_n20_mongosh
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "5.0.x"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m50xc_n20_mongosh"
+          mongosh_run_only_in_package: "mongosh"
+  - name: test_m50xe_n20_mongosh
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "5.0.x-enterprise"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m50xe_n20_mongosh"
+          mongosh_run_only_in_package: "mongosh"
+  - name: test_m60xc_n20_mongosh
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "6.0.x"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m60xc_n20_mongosh"
+          mongosh_run_only_in_package: "mongosh"
+  - name: test_m60xe_n20_mongosh
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "6.0.x-enterprise"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m60xe_n20_mongosh"
+          mongosh_run_only_in_package: "mongosh"
+  - name: test_m70xc_n20_mongosh
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "7.0.x"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m70xc_n20_mongosh"
+          mongosh_run_only_in_package: "mongosh"
+  - name: test_m70xe_n20_mongosh
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "7.0.x-enterprise"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m70xe_n20_mongosh"
+          mongosh_run_only_in_package: "mongosh"
+  - name: test_mlatest_n20_mongosh
+    tags: ["unit-test","mlatest"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "latest-alpha-enterprise"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "mlatest_n20_mongosh"
+          mongosh_run_only_in_package: "mongosh"
+  - name: test_m42xc_n16_mongosh
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "4.2.x"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m42xc_n16_mongosh"
+          mongosh_run_only_in_package: "mongosh"
+  - name: test_m42xe_n16_mongosh
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "4.2.x-enterprise"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m42xe_n16_mongosh"
+          mongosh_run_only_in_package: "mongosh"
+  - name: test_m44xc_n16_mongosh
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "4.4.x"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m44xc_n16_mongosh"
+          mongosh_run_only_in_package: "mongosh"
+  - name: test_m44xe_n16_mongosh
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "4.4.x-enterprise"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m44xe_n16_mongosh"
+          mongosh_run_only_in_package: "mongosh"
+  - name: test_m50xc_n16_mongosh
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "5.0.x"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m50xc_n16_mongosh"
+          mongosh_run_only_in_package: "mongosh"
+  - name: test_m50xe_n16_mongosh
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "5.0.x-enterprise"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m50xe_n16_mongosh"
+          mongosh_run_only_in_package: "mongosh"
+  - name: test_m60xc_n16_mongosh
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "6.0.x"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m60xc_n16_mongosh"
+          mongosh_run_only_in_package: "mongosh"
+  - name: test_m60xe_n16_mongosh
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "6.0.x-enterprise"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m60xe_n16_mongosh"
+          mongosh_run_only_in_package: "mongosh"
+  - name: test_m70xc_n16_mongosh
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "7.0.x"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m70xc_n16_mongosh"
+          mongosh_run_only_in_package: "mongosh"
+  - name: test_m70xe_n16_mongosh
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "7.0.x-enterprise"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m70xe_n16_mongosh"
+          mongosh_run_only_in_package: "mongosh"
+  - name: test_mlatest_n16_mongosh
+    tags: ["unit-test","mlatest"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "latest-alpha-enterprise"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "mlatest_n16_mongosh"
+          mongosh_run_only_in_package: "mongosh"
+  - name: test_m42xc_n20_node_runtime_worker_thread
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "4.2.x"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m42xc_n20_node_runtime_worker_thread"
+          mongosh_run_only_in_package: "node-runtime-worker-thread"
+  - name: test_m42xe_n20_node_runtime_worker_thread
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "4.2.x-enterprise"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m42xe_n20_node_runtime_worker_thread"
+          mongosh_run_only_in_package: "node-runtime-worker-thread"
+  - name: test_m44xc_n20_node_runtime_worker_thread
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "4.4.x"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m44xc_n20_node_runtime_worker_thread"
+          mongosh_run_only_in_package: "node-runtime-worker-thread"
+  - name: test_m44xe_n20_node_runtime_worker_thread
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "4.4.x-enterprise"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m44xe_n20_node_runtime_worker_thread"
+          mongosh_run_only_in_package: "node-runtime-worker-thread"
+  - name: test_m50xc_n20_node_runtime_worker_thread
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "5.0.x"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m50xc_n20_node_runtime_worker_thread"
+          mongosh_run_only_in_package: "node-runtime-worker-thread"
+  - name: test_m50xe_n20_node_runtime_worker_thread
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "5.0.x-enterprise"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m50xe_n20_node_runtime_worker_thread"
+          mongosh_run_only_in_package: "node-runtime-worker-thread"
+  - name: test_m60xc_n20_node_runtime_worker_thread
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "6.0.x"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m60xc_n20_node_runtime_worker_thread"
+          mongosh_run_only_in_package: "node-runtime-worker-thread"
+  - name: test_m60xe_n20_node_runtime_worker_thread
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "6.0.x-enterprise"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m60xe_n20_node_runtime_worker_thread"
+          mongosh_run_only_in_package: "node-runtime-worker-thread"
+  - name: test_m70xc_n20_node_runtime_worker_thread
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "7.0.x"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m70xc_n20_node_runtime_worker_thread"
+          mongosh_run_only_in_package: "node-runtime-worker-thread"
+  - name: test_m70xe_n20_node_runtime_worker_thread
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "7.0.x-enterprise"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m70xe_n20_node_runtime_worker_thread"
+          mongosh_run_only_in_package: "node-runtime-worker-thread"
+  - name: test_mlatest_n20_node_runtime_worker_thread
+    tags: ["unit-test","mlatest"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "latest-alpha-enterprise"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "mlatest_n20_node_runtime_worker_thread"
+          mongosh_run_only_in_package: "node-runtime-worker-thread"
+  - name: test_m42xc_n16_node_runtime_worker_thread
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "4.2.x"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m42xc_n16_node_runtime_worker_thread"
+          mongosh_run_only_in_package: "node-runtime-worker-thread"
+  - name: test_m42xe_n16_node_runtime_worker_thread
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "4.2.x-enterprise"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m42xe_n16_node_runtime_worker_thread"
+          mongosh_run_only_in_package: "node-runtime-worker-thread"
+  - name: test_m44xc_n16_node_runtime_worker_thread
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "4.4.x"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m44xc_n16_node_runtime_worker_thread"
+          mongosh_run_only_in_package: "node-runtime-worker-thread"
+  - name: test_m44xe_n16_node_runtime_worker_thread
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "4.4.x-enterprise"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m44xe_n16_node_runtime_worker_thread"
+          mongosh_run_only_in_package: "node-runtime-worker-thread"
+  - name: test_m50xc_n16_node_runtime_worker_thread
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "5.0.x"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m50xc_n16_node_runtime_worker_thread"
+          mongosh_run_only_in_package: "node-runtime-worker-thread"
+  - name: test_m50xe_n16_node_runtime_worker_thread
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "5.0.x-enterprise"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m50xe_n16_node_runtime_worker_thread"
+          mongosh_run_only_in_package: "node-runtime-worker-thread"
+  - name: test_m60xc_n16_node_runtime_worker_thread
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "6.0.x"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m60xc_n16_node_runtime_worker_thread"
+          mongosh_run_only_in_package: "node-runtime-worker-thread"
+  - name: test_m60xe_n16_node_runtime_worker_thread
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "6.0.x-enterprise"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m60xe_n16_node_runtime_worker_thread"
+          mongosh_run_only_in_package: "node-runtime-worker-thread"
+  - name: test_m70xc_n16_node_runtime_worker_thread
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "7.0.x"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m70xc_n16_node_runtime_worker_thread"
+          mongosh_run_only_in_package: "node-runtime-worker-thread"
+  - name: test_m70xe_n16_node_runtime_worker_thread
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "7.0.x-enterprise"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m70xe_n16_node_runtime_worker_thread"
+          mongosh_run_only_in_package: "node-runtime-worker-thread"
+  - name: test_mlatest_n16_node_runtime_worker_thread
+    tags: ["unit-test","mlatest"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "latest-alpha-enterprise"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "mlatest_n16_node_runtime_worker_thread"
+          mongosh_run_only_in_package: "node-runtime-worker-thread"
+  - name: test_n20_service_provider_core
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: ""
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "n20_service_provider_core"
+          mongosh_run_only_in_package: "service-provider-core"
+  - name: test_n16_service_provider_core
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: ""
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "n16_service_provider_core"
+          mongosh_run_only_in_package: "service-provider-core"
+  - name: test_m42xc_n20_service_provider_server
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "4.2.x"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m42xc_n20_service_provider_server"
+          mongosh_run_only_in_package: "service-provider-server"
+  - name: test_m42xe_n20_service_provider_server
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "4.2.x-enterprise"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m42xe_n20_service_provider_server"
+          mongosh_run_only_in_package: "service-provider-server"
+  - name: test_m44xc_n20_service_provider_server
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "4.4.x"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m44xc_n20_service_provider_server"
+          mongosh_run_only_in_package: "service-provider-server"
+  - name: test_m44xe_n20_service_provider_server
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "4.4.x-enterprise"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m44xe_n20_service_provider_server"
+          mongosh_run_only_in_package: "service-provider-server"
+  - name: test_m50xc_n20_service_provider_server
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "5.0.x"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m50xc_n20_service_provider_server"
+          mongosh_run_only_in_package: "service-provider-server"
+  - name: test_m50xe_n20_service_provider_server
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "5.0.x-enterprise"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m50xe_n20_service_provider_server"
+          mongosh_run_only_in_package: "service-provider-server"
+  - name: test_m60xc_n20_service_provider_server
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "6.0.x"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m60xc_n20_service_provider_server"
+          mongosh_run_only_in_package: "service-provider-server"
+  - name: test_m60xe_n20_service_provider_server
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "6.0.x-enterprise"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m60xe_n20_service_provider_server"
+          mongosh_run_only_in_package: "service-provider-server"
+  - name: test_m70xc_n20_service_provider_server
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "7.0.x"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m70xc_n20_service_provider_server"
+          mongosh_run_only_in_package: "service-provider-server"
+  - name: test_m70xe_n20_service_provider_server
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "7.0.x-enterprise"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m70xe_n20_service_provider_server"
+          mongosh_run_only_in_package: "service-provider-server"
+  - name: test_mlatest_n20_service_provider_server
+    tags: ["unit-test","mlatest"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "latest-alpha-enterprise"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "mlatest_n20_service_provider_server"
+          mongosh_run_only_in_package: "service-provider-server"
+  - name: test_m42xc_n16_service_provider_server
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "4.2.x"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m42xc_n16_service_provider_server"
+          mongosh_run_only_in_package: "service-provider-server"
+  - name: test_m42xe_n16_service_provider_server
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "4.2.x-enterprise"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m42xe_n16_service_provider_server"
+          mongosh_run_only_in_package: "service-provider-server"
+  - name: test_m44xc_n16_service_provider_server
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "4.4.x"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m44xc_n16_service_provider_server"
+          mongosh_run_only_in_package: "service-provider-server"
+  - name: test_m44xe_n16_service_provider_server
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "4.4.x-enterprise"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m44xe_n16_service_provider_server"
+          mongosh_run_only_in_package: "service-provider-server"
+  - name: test_m50xc_n16_service_provider_server
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "5.0.x"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m50xc_n16_service_provider_server"
+          mongosh_run_only_in_package: "service-provider-server"
+  - name: test_m50xe_n16_service_provider_server
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "5.0.x-enterprise"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m50xe_n16_service_provider_server"
+          mongosh_run_only_in_package: "service-provider-server"
+  - name: test_m60xc_n16_service_provider_server
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "6.0.x"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m60xc_n16_service_provider_server"
+          mongosh_run_only_in_package: "service-provider-server"
+  - name: test_m60xe_n16_service_provider_server
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "6.0.x-enterprise"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m60xe_n16_service_provider_server"
+          mongosh_run_only_in_package: "service-provider-server"
+  - name: test_m70xc_n16_service_provider_server
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "7.0.x"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m70xc_n16_service_provider_server"
+          mongosh_run_only_in_package: "service-provider-server"
+  - name: test_m70xe_n16_service_provider_server
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "7.0.x-enterprise"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m70xe_n16_service_provider_server"
+          mongosh_run_only_in_package: "service-provider-server"
+  - name: test_mlatest_n16_service_provider_server
+    tags: ["unit-test","mlatest"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "latest-alpha-enterprise"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "mlatest_n16_service_provider_server"
+          mongosh_run_only_in_package: "service-provider-server"
+  - name: test_m42xc_n20_shell_api
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "4.2.x"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m42xc_n20_shell_api"
+          mongosh_run_only_in_package: "shell-api"
+  - name: test_m42xe_n20_shell_api
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "4.2.x-enterprise"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m42xe_n20_shell_api"
+          mongosh_run_only_in_package: "shell-api"
+  - name: test_m44xc_n20_shell_api
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "4.4.x"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m44xc_n20_shell_api"
+          mongosh_run_only_in_package: "shell-api"
+  - name: test_m44xe_n20_shell_api
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "4.4.x-enterprise"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m44xe_n20_shell_api"
+          mongosh_run_only_in_package: "shell-api"
+  - name: test_m50xc_n20_shell_api
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "5.0.x"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m50xc_n20_shell_api"
+          mongosh_run_only_in_package: "shell-api"
+  - name: test_m50xe_n20_shell_api
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "5.0.x-enterprise"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m50xe_n20_shell_api"
+          mongosh_run_only_in_package: "shell-api"
+  - name: test_m60xc_n20_shell_api
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "6.0.x"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m60xc_n20_shell_api"
+          mongosh_run_only_in_package: "shell-api"
+  - name: test_m60xe_n20_shell_api
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "6.0.x-enterprise"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m60xe_n20_shell_api"
+          mongosh_run_only_in_package: "shell-api"
+  - name: test_m70xc_n20_shell_api
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "7.0.x"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m70xc_n20_shell_api"
+          mongosh_run_only_in_package: "shell-api"
+  - name: test_m70xe_n20_shell_api
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "7.0.x-enterprise"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m70xe_n20_shell_api"
+          mongosh_run_only_in_package: "shell-api"
+  - name: test_mlatest_n20_shell_api
+    tags: ["unit-test","mlatest"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: "latest-alpha-enterprise"
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "mlatest_n20_shell_api"
+          mongosh_run_only_in_package: "shell-api"
+  - name: test_m42xc_n16_shell_api
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "4.2.x"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m42xc_n16_shell_api"
+          mongosh_run_only_in_package: "shell-api"
+  - name: test_m42xe_n16_shell_api
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "4.2.x-enterprise"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m42xe_n16_shell_api"
+          mongosh_run_only_in_package: "shell-api"
+  - name: test_m44xc_n16_shell_api
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "4.4.x"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m44xc_n16_shell_api"
+          mongosh_run_only_in_package: "shell-api"
+  - name: test_m44xe_n16_shell_api
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "4.4.x-enterprise"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m44xe_n16_shell_api"
+          mongosh_run_only_in_package: "shell-api"
+  - name: test_m50xc_n16_shell_api
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "5.0.x"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m50xc_n16_shell_api"
+          mongosh_run_only_in_package: "shell-api"
+  - name: test_m50xe_n16_shell_api
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "5.0.x-enterprise"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m50xe_n16_shell_api"
+          mongosh_run_only_in_package: "shell-api"
+  - name: test_m60xc_n16_shell_api
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "6.0.x"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m60xc_n16_shell_api"
+          mongosh_run_only_in_package: "shell-api"
+  - name: test_m60xe_n16_shell_api
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "6.0.x-enterprise"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m60xe_n16_shell_api"
+          mongosh_run_only_in_package: "shell-api"
+  - name: test_m70xc_n16_shell_api
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "7.0.x"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m70xc_n16_shell_api"
+          mongosh_run_only_in_package: "shell-api"
+  - name: test_m70xe_n16_shell_api
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "7.0.x-enterprise"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "m70xe_n16_shell_api"
+          mongosh_run_only_in_package: "shell-api"
+  - name: test_mlatest_n16_shell_api
+    tags: ["unit-test","mlatest"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: "latest-alpha-enterprise"
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "mlatest_n16_shell_api"
+          mongosh_run_only_in_package: "shell-api"
+  - name: test_n20_shell_evaluator
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: ""
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "n20_shell_evaluator"
+          mongosh_run_only_in_package: "shell-evaluator"
+  - name: test_n16_shell_evaluator
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: ""
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "n16_shell_evaluator"
+          mongosh_run_only_in_package: "shell-evaluator"
+  - name: test_n20_snippet_manager
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: ""
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "n20_snippet_manager"
+          mongosh_run_only_in_package: "snippet-manager"
+  - name: test_n16_snippet_manager
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: ""
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "n16_snippet_manager"
+          mongosh_run_only_in_package: "snippet-manager"
+  - name: test_n20_types
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test
+        vars:
+          mongosh_server_test_version: ""
+          node_js_version: "20.9.0"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "n20_types"
+          mongosh_run_only_in_package: "types"
+  - name: test_n16_types
+    tags: ["unit-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "16.20.2"
+      - func: test
+        vars:
+          mongosh_server_test_version: ""
+          node_js_version: "16.20.2"
+          mongosh_skip_node_version_check: ""
+          mongosh_test_id: "n16_types"
+          mongosh_run_only_in_package: "types"
+
+  ###
+  # INTEGRATION TESTS
+  ###
+  - name: test_vscode
+    tags: ["extra-integration-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test_vscode
+        vars:
+          node_js_version: "20.9.0"
+  - name: test_connectivity
+    tags: ["extra-integration-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test_connectivity
+        vars:
+          node_js_version: "20.9.0"
+  - name: test_apistrict
+    tags: ["extra-integration-test"]
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test_apistrict
+        vars:
+          node_js_version: "20.9.0"
+          mongosh_server_test_version: "latest-alpha-enterprise"
+          mongosh_test_force_api_strict: "1"
+  - name: compile_artifact
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: compile_artifact
+        vars:
+          node_js_version: "20.9.0"
+
+  - name: generate_license_and_vulnerability_report
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: generate_license_and_vulnerability_report
+        vars:
+          node_js_version: "20.9.0"
+
+  ###
+  # E2E TESTS
+  ###
+  - name: e2e_tests_darwin_x64_fips
+    tags: ["e2e-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: darwin
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: darwin-x64
+      - func: run_e2e_tests
+        vars:
+          node_js_version: "20.9.0"
+          mongosh_server_test_version: "stable-enterprise"
+          mongosh_test_e2e_force_fips: "1"
+          disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
+  - name: e2e_tests_darwin_x64
+    tags: ["e2e-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: darwin
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: darwin-x64
+      - func: run_e2e_tests
+        vars:
+          node_js_version: "20.9.0"
+          mongosh_server_test_version: "stable-enterprise"
+          mongosh_test_e2e_force_fips: ""
+          disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
+  - name: e2e_tests_darwin_x64_60x_fips
+    tags: ["e2e-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: darwin
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: darwin-x64
+      - func: run_e2e_tests
+        vars:
+          node_js_version: "20.9.0"
+          mongosh_server_test_version: "6.0.x-enterprise"
+          mongosh_test_e2e_force_fips: "1"
+          disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
+  - name: e2e_tests_darwin_x64_60x
+    tags: ["e2e-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: darwin
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: darwin-x64
+      - func: run_e2e_tests
+        vars:
+          node_js_version: "20.9.0"
+          mongosh_server_test_version: "6.0.x-enterprise"
+          mongosh_test_e2e_force_fips: ""
+          disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
+  - name: e2e_tests_darwin_arm64_fips
+    tags: ["e2e-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: darwin_arm64
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: darwin-arm64
+      - func: run_e2e_tests
+        vars:
+          node_js_version: "20.9.0"
+          mongosh_server_test_version: "stable-enterprise"
+          mongosh_test_e2e_force_fips: "1"
+          disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
+  - name: e2e_tests_darwin_arm64
+    tags: ["e2e-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: darwin_arm64
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: darwin-arm64
+      - func: run_e2e_tests
+        vars:
+          node_js_version: "20.9.0"
+          mongosh_server_test_version: "stable-enterprise"
+          mongosh_test_e2e_force_fips: ""
+          disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
+  - name: e2e_tests_darwin_arm64_60x_fips
+    tags: ["e2e-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: darwin_arm64
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: darwin-arm64
+      - func: run_e2e_tests
+        vars:
+          node_js_version: "20.9.0"
+          mongosh_server_test_version: "6.0.x-enterprise"
+          mongosh_test_e2e_force_fips: "1"
+          disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
+  - name: e2e_tests_darwin_arm64_60x
+    tags: ["e2e-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: darwin_arm64
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: darwin-arm64
+      - func: run_e2e_tests
+        vars:
+          node_js_version: "20.9.0"
+          mongosh_server_test_version: "6.0.x-enterprise"
+          mongosh_test_e2e_force_fips: ""
+          disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
+  - name: e2e_tests_linux_x64_fips
+    tags: ["e2e-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_x64_build
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-x64
+      - func: run_e2e_tests
+        vars:
+          node_js_version: "20.9.0"
+          mongosh_server_test_version: "stable-enterprise"
+          mongosh_test_e2e_force_fips: "1"
+          disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
+  - name: e2e_tests_linux_x64
+    tags: ["e2e-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_x64_build
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-x64
+      - func: run_e2e_tests
+        vars:
+          node_js_version: "20.9.0"
+          mongosh_server_test_version: "stable-enterprise"
+          mongosh_test_e2e_force_fips: ""
+          disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
+  - name: e2e_tests_linux_x64_60x_fips
+    tags: ["e2e-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_x64_build
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-x64
+      - func: run_e2e_tests
+        vars:
+          node_js_version: "20.9.0"
+          mongosh_server_test_version: "6.0.x-enterprise"
+          mongosh_test_e2e_force_fips: "1"
+          disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
+  - name: e2e_tests_linux_x64_60x
+    tags: ["e2e-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_x64_build
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-x64
+      - func: run_e2e_tests
+        vars:
+          node_js_version: "20.9.0"
+          mongosh_server_test_version: "6.0.x-enterprise"
+          mongosh_test_e2e_force_fips: ""
+          disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
+  - name: e2e_tests_linux_x64_openssl11_fips
+    tags: ["e2e-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_x64_build_openssl11
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-x64-openssl11
+      - func: run_e2e_tests
+        vars:
+          node_js_version: "20.9.0"
+          mongosh_server_test_version: "stable-enterprise"
+          mongosh_test_e2e_force_fips: "1"
+          disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
+  - name: e2e_tests_linux_x64_openssl11
+    tags: ["e2e-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_x64_build_openssl11
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-x64-openssl11
+      - func: run_e2e_tests
+        vars:
+          node_js_version: "20.9.0"
+          mongosh_server_test_version: "stable-enterprise"
+          mongosh_test_e2e_force_fips: ""
+          disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
+  - name: e2e_tests_linux_x64_openssl11_60x_fips
+    tags: ["e2e-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_x64_build_openssl11
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-x64-openssl11
+      - func: run_e2e_tests
+        vars:
+          node_js_version: "20.9.0"
+          mongosh_server_test_version: "6.0.x-enterprise"
+          mongosh_test_e2e_force_fips: "1"
+          disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
+  - name: e2e_tests_linux_x64_openssl11_60x
+    tags: ["e2e-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_x64_build_openssl11
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-x64-openssl11
+      - func: run_e2e_tests
+        vars:
+          node_js_version: "20.9.0"
+          mongosh_server_test_version: "6.0.x-enterprise"
+          mongosh_test_e2e_force_fips: ""
+          disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
+  - name: e2e_tests_linux_x64_openssl3_fips
+    tags: ["e2e-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_x64_build_openssl3
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-x64-openssl3
+      - func: run_e2e_tests
+        vars:
+          node_js_version: "20.9.0"
+          mongosh_server_test_version: "stable-enterprise"
+          mongosh_test_e2e_force_fips: "1"
+          disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
+  - name: e2e_tests_linux_x64_openssl3
+    tags: ["e2e-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_x64_build_openssl3
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-x64-openssl3
+      - func: run_e2e_tests
+        vars:
+          node_js_version: "20.9.0"
+          mongosh_server_test_version: "stable-enterprise"
+          mongosh_test_e2e_force_fips: ""
+          disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
+  - name: e2e_tests_linux_x64_openssl3_60x_fips
+    tags: ["e2e-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_x64_build_openssl3
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-x64-openssl3
+      - func: run_e2e_tests
+        vars:
+          node_js_version: "20.9.0"
+          mongosh_server_test_version: "6.0.x-enterprise"
+          mongosh_test_e2e_force_fips: "1"
+          disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
+  - name: e2e_tests_linux_x64_openssl3_60x
+    tags: ["e2e-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_x64_build_openssl3
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-x64-openssl3
+      - func: run_e2e_tests
+        vars:
+          node_js_version: "20.9.0"
+          mongosh_server_test_version: "6.0.x-enterprise"
+          mongosh_test_e2e_force_fips: ""
+          disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
+  - name: e2e_tests_linux_arm64_fips
+    tags: ["e2e-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_arm64_build
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-arm64
+      - func: run_e2e_tests
+        vars:
+          node_js_version: "20.9.0"
+          mongosh_server_test_version: "stable-enterprise"
+          mongosh_test_e2e_force_fips: "1"
+          disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
+  - name: e2e_tests_linux_arm64
+    tags: ["e2e-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_arm64_build
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-arm64
+      - func: run_e2e_tests
+        vars:
+          node_js_version: "20.9.0"
+          mongosh_server_test_version: "stable-enterprise"
+          mongosh_test_e2e_force_fips: ""
+          disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
+  - name: e2e_tests_linux_arm64_60x_fips
+    tags: ["e2e-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_arm64_build
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-arm64
+      - func: run_e2e_tests
+        vars:
+          node_js_version: "20.9.0"
+          mongosh_server_test_version: "6.0.x-enterprise"
+          mongosh_test_e2e_force_fips: "1"
+          disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
+  - name: e2e_tests_linux_arm64_60x
+    tags: ["e2e-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_arm64_build
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-arm64
+      - func: run_e2e_tests
+        vars:
+          node_js_version: "20.9.0"
+          mongosh_server_test_version: "6.0.x-enterprise"
+          mongosh_test_e2e_force_fips: ""
+          disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
+  - name: e2e_tests_linux_arm64_openssl11_fips
+    tags: ["e2e-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_arm64_build_openssl11
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-arm64-openssl11
+      - func: run_e2e_tests
+        vars:
+          node_js_version: "20.9.0"
+          mongosh_server_test_version: "stable-enterprise"
+          mongosh_test_e2e_force_fips: "1"
+          disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
+  - name: e2e_tests_linux_arm64_openssl11
+    tags: ["e2e-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_arm64_build_openssl11
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-arm64-openssl11
+      - func: run_e2e_tests
+        vars:
+          node_js_version: "20.9.0"
+          mongosh_server_test_version: "stable-enterprise"
+          mongosh_test_e2e_force_fips: ""
+          disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
+  - name: e2e_tests_linux_arm64_openssl11_60x_fips
+    tags: ["e2e-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_arm64_build_openssl11
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-arm64-openssl11
+      - func: run_e2e_tests
+        vars:
+          node_js_version: "20.9.0"
+          mongosh_server_test_version: "6.0.x-enterprise"
+          mongosh_test_e2e_force_fips: "1"
+          disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
+  - name: e2e_tests_linux_arm64_openssl11_60x
+    tags: ["e2e-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_arm64_build_openssl11
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-arm64-openssl11
+      - func: run_e2e_tests
+        vars:
+          node_js_version: "20.9.0"
+          mongosh_server_test_version: "6.0.x-enterprise"
+          mongosh_test_e2e_force_fips: ""
+          disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
+  - name: e2e_tests_linux_arm64_openssl3_fips
+    tags: ["e2e-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_arm64_build_openssl3
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-arm64-openssl3
+      - func: run_e2e_tests
+        vars:
+          node_js_version: "20.9.0"
+          mongosh_server_test_version: "stable-enterprise"
+          mongosh_test_e2e_force_fips: "1"
+          disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
+  - name: e2e_tests_linux_arm64_openssl3
+    tags: ["e2e-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_arm64_build_openssl3
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-arm64-openssl3
+      - func: run_e2e_tests
+        vars:
+          node_js_version: "20.9.0"
+          mongosh_server_test_version: "stable-enterprise"
+          mongosh_test_e2e_force_fips: ""
+          disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
+  - name: e2e_tests_linux_arm64_openssl3_60x_fips
+    tags: ["e2e-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_arm64_build_openssl3
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-arm64-openssl3
+      - func: run_e2e_tests
+        vars:
+          node_js_version: "20.9.0"
+          mongosh_server_test_version: "6.0.x-enterprise"
+          mongosh_test_e2e_force_fips: "1"
+          disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
+  - name: e2e_tests_linux_arm64_openssl3_60x
+    tags: ["e2e-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_arm64_build_openssl3
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-arm64-openssl3
+      - func: run_e2e_tests
+        vars:
+          node_js_version: "20.9.0"
+          mongosh_server_test_version: "6.0.x-enterprise"
+          mongosh_test_e2e_force_fips: ""
+          disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
+  - name: e2e_tests_linux_ppc64le_fips
+    tags: ["e2e-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_ppc64le_build
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-ppc64le
+      - func: run_e2e_tests
+        vars:
+          node_js_version: "20.9.0"
+          mongosh_server_test_version: "stable-enterprise"
+          mongosh_test_e2e_force_fips: "1"
+          disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
+  - name: e2e_tests_linux_ppc64le
+    tags: ["e2e-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_ppc64le_build
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-ppc64le
+      - func: run_e2e_tests
+        vars:
+          node_js_version: "20.9.0"
+          mongosh_server_test_version: "stable-enterprise"
+          mongosh_test_e2e_force_fips: ""
+          disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
+  - name: e2e_tests_linux_ppc64le_60x_fips
+    tags: ["e2e-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_ppc64le_build
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-ppc64le
+      - func: run_e2e_tests
+        vars:
+          node_js_version: "20.9.0"
+          mongosh_server_test_version: "6.0.x-enterprise"
+          mongosh_test_e2e_force_fips: "1"
+          disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
+  - name: e2e_tests_linux_ppc64le_60x
+    tags: ["e2e-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_ppc64le_build
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-ppc64le
+      - func: run_e2e_tests
+        vars:
+          node_js_version: "20.9.0"
+          mongosh_server_test_version: "6.0.x-enterprise"
+          mongosh_test_e2e_force_fips: ""
+          disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
+  - name: e2e_tests_linux_s390x_fips
+    tags: ["e2e-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_s390x_build
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-s390x
+      - func: run_e2e_tests
+        vars:
+          node_js_version: "20.9.0"
+          mongosh_server_test_version: "stable-enterprise"
+          mongosh_test_e2e_force_fips: "1"
+          disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
+  - name: e2e_tests_linux_s390x
+    tags: ["e2e-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_s390x_build
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-s390x
+      - func: run_e2e_tests
+        vars:
+          node_js_version: "20.9.0"
+          mongosh_server_test_version: "stable-enterprise"
+          mongosh_test_e2e_force_fips: ""
+          disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
+  - name: e2e_tests_linux_s390x_60x_fips
+    tags: ["e2e-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_s390x_build
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-s390x
+      - func: run_e2e_tests
+        vars:
+          node_js_version: "20.9.0"
+          mongosh_server_test_version: "6.0.x-enterprise"
+          mongosh_test_e2e_force_fips: "1"
+          disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
+  - name: e2e_tests_linux_s390x_60x
+    tags: ["e2e-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_s390x_build
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-s390x
+      - func: run_e2e_tests
+        vars:
+          node_js_version: "20.9.0"
+          mongosh_server_test_version: "6.0.x-enterprise"
+          mongosh_test_e2e_force_fips: ""
+          disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
+  - name: e2e_tests_win32_fips
+    tags: ["e2e-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: win32_build
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: win32
+      - func: run_e2e_tests
+        vars:
+          node_js_version: "20.9.0"
+          mongosh_server_test_version: "stable-enterprise"
+          mongosh_test_e2e_force_fips: "1"
+          disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
+  - name: e2e_tests_win32
+    tags: ["e2e-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: win32_build
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: win32
+      - func: run_e2e_tests
+        vars:
+          node_js_version: "20.9.0"
+          mongosh_server_test_version: "stable-enterprise"
+          mongosh_test_e2e_force_fips: ""
+          disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
+  - name: e2e_tests_win32_60x_fips
+    tags: ["e2e-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: win32_build
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: win32
+      - func: run_e2e_tests
+        vars:
+          node_js_version: "20.9.0"
+          mongosh_server_test_version: "6.0.x-enterprise"
+          mongosh_test_e2e_force_fips: "1"
+          disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
+  - name: e2e_tests_win32_60x
+    tags: ["e2e-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: win32_build
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: win32
+      - func: run_e2e_tests
+        vars:
+          node_js_version: "20.9.0"
+          mongosh_server_test_version: "6.0.x-enterprise"
+          mongosh_test_e2e_force_fips: ""
+          disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
+
+  ###
+  # EXECUTABLE CONNECTIVITY TESTS
+  ###
+  - name: executable_connectivity_test_linux_x64_rocky8
+    tags: ["connectivity-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_x64_build
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-x64
+      - func: test_connectivity
+        vars:
+          node_js_version: "20.9.0"
+          test_mongosh_executable: dist/mongosh
+          kerberos_jumphost_dockerfile: "Dockerfile.rocky8"
+  - name: executable_connectivity_test_linux_x64_ubuntu2004
+    tags: ["connectivity-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_x64_build
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-x64
+      - func: test_connectivity
+        vars:
+          node_js_version: "20.9.0"
+          test_mongosh_executable: dist/mongosh
+          kerberos_jumphost_dockerfile: "Dockerfile.ubuntu2004"
+  - name: executable_connectivity_test_linux_x64_node20
+    tags: ["connectivity-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_x64_build
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-x64
+      - func: test_connectivity
+        vars:
+          node_js_version: "20.9.0"
+          test_mongosh_executable: dist/mongosh
+          kerberos_jumphost_dockerfile: "Dockerfile.node20"
+  - name: executable_connectivity_test_linux_x64_rocky9
+    tags: ["connectivity-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_x64_build
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-x64
+      - func: test_connectivity
+        vars:
+          node_js_version: "20.9.0"
+          test_mongosh_executable: dist/mongosh
+          kerberos_jumphost_dockerfile: "Dockerfile.rocky9"
+  - name: executable_connectivity_test_linux_x64_ubuntu2204
+    tags: ["connectivity-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_x64_build
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-x64
+      - func: test_connectivity
+        vars:
+          node_js_version: "20.9.0"
+          test_mongosh_executable: dist/mongosh
+          kerberos_jumphost_dockerfile: "Dockerfile.ubuntu2204"
+  - name: executable_connectivity_test_linux_x64_openssl11_rocky8
+    tags: ["connectivity-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_x64_build_openssl11
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-x64-openssl11
+      - func: test_connectivity
+        vars:
+          node_js_version: "20.9.0"
+          test_mongosh_executable: dist/mongosh
+          kerberos_jumphost_dockerfile: "Dockerfile.rocky8"
+  - name: executable_connectivity_test_linux_x64_openssl11_ubuntu2004
+    tags: ["connectivity-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_x64_build_openssl11
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-x64-openssl11
+      - func: test_connectivity
+        vars:
+          node_js_version: "20.9.0"
+          test_mongosh_executable: dist/mongosh
+          kerberos_jumphost_dockerfile: "Dockerfile.ubuntu2004"
+  - name: executable_connectivity_test_linux_x64_openssl3_node20
+    tags: ["connectivity-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_x64_build_openssl3
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-x64-openssl3
+      - func: test_connectivity
+        vars:
+          node_js_version: "20.9.0"
+          test_mongosh_executable: dist/mongosh
+          kerberos_jumphost_dockerfile: "Dockerfile.node20"
+  - name: executable_connectivity_test_linux_x64_openssl3_rocky9
+    tags: ["connectivity-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_x64_build_openssl3
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-x64-openssl3
+      - func: test_connectivity
+        vars:
+          node_js_version: "20.9.0"
+          test_mongosh_executable: dist/mongosh
+          kerberos_jumphost_dockerfile: "Dockerfile.rocky9"
+  - name: executable_connectivity_test_linux_x64_openssl3_ubuntu2204
+    tags: ["connectivity-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_x64_build_openssl3
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-x64-openssl3
+      - func: test_connectivity
+        vars:
+          node_js_version: "20.9.0"
+          test_mongosh_executable: dist/mongosh
+          kerberos_jumphost_dockerfile: "Dockerfile.ubuntu2204"
+  - name: executable_connectivity_test_linux_arm64_rocky8
+    tags: ["connectivity-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_arm64_build
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-arm64
+      - func: test_connectivity
+        vars:
+          node_js_version: "20.9.0"
+          test_mongosh_executable: dist/mongosh
+          kerberos_jumphost_dockerfile: "Dockerfile.rocky8"
+  - name: executable_connectivity_test_linux_arm64_ubuntu2004
+    tags: ["connectivity-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_arm64_build
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-arm64
+      - func: test_connectivity
+        vars:
+          node_js_version: "20.9.0"
+          test_mongosh_executable: dist/mongosh
+          kerberos_jumphost_dockerfile: "Dockerfile.ubuntu2004"
+  - name: executable_connectivity_test_linux_arm64_node20
+    tags: ["connectivity-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_arm64_build
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-arm64
+      - func: test_connectivity
+        vars:
+          node_js_version: "20.9.0"
+          test_mongosh_executable: dist/mongosh
+          kerberos_jumphost_dockerfile: "Dockerfile.node20"
+  - name: executable_connectivity_test_linux_arm64_rocky9
+    tags: ["connectivity-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_arm64_build
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-arm64
+      - func: test_connectivity
+        vars:
+          node_js_version: "20.9.0"
+          test_mongosh_executable: dist/mongosh
+          kerberos_jumphost_dockerfile: "Dockerfile.rocky9"
+  - name: executable_connectivity_test_linux_arm64_ubuntu2204
+    tags: ["connectivity-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_arm64_build
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-arm64
+      - func: test_connectivity
+        vars:
+          node_js_version: "20.9.0"
+          test_mongosh_executable: dist/mongosh
+          kerberos_jumphost_dockerfile: "Dockerfile.ubuntu2204"
+  - name: executable_connectivity_test_linux_arm64_openssl11_rocky8
+    tags: ["connectivity-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_arm64_build_openssl11
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-arm64-openssl11
+      - func: test_connectivity
+        vars:
+          node_js_version: "20.9.0"
+          test_mongosh_executable: dist/mongosh
+          kerberos_jumphost_dockerfile: "Dockerfile.rocky8"
+  - name: executable_connectivity_test_linux_arm64_openssl11_ubuntu2004
+    tags: ["connectivity-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_arm64_build_openssl11
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-arm64-openssl11
+      - func: test_connectivity
+        vars:
+          node_js_version: "20.9.0"
+          test_mongosh_executable: dist/mongosh
+          kerberos_jumphost_dockerfile: "Dockerfile.ubuntu2004"
+  - name: executable_connectivity_test_linux_arm64_openssl3_node20
+    tags: ["connectivity-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_arm64_build_openssl3
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-arm64-openssl3
+      - func: test_connectivity
+        vars:
+          node_js_version: "20.9.0"
+          test_mongosh_executable: dist/mongosh
+          kerberos_jumphost_dockerfile: "Dockerfile.node20"
+  - name: executable_connectivity_test_linux_arm64_openssl3_rocky9
+    tags: ["connectivity-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_arm64_build_openssl3
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-arm64-openssl3
+      - func: test_connectivity
+        vars:
+          node_js_version: "20.9.0"
+          test_mongosh_executable: dist/mongosh
+          kerberos_jumphost_dockerfile: "Dockerfile.rocky9"
+  - name: executable_connectivity_test_linux_arm64_openssl3_ubuntu2204
+    tags: ["connectivity-test"]
+    depends_on:
+      - name: compile_artifact
+        variant: linux_arm64_build_openssl3
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-arm64-openssl3
+      - func: test_connectivity
+        vars:
+          node_js_version: "20.9.0"
+          test_mongosh_executable: dist/mongosh
+          kerberos_jumphost_dockerfile: "Dockerfile.ubuntu2204"
+
+  ###
+  # PACKAGING
+  ###
+  - name: package_and_upload_artifact_darwin_x64
+    depends_on:
+      - name: compile_artifact
+        variant: darwin
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: package_and_upload_artifact
+        vars:
+          node_js_version: "20.9.0"
+          package_variant: darwin-x64
+          executable_os_id: darwin-x64
+  - name: package_and_upload_artifact_darwin_arm64
+    depends_on:
+      - name: compile_artifact
+        variant: darwin_arm64
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: package_and_upload_artifact
+        vars:
+          node_js_version: "20.9.0"
+          package_variant: darwin-arm64
+          executable_os_id: darwin-arm64
+  - name: package_and_upload_artifact_linux_x64
+    depends_on:
+      - name: compile_artifact
+        variant: linux_x64_build
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: package_and_upload_artifact
+        vars:
+          node_js_version: "20.9.0"
+          package_variant: linux-x64
+          executable_os_id: linux-x64
+  - name: package_and_upload_artifact_deb_x64
+    depends_on:
+      - name: compile_artifact
+        variant: linux_x64_build
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: package_and_upload_artifact
+        vars:
+          node_js_version: "20.9.0"
+          package_variant: deb-x64
+          executable_os_id: linux-x64
+  - name: package_and_upload_artifact_rpm_x64
+    depends_on:
+      - name: compile_artifact
+        variant: linux_x64_build
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: package_and_upload_artifact
+        vars:
+          node_js_version: "20.9.0"
+          package_variant: rpm-x64
+          executable_os_id: linux-x64
+  - name: package_and_upload_artifact_linux_x64_openssl11
+    depends_on:
+      - name: compile_artifact
+        variant: linux_x64_build_openssl11
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: package_and_upload_artifact
+        vars:
+          node_js_version: "20.9.0"
+          package_variant: linux-x64-openssl11
+          executable_os_id: linux-x64-openssl11
+  - name: package_and_upload_artifact_deb_x64_openssl11
+    depends_on:
+      - name: compile_artifact
+        variant: linux_x64_build_openssl11
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: package_and_upload_artifact
+        vars:
+          node_js_version: "20.9.0"
+          package_variant: deb-x64-openssl11
+          executable_os_id: linux-x64-openssl11
+  - name: package_and_upload_artifact_rpm_x64_openssl11
+    depends_on:
+      - name: compile_artifact
+        variant: linux_x64_build_openssl11
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: package_and_upload_artifact
+        vars:
+          node_js_version: "20.9.0"
+          package_variant: rpm-x64-openssl11
+          executable_os_id: linux-x64-openssl11
+  - name: package_and_upload_artifact_linux_x64_openssl3
+    depends_on:
+      - name: compile_artifact
+        variant: linux_x64_build_openssl3
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: package_and_upload_artifact
+        vars:
+          node_js_version: "20.9.0"
+          package_variant: linux-x64-openssl3
+          executable_os_id: linux-x64-openssl3
+  - name: package_and_upload_artifact_deb_x64_openssl3
+    depends_on:
+      - name: compile_artifact
+        variant: linux_x64_build_openssl3
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: package_and_upload_artifact
+        vars:
+          node_js_version: "20.9.0"
+          package_variant: deb-x64-openssl3
+          executable_os_id: linux-x64-openssl3
+  - name: package_and_upload_artifact_rpm_x64_openssl3
+    depends_on:
+      - name: compile_artifact
+        variant: linux_x64_build_openssl3
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: package_and_upload_artifact
+        vars:
+          node_js_version: "20.9.0"
+          package_variant: rpm-x64-openssl3
+          executable_os_id: linux-x64-openssl3
+  - name: package_and_upload_artifact_linux_arm64
+    depends_on:
+      - name: compile_artifact
+        variant: linux_arm64_build
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: package_and_upload_artifact
+        vars:
+          node_js_version: "20.9.0"
+          package_variant: linux-arm64
+          executable_os_id: linux-arm64
+  - name: package_and_upload_artifact_deb_arm64
+    depends_on:
+      - name: compile_artifact
+        variant: linux_arm64_build
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: package_and_upload_artifact
+        vars:
+          node_js_version: "20.9.0"
+          package_variant: deb-arm64
+          executable_os_id: linux-arm64
+  - name: package_and_upload_artifact_rpm_arm64
+    depends_on:
+      - name: compile_artifact
+        variant: linux_arm64_build
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: package_and_upload_artifact
+        vars:
+          node_js_version: "20.9.0"
+          package_variant: rpm-arm64
+          executable_os_id: linux-arm64
+  - name: package_and_upload_artifact_linux_arm64_openssl11
+    depends_on:
+      - name: compile_artifact
+        variant: linux_arm64_build_openssl11
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: package_and_upload_artifact
+        vars:
+          node_js_version: "20.9.0"
+          package_variant: linux-arm64-openssl11
+          executable_os_id: linux-arm64-openssl11
+  - name: package_and_upload_artifact_deb_arm64_openssl11
+    depends_on:
+      - name: compile_artifact
+        variant: linux_arm64_build_openssl11
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: package_and_upload_artifact
+        vars:
+          node_js_version: "20.9.0"
+          package_variant: deb-arm64-openssl11
+          executable_os_id: linux-arm64-openssl11
+  - name: package_and_upload_artifact_rpm_arm64_openssl11
+    depends_on:
+      - name: compile_artifact
+        variant: linux_arm64_build_openssl11
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: package_and_upload_artifact
+        vars:
+          node_js_version: "20.9.0"
+          package_variant: rpm-arm64-openssl11
+          executable_os_id: linux-arm64-openssl11
+  - name: package_and_upload_artifact_linux_arm64_openssl3
+    depends_on:
+      - name: compile_artifact
+        variant: linux_arm64_build_openssl3
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: package_and_upload_artifact
+        vars:
+          node_js_version: "20.9.0"
+          package_variant: linux-arm64-openssl3
+          executable_os_id: linux-arm64-openssl3
+  - name: package_and_upload_artifact_deb_arm64_openssl3
+    depends_on:
+      - name: compile_artifact
+        variant: linux_arm64_build_openssl3
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: package_and_upload_artifact
+        vars:
+          node_js_version: "20.9.0"
+          package_variant: deb-arm64-openssl3
+          executable_os_id: linux-arm64-openssl3
+  - name: package_and_upload_artifact_rpm_arm64_openssl3
+    depends_on:
+      - name: compile_artifact
+        variant: linux_arm64_build_openssl3
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: package_and_upload_artifact
+        vars:
+          node_js_version: "20.9.0"
+          package_variant: rpm-arm64-openssl3
+          executable_os_id: linux-arm64-openssl3
+  - name: package_and_upload_artifact_linux_ppc64le
+    depends_on:
+      - name: compile_artifact
+        variant: linux_ppc64le_build
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: package_and_upload_artifact
+        vars:
+          node_js_version: "20.9.0"
+          package_variant: linux-ppc64le
+          executable_os_id: linux-ppc64le
+  - name: package_and_upload_artifact_rpm_ppc64le
+    depends_on:
+      - name: compile_artifact
+        variant: linux_ppc64le_build
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: package_and_upload_artifact
+        vars:
+          node_js_version: "20.9.0"
+          package_variant: rpm-ppc64le
+          executable_os_id: linux-ppc64le
+  - name: package_and_upload_artifact_linux_s390x
+    depends_on:
+      - name: compile_artifact
+        variant: linux_s390x_build
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: package_and_upload_artifact
+        vars:
+          node_js_version: "20.9.0"
+          package_variant: linux-s390x
+          executable_os_id: linux-s390x
+  - name: package_and_upload_artifact_rpm_s390x
+    depends_on:
+      - name: compile_artifact
+        variant: linux_s390x_build
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: package_and_upload_artifact
+        vars:
+          node_js_version: "20.9.0"
+          package_variant: rpm-s390x
+          executable_os_id: linux-s390x
+  - name: package_and_upload_artifact_win32_x64
+    depends_on:
+      - name: compile_artifact
+        variant: win32_build
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: package_and_upload_artifact
+        vars:
+          node_js_version: "20.9.0"
+          package_variant: win32-x64
+          executable_os_id: win32
+  - name: package_and_upload_artifact_win32msi_x64
+    depends_on:
+      - name: compile_artifact
+        variant: win32_build
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: package_and_upload_artifact
+        vars:
+          node_js_version: "20.9.0"
+          package_variant: win32msi-x64
+          executable_os_id: win32
+
+  ###
+  # SMOKE TESTS
+  ###
+  - name: pkg_test_macos_darwin_x64
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_darwin_x64
+        variant: darwin
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: darwin-x64
+      - func: write_preload_script
+      - func: test_artifact_macos
+  - name: pkg_test_macos_darwin_arm64
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_darwin_arm64
+        variant: darwin
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: darwin-arm64
+      - func: write_preload_script
+      - func: test_artifact_macos
+  - name: pkg_test_docker_linux_x64_ubuntu20_04_tgz
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_linux_x64
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: linux-x64
+      - func: write_preload_script
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test_artifact_docker
+        vars:
+          node_js_version: "20.9.0"
+          dockerfile: ubuntu20.04-tgz
+  - name: pkg_test_docker_deb_x64_ubuntu18_04_deb
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_deb_x64
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: deb-x64
+      - func: write_preload_script
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test_artifact_docker
+        vars:
+          node_js_version: "20.9.0"
+          dockerfile: ubuntu18.04-deb
+  - name: pkg_test_docker_deb_x64_ubuntu20_04_deb
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_deb_x64
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: deb-x64
+      - func: write_preload_script
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test_artifact_docker
+        vars:
+          node_js_version: "20.9.0"
+          dockerfile: ubuntu20.04-deb
+  - name: pkg_test_docker_deb_x64_ubuntu22_04_deb
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_deb_x64
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: deb-x64
+      - func: write_preload_script
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test_artifact_docker
+        vars:
+          node_js_version: "20.9.0"
+          dockerfile: ubuntu22.04-deb
+  - name: pkg_test_docker_deb_x64_ubuntu22_04_nohome_deb
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_deb_x64
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: deb-x64
+      - func: write_preload_script
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test_artifact_docker
+        vars:
+          node_js_version: "20.9.0"
+          dockerfile: ubuntu22.04-nohome-deb
+  - name: pkg_test_docker_deb_x64_debian10_deb
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_deb_x64
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: deb-x64
+      - func: write_preload_script
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test_artifact_docker
+        vars:
+          node_js_version: "20.9.0"
+          dockerfile: debian10-deb
+  - name: pkg_test_docker_deb_x64_debian11_deb
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_deb_x64
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: deb-x64
+      - func: write_preload_script
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test_artifact_docker
+        vars:
+          node_js_version: "20.9.0"
+          dockerfile: debian11-deb
+  - name: pkg_test_docker_deb_x64_debian12_deb
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_deb_x64
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: deb-x64
+      - func: write_preload_script
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test_artifact_docker
+        vars:
+          node_js_version: "20.9.0"
+          dockerfile: debian12-deb
+  - name: pkg_test_docker_rpm_x64_centos7_rpm
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_rpm_x64
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: rpm-x64
+      - func: write_preload_script
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test_artifact_docker
+        vars:
+          node_js_version: "20.9.0"
+          dockerfile: centos7-rpm
+  - name: pkg_test_docker_rpm_x64_amazonlinux2_rpm
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_rpm_x64
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: rpm-x64
+      - func: write_preload_script
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test_artifact_docker
+        vars:
+          node_js_version: "20.9.0"
+          dockerfile: amazonlinux2-rpm
+  - name: pkg_test_docker_rpm_x64_amazonlinux2023_rpm
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_rpm_x64
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: rpm-x64
+      - func: write_preload_script
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test_artifact_docker
+        vars:
+          node_js_version: "20.9.0"
+          dockerfile: amazonlinux2023-rpm
+  - name: pkg_test_docker_rpm_x64_rocky8_rpm
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_rpm_x64
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: rpm-x64
+      - func: write_preload_script
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test_artifact_docker
+        vars:
+          node_js_version: "20.9.0"
+          dockerfile: rocky8-rpm
+  - name: pkg_test_docker_rpm_x64_rocky9_rpm
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_rpm_x64
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: rpm-x64
+      - func: write_preload_script
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test_artifact_docker
+        vars:
+          node_js_version: "20.9.0"
+          dockerfile: rocky9-rpm
+  - name: pkg_test_docker_rpm_x64_fedora34_rpm
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_rpm_x64
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: rpm-x64
+      - func: write_preload_script
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test_artifact_docker
+        vars:
+          node_js_version: "20.9.0"
+          dockerfile: fedora34-rpm
+  - name: pkg_test_docker_rpm_x64_suse12_rpm
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_rpm_x64
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: rpm-x64
+      - func: write_preload_script
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test_artifact_docker
+        vars:
+          node_js_version: "20.9.0"
+          dockerfile: suse12-rpm
+  - name: pkg_test_docker_rpm_x64_suse15_rpm
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_rpm_x64
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: rpm-x64
+      - func: write_preload_script
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test_artifact_docker
+        vars:
+          node_js_version: "20.9.0"
+          dockerfile: suse15-rpm
+  - name: pkg_test_docker_deb_x64_openssl11_ubuntu20_04_deb
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_deb_x64_openssl11
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: deb-x64-openssl11
+      - func: write_preload_script
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test_artifact_docker
+        vars:
+          node_js_version: "20.9.0"
+          dockerfile: ubuntu20.04-deb
+  - name: pkg_test_docker_deb_x64_openssl11_debian10_deb
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_deb_x64_openssl11
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: deb-x64-openssl11
+      - func: write_preload_script
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test_artifact_docker
+        vars:
+          node_js_version: "20.9.0"
+          dockerfile: debian10-deb
+  - name: pkg_test_docker_deb_x64_openssl11_debian11_deb
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_deb_x64_openssl11
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: deb-x64-openssl11
+      - func: write_preload_script
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test_artifact_docker
+        vars:
+          node_js_version: "20.9.0"
+          dockerfile: debian11-deb
+  - name: pkg_test_docker_rpm_x64_openssl11_centos7_epel_rpm
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_rpm_x64_openssl11
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: rpm-x64-openssl11
+      - func: write_preload_script
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test_artifact_docker
+        vars:
+          node_js_version: "20.9.0"
+          dockerfile: centos7-epel-rpm
+  - name: pkg_test_docker_rpm_x64_openssl11_amazonlinux2_rpm
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_rpm_x64_openssl11
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: rpm-x64-openssl11
+      - func: write_preload_script
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test_artifact_docker
+        vars:
+          node_js_version: "20.9.0"
+          dockerfile: amazonlinux2-rpm
+  - name: pkg_test_docker_rpm_x64_openssl11_rocky8_rpm
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_rpm_x64_openssl11
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: rpm-x64-openssl11
+      - func: write_preload_script
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test_artifact_docker
+        vars:
+          node_js_version: "20.9.0"
+          dockerfile: rocky8-rpm
+  - name: pkg_test_docker_rpm_x64_openssl11_rocky9_rpm
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_rpm_x64_openssl11
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: rpm-x64-openssl11
+      - func: write_preload_script
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test_artifact_docker
+        vars:
+          node_js_version: "20.9.0"
+          dockerfile: rocky9-rpm
+  - name: pkg_test_docker_rpm_x64_openssl11_fedora34_rpm
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_rpm_x64_openssl11
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: rpm-x64-openssl11
+      - func: write_preload_script
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test_artifact_docker
+        vars:
+          node_js_version: "20.9.0"
+          dockerfile: fedora34-rpm
+  - name: pkg_test_docker_deb_x64_openssl3_ubuntu22_04_deb
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_deb_x64_openssl3
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: deb-x64-openssl3
+      - func: write_preload_script
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test_artifact_docker
+        vars:
+          node_js_version: "20.9.0"
+          dockerfile: ubuntu22.04-deb
+  - name: pkg_test_docker_deb_x64_openssl3_ubuntu22_04_fips_deb
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_deb_x64_openssl3
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: deb-x64-openssl3
+      - func: write_preload_script
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test_artifact_docker
+        vars:
+          node_js_version: "20.9.0"
+          dockerfile: ubuntu22.04-fips-deb
+  - name: pkg_test_docker_deb_x64_openssl3_debian12_deb
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_deb_x64_openssl3
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: deb-x64-openssl3
+      - func: write_preload_script
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test_artifact_docker
+        vars:
+          node_js_version: "20.9.0"
+          dockerfile: debian12-deb
+  - name: pkg_test_docker_rpm_x64_openssl3_rocky8_epel_rpm
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_rpm_x64_openssl3
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: rpm-x64-openssl3
+      - func: write_preload_script
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test_artifact_docker
+        vars:
+          node_js_version: "20.9.0"
+          dockerfile: rocky8-epel-rpm
+  - name: pkg_test_docker_rpm_x64_openssl3_rocky9_rpm
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_rpm_x64_openssl3
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: rpm-x64-openssl3
+      - func: write_preload_script
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test_artifact_docker
+        vars:
+          node_js_version: "20.9.0"
+          dockerfile: rocky9-rpm
+  - name: pkg_test_docker_rpm_x64_openssl3_rocky9_fips_rpm
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_rpm_x64_openssl3
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: rpm-x64-openssl3
+      - func: write_preload_script
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test_artifact_docker
+        vars:
+          node_js_version: "20.9.0"
+          dockerfile: rocky9-fips-rpm
+  - name: pkg_test_docker_rpm_x64_openssl3_amazonlinux2023_rpm
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_rpm_x64_openssl3
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: rpm-x64-openssl3
+      - func: write_preload_script
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test_artifact_docker
+        vars:
+          node_js_version: "20.9.0"
+          dockerfile: amazonlinux2023-rpm
+  - name: pkg_test_docker_linux_arm64_ubuntu20_04_tgz
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_linux_arm64
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: linux-arm64
+      - func: write_preload_script
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test_artifact_docker
+        vars:
+          node_js_version: "20.9.0"
+          dockerfile: ubuntu20.04-tgz
+  - name: pkg_test_docker_deb_arm64_ubuntu18_04_deb
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_deb_arm64
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: deb-arm64
+      - func: write_preload_script
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test_artifact_docker
+        vars:
+          node_js_version: "20.9.0"
+          dockerfile: ubuntu18.04-deb
+  - name: pkg_test_docker_deb_arm64_ubuntu20_04_deb
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_deb_arm64
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: deb-arm64
+      - func: write_preload_script
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test_artifact_docker
+        vars:
+          node_js_version: "20.9.0"
+          dockerfile: ubuntu20.04-deb
+  - name: pkg_test_docker_deb_arm64_ubuntu22_04_deb
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_deb_arm64
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: deb-arm64
+      - func: write_preload_script
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test_artifact_docker
+        vars:
+          node_js_version: "20.9.0"
+          dockerfile: ubuntu22.04-deb
+  - name: pkg_test_docker_deb_arm64_debian10_deb
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_deb_arm64
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: deb-arm64
+      - func: write_preload_script
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test_artifact_docker
+        vars:
+          node_js_version: "20.9.0"
+          dockerfile: debian10-deb
+  - name: pkg_test_docker_deb_arm64_debian11_deb
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_deb_arm64
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: deb-arm64
+      - func: write_preload_script
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test_artifact_docker
+        vars:
+          node_js_version: "20.9.0"
+          dockerfile: debian11-deb
+  - name: pkg_test_docker_deb_arm64_debian12_deb
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_deb_arm64
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: deb-arm64
+      - func: write_preload_script
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test_artifact_docker
+        vars:
+          node_js_version: "20.9.0"
+          dockerfile: debian12-deb
+  - name: pkg_test_docker_rpm_arm64_rocky8_rpm
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_rpm_arm64
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: rpm-arm64
+      - func: write_preload_script
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test_artifact_docker
+        vars:
+          node_js_version: "20.9.0"
+          dockerfile: rocky8-rpm
+  - name: pkg_test_docker_rpm_arm64_rocky9_rpm
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_rpm_arm64
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: rpm-arm64
+      - func: write_preload_script
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test_artifact_docker
+        vars:
+          node_js_version: "20.9.0"
+          dockerfile: rocky9-rpm
+  - name: pkg_test_docker_rpm_arm64_fedora34_rpm
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_rpm_arm64
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: rpm-arm64
+      - func: write_preload_script
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test_artifact_docker
+        vars:
+          node_js_version: "20.9.0"
+          dockerfile: fedora34-rpm
+  - name: pkg_test_docker_rpm_arm64_amazonlinux2_rpm
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_rpm_arm64
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: rpm-arm64
+      - func: write_preload_script
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test_artifact_docker
+        vars:
+          node_js_version: "20.9.0"
+          dockerfile: amazonlinux2-rpm
+  - name: pkg_test_docker_rpm_arm64_amazonlinux2023_rpm
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_rpm_arm64
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: rpm-arm64
+      - func: write_preload_script
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test_artifact_docker
+        vars:
+          node_js_version: "20.9.0"
+          dockerfile: amazonlinux2023-rpm
+  - name: pkg_test_docker_deb_arm64_openssl11_ubuntu20_04_deb
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_deb_arm64_openssl11
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: deb-arm64-openssl11
+      - func: write_preload_script
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test_artifact_docker
+        vars:
+          node_js_version: "20.9.0"
+          dockerfile: ubuntu20.04-deb
+  - name: pkg_test_docker_deb_arm64_openssl11_debian10_deb
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_deb_arm64_openssl11
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: deb-arm64-openssl11
+      - func: write_preload_script
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test_artifact_docker
+        vars:
+          node_js_version: "20.9.0"
+          dockerfile: debian10-deb
+  - name: pkg_test_docker_deb_arm64_openssl11_debian11_deb
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_deb_arm64_openssl11
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: deb-arm64-openssl11
+      - func: write_preload_script
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test_artifact_docker
+        vars:
+          node_js_version: "20.9.0"
+          dockerfile: debian11-deb
+  - name: pkg_test_docker_rpm_arm64_openssl11_rocky8_rpm
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_rpm_arm64_openssl11
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: rpm-arm64-openssl11
+      - func: write_preload_script
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test_artifact_docker
+        vars:
+          node_js_version: "20.9.0"
+          dockerfile: rocky8-rpm
+  - name: pkg_test_docker_rpm_arm64_openssl11_rocky9_rpm
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_rpm_arm64_openssl11
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: rpm-arm64-openssl11
+      - func: write_preload_script
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test_artifact_docker
+        vars:
+          node_js_version: "20.9.0"
+          dockerfile: rocky9-rpm
+  - name: pkg_test_docker_rpm_arm64_openssl11_fedora34_rpm
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_rpm_arm64_openssl11
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: rpm-arm64-openssl11
+      - func: write_preload_script
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test_artifact_docker
+        vars:
+          node_js_version: "20.9.0"
+          dockerfile: fedora34-rpm
+  - name: pkg_test_docker_rpm_arm64_openssl11_amazonlinux2_rpm
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_rpm_arm64_openssl11
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: rpm-arm64-openssl11
+      - func: write_preload_script
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test_artifact_docker
+        vars:
+          node_js_version: "20.9.0"
+          dockerfile: amazonlinux2-rpm
+  - name: pkg_test_docker_deb_arm64_openssl3_ubuntu22_04_deb
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_deb_arm64_openssl3
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: deb-arm64-openssl3
+      - func: write_preload_script
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test_artifact_docker
+        vars:
+          node_js_version: "20.9.0"
+          dockerfile: ubuntu22.04-deb
+  - name: pkg_test_docker_deb_arm64_openssl3_ubuntu22_04_fips_deb
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_deb_arm64_openssl3
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: deb-arm64-openssl3
+      - func: write_preload_script
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test_artifact_docker
+        vars:
+          node_js_version: "20.9.0"
+          dockerfile: ubuntu22.04-fips-deb
+  - name: pkg_test_docker_deb_arm64_openssl3_debian12_deb
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_deb_arm64_openssl3
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: deb-arm64-openssl3
+      - func: write_preload_script
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test_artifact_docker
+        vars:
+          node_js_version: "20.9.0"
+          dockerfile: debian12-deb
+  - name: pkg_test_docker_rpm_arm64_openssl3_rocky8_epel_rpm
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_rpm_arm64_openssl3
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: rpm-arm64-openssl3
+      - func: write_preload_script
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test_artifact_docker
+        vars:
+          node_js_version: "20.9.0"
+          dockerfile: rocky8-epel-rpm
+  - name: pkg_test_docker_rpm_arm64_openssl3_rocky9_rpm
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_rpm_arm64_openssl3
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: rpm-arm64-openssl3
+      - func: write_preload_script
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test_artifact_docker
+        vars:
+          node_js_version: "20.9.0"
+          dockerfile: rocky9-rpm
+  - name: pkg_test_docker_rpm_arm64_openssl3_rocky9_fips_rpm
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_rpm_arm64_openssl3
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: rpm-arm64-openssl3
+      - func: write_preload_script
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test_artifact_docker
+        vars:
+          node_js_version: "20.9.0"
+          dockerfile: rocky9-fips-rpm
+  - name: pkg_test_docker_rpm_arm64_openssl3_amazonlinux2023_rpm
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_rpm_arm64_openssl3
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: rpm-arm64-openssl3
+      - func: write_preload_script
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: test_artifact_docker
+        vars:
+          node_js_version: "20.9.0"
+          dockerfile: amazonlinux2023-rpm
+  - name: pkg_test_rpmextract_rpm_ppc64le
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_rpm_ppc64le
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: rpm-ppc64le
+      - func: write_preload_script
+      - func: test_artifact_rpmextract
+  - name: pkg_test_rpmextract_rpm_s390x
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_rpm_s390x
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: rpm-s390x
+      - func: write_preload_script
+      - func: test_artifact_rpmextract
+  - name: pkg_test_ssh_win32_x64
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_win32_x64
+        variant: win32
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: win32-x64
+      - func: write_preload_script
+      - func: spawn_host
+        vars:
+          distro: windows-vsCurrent-small
+      - func: run_pkg_tests_through_ssh
+        vars:
+          admin_user_name: Administrator
+          onhost_script_path: .evergreen/test-package-win32.sh
+          preload_script_path: preload.sh
+  - name: pkg_test_ssh_win32msi_x64
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_win32msi_x64
+        variant: win32
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: win32msi-x64
+      - func: write_preload_script
+      - func: spawn_host
+        vars:
+          distro: windows-vsCurrent-small
+      - func: run_pkg_tests_through_ssh
+        vars:
+          admin_user_name: Administrator
+          onhost_script_path: .evergreen/test-package-win32.sh
+          preload_script_path: preload.sh
+
+  ###
+  # RELEASE TASKS
+  ###
+  - name: release_draft
+    git_tag_only: true
+    depends_on:
+      - name: ".smoke-test"
+        variant: "*"
+      - name: ".extra-integration-test"
+        variant: "*"
+      - name: ".e2e-test"
+        variant: "*"
+      - name: ".connectivity-test"
+        variant: "*"
+      - name: check
+        variant: "*"
+      - name: ".unit-test"
+        variant: "*"
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: release_draft
+        vars:
+          node_js_version: "20.9.0"
+  - name: release_publish_dry_run
+    git_tag_only: true
+    exec_timeout_secs: 86400
+    depends_on:
+      - name: release_draft
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: release_publish_dry_run
+        vars:
+          node_js_version: "20.9.0"
+  - name: release_publish
+    tags: ["publish"]
+    git_tag_only: true
+    exec_timeout_secs: 86400
+    depends_on:
+      - name: compile_ts
+        variant: linux_unit
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.9.0"
+      - func: release_publish
+        vars:
+          node_js_version: "20.9.0"
+
+# Need to run builds for every possible build variant.
+buildvariants:
+  - name: darwin_unit
+    disabled: true
+    display_name: "MacOS Big Sur (Unit tests)"
+    run_on: macos-1100
+    expansions:
+      executable_os_id: darwin-x64
+    tasks:
+      - name: check
+      - name: test_n20_arg_parser
+      - name: test_n16_arg_parser
+      - name: test_n20_async_rewriter2
+      - name: test_n16_async_rewriter2
+      - name: test_n20_autocomplete
+      - name: test_n16_autocomplete
+      - name: test_n20_browser_repl
+      - name: test_n16_browser_repl
+      - name: test_n20_browser_runtime_core
+      - name: test_n16_browser_runtime_core
+      - name: test_n20_browser_runtime_electron
+      - name: test_n16_browser_runtime_electron
+      - name: test_n20_build
+      - name: test_n16_build
+      - name: test_m42xc_n20_cli_repl
+      - name: test_m42xe_n20_cli_repl
+      - name: test_m44xc_n20_cli_repl
+      - name: test_m44xe_n20_cli_repl
+      - name: test_m50xc_n20_cli_repl
+      - name: test_m50xe_n20_cli_repl
+      - name: test_m60xc_n20_cli_repl
+      - name: test_m60xe_n20_cli_repl
+      - name: test_m70xc_n20_cli_repl
+      - name: test_m70xe_n20_cli_repl
+      - name: test_mlatest_n20_cli_repl
+      - name: test_m42xc_n16_cli_repl
+      - name: test_m42xe_n16_cli_repl
+      - name: test_m44xc_n16_cli_repl
+      - name: test_m44xe_n16_cli_repl
+      - name: test_m50xc_n16_cli_repl
+      - name: test_m50xe_n16_cli_repl
+      - name: test_m60xc_n16_cli_repl
+      - name: test_m60xe_n16_cli_repl
+      - name: test_m70xc_n16_cli_repl
+      - name: test_m70xe_n16_cli_repl
+      - name: test_mlatest_n16_cli_repl
+      - name: test_m42xc_n20_e2e_tests
+      - name: test_m42xe_n20_e2e_tests
+      - name: test_m44xc_n20_e2e_tests
+      - name: test_m44xe_n20_e2e_tests
+      - name: test_m50xc_n20_e2e_tests
+      - name: test_m50xe_n20_e2e_tests
+      - name: test_m60xc_n20_e2e_tests
+      - name: test_m60xe_n20_e2e_tests
+      - name: test_m70xc_n20_e2e_tests
+      - name: test_m70xe_n20_e2e_tests
+      - name: test_mlatest_n20_e2e_tests
+      - name: test_m42xc_n16_e2e_tests
+      - name: test_m42xe_n16_e2e_tests
+      - name: test_m44xc_n16_e2e_tests
+      - name: test_m44xe_n16_e2e_tests
+      - name: test_m50xc_n16_e2e_tests
+      - name: test_m50xe_n16_e2e_tests
+      - name: test_m60xc_n16_e2e_tests
+      - name: test_m60xe_n16_e2e_tests
+      - name: test_m70xc_n16_e2e_tests
+      - name: test_m70xe_n16_e2e_tests
+      - name: test_mlatest_n16_e2e_tests
+      - name: test_n20_editor
+      - name: test_n16_editor
+      - name: test_n20_errors
+      - name: test_n16_errors
+      - name: test_n20_history
+      - name: test_n16_history
+      - name: test_n20_i18n
+      - name: test_n16_i18n
+      - name: test_n20_js_multiline_to_singleline
+      - name: test_n16_js_multiline_to_singleline
+      - name: test_n20_logging
+      - name: test_n16_logging
+      - name: test_m42xc_n20_node_runtime_worker_thread
+      - name: test_m42xe_n20_node_runtime_worker_thread
+      - name: test_m44xc_n20_node_runtime_worker_thread
+      - name: test_m44xe_n20_node_runtime_worker_thread
+      - name: test_m50xc_n20_node_runtime_worker_thread
+      - name: test_m50xe_n20_node_runtime_worker_thread
+      - name: test_m60xc_n20_node_runtime_worker_thread
+      - name: test_m60xe_n20_node_runtime_worker_thread
+      - name: test_m70xc_n20_node_runtime_worker_thread
+      - name: test_m70xe_n20_node_runtime_worker_thread
+      - name: test_mlatest_n20_node_runtime_worker_thread
+      - name: test_m42xc_n16_node_runtime_worker_thread
+      - name: test_m42xe_n16_node_runtime_worker_thread
+      - name: test_m44xc_n16_node_runtime_worker_thread
+      - name: test_m44xe_n16_node_runtime_worker_thread
+      - name: test_m50xc_n16_node_runtime_worker_thread
+      - name: test_m50xe_n16_node_runtime_worker_thread
+      - name: test_m60xc_n16_node_runtime_worker_thread
+      - name: test_m60xe_n16_node_runtime_worker_thread
+      - name: test_m70xc_n16_node_runtime_worker_thread
+      - name: test_m70xe_n16_node_runtime_worker_thread
+      - name: test_mlatest_n16_node_runtime_worker_thread
+      - name: test_n20_service_provider_core
+      - name: test_n16_service_provider_core
+      - name: test_m42xc_n20_service_provider_server
+      - name: test_m42xe_n20_service_provider_server
+      - name: test_m44xc_n20_service_provider_server
+      - name: test_m44xe_n20_service_provider_server
+      - name: test_m50xc_n20_service_provider_server
+      - name: test_m50xe_n20_service_provider_server
+      - name: test_m60xc_n20_service_provider_server
+      - name: test_m60xe_n20_service_provider_server
+      - name: test_m70xc_n20_service_provider_server
+      - name: test_m70xe_n20_service_provider_server
+      - name: test_mlatest_n20_service_provider_server
+      - name: test_m42xc_n16_service_provider_server
+      - name: test_m42xe_n16_service_provider_server
+      - name: test_m44xc_n16_service_provider_server
+      - name: test_m44xe_n16_service_provider_server
+      - name: test_m50xc_n16_service_provider_server
+      - name: test_m50xe_n16_service_provider_server
+      - name: test_m60xc_n16_service_provider_server
+      - name: test_m60xe_n16_service_provider_server
+      - name: test_m70xc_n16_service_provider_server
+      - name: test_m70xe_n16_service_provider_server
+      - name: test_mlatest_n16_service_provider_server
+      - name: test_m42xc_n20_shell_api
+      - name: test_m42xe_n20_shell_api
+      - name: test_m44xc_n20_shell_api
+      - name: test_m44xe_n20_shell_api
+      - name: test_m50xc_n20_shell_api
+      - name: test_m50xe_n20_shell_api
+      - name: test_m60xc_n20_shell_api
+      - name: test_m60xe_n20_shell_api
+      - name: test_m70xc_n20_shell_api
+      - name: test_m70xe_n20_shell_api
+      - name: test_mlatest_n20_shell_api
+      - name: test_m42xc_n16_shell_api
+      - name: test_m42xe_n16_shell_api
+      - name: test_m44xc_n16_shell_api
+      - name: test_m44xe_n16_shell_api
+      - name: test_m50xc_n16_shell_api
+      - name: test_m50xe_n16_shell_api
+      - name: test_m60xc_n16_shell_api
+      - name: test_m60xe_n16_shell_api
+      - name: test_m70xc_n16_shell_api
+      - name: test_m70xe_n16_shell_api
+      - name: test_mlatest_n16_shell_api
+      - name: test_n20_shell_evaluator
+      - name: test_n16_shell_evaluator
+      - name: test_n20_snippet_manager
+      - name: test_n16_snippet_manager
+      - name: test_n20_types
+      - name: test_n16_types
+  - name: darwin
+    disabled: true
+    display_name: "MacOS Big Sur"
+    run_on: macos-1100
+    expansions:
+      executable_os_id: darwin-x64
+    tasks:
+      - name: compile_artifact
+      - name: e2e_tests_darwin_x64
+      - name: package_and_upload_artifact_darwin_x64
+      - name: package_and_upload_artifact_darwin_arm64
+  - name: darwin_arm64
+    disabled: true
+    display_name: "MacOS Big Sur (arm64)"
+    run_on: macos-1100-arm64
+    expansions:
+      executable_os_id: darwin-arm64
+    tasks:
+      - name: compile_artifact
+      - name: e2e_tests_darwin_arm64
+
+  - name: linux_unit
+    disabled: false
+    display_name: "Ubuntu 18.04 x64 (Unit tests)"
+    run_on: ubuntu2004-small
+    tasks:
+      - name: compile_ts
+      - name: check
+      - name: test_n20_arg_parser
+      - name: test_n16_arg_parser
+      - name: test_n20_async_rewriter2
+      - name: test_n16_async_rewriter2
+      - name: test_n20_autocomplete
+      - name: test_n16_autocomplete
+      - name: test_n20_browser_runtime_core
+      - name: test_n16_browser_runtime_core
+      - name: test_n20_browser_runtime_electron
+      - name: test_n16_browser_runtime_electron
+      - name: test_n20_build
+      - name: test_n16_build
+      - name: test_m42xc_n20_cli_repl
+      - name: test_m44xc_n20_cli_repl
+      - name: test_m44xe_n20_cli_repl
+      - name: test_m50xc_n20_cli_repl
+      - name: test_m50xe_n20_cli_repl
+      - name: test_m60xc_n20_cli_repl
+      - name: test_m60xe_n20_cli_repl
+      - name: test_m70xc_n20_cli_repl
+      - name: test_m70xe_n20_cli_repl
+      - name: test_mlatest_n20_cli_repl
+      - name: test_m42xc_n16_cli_repl
+      - name: test_m44xc_n16_cli_repl
+      - name: test_m44xe_n16_cli_repl
+      - name: test_m50xc_n16_cli_repl
+      - name: test_m50xe_n16_cli_repl
+      - name: test_m60xc_n16_cli_repl
+      - name: test_m60xe_n16_cli_repl
+      - name: test_m70xc_n16_cli_repl
+      - name: test_m70xe_n16_cli_repl
+      - name: test_mlatest_n16_cli_repl
+      - name: test_m42xc_n20_e2e_tests
+      - name: test_m44xc_n20_e2e_tests
+      - name: test_m44xe_n20_e2e_tests
+      - name: test_m50xc_n20_e2e_tests
+      - name: test_m50xe_n20_e2e_tests
+      - name: test_m60xc_n20_e2e_tests
+      - name: test_m60xe_n20_e2e_tests
+      - name: test_m70xc_n20_e2e_tests
+      - name: test_m70xe_n20_e2e_tests
+      - name: test_mlatest_n20_e2e_tests
+      - name: test_m42xc_n16_e2e_tests
+      - name: test_m44xc_n16_e2e_tests
+      - name: test_m44xe_n16_e2e_tests
+      - name: test_m50xc_n16_e2e_tests
+      - name: test_m50xe_n16_e2e_tests
+      - name: test_m60xc_n16_e2e_tests
+      - name: test_m60xe_n16_e2e_tests
+      - name: test_m70xc_n16_e2e_tests
+      - name: test_m70xe_n16_e2e_tests
+      - name: test_mlatest_n16_e2e_tests
+      - name: test_n20_editor
+      - name: test_n16_editor
+      - name: test_n20_errors
+      - name: test_n16_errors
+      - name: test_n20_history
+      - name: test_n16_history
+      - name: test_n20_i18n
+      - name: test_n16_i18n
+      - name: test_m42xc_n20_java_shell
+      - name: test_m44xc_n20_java_shell
+      - name: test_m44xe_n20_java_shell
+      - name: test_m50xc_n20_java_shell
+      - name: test_m50xe_n20_java_shell
+      - name: test_m60xc_n20_java_shell
+      - name: test_m60xe_n20_java_shell
+      - name: test_m70xc_n20_java_shell
+      - name: test_m70xe_n20_java_shell
+      - name: test_mlatest_n20_java_shell
+      - name: test_m42xc_n16_java_shell
+      - name: test_m44xc_n16_java_shell
+      - name: test_m44xe_n16_java_shell
+      - name: test_m50xc_n16_java_shell
+      - name: test_m50xe_n16_java_shell
+      - name: test_m60xc_n16_java_shell
+      - name: test_m60xe_n16_java_shell
+      - name: test_m70xc_n16_java_shell
+      - name: test_m70xe_n16_java_shell
+      - name: test_mlatest_n16_java_shell
+      - name: test_n20_js_multiline_to_singleline
+      - name: test_n16_js_multiline_to_singleline
+      - name: test_n20_logging
+      - name: test_n16_logging
+      - name: test_m42xc_n20_node_runtime_worker_thread
+      - name: test_m44xc_n20_node_runtime_worker_thread
+      - name: test_m44xe_n20_node_runtime_worker_thread
+      - name: test_m50xc_n20_node_runtime_worker_thread
+      - name: test_m50xe_n20_node_runtime_worker_thread
+      - name: test_m60xc_n20_node_runtime_worker_thread
+      - name: test_m60xe_n20_node_runtime_worker_thread
+      - name: test_m70xc_n20_node_runtime_worker_thread
+      - name: test_m70xe_n20_node_runtime_worker_thread
+      - name: test_mlatest_n20_node_runtime_worker_thread
+      - name: test_m42xc_n16_node_runtime_worker_thread
+      - name: test_m44xc_n16_node_runtime_worker_thread
+      - name: test_m44xe_n16_node_runtime_worker_thread
+      - name: test_m50xc_n16_node_runtime_worker_thread
+      - name: test_m50xe_n16_node_runtime_worker_thread
+      - name: test_m60xc_n16_node_runtime_worker_thread
+      - name: test_m60xe_n16_node_runtime_worker_thread
+      - name: test_m70xc_n16_node_runtime_worker_thread
+      - name: test_m70xe_n16_node_runtime_worker_thread
+      - name: test_mlatest_n16_node_runtime_worker_thread
+      - name: test_n20_service_provider_core
+      - name: test_n16_service_provider_core
+      - name: test_m42xc_n20_service_provider_server
+      - name: test_m44xc_n20_service_provider_server
+      - name: test_m44xe_n20_service_provider_server
+      - name: test_m50xc_n20_service_provider_server
+      - name: test_m50xe_n20_service_provider_server
+      - name: test_m60xc_n20_service_provider_server
+      - name: test_m60xe_n20_service_provider_server
+      - name: test_m70xc_n20_service_provider_server
+      - name: test_m70xe_n20_service_provider_server
+      - name: test_mlatest_n20_service_provider_server
+      - name: test_m42xc_n16_service_provider_server
+      - name: test_m44xc_n16_service_provider_server
+      - name: test_m44xe_n16_service_provider_server
+      - name: test_m50xc_n16_service_provider_server
+      - name: test_m50xe_n16_service_provider_server
+      - name: test_m60xc_n16_service_provider_server
+      - name: test_m60xe_n16_service_provider_server
+      - name: test_m70xc_n16_service_provider_server
+      - name: test_m70xe_n16_service_provider_server
+      - name: test_mlatest_n16_service_provider_server
+      - name: test_m42xc_n20_shell_api
+      - name: test_m44xc_n20_shell_api
+      - name: test_m44xe_n20_shell_api
+      - name: test_m50xc_n20_shell_api
+      - name: test_m50xe_n20_shell_api
+      - name: test_m60xc_n20_shell_api
+      - name: test_m60xe_n20_shell_api
+      - name: test_m70xc_n20_shell_api
+      - name: test_m70xe_n20_shell_api
+      - name: test_mlatest_n20_shell_api
+      - name: test_m42xc_n16_shell_api
+      - name: test_m44xc_n16_shell_api
+      - name: test_m44xe_n16_shell_api
+      - name: test_m50xc_n16_shell_api
+      - name: test_m50xe_n16_shell_api
+      - name: test_m60xc_n16_shell_api
+      - name: test_m60xe_n16_shell_api
+      - name: test_m70xc_n16_shell_api
+      - name: test_m70xe_n16_shell_api
+      - name: test_mlatest_n16_shell_api
+      - name: test_n20_shell_evaluator
+      - name: test_n16_shell_evaluator
+      - name: test_n20_snippet_manager
+      - name: test_n16_snippet_manager
+      - name: test_n20_types
+      - name: test_n16_types
+      - name: test_vscode
+      - name: test_connectivity
+      - name: test_apistrict
+  - name: linux_coverage
+    disabled: true
+    display_name: "Coverage Check"
+    run_on: ubuntu2004-small
+    tasks:
+      - name: check_coverage
+  - name: linux_package
+    disabled: false
+    display_name: "Ubuntu 18.04 x64 (Packaging)"
+    run_on: ubuntu2004-small
+    tasks:
+      - name: package_and_upload_artifact_linux_x64
+      - name: package_and_upload_artifact_deb_x64
+      - name: package_and_upload_artifact_rpm_x64
+      - name: package_and_upload_artifact_linux_x64_openssl11
+      - name: package_and_upload_artifact_deb_x64_openssl11
+      - name: package_and_upload_artifact_rpm_x64_openssl11
+      - name: package_and_upload_artifact_linux_x64_openssl3
+      - name: package_and_upload_artifact_deb_x64_openssl3
+      - name: package_and_upload_artifact_rpm_x64_openssl3
+      - name: package_and_upload_artifact_linux_arm64
+      - name: package_and_upload_artifact_deb_arm64
+      - name: package_and_upload_artifact_rpm_arm64
+      - name: package_and_upload_artifact_linux_arm64_openssl11
+      - name: package_and_upload_artifact_deb_arm64_openssl11
+      - name: package_and_upload_artifact_rpm_arm64_openssl11
+      - name: package_and_upload_artifact_linux_arm64_openssl3
+      - name: package_and_upload_artifact_deb_arm64_openssl3
+      - name: package_and_upload_artifact_rpm_arm64_openssl3
+      - name: package_and_upload_artifact_linux_ppc64le
+      - name: package_and_upload_artifact_rpm_ppc64le
+      - name: package_and_upload_artifact_linux_s390x
+      - name: package_and_upload_artifact_rpm_s390x
+  - name: linux_x64_build
+    disabled: false
+    display_name: "RHEL 7.0 x64 (build)"
+    run_on: rhel70-build
+    expansions:
+      executable_os_id: linux-x64
+    tasks:
+      - name: compile_artifact
+  - name: linux_x64_build_rhel8
+    disabled: false
+    display_name: "RHEL 8.0 x64 (build)"
+    run_on: rhel80-small
+    expansions:
+      executable_os_id: linux-x64
+    tasks:
+      - name: compile_artifact
+  - name: linux_x64_build_openssl11
+    disabled: false
+    display_name: "RHEL 7.0 x64 (build, shared OpenSSL 1.1)"
+    run_on: rhel70-build
+    expansions:
+      executable_os_id: linux-x64-openssl11
+      mongosh_shared_openssl: openssl11
+    tasks:
+      - name: compile_artifact
+  - name: linux_x64_build_openssl11_rhel8
+    disabled: false
+    display_name: "RHEL 8.0 x64 (build, shared OpenSSL 1.1)"
+    run_on: rhel80-small
+    expansions:
+      executable_os_id: linux-x64-openssl11
+      mongosh_shared_openssl: openssl11
+    tasks:
+      - name: compile_artifact
+  - name: linux_x64_build_openssl3
+    disabled: false
+    display_name: "RHEL 7.0 x64 (build, shared OpenSSL 3)"
+    run_on: rhel70-build
+    expansions:
+      executable_os_id: linux-x64-openssl3
+      mongosh_shared_openssl: openssl3
+    tasks:
+      - name: compile_artifact
+  - name: linux_x64_build_openssl3_rhel8
+    disabled: false
+    display_name: "RHEL 8.0 x64 (build, shared OpenSSL 3)"
+    run_on: rhel80-small
+    expansions:
+      executable_os_id: linux-x64-openssl3
+      mongosh_shared_openssl: openssl3
+    tasks:
+      - name: compile_artifact
+  - name: linux_arm64_build
+    disabled: true
+    display_name: "Amazon 2 arm64 (build)"
+    run_on: amazon2-arm64-large
+    expansions:
+      executable_os_id: linux-arm64
+    tasks:
+      - name: compile_artifact
+  - name: linux_arm64_build_openssl11
+    disabled: true
+    display_name: "Amazon 2 arm64 (build, shared OpenSSL 1.1)"
+    run_on: amazon2-arm64-large
+    expansions:
+      executable_os_id: linux-arm64-openssl11
+      mongosh_shared_openssl: openssl11
+    tasks:
+      - name: compile_artifact
+  - name: linux_arm64_build_openssl3
+    disabled: true
+    display_name: "Amazon 2 arm64 (build, shared OpenSSL 3)"
+    run_on: amazon2-arm64-large
+    expansions:
+      executable_os_id: linux-arm64-openssl3
+      mongosh_shared_openssl: openssl3
+    tasks:
+      - name: compile_artifact
+  - name: linux_ppc64le_build
+    disabled: true
+    display_name: "RHEL 8.1 PPC (build)"
+    run_on: rhel81-power8-small
+    expansions:
+      executable_os_id: linux-ppc64le
+    tasks:
+      - name: compile_artifact
+  - name: linux_s390x_build
+    disabled: true
+    display_name: "RHEL 7.2 s390x (build)"
+    run_on: rhel72-zseries-large
+    expansions:
+      executable_os_id: linux-s390x
+    tasks:
+      - name: compile_artifact
+
+  - name: e2e_rhel70_x64
+    disabled: false
+    display_name: "RHEL 7.0 x64 (E2E Tests)"
+    run_on: rhel70-large
+    tasks:
+      - name: e2e_tests_linux_x64
+  - name: e2e_rhel76_x64
+    disabled: false
+    display_name: "RHEL 7.6 x64 (E2E Tests)"
+    run_on: rhel76-large
+    tasks:
+      - name: e2e_tests_linux_x64
+  - name: e2e_rhel80_x64
+    disabled: false
+    display_name: "RHEL 8.0 x64 (E2E Tests)"
+    run_on: rhel80-small
+    tasks:
+      - name: e2e_tests_linux_x64
+  - name: e2e_rhel90_x64
+    disabled: false
+    display_name: "RHEL 9.0 x64 (E2E Tests)"
+    run_on: rhel90-small
+    expansions:
+      disable_openssl_shared_config_for_bundled_openssl: true
+    tasks:
+      - name: e2e_tests_linux_x64
+  - name: e2e_rhel83_x64
+    disabled: false
+    display_name: "RHEL 8.3 x64 (E2E Tests, FIPS-available OS)"
+    run_on: rhel83-fips
+    tasks:
+      - name: e2e_tests_linux_x64
+      - name: e2e_tests_linux_x64_openssl11
+      - name: e2e_tests_linux_x64_openssl11_fips
+  - name: e2e_rhel92_x64
+    disabled: false
+    display_name: "RHEL 9.2 x64 (E2E Tests, FIPS-available OS)"
+    run_on: rhel92-fips
+    tasks:
+      - name: e2e_tests_linux_x64
+      - name: e2e_tests_linux_x64_openssl3
+      - name: e2e_tests_linux_x64_openssl3_fips
+  - name: e2e_ubuntu1804_x64
+    disabled: false
+    display_name: "Ubuntu 18.04 x64 (E2E Tests)"
+    run_on: ubuntu1804-large
+    tasks:
+      - name: e2e_tests_linux_x64_60x
+  - name: e2e_ubuntu2004_x64
+    disabled: false
+    display_name: "Ubuntu 20.04 x64 (E2E Tests)"
+    run_on: ubuntu2004-small
+    tasks:
+      - name: e2e_tests_linux_x64
+      - name: e2e_tests_linux_x64_openssl11
+  - name: e2e_ubuntu2204_x64
+    disabled: false
+    display_name: "Ubuntu 22.04 x64 (E2E Tests)"
+    run_on: ubuntu2204-small
+    tasks:
+      - name: e2e_tests_linux_x64
+      - name: e2e_tests_linux_x64_openssl3
+  - name: e2e_debian10_x64
+    disabled: false
+    display_name: "Debian 10 x64 (E2E Tests)"
+    run_on: debian10-small
+    tasks:
+      - name: e2e_tests_linux_x64_60x
+      - name: e2e_tests_linux_x64_openssl11_60x
+  - name: e2e_debian11_x64
+    disabled: false
+    display_name: "Debian 11 x64 (E2E Tests)"
+    run_on: debian11-small
+    tasks:
+      - name: e2e_tests_linux_x64
+      - name: e2e_tests_linux_x64_openssl11
+  - name: e2e_amazon2_x64
+    disabled: false
+    display_name: "Amazon Linux 2 x64 (E2E Tests)"
+    run_on: amazon2-large
+    tasks:
+      - name: e2e_tests_linux_x64
+  - name: e2e_amazon2023_x64
+    disabled: false
+    display_name: "Amazon Linux 2023 x64 (E2E Tests)"
+    run_on: amazon2023.0-small
+    expansions:
+      disable_openssl_shared_config_for_bundled_openssl: true
+    tasks:
+      - name: e2e_tests_linux_x64
+  - name: e2e_suse12_x64
+    disabled: false
+    display_name: "SLES 12 x64 (E2E Tests)"
+    run_on: suse12-sp5-large
+    tasks:
+      - name: e2e_tests_linux_x64
+  - name: e2e_suse15_x64
+    disabled: false
+    display_name: "SLES 15 x64 (E2E Tests)"
+    run_on: suse15sp4-small
+    tasks:
+      - name: e2e_tests_linux_x64
+  - name: e2e_ubuntu1804_arm64
+    disabled: true
+    display_name: "Ubuntu 18.04 arm64 (E2E Tests)"
+    run_on: ubuntu1804-arm64-large
+    tasks:
+      - name: e2e_tests_linux_arm64_60x
+  - name: e2e_ubuntu2004_arm64
+    disabled: true
+    display_name: "Ubuntu 20.04 arm64 (E2E Tests)"
+    run_on: ubuntu2004-arm64-small
+    tasks:
+      - name: e2e_tests_linux_arm64
+      - name: e2e_tests_linux_arm64_openssl11
+  - name: e2e_ubuntu2204_arm64
+    disabled: true
+    display_name: "Ubuntu 22.04 arm64 (E2E Tests)"
+    run_on: ubuntu2204-arm64-small
+    tasks:
+      - name: e2e_tests_linux_arm64
+      - name: e2e_tests_linux_arm64_openssl3
+  - name: e2e_amazon2_arm64
+    disabled: true
+    display_name: "Amazon Linux 2 arm64 (E2E Tests)"
+    run_on: amazon2-arm64-large
+    tasks:
+      - name: e2e_tests_linux_arm64
+  - name: e2e_amazon2023_arm64
+    disabled: true
+    display_name: "Amazon Linux 2023 arm64 (E2E Tests)"
+    run_on: amazon2023.0-arm64-small
+    expansions:
+      disable_openssl_shared_config_for_bundled_openssl: true
+    tasks:
+      - name: e2e_tests_linux_arm64
+  - name: e2e_rhel82_arm64
+    disabled: true
+    display_name: "RHEL 8.2 arm64 (E2E Tests)"
+    run_on: rhel82-arm64-small
+    tasks:
+      - name: e2e_tests_linux_arm64
+  - name: e2e_rhel90_arm64
+    disabled: true
+    display_name: "RHEL 9.0 arm64 (E2E Tests)"
+    run_on: rhel90-arm64-small
+    expansions:
+      disable_openssl_shared_config_for_bundled_openssl: true
+    tasks:
+      - name: e2e_tests_linux_arm64
+      - name: e2e_tests_linux_arm64_openssl3
+  - name: e2e_rhel81_ppc64le
+    disabled: true
+    display_name: "RHEL 8.1 PPC (E2E Tests)"
+    run_on: rhel81-power8-small
+    tasks:
+      - name: e2e_tests_linux_ppc64le
+  - name: e2e_rhel72_s390x
+    disabled: true
+    display_name: "RHEL 7.2 s390x (E2E Tests)"
+    run_on: rhel72-zseries-large
+    tasks:
+      - name: e2e_tests_linux_s390x_60x
+  - name: e2e_rhel83_s390x
+    disabled: true
+    display_name: "RHEL 8.3 s390x (E2E Tests)"
+    run_on: rhel83-zseries-small
+    tasks:
+      - name: e2e_tests_linux_s390x
+
+  - name: win32_unit
+    disabled: true
+    display_name: "Windows (Unit tests)"
+    run_on: windows-vsCurrent-small
+    expansions:
+      executable_os_id: win32
+    tasks:
+      - name: check
+      - name: test_n20_arg_parser
+      - name: test_n16_arg_parser
+      - name: test_n20_async_rewriter2
+      - name: test_n16_async_rewriter2
+      - name: test_n20_autocomplete
+      - name: test_n16_autocomplete
+      - name: test_n20_browser_runtime_core
+      - name: test_n16_browser_runtime_core
+      - name: test_n20_browser_runtime_electron
+      - name: test_n16_browser_runtime_electron
+      - name: test_n20_build
+      - name: test_n16_build
+      - name: test_m42xc_n20_cli_repl
+      - name: test_m42xe_n20_cli_repl
+      - name: test_m44xc_n20_cli_repl
+      - name: test_m44xe_n20_cli_repl
+      - name: test_m50xc_n20_cli_repl
+      - name: test_m50xe_n20_cli_repl
+      - name: test_m60xc_n20_cli_repl
+      - name: test_m60xe_n20_cli_repl
+      - name: test_m70xc_n20_cli_repl
+      - name: test_m70xe_n20_cli_repl
+      - name: test_mlatest_n20_cli_repl
+      - name: test_m42xc_n16_cli_repl
+      - name: test_m42xe_n16_cli_repl
+      - name: test_m44xc_n16_cli_repl
+      - name: test_m44xe_n16_cli_repl
+      - name: test_m50xc_n16_cli_repl
+      - name: test_m50xe_n16_cli_repl
+      - name: test_m60xc_n16_cli_repl
+      - name: test_m60xe_n16_cli_repl
+      - name: test_m70xc_n16_cli_repl
+      - name: test_m70xe_n16_cli_repl
+      - name: test_mlatest_n16_cli_repl
+      - name: test_m42xc_n20_e2e_tests
+      - name: test_m42xe_n20_e2e_tests
+      - name: test_m44xc_n20_e2e_tests
+      - name: test_m44xe_n20_e2e_tests
+      - name: test_m50xc_n20_e2e_tests
+      - name: test_m50xe_n20_e2e_tests
+      - name: test_m60xc_n20_e2e_tests
+      - name: test_m60xe_n20_e2e_tests
+      - name: test_m70xc_n20_e2e_tests
+      - name: test_m70xe_n20_e2e_tests
+      - name: test_mlatest_n20_e2e_tests
+      - name: test_m42xc_n16_e2e_tests
+      - name: test_m42xe_n16_e2e_tests
+      - name: test_m44xc_n16_e2e_tests
+      - name: test_m44xe_n16_e2e_tests
+      - name: test_m50xc_n16_e2e_tests
+      - name: test_m50xe_n16_e2e_tests
+      - name: test_m60xc_n16_e2e_tests
+      - name: test_m60xe_n16_e2e_tests
+      - name: test_m70xc_n16_e2e_tests
+      - name: test_m70xe_n16_e2e_tests
+      - name: test_mlatest_n16_e2e_tests
+      - name: test_n20_editor
+      - name: test_n16_editor
+      - name: test_n20_errors
+      - name: test_n16_errors
+      - name: test_n20_history
+      - name: test_n16_history
+      - name: test_n20_i18n
+      - name: test_n16_i18n
+      - name: test_n20_js_multiline_to_singleline
+      - name: test_n16_js_multiline_to_singleline
+      - name: test_n20_logging
+      - name: test_n16_logging
+      - name: test_m42xc_n20_node_runtime_worker_thread
+      - name: test_m42xe_n20_node_runtime_worker_thread
+      - name: test_m44xc_n20_node_runtime_worker_thread
+      - name: test_m44xe_n20_node_runtime_worker_thread
+      - name: test_m50xc_n20_node_runtime_worker_thread
+      - name: test_m50xe_n20_node_runtime_worker_thread
+      - name: test_m60xc_n20_node_runtime_worker_thread
+      - name: test_m60xe_n20_node_runtime_worker_thread
+      - name: test_m70xc_n20_node_runtime_worker_thread
+      - name: test_m70xe_n20_node_runtime_worker_thread
+      - name: test_mlatest_n20_node_runtime_worker_thread
+      - name: test_m42xc_n16_node_runtime_worker_thread
+      - name: test_m42xe_n16_node_runtime_worker_thread
+      - name: test_m44xc_n16_node_runtime_worker_thread
+      - name: test_m44xe_n16_node_runtime_worker_thread
+      - name: test_m50xc_n16_node_runtime_worker_thread
+      - name: test_m50xe_n16_node_runtime_worker_thread
+      - name: test_m60xc_n16_node_runtime_worker_thread
+      - name: test_m60xe_n16_node_runtime_worker_thread
+      - name: test_m70xc_n16_node_runtime_worker_thread
+      - name: test_m70xe_n16_node_runtime_worker_thread
+      - name: test_mlatest_n16_node_runtime_worker_thread
+      - name: test_n20_service_provider_core
+      - name: test_n16_service_provider_core
+      - name: test_m42xc_n20_service_provider_server
+      - name: test_m42xe_n20_service_provider_server
+      - name: test_m44xc_n20_service_provider_server
+      - name: test_m44xe_n20_service_provider_server
+      - name: test_m50xc_n20_service_provider_server
+      - name: test_m50xe_n20_service_provider_server
+      - name: test_m60xc_n20_service_provider_server
+      - name: test_m60xe_n20_service_provider_server
+      - name: test_m70xc_n20_service_provider_server
+      - name: test_m70xe_n20_service_provider_server
+      - name: test_mlatest_n20_service_provider_server
+      - name: test_m42xc_n16_service_provider_server
+      - name: test_m42xe_n16_service_provider_server
+      - name: test_m44xc_n16_service_provider_server
+      - name: test_m44xe_n16_service_provider_server
+      - name: test_m50xc_n16_service_provider_server
+      - name: test_m50xe_n16_service_provider_server
+      - name: test_m60xc_n16_service_provider_server
+      - name: test_m60xe_n16_service_provider_server
+      - name: test_m70xc_n16_service_provider_server
+      - name: test_m70xe_n16_service_provider_server
+      - name: test_mlatest_n16_service_provider_server
+      - name: test_m42xc_n20_shell_api
+      - name: test_m42xe_n20_shell_api
+      - name: test_m44xc_n20_shell_api
+      - name: test_m44xe_n20_shell_api
+      - name: test_m50xc_n20_shell_api
+      - name: test_m50xe_n20_shell_api
+      - name: test_m60xc_n20_shell_api
+      - name: test_m60xe_n20_shell_api
+      - name: test_m70xc_n20_shell_api
+      - name: test_m70xe_n20_shell_api
+      - name: test_mlatest_n20_shell_api
+      - name: test_m42xc_n16_shell_api
+      - name: test_m42xe_n16_shell_api
+      - name: test_m44xc_n16_shell_api
+      - name: test_m44xe_n16_shell_api
+      - name: test_m50xc_n16_shell_api
+      - name: test_m50xe_n16_shell_api
+      - name: test_m60xc_n16_shell_api
+      - name: test_m60xe_n16_shell_api
+      - name: test_m70xc_n16_shell_api
+      - name: test_m70xe_n16_shell_api
+      - name: test_mlatest_n16_shell_api
+      - name: test_n20_shell_evaluator
+      - name: test_n16_shell_evaluator
+      - name: test_n20_snippet_manager
+      - name: test_n16_snippet_manager
+      - name: test_n20_types
+      - name: test_n16_types
+  - name: win32
+    disabled: true
+    display_name: "Windows VS 2019"
+    run_on: windows-64-vs2019-small
+    expansions:
+      executable_os_id: win32
+    tasks:
+      - name: e2e_tests_win32
+      - name: package_and_upload_artifact_win32_x64
+      - name: package_and_upload_artifact_win32msi_x64
+  - name: win32_build
+    disabled: true
+    display_name: "Windows VS 2019 (build)"
+    run_on: windows-64-vs2019-build
+    expansions:
+      executable_os_id: win32
+    tasks:
+      - name: compile_artifact
+
+  - name: pkg_smoke_tests_docker_x64
+    disabled: false
+    display_name: "package smoke (x64 Docker)"
+    run_on: ubuntu2004-small
+    tasks:
+      - name: pkg_test_docker_linux_x64_ubuntu20_04_tgz
+      - name: pkg_test_docker_deb_x64_ubuntu18_04_deb
+      - name: pkg_test_docker_deb_x64_ubuntu20_04_deb
+      - name: pkg_test_docker_deb_x64_ubuntu22_04_deb
+      - name: pkg_test_docker_deb_x64_ubuntu22_04_nohome_deb
+      - name: pkg_test_docker_deb_x64_debian10_deb
+      - name: pkg_test_docker_deb_x64_debian11_deb
+      - name: pkg_test_docker_deb_x64_debian12_deb
+      - name: pkg_test_docker_rpm_x64_centos7_rpm
+      - name: pkg_test_docker_rpm_x64_amazonlinux2_rpm
+      - name: pkg_test_docker_rpm_x64_amazonlinux2023_rpm
+      - name: pkg_test_docker_rpm_x64_rocky8_rpm
+      - name: pkg_test_docker_rpm_x64_rocky9_rpm
+      - name: pkg_test_docker_rpm_x64_fedora34_rpm
+      - name: pkg_test_docker_rpm_x64_suse12_rpm
+      - name: pkg_test_docker_rpm_x64_suse15_rpm
+      - name: pkg_test_docker_deb_x64_openssl11_ubuntu20_04_deb
+      - name: pkg_test_docker_deb_x64_openssl11_debian10_deb
+      - name: pkg_test_docker_deb_x64_openssl11_debian11_deb
+      - name: pkg_test_docker_rpm_x64_openssl11_centos7_epel_rpm
+      - name: pkg_test_docker_rpm_x64_openssl11_amazonlinux2_rpm
+      - name: pkg_test_docker_rpm_x64_openssl11_rocky8_rpm
+      - name: pkg_test_docker_rpm_x64_openssl11_rocky9_rpm
+      - name: pkg_test_docker_rpm_x64_openssl11_fedora34_rpm
+      - name: pkg_test_docker_deb_x64_openssl3_ubuntu22_04_deb
+      - name: pkg_test_docker_deb_x64_openssl3_ubuntu22_04_fips_deb
+      - name: pkg_test_docker_deb_x64_openssl3_debian12_deb
+      - name: pkg_test_docker_rpm_x64_openssl3_rocky8_epel_rpm
+      - name: pkg_test_docker_rpm_x64_openssl3_rocky9_rpm
+      - name: pkg_test_docker_rpm_x64_openssl3_rocky9_fips_rpm
+      - name: pkg_test_docker_rpm_x64_openssl3_amazonlinux2023_rpm
+  - name: pkg_smoke_tests_docker_arm64
+    disabled: true
+    display_name: "package smoke (arm64 Docker)"
+    run_on: ubuntu2004-arm64-small
+    tasks:
+      - name: pkg_test_docker_linux_arm64_ubuntu20_04_tgz
+      - name: pkg_test_docker_deb_arm64_ubuntu18_04_deb
+      - name: pkg_test_docker_deb_arm64_ubuntu20_04_deb
+      - name: pkg_test_docker_deb_arm64_ubuntu22_04_deb
+      - name: pkg_test_docker_deb_arm64_debian10_deb
+      - name: pkg_test_docker_deb_arm64_debian11_deb
+      - name: pkg_test_docker_deb_arm64_debian12_deb
+      - name: pkg_test_docker_rpm_arm64_rocky8_rpm
+      - name: pkg_test_docker_rpm_arm64_rocky9_rpm
+      - name: pkg_test_docker_rpm_arm64_fedora34_rpm
+      - name: pkg_test_docker_rpm_arm64_amazonlinux2_rpm
+      - name: pkg_test_docker_rpm_arm64_amazonlinux2023_rpm
+      - name: pkg_test_docker_deb_arm64_openssl11_ubuntu20_04_deb
+      - name: pkg_test_docker_deb_arm64_openssl11_debian10_deb
+      - name: pkg_test_docker_deb_arm64_openssl11_debian11_deb
+      - name: pkg_test_docker_rpm_arm64_openssl11_rocky8_rpm
+      - name: pkg_test_docker_rpm_arm64_openssl11_rocky9_rpm
+      - name: pkg_test_docker_rpm_arm64_openssl11_fedora34_rpm
+      - name: pkg_test_docker_rpm_arm64_openssl11_amazonlinux2_rpm
+      - name: pkg_test_docker_deb_arm64_openssl3_ubuntu22_04_deb
+      - name: pkg_test_docker_deb_arm64_openssl3_ubuntu22_04_fips_deb
+      - name: pkg_test_docker_deb_arm64_openssl3_debian12_deb
+      - name: pkg_test_docker_rpm_arm64_openssl3_rocky8_epel_rpm
+      - name: pkg_test_docker_rpm_arm64_openssl3_rocky9_rpm
+      - name: pkg_test_docker_rpm_arm64_openssl3_rocky9_fips_rpm
+      - name: pkg_test_docker_rpm_arm64_openssl3_amazonlinux2023_rpm
+  - name: exec_connectitivty_tests_docker_x64_openssl11
+    disabled: false
+    display_name: "executable connectivity tests (x64 Docker for OpenSSL 1.1 base OS)"
+    run_on: ubuntu2004-small
+    tasks:
+      - name: executable_connectivity_test_linux_x64_rocky8
+      - name: executable_connectivity_test_linux_x64_ubuntu2004
+      - name: executable_connectivity_test_linux_x64_node20
+      - name: executable_connectivity_test_linux_x64_rocky9
+      - name: executable_connectivity_test_linux_x64_ubuntu2204
+      - name: executable_connectivity_test_linux_x64_openssl11_rocky8
+      - name: executable_connectivity_test_linux_x64_openssl11_ubuntu2004
+  - name: exec_connectitivty_tests_docker_arm64_openssl11
+    disabled: true
+    display_name: "executable connectivity tests (arm64 Docker for OpenSSL 1.1 base OS)"
+    run_on: ubuntu2004-arm64-small
+    tasks:
+      - name: executable_connectivity_test_linux_arm64_rocky8
+      - name: executable_connectivity_test_linux_arm64_ubuntu2004
+      - name: executable_connectivity_test_linux_arm64_node20
+      - name: executable_connectivity_test_linux_arm64_rocky9
+      - name: executable_connectivity_test_linux_arm64_ubuntu2204
+      - name: executable_connectivity_test_linux_arm64_openssl11_rocky8
+      - name: executable_connectivity_test_linux_arm64_openssl11_ubuntu2004
+  - name: exec_connectitivty_tests_docker_x64_openssl3
+    disabled: false
+    display_name: "executable connectivity tests (x64 Docker for OpenSSL 3 base OS)"
+    run_on: ubuntu2204-small
+    tasks:
+      - name: executable_connectivity_test_linux_x64_rocky8
+      - name: executable_connectivity_test_linux_x64_ubuntu2004
+      - name: executable_connectivity_test_linux_x64_node20
+      - name: executable_connectivity_test_linux_x64_rocky9
+      - name: executable_connectivity_test_linux_x64_ubuntu2204
+      - name: executable_connectivity_test_linux_x64_openssl3_node20
+      - name: executable_connectivity_test_linux_x64_openssl3_rocky9
+      - name: executable_connectivity_test_linux_x64_openssl3_ubuntu2204
+  - name: exec_connectitivty_tests_docker_arm64_openssl3
+    disabled: true
+    display_name: "executable connectivity tests (arm64 Docker for OpenSSL 3 base OS)"
+    run_on: ubuntu2204-arm64-small
+    tasks:
+      - name: executable_connectivity_test_linux_arm64_rocky8
+      - name: executable_connectivity_test_linux_arm64_ubuntu2004
+      - name: executable_connectivity_test_linux_arm64_node20
+      - name: executable_connectivity_test_linux_arm64_rocky9
+      - name: executable_connectivity_test_linux_arm64_ubuntu2204
+      - name: executable_connectivity_test_linux_arm64_openssl3_node20
+      - name: executable_connectivity_test_linux_arm64_openssl3_rocky9
+      - name: executable_connectivity_test_linux_arm64_openssl3_ubuntu2204
+  - name: pkg_smoke_tests_win32
+    disabled: true
+    display_name: "package smoke tests (win32)"
+    run_on: ubuntu2004-small
+    tasks:
+      - name: pkg_test_ssh_win32_x64
+      - name: pkg_test_ssh_win32msi_x64
+  - name: pkg_smoke_tests_macos_1100_x64
+    disabled: true
+    display_name: "package smoke tests (macos 11.00 x64)"
+    run_on: macos-1100
+    tasks:
+      - name: pkg_test_macos_darwin_x64
+  - name: pkg_smoke_tests_macos_1100_arm64
+    disabled: true
+    display_name: "package smoke tests (macos 11.00 arm64)"
+    run_on: macos-1100-arm64
+    tasks:
+      - name: pkg_test_macos_darwin_arm64
+  - name: pkg_smoke_tests_macos_1300_arm64
+    disabled: true
+    display_name: "package smoke tests (macos 13.00 arm64)"
+    run_on: macos-1300-arm64
+    tasks:
+      - name: pkg_test_macos_darwin_arm64
+  - name: pkg_smoke_tests_rhel72_s390x
+    disabled: true
+    display_name: "package smoke tests (RHEL 7.2 s390x)"
+    run_on: rhel72-zseries-small
+    tasks:
+      - name: pkg_test_rpmextract_rpm_s390x
+  - name: pkg_smoke_tests_rhel83_s390x
+    disabled: true
+    display_name: "package smoke tests (RHEL 8.3 s390x)"
+    run_on: rhel83-zseries-small
+    tasks:
+      - name: pkg_test_rpmextract_rpm_s390x
+  - name: pkg_smoke_tests_rhel81_ppc64le
+    disabled: true
+    display_name: "package smoke tests (RHEL 8.1 ppc64le)"
+    run_on: rhel81-power8-small
+    tasks:
+      - name: pkg_test_rpmextract_rpm_ppc64le
+
+  - name: draft_publish_release
+    disabled: true
+    display_name: "Draft/Publish Release"
+    run_on: ubuntu2004-small
+    tasks:
+      - name: release_draft
+      - name: release_publish_dry_run
+      - name: release_publish
+
+  - name: generate_license_and_vulnerability_report
+    disabled: true
+    display_name: "License and Vulnerability Report"
+    run_on: ubuntu2004-small
+    tasks:
+      - name: generate_license_and_vulnerability_report

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -1,6 +1,11 @@
 # Regenerate using `npm run update-evergreen-config`
 # https://jira.mongodb.org/browse/EVG-20276
 unset_function_vars: true
+
+# https://github.com/evergreen-ci/evergreen/blob/main/docs/Project-Configuration/Parameterized-Builds.md#project-config
+parameters:
+  - key: mongodb_driver_version_override
+    value: 
 exec_timeout_secs: 10800
 
 post_error_fails_task: true
@@ -12986,6 +12991,7 @@ tasks:
 # Need to run builds for every possible build variant.
 buildvariants:
   - name: darwin_unit
+    disabled: false
     display_name: "MacOS Big Sur (Unit tests)"
     run_on: macos-1100
     expansions:
@@ -13137,6 +13143,7 @@ buildvariants:
       - name: test_n20_types
       - name: test_n16_types
   - name: darwin
+    disabled: false
     display_name: "MacOS Big Sur"
     run_on: macos-1100
     expansions:
@@ -13147,6 +13154,7 @@ buildvariants:
       - name: package_and_upload_artifact_darwin_x64
       - name: package_and_upload_artifact_darwin_arm64
   - name: darwin_arm64
+    disabled: false
     display_name: "MacOS Big Sur (arm64)"
     run_on: macos-1100-arm64
     expansions:
@@ -13156,6 +13164,7 @@ buildvariants:
       - name: e2e_tests_darwin_arm64
 
   - name: linux_unit
+    disabled: false
     display_name: "Ubuntu 18.04 x64 (Unit tests)"
     run_on: ubuntu2004-small
     tasks:
@@ -13317,11 +13326,13 @@ buildvariants:
       - name: test_connectivity
       - name: test_apistrict
   - name: linux_coverage
+    disabled: false
     display_name: "Coverage Check"
     run_on: ubuntu2004-small
     tasks:
       - name: check_coverage
   - name: linux_package
+    disabled: false
     display_name: "Ubuntu 18.04 x64 (Packaging)"
     run_on: ubuntu2004-small
     tasks:
@@ -13348,6 +13359,7 @@ buildvariants:
       - name: package_and_upload_artifact_linux_s390x
       - name: package_and_upload_artifact_rpm_s390x
   - name: linux_x64_build
+    disabled: false
     display_name: "RHEL 7.0 x64 (build)"
     run_on: rhel70-build
     expansions:
@@ -13355,6 +13367,7 @@ buildvariants:
     tasks:
       - name: compile_artifact
   - name: linux_x64_build_rhel8
+    disabled: false
     display_name: "RHEL 8.0 x64 (build)"
     run_on: rhel80-small
     expansions:
@@ -13362,6 +13375,7 @@ buildvariants:
     tasks:
       - name: compile_artifact
   - name: linux_x64_build_openssl11
+    disabled: false
     display_name: "RHEL 7.0 x64 (build, shared OpenSSL 1.1)"
     run_on: rhel70-build
     expansions:
@@ -13370,6 +13384,7 @@ buildvariants:
     tasks:
       - name: compile_artifact
   - name: linux_x64_build_openssl11_rhel8
+    disabled: false
     display_name: "RHEL 8.0 x64 (build, shared OpenSSL 1.1)"
     run_on: rhel80-small
     expansions:
@@ -13378,6 +13393,7 @@ buildvariants:
     tasks:
       - name: compile_artifact
   - name: linux_x64_build_openssl3
+    disabled: false
     display_name: "RHEL 7.0 x64 (build, shared OpenSSL 3)"
     run_on: rhel70-build
     expansions:
@@ -13386,6 +13402,7 @@ buildvariants:
     tasks:
       - name: compile_artifact
   - name: linux_x64_build_openssl3_rhel8
+    disabled: false
     display_name: "RHEL 8.0 x64 (build, shared OpenSSL 3)"
     run_on: rhel80-small
     expansions:
@@ -13394,6 +13411,7 @@ buildvariants:
     tasks:
       - name: compile_artifact
   - name: linux_arm64_build
+    disabled: false
     display_name: "Amazon 2 arm64 (build)"
     run_on: amazon2-arm64-large
     expansions:
@@ -13401,6 +13419,7 @@ buildvariants:
     tasks:
       - name: compile_artifact
   - name: linux_arm64_build_openssl11
+    disabled: false
     display_name: "Amazon 2 arm64 (build, shared OpenSSL 1.1)"
     run_on: amazon2-arm64-large
     expansions:
@@ -13409,6 +13428,7 @@ buildvariants:
     tasks:
       - name: compile_artifact
   - name: linux_arm64_build_openssl3
+    disabled: false
     display_name: "Amazon 2 arm64 (build, shared OpenSSL 3)"
     run_on: amazon2-arm64-large
     expansions:
@@ -13417,6 +13437,7 @@ buildvariants:
     tasks:
       - name: compile_artifact
   - name: linux_ppc64le_build
+    disabled: false
     display_name: "RHEL 8.1 PPC (build)"
     run_on: rhel81-power8-small
     expansions:
@@ -13424,6 +13445,7 @@ buildvariants:
     tasks:
       - name: compile_artifact
   - name: linux_s390x_build
+    disabled: false
     display_name: "RHEL 7.2 s390x (build)"
     run_on: rhel72-zseries-large
     expansions:
@@ -13432,21 +13454,25 @@ buildvariants:
       - name: compile_artifact
 
   - name: e2e_rhel70_x64
+    disabled: false
     display_name: "RHEL 7.0 x64 (E2E Tests)"
     run_on: rhel70-large
     tasks:
       - name: e2e_tests_linux_x64
   - name: e2e_rhel76_x64
+    disabled: false
     display_name: "RHEL 7.6 x64 (E2E Tests)"
     run_on: rhel76-large
     tasks:
       - name: e2e_tests_linux_x64
   - name: e2e_rhel80_x64
+    disabled: false
     display_name: "RHEL 8.0 x64 (E2E Tests)"
     run_on: rhel80-small
     tasks:
       - name: e2e_tests_linux_x64
   - name: e2e_rhel90_x64
+    disabled: false
     display_name: "RHEL 9.0 x64 (E2E Tests)"
     run_on: rhel90-small
     expansions:
@@ -13454,6 +13480,7 @@ buildvariants:
     tasks:
       - name: e2e_tests_linux_x64
   - name: e2e_rhel83_x64
+    disabled: false
     display_name: "RHEL 8.3 x64 (E2E Tests, FIPS-available OS)"
     run_on: rhel83-fips
     tasks:
@@ -13461,6 +13488,7 @@ buildvariants:
       - name: e2e_tests_linux_x64_openssl11
       - name: e2e_tests_linux_x64_openssl11_fips
   - name: e2e_rhel92_x64
+    disabled: false
     display_name: "RHEL 9.2 x64 (E2E Tests, FIPS-available OS)"
     run_on: rhel92-fips
     tasks:
@@ -13468,40 +13496,47 @@ buildvariants:
       - name: e2e_tests_linux_x64_openssl3
       - name: e2e_tests_linux_x64_openssl3_fips
   - name: e2e_ubuntu1804_x64
+    disabled: false
     display_name: "Ubuntu 18.04 x64 (E2E Tests)"
     run_on: ubuntu1804-large
     tasks:
       - name: e2e_tests_linux_x64_60x
   - name: e2e_ubuntu2004_x64
+    disabled: false
     display_name: "Ubuntu 20.04 x64 (E2E Tests)"
     run_on: ubuntu2004-small
     tasks:
       - name: e2e_tests_linux_x64
       - name: e2e_tests_linux_x64_openssl11
   - name: e2e_ubuntu2204_x64
+    disabled: false
     display_name: "Ubuntu 22.04 x64 (E2E Tests)"
     run_on: ubuntu2204-small
     tasks:
       - name: e2e_tests_linux_x64
       - name: e2e_tests_linux_x64_openssl3
   - name: e2e_debian10_x64
+    disabled: false
     display_name: "Debian 10 x64 (E2E Tests)"
     run_on: debian10-small
     tasks:
       - name: e2e_tests_linux_x64_60x
       - name: e2e_tests_linux_x64_openssl11_60x
   - name: e2e_debian11_x64
+    disabled: false
     display_name: "Debian 11 x64 (E2E Tests)"
     run_on: debian11-small
     tasks:
       - name: e2e_tests_linux_x64
       - name: e2e_tests_linux_x64_openssl11
   - name: e2e_amazon2_x64
+    disabled: false
     display_name: "Amazon Linux 2 x64 (E2E Tests)"
     run_on: amazon2-large
     tasks:
       - name: e2e_tests_linux_x64
   - name: e2e_amazon2023_x64
+    disabled: false
     display_name: "Amazon Linux 2023 x64 (E2E Tests)"
     run_on: amazon2023.0-small
     expansions:
@@ -13509,38 +13544,45 @@ buildvariants:
     tasks:
       - name: e2e_tests_linux_x64
   - name: e2e_suse12_x64
+    disabled: false
     display_name: "SLES 12 x64 (E2E Tests)"
     run_on: suse12-sp5-large
     tasks:
       - name: e2e_tests_linux_x64
   - name: e2e_suse15_x64
+    disabled: false
     display_name: "SLES 15 x64 (E2E Tests)"
     run_on: suse15sp4-small
     tasks:
       - name: e2e_tests_linux_x64
   - name: e2e_ubuntu1804_arm64
+    disabled: false
     display_name: "Ubuntu 18.04 arm64 (E2E Tests)"
     run_on: ubuntu1804-arm64-large
     tasks:
       - name: e2e_tests_linux_arm64_60x
   - name: e2e_ubuntu2004_arm64
+    disabled: false
     display_name: "Ubuntu 20.04 arm64 (E2E Tests)"
     run_on: ubuntu2004-arm64-small
     tasks:
       - name: e2e_tests_linux_arm64
       - name: e2e_tests_linux_arm64_openssl11
   - name: e2e_ubuntu2204_arm64
+    disabled: false
     display_name: "Ubuntu 22.04 arm64 (E2E Tests)"
     run_on: ubuntu2204-arm64-small
     tasks:
       - name: e2e_tests_linux_arm64
       - name: e2e_tests_linux_arm64_openssl3
   - name: e2e_amazon2_arm64
+    disabled: false
     display_name: "Amazon Linux 2 arm64 (E2E Tests)"
     run_on: amazon2-arm64-large
     tasks:
       - name: e2e_tests_linux_arm64
   - name: e2e_amazon2023_arm64
+    disabled: false
     display_name: "Amazon Linux 2023 arm64 (E2E Tests)"
     run_on: amazon2023.0-arm64-small
     expansions:
@@ -13548,11 +13590,13 @@ buildvariants:
     tasks:
       - name: e2e_tests_linux_arm64
   - name: e2e_rhel82_arm64
+    disabled: false
     display_name: "RHEL 8.2 arm64 (E2E Tests)"
     run_on: rhel82-arm64-small
     tasks:
       - name: e2e_tests_linux_arm64
   - name: e2e_rhel90_arm64
+    disabled: false
     display_name: "RHEL 9.0 arm64 (E2E Tests)"
     run_on: rhel90-arm64-small
     expansions:
@@ -13561,22 +13605,26 @@ buildvariants:
       - name: e2e_tests_linux_arm64
       - name: e2e_tests_linux_arm64_openssl3
   - name: e2e_rhel81_ppc64le
+    disabled: false
     display_name: "RHEL 8.1 PPC (E2E Tests)"
     run_on: rhel81-power8-small
     tasks:
       - name: e2e_tests_linux_ppc64le
   - name: e2e_rhel72_s390x
+    disabled: false
     display_name: "RHEL 7.2 s390x (E2E Tests)"
     run_on: rhel72-zseries-large
     tasks:
       - name: e2e_tests_linux_s390x_60x
   - name: e2e_rhel83_s390x
+    disabled: false
     display_name: "RHEL 8.3 s390x (E2E Tests)"
     run_on: rhel83-zseries-small
     tasks:
       - name: e2e_tests_linux_s390x
 
   - name: win32_unit
+    disabled: false
     display_name: "Windows (Unit tests)"
     run_on: windows-vsCurrent-small
     expansions:
@@ -13726,6 +13774,7 @@ buildvariants:
       - name: test_n20_types
       - name: test_n16_types
   - name: win32
+    disabled: false
     display_name: "Windows VS 2019"
     run_on: windows-64-vs2019-small
     expansions:
@@ -13735,6 +13784,7 @@ buildvariants:
       - name: package_and_upload_artifact_win32_x64
       - name: package_and_upload_artifact_win32msi_x64
   - name: win32_build
+    disabled: false
     display_name: "Windows VS 2019 (build)"
     run_on: windows-64-vs2019-build
     expansions:
@@ -13743,6 +13793,7 @@ buildvariants:
       - name: compile_artifact
 
   - name: pkg_smoke_tests_docker_x64
+    disabled: false
     display_name: "package smoke (x64 Docker)"
     run_on: ubuntu2004-small
     tasks:
@@ -13778,6 +13829,7 @@ buildvariants:
       - name: pkg_test_docker_rpm_x64_openssl3_rocky9_fips_rpm
       - name: pkg_test_docker_rpm_x64_openssl3_amazonlinux2023_rpm
   - name: pkg_smoke_tests_docker_arm64
+    disabled: false
     display_name: "package smoke (arm64 Docker)"
     run_on: ubuntu2004-arm64-small
     tasks:
@@ -13808,6 +13860,7 @@ buildvariants:
       - name: pkg_test_docker_rpm_arm64_openssl3_rocky9_fips_rpm
       - name: pkg_test_docker_rpm_arm64_openssl3_amazonlinux2023_rpm
   - name: exec_connectitivty_tests_docker_x64_openssl11
+    disabled: false
     display_name: "executable connectivity tests (x64 Docker for OpenSSL 1.1 base OS)"
     run_on: ubuntu2004-small
     tasks:
@@ -13819,6 +13872,7 @@ buildvariants:
       - name: executable_connectivity_test_linux_x64_openssl11_rocky8
       - name: executable_connectivity_test_linux_x64_openssl11_ubuntu2004
   - name: exec_connectitivty_tests_docker_arm64_openssl11
+    disabled: false
     display_name: "executable connectivity tests (arm64 Docker for OpenSSL 1.1 base OS)"
     run_on: ubuntu2004-arm64-small
     tasks:
@@ -13830,6 +13884,7 @@ buildvariants:
       - name: executable_connectivity_test_linux_arm64_openssl11_rocky8
       - name: executable_connectivity_test_linux_arm64_openssl11_ubuntu2004
   - name: exec_connectitivty_tests_docker_x64_openssl3
+    disabled: false
     display_name: "executable connectivity tests (x64 Docker for OpenSSL 3 base OS)"
     run_on: ubuntu2204-small
     tasks:
@@ -13842,6 +13897,7 @@ buildvariants:
       - name: executable_connectivity_test_linux_x64_openssl3_rocky9
       - name: executable_connectivity_test_linux_x64_openssl3_ubuntu2204
   - name: exec_connectitivty_tests_docker_arm64_openssl3
+    disabled: false
     display_name: "executable connectivity tests (arm64 Docker for OpenSSL 3 base OS)"
     run_on: ubuntu2204-arm64-small
     tasks:
@@ -13854,43 +13910,51 @@ buildvariants:
       - name: executable_connectivity_test_linux_arm64_openssl3_rocky9
       - name: executable_connectivity_test_linux_arm64_openssl3_ubuntu2204
   - name: pkg_smoke_tests_win32
+    disabled: false
     display_name: "package smoke tests (win32)"
     run_on: ubuntu2004-small
     tasks:
       - name: pkg_test_ssh_win32_x64
       - name: pkg_test_ssh_win32msi_x64
   - name: pkg_smoke_tests_macos_1100_x64
+    disabled: false
     display_name: "package smoke tests (macos 11.00 x64)"
     run_on: macos-1100
     tasks:
       - name: pkg_test_macos_darwin_x64
   - name: pkg_smoke_tests_macos_1100_arm64
+    disabled: false
     display_name: "package smoke tests (macos 11.00 arm64)"
     run_on: macos-1100-arm64
     tasks:
       - name: pkg_test_macos_darwin_arm64
   - name: pkg_smoke_tests_macos_1300_arm64
+    disabled: false
     display_name: "package smoke tests (macos 13.00 arm64)"
     run_on: macos-1300-arm64
     tasks:
       - name: pkg_test_macos_darwin_arm64
   - name: pkg_smoke_tests_rhel72_s390x
+    disabled: false
     display_name: "package smoke tests (RHEL 7.2 s390x)"
     run_on: rhel72-zseries-small
     tasks:
       - name: pkg_test_rpmextract_rpm_s390x
   - name: pkg_smoke_tests_rhel83_s390x
+    disabled: false
     display_name: "package smoke tests (RHEL 8.3 s390x)"
     run_on: rhel83-zseries-small
     tasks:
       - name: pkg_test_rpmextract_rpm_s390x
   - name: pkg_smoke_tests_rhel81_ppc64le
+    disabled: false
     display_name: "package smoke tests (RHEL 8.1 ppc64le)"
     run_on: rhel81-power8-small
     tasks:
       - name: pkg_test_rpmextract_rpm_ppc64le
 
   - name: draft_publish_release
+    disabled: false
     display_name: "Draft/Publish Release"
     run_on: ubuntu2004-small
     tasks:
@@ -13899,6 +13963,7 @@ buildvariants:
       - name: release_publish
 
   - name: generate_license_and_vulnerability_report
+    disabled: false
     display_name: "License and Vulnerability Report"
     run_on: ubuntu2004-small
     tasks:

--- a/.evergreen/evergreen.yml.in
+++ b/.evergreen/evergreen.yml.in
@@ -2,6 +2,11 @@
 # https://jira.mongodb.org/browse/EVG-20276
 unset_function_vars: true
 
+# https://github.com/evergreen-ci/evergreen/blob/main/docs/Project-Configuration/Parameterized-Builds.md#project-config
+parameters:
+  - key: mongodb_driver_version_override
+    value: <% process.env.NIGHTLY_DRIVER ? out('nightly') : out('') %>
+
 <%
 const path = require('path');
 
@@ -1170,6 +1175,7 @@ tasks:
 # Need to run builds for every possible build variant.
 buildvariants:
   - name: darwin_unit
+    disabled: <% process.env.NIGHTLY_DRIVER ? out('true') : out('false') %>
     display_name: "MacOS Big Sur (Unit tests)"
     run_on: macos-1100
     expansions:
@@ -1180,6 +1186,7 @@ buildvariants:
       - name: test_<% out(test.id) %>
       <% } %>
   - name: darwin
+    disabled: <% process.env.NIGHTLY_DRIVER ? out('true') : out('false') %>
     display_name: "MacOS Big Sur"
     run_on: macos-1100
     expansions:
@@ -1190,6 +1197,7 @@ buildvariants:
       - name: package_and_upload_artifact_darwin_x64
       - name: package_and_upload_artifact_darwin_arm64
   - name: darwin_arm64
+    disabled: <% process.env.NIGHTLY_DRIVER ? out('true') : out('false') %>
     display_name: "MacOS Big Sur (arm64)"
     run_on: macos-1100-arm64
     expansions:
@@ -1199,6 +1207,7 @@ buildvariants:
       - name: e2e_tests_darwin_arm64
 
   - name: linux_unit
+    disabled: false
     display_name: "Ubuntu 18.04 x64 (Unit tests)"
     run_on: ubuntu2004-small
     tasks:
@@ -1211,11 +1220,13 @@ buildvariants:
       - name: test_connectivity
       - name: test_apistrict
   - name: linux_coverage
+    disabled: <% process.env.NIGHTLY_DRIVER ? out('true') : out('false') %>
     display_name: "Coverage Check"
     run_on: ubuntu2004-small
     tasks:
       - name: check_coverage
   - name: linux_package
+    disabled: false
     display_name: "Ubuntu 18.04 x64 (Packaging)"
     run_on: ubuntu2004-small
     tasks:
@@ -1225,6 +1236,7 @@ buildvariants:
       - name: package_and_upload_artifact_<% out(packageVariant.replace(/-/g, '_')) %>
       <% } } } %>
   - name: linux_x64_build
+    disabled: false
     display_name: "RHEL 7.0 x64 (build)"
     run_on: rhel70-build
     expansions:
@@ -1232,6 +1244,7 @@ buildvariants:
     tasks:
       - name: compile_artifact
   - name: linux_x64_build_rhel8
+    disabled: false
     display_name: "RHEL 8.0 x64 (build)"
     run_on: rhel80-small
     expansions:
@@ -1239,6 +1252,7 @@ buildvariants:
     tasks:
       - name: compile_artifact
   - name: linux_x64_build_openssl11
+    disabled: false
     display_name: "RHEL 7.0 x64 (build, shared OpenSSL 1.1)"
     run_on: rhel70-build
     expansions:
@@ -1247,6 +1261,7 @@ buildvariants:
     tasks:
       - name: compile_artifact
   - name: linux_x64_build_openssl11_rhel8
+    disabled: false
     display_name: "RHEL 8.0 x64 (build, shared OpenSSL 1.1)"
     run_on: rhel80-small
     expansions:
@@ -1255,6 +1270,7 @@ buildvariants:
     tasks:
       - name: compile_artifact
   - name: linux_x64_build_openssl3
+    disabled: false
     display_name: "RHEL 7.0 x64 (build, shared OpenSSL 3)"
     run_on: rhel70-build
     expansions:
@@ -1263,6 +1279,7 @@ buildvariants:
     tasks:
       - name: compile_artifact
   - name: linux_x64_build_openssl3_rhel8
+    disabled: false
     display_name: "RHEL 8.0 x64 (build, shared OpenSSL 3)"
     run_on: rhel80-small
     expansions:
@@ -1271,6 +1288,7 @@ buildvariants:
     tasks:
       - name: compile_artifact
   - name: linux_arm64_build
+    disabled: <% process.env.NIGHTLY_DRIVER ? out('true') : out('false') %>
     display_name: "Amazon 2 arm64 (build)"
     run_on: amazon2-arm64-large
     expansions:
@@ -1278,6 +1296,7 @@ buildvariants:
     tasks:
       - name: compile_artifact
   - name: linux_arm64_build_openssl11
+    disabled: <% process.env.NIGHTLY_DRIVER ? out('true') : out('false') %>
     display_name: "Amazon 2 arm64 (build, shared OpenSSL 1.1)"
     run_on: amazon2-arm64-large
     expansions:
@@ -1286,6 +1305,7 @@ buildvariants:
     tasks:
       - name: compile_artifact
   - name: linux_arm64_build_openssl3
+    disabled: <% process.env.NIGHTLY_DRIVER ? out('true') : out('false') %>
     display_name: "Amazon 2 arm64 (build, shared OpenSSL 3)"
     run_on: amazon2-arm64-large
     expansions:
@@ -1294,6 +1314,7 @@ buildvariants:
     tasks:
       - name: compile_artifact
   - name: linux_ppc64le_build
+    disabled: <% process.env.NIGHTLY_DRIVER ? out('true') : out('false') %>
     display_name: "RHEL 8.1 PPC (build)"
     run_on: rhel81-power8-small
     expansions:
@@ -1301,6 +1322,7 @@ buildvariants:
     tasks:
       - name: compile_artifact
   - name: linux_s390x_build
+    disabled: <% process.env.NIGHTLY_DRIVER ? out('true') : out('false') %>
     display_name: "RHEL 7.2 s390x (build)"
     run_on: rhel72-zseries-large
     expansions:
@@ -1309,21 +1331,25 @@ buildvariants:
       - name: compile_artifact
 
   - name: e2e_rhel70_x64
+    disabled: false
     display_name: "RHEL 7.0 x64 (E2E Tests)"
     run_on: rhel70-large
     tasks:
       - name: e2e_tests_linux_x64
   - name: e2e_rhel76_x64
+    disabled: false
     display_name: "RHEL 7.6 x64 (E2E Tests)"
     run_on: rhel76-large
     tasks:
       - name: e2e_tests_linux_x64
   - name: e2e_rhel80_x64
+    disabled: false
     display_name: "RHEL 8.0 x64 (E2E Tests)"
     run_on: rhel80-small
     tasks:
       - name: e2e_tests_linux_x64
   - name: e2e_rhel90_x64
+    disabled: false
     display_name: "RHEL 9.0 x64 (E2E Tests)"
     run_on: rhel90-small
     expansions:
@@ -1331,6 +1357,7 @@ buildvariants:
     tasks:
       - name: e2e_tests_linux_x64
   - name: e2e_rhel83_x64
+    disabled: false
     display_name: "RHEL 8.3 x64 (E2E Tests, FIPS-available OS)"
     run_on: rhel83-fips
     tasks:
@@ -1338,6 +1365,7 @@ buildvariants:
       - name: e2e_tests_linux_x64_openssl11
       - name: e2e_tests_linux_x64_openssl11_fips
   - name: e2e_rhel92_x64
+    disabled: false
     display_name: "RHEL 9.2 x64 (E2E Tests, FIPS-available OS)"
     run_on: rhel92-fips
     tasks:
@@ -1345,40 +1373,47 @@ buildvariants:
       - name: e2e_tests_linux_x64_openssl3
       - name: e2e_tests_linux_x64_openssl3_fips
   - name: e2e_ubuntu1804_x64
+    disabled: false
     display_name: "Ubuntu 18.04 x64 (E2E Tests)"
     run_on: ubuntu1804-large
     tasks:
       - name: e2e_tests_linux_x64_60x
   - name: e2e_ubuntu2004_x64
+    disabled: false
     display_name: "Ubuntu 20.04 x64 (E2E Tests)"
     run_on: ubuntu2004-small
     tasks:
       - name: e2e_tests_linux_x64
       - name: e2e_tests_linux_x64_openssl11
   - name: e2e_ubuntu2204_x64
+    disabled: false
     display_name: "Ubuntu 22.04 x64 (E2E Tests)"
     run_on: ubuntu2204-small
     tasks:
       - name: e2e_tests_linux_x64
       - name: e2e_tests_linux_x64_openssl3
   - name: e2e_debian10_x64
+    disabled: false
     display_name: "Debian 10 x64 (E2E Tests)"
     run_on: debian10-small
     tasks:
       - name: e2e_tests_linux_x64_60x
       - name: e2e_tests_linux_x64_openssl11_60x
   - name: e2e_debian11_x64
+    disabled: false
     display_name: "Debian 11 x64 (E2E Tests)"
     run_on: debian11-small
     tasks:
       - name: e2e_tests_linux_x64
       - name: e2e_tests_linux_x64_openssl11
   - name: e2e_amazon2_x64
+    disabled: false
     display_name: "Amazon Linux 2 x64 (E2E Tests)"
     run_on: amazon2-large
     tasks:
       - name: e2e_tests_linux_x64
   - name: e2e_amazon2023_x64
+    disabled: false
     display_name: "Amazon Linux 2023 x64 (E2E Tests)"
     run_on: amazon2023.0-small
     expansions:
@@ -1386,38 +1421,45 @@ buildvariants:
     tasks:
       - name: e2e_tests_linux_x64
   - name: e2e_suse12_x64
+    disabled: false
     display_name: "SLES 12 x64 (E2E Tests)"
     run_on: suse12-sp5-large
     tasks:
       - name: e2e_tests_linux_x64
   - name: e2e_suse15_x64
+    disabled: false
     display_name: "SLES 15 x64 (E2E Tests)"
     run_on: suse15sp4-small
     tasks:
       - name: e2e_tests_linux_x64
   - name: e2e_ubuntu1804_arm64
+    disabled: <% process.env.NIGHTLY_DRIVER ? out('true') : out('false') %>
     display_name: "Ubuntu 18.04 arm64 (E2E Tests)"
     run_on: ubuntu1804-arm64-large
     tasks:
       - name: e2e_tests_linux_arm64_60x
   - name: e2e_ubuntu2004_arm64
+    disabled: <% process.env.NIGHTLY_DRIVER ? out('true') : out('false') %>
     display_name: "Ubuntu 20.04 arm64 (E2E Tests)"
     run_on: ubuntu2004-arm64-small
     tasks:
       - name: e2e_tests_linux_arm64
       - name: e2e_tests_linux_arm64_openssl11
   - name: e2e_ubuntu2204_arm64
+    disabled: <% process.env.NIGHTLY_DRIVER ? out('true') : out('false') %>
     display_name: "Ubuntu 22.04 arm64 (E2E Tests)"
     run_on: ubuntu2204-arm64-small
     tasks:
       - name: e2e_tests_linux_arm64
       - name: e2e_tests_linux_arm64_openssl3
   - name: e2e_amazon2_arm64
+    disabled: <% process.env.NIGHTLY_DRIVER ? out('true') : out('false') %>
     display_name: "Amazon Linux 2 arm64 (E2E Tests)"
     run_on: amazon2-arm64-large
     tasks:
       - name: e2e_tests_linux_arm64
   - name: e2e_amazon2023_arm64
+    disabled: <% process.env.NIGHTLY_DRIVER ? out('true') : out('false') %>
     display_name: "Amazon Linux 2023 arm64 (E2E Tests)"
     run_on: amazon2023.0-arm64-small
     expansions:
@@ -1425,11 +1467,13 @@ buildvariants:
     tasks:
       - name: e2e_tests_linux_arm64
   - name: e2e_rhel82_arm64
+    disabled: <% process.env.NIGHTLY_DRIVER ? out('true') : out('false') %>
     display_name: "RHEL 8.2 arm64 (E2E Tests)"
     run_on: rhel82-arm64-small
     tasks:
       - name: e2e_tests_linux_arm64
   - name: e2e_rhel90_arm64
+    disabled: <% process.env.NIGHTLY_DRIVER ? out('true') : out('false') %>
     display_name: "RHEL 9.0 arm64 (E2E Tests)"
     run_on: rhel90-arm64-small
     expansions:
@@ -1438,22 +1482,26 @@ buildvariants:
       - name: e2e_tests_linux_arm64
       - name: e2e_tests_linux_arm64_openssl3
   - name: e2e_rhel81_ppc64le
+    disabled: <% process.env.NIGHTLY_DRIVER ? out('true') : out('false') %>
     display_name: "RHEL 8.1 PPC (E2E Tests)"
     run_on: rhel81-power8-small
     tasks:
       - name: e2e_tests_linux_ppc64le
   - name: e2e_rhel72_s390x
+    disabled: <% process.env.NIGHTLY_DRIVER ? out('true') : out('false') %>
     display_name: "RHEL 7.2 s390x (E2E Tests)"
     run_on: rhel72-zseries-large
     tasks:
       - name: e2e_tests_linux_s390x_60x
   - name: e2e_rhel83_s390x
+    disabled: <% process.env.NIGHTLY_DRIVER ? out('true') : out('false') %>
     display_name: "RHEL 8.3 s390x (E2E Tests)"
     run_on: rhel83-zseries-small
     tasks:
       - name: e2e_tests_linux_s390x
 
   - name: win32_unit
+    disabled: <% process.env.NIGHTLY_DRIVER ? out('true') : out('false') %>
     display_name: "Windows (Unit tests)"
     run_on: windows-vsCurrent-small
     expansions:
@@ -1464,6 +1512,7 @@ buildvariants:
       - name: test_<% out(test.id) %>
       <% } %>
   - name: win32
+    disabled: <% process.env.NIGHTLY_DRIVER ? out('true') : out('false') %>
     display_name: "Windows VS 2019"
     run_on: windows-64-vs2019-small
     expansions:
@@ -1473,6 +1522,7 @@ buildvariants:
       - name: package_and_upload_artifact_win32_x64
       - name: package_and_upload_artifact_win32msi_x64
   - name: win32_build
+    disabled: <% process.env.NIGHTLY_DRIVER ? out('true') : out('false') %>
     display_name: "Windows VS 2019 (build)"
     run_on: windows-64-vs2019-build
     expansions:
@@ -1481,6 +1531,7 @@ buildvariants:
       - name: compile_artifact
 
   - name: pkg_smoke_tests_docker_x64
+    disabled: false
     display_name: "package smoke (x64 Docker)"
     run_on: ubuntu2004-small
     tasks:
@@ -1489,6 +1540,7 @@ buildvariants:
       - name: <% out(taskName) %>
   <% } } %>
   - name: pkg_smoke_tests_docker_arm64
+    disabled: <% process.env.NIGHTLY_DRIVER ? out('true') : out('false') %>
     display_name: "package smoke (arm64 Docker)"
     run_on: ubuntu2004-arm64-small
     tasks:
@@ -1497,6 +1549,7 @@ buildvariants:
       - name: <% out(taskName) %>
   <% } } %>
   - name: exec_connectitivty_tests_docker_x64_openssl11
+    disabled: false
     display_name: "executable connectivity tests (x64 Docker for OpenSSL 1.1 base OS)"
     run_on: ubuntu2004-small
     tasks:
@@ -1505,6 +1558,7 @@ buildvariants:
       - name: <% out(taskName) %>
   <% } } %>
   - name: exec_connectitivty_tests_docker_arm64_openssl11
+    disabled: <% process.env.NIGHTLY_DRIVER ? out('true') : out('false') %>
     display_name: "executable connectivity tests (arm64 Docker for OpenSSL 1.1 base OS)"
     run_on: ubuntu2004-arm64-small
     tasks:
@@ -1513,6 +1567,7 @@ buildvariants:
       - name: <% out(taskName) %>
   <% } } %>
   - name: exec_connectitivty_tests_docker_x64_openssl3
+    disabled: false
     display_name: "executable connectivity tests (x64 Docker for OpenSSL 3 base OS)"
     run_on: ubuntu2204-small
     tasks:
@@ -1521,6 +1576,7 @@ buildvariants:
       - name: <% out(taskName) %>
   <% } } %>
   - name: exec_connectitivty_tests_docker_arm64_openssl3
+    disabled: <% process.env.NIGHTLY_DRIVER ? out('true') : out('false') %>
     display_name: "executable connectivity tests (arm64 Docker for OpenSSL 3 base OS)"
     run_on: ubuntu2204-arm64-small
     tasks:
@@ -1529,43 +1585,51 @@ buildvariants:
       - name: <% out(taskName) %>
   <% } } %>
   - name: pkg_smoke_tests_win32
+    disabled: <% process.env.NIGHTLY_DRIVER ? out('true') : out('false') %>
     display_name: "package smoke tests (win32)"
     run_on: ubuntu2004-small
     tasks:
       - name: pkg_test_ssh_win32_x64
       - name: pkg_test_ssh_win32msi_x64
   - name: pkg_smoke_tests_macos_1100_x64
+    disabled: <% process.env.NIGHTLY_DRIVER ? out('true') : out('false') %>
     display_name: "package smoke tests (macos 11.00 x64)"
     run_on: macos-1100
     tasks:
       - name: pkg_test_macos_darwin_x64
   - name: pkg_smoke_tests_macos_1100_arm64
+    disabled: <% process.env.NIGHTLY_DRIVER ? out('true') : out('false') %>
     display_name: "package smoke tests (macos 11.00 arm64)"
     run_on: macos-1100-arm64
     tasks:
       - name: pkg_test_macos_darwin_arm64
   - name: pkg_smoke_tests_macos_1300_arm64
+    disabled: <% process.env.NIGHTLY_DRIVER ? out('true') : out('false') %>
     display_name: "package smoke tests (macos 13.00 arm64)"
     run_on: macos-1300-arm64
     tasks:
       - name: pkg_test_macos_darwin_arm64
   - name: pkg_smoke_tests_rhel72_s390x
+    disabled: <% process.env.NIGHTLY_DRIVER ? out('true') : out('false') %>
     display_name: "package smoke tests (RHEL 7.2 s390x)"
     run_on: rhel72-zseries-small
     tasks:
       - name: pkg_test_rpmextract_rpm_s390x
   - name: pkg_smoke_tests_rhel83_s390x
+    disabled: <% process.env.NIGHTLY_DRIVER ? out('true') : out('false') %>
     display_name: "package smoke tests (RHEL 8.3 s390x)"
     run_on: rhel83-zseries-small
     tasks:
       - name: pkg_test_rpmextract_rpm_s390x
   - name: pkg_smoke_tests_rhel81_ppc64le
+    disabled: <% process.env.NIGHTLY_DRIVER ? out('true') : out('false') %>
     display_name: "package smoke tests (RHEL 8.1 ppc64le)"
     run_on: rhel81-power8-small
     tasks:
       - name: pkg_test_rpmextract_rpm_ppc64le
 
   - name: draft_publish_release
+    disabled: <% process.env.NIGHTLY_DRIVER ? out('true') : out('false') %>
     display_name: "Draft/Publish Release"
     run_on: ubuntu2004-small
     tasks:
@@ -1574,6 +1638,7 @@ buildvariants:
       - name: release_publish
 
   - name: generate_license_and_vulnerability_report
+    disabled: <% process.env.NIGHTLY_DRIVER ? out('true') : out('false') %>
     display_name: "License and Vulnerability Report"
     run_on: ubuntu2004-small
     tasks:

--- a/.evergreen/install-npm-deps.sh
+++ b/.evergreen/install-npm-deps.sh
@@ -9,7 +9,13 @@ echo "MONOGDB_DRIVER_VERSION_OVERRIDE:$MONOGDB_DRIVER_VERSION_OVERRIDE"
 if [[ -n "$MONOGDB_DRIVER_VERSION_OVERRIDE" ]]; then
   export REPLACE_PACKAGE="mongodb:$MONOGDB_DRIVER_VERSION_OVERRIDE"
   npm run replace-package
-  npm ci --verbose --force # force because of issues with peer deps and semver pre-releases
+  # force because of issues with peer deps and semver pre-releases,
+  # install rather than ci because `npm ci` can only install packages when your
+  # package.json and package-lock.json or npm-shrinkwrap.json are in sync.
+  # NOTE: this won't work on some more exotic platforms because not every dep
+  # can be installed on them. That's why we only run on linux x64 platforms when
+  # we set MONOGDB_DRIVER_VERSION_OVERRIDE=nightly in CI
+  npm i --verbose --force
 fi
 
 # if we rewrote this script in javascript using just builtin node modules we could skip the npm ci above

--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
     "preupdate-third-party-notices": "npm run webpack-build -w packages/cli-repl",
     "update-third-party-notices": "mongodb-sbom-tools generate-3rd-party-notices --product='mongosh' --dependencies=.sbom/dependencies.json > THIRD_PARTY_NOTICES.md",
     "update-node-js-versions": "npx @pkgjs/nv ls v20 > .evergreen/node-20-latest.json && npx @pkgjs/nv ls v16 > .evergreen/node-16-latest.json",
-    "update-evergreen-config": "npm run test-evergreen-expansions && node .evergreen/generate-evergreen-yml.js .evergreen/evergreen.yml.in > .evergreen.yml",
+    "update-evergreen-config": "npm run test-evergreen-expansions && node .evergreen/generate-evergreen-yml.js .evergreen/evergreen.yml.in > .evergreen.yml && npx cross-env NIGHTLY_DRIVER=true node .evergreen/generate-evergreen-yml.js .evergreen/evergreen.yml.in > .evergreen-nightly-driver.yml",
     "mark-ci-required-optional-dependencies": "ts-node scripts/mark-ci-required-optional-dependencies.ts",
     "write-node-js-dep": "echo '[{\"name\": \".node.js\", \"version\":\"'\"$NODE_JS_VERSION\"'\"}]' > .sbom/node-js-dep.json",
     "scan-node-js": "mongodb-sbom-tools scan-node-js --version=$NODE_JS_VERSION > .sbom/node-js-vuln.json",


### PR DESCRIPTION
Follow-up to https://github.com/mongodb-js/mongosh/pull/1780

npm ci doesn't work if your package lock doesn't match what it should be so we have to npm i but then npm i doesn't work on all the exotic platforms due to all the deps we can't install there.. But there's no point running the nightly driver on every platform anyway, so let's only run it on x64 linux while at it.

This pull request now reuses the same templating we have to make .evergreen.yml to also make .evergreen-nightly-driver.yml so we can have one with all the build variants we don't want disabled.


All this to work around the limitations of evergreen's periodic builds. Another option would be to use the evergreen CLI to filter the variants/tasks that will be run, but then we need that set up somewhere we can run it. (github workflows, perhaps?)