### PR TITLE
chore: use patch aliases to run just some of the build variants for the nightly driver tests

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -1,11 +1,6 @@
 # Regenerate using `npm run update-evergreen-config`
 # https://jira.mongodb.org/browse/EVG-20276
 unset_function_vars: true
-
-patch_aliases:
-  - alias: "nightly-driver"
-    variant_tags: ["nightly-driver"]
-    task: ".*"
 exec_timeout_secs: 10800
 
 post_error_fails_task: true
@@ -13163,7 +13158,7 @@ buildvariants:
   - name: linux_unit
     display_name: "Ubuntu 18.04 x64 (Unit tests)"
     run_on: ubuntu2004-small
-    tags: ["driver-nightly"]
+    tags: ["nightly-driver"]
     tasks:
       - name: compile_ts
       - name: check

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -13325,6 +13325,7 @@ buildvariants:
   - name: linux_package
     display_name: "Ubuntu 18.04 x64 (Packaging)"
     run_on: ubuntu2004-small
+    tags: ["nightly-driver"]
     tasks:
       - name: package_and_upload_artifact_linux_x64
       - name: package_and_upload_artifact_deb_x64
@@ -13353,6 +13354,7 @@ buildvariants:
     run_on: rhel70-build
     expansions:
       executable_os_id: linux-x64
+    tags: ["nightly-driver"]
     tasks:
       - name: compile_artifact
   - name: linux_x64_build_rhel8
@@ -13360,6 +13362,7 @@ buildvariants:
     run_on: rhel80-small
     expansions:
       executable_os_id: linux-x64
+    tags: ["nightly-driver"]
     tasks:
       - name: compile_artifact
   - name: linux_x64_build_openssl11
@@ -13368,6 +13371,7 @@ buildvariants:
     expansions:
       executable_os_id: linux-x64-openssl11
       mongosh_shared_openssl: openssl11
+    tags: ["nightly-driver"]
     tasks:
       - name: compile_artifact
   - name: linux_x64_build_openssl11_rhel8
@@ -13376,6 +13380,7 @@ buildvariants:
     expansions:
       executable_os_id: linux-x64-openssl11
       mongosh_shared_openssl: openssl11
+    tags: ["nightly-driver"]
     tasks:
       - name: compile_artifact
   - name: linux_x64_build_openssl3
@@ -13384,6 +13389,7 @@ buildvariants:
     expansions:
       executable_os_id: linux-x64-openssl3
       mongosh_shared_openssl: openssl3
+    tags: ["nightly-driver"]
     tasks:
       - name: compile_artifact
   - name: linux_x64_build_openssl3_rhel8
@@ -13392,6 +13398,7 @@ buildvariants:
     expansions:
       executable_os_id: linux-x64-openssl3
       mongosh_shared_openssl: openssl3
+    tags: ["nightly-driver"]
     tasks:
       - name: compile_artifact
   - name: linux_arm64_build
@@ -13435,16 +13442,19 @@ buildvariants:
   - name: e2e_rhel70_x64
     display_name: "RHEL 7.0 x64 (E2E Tests)"
     run_on: rhel70-large
+    tags: ["nightly-driver"]
     tasks:
       - name: e2e_tests_linux_x64
   - name: e2e_rhel76_x64
     display_name: "RHEL 7.6 x64 (E2E Tests)"
     run_on: rhel76-large
+    tags: ["nightly-driver"]
     tasks:
       - name: e2e_tests_linux_x64
   - name: e2e_rhel80_x64
     display_name: "RHEL 8.0 x64 (E2E Tests)"
     run_on: rhel80-small
+    tags: ["nightly-driver"]
     tasks:
       - name: e2e_tests_linux_x64
   - name: e2e_rhel90_x64
@@ -13452,11 +13462,13 @@ buildvariants:
     run_on: rhel90-small
     expansions:
       disable_openssl_shared_config_for_bundled_openssl: true
+    tags: ["nightly-driver"]
     tasks:
       - name: e2e_tests_linux_x64
   - name: e2e_rhel83_x64
     display_name: "RHEL 8.3 x64 (E2E Tests, FIPS-available OS)"
     run_on: rhel83-fips
+    tags: ["nightly-driver"]
     tasks:
       - name: e2e_tests_linux_x64
       - name: e2e_tests_linux_x64_openssl11
@@ -13464,6 +13476,7 @@ buildvariants:
   - name: e2e_rhel92_x64
     display_name: "RHEL 9.2 x64 (E2E Tests, FIPS-available OS)"
     run_on: rhel92-fips
+    tags: ["nightly-driver"]
     tasks:
       - name: e2e_tests_linux_x64
       - name: e2e_tests_linux_x64_openssl3
@@ -13471,35 +13484,41 @@ buildvariants:
   - name: e2e_ubuntu1804_x64
     display_name: "Ubuntu 18.04 x64 (E2E Tests)"
     run_on: ubuntu1804-large
+    tags: ["nightly-driver"]
     tasks:
       - name: e2e_tests_linux_x64_60x
   - name: e2e_ubuntu2004_x64
     display_name: "Ubuntu 20.04 x64 (E2E Tests)"
     run_on: ubuntu2004-small
+    tags: ["nightly-driver"]
     tasks:
       - name: e2e_tests_linux_x64
       - name: e2e_tests_linux_x64_openssl11
   - name: e2e_ubuntu2204_x64
     display_name: "Ubuntu 22.04 x64 (E2E Tests)"
     run_on: ubuntu2204-small
+    tags: ["nightly-driver"]
     tasks:
       - name: e2e_tests_linux_x64
       - name: e2e_tests_linux_x64_openssl3
   - name: e2e_debian10_x64
     display_name: "Debian 10 x64 (E2E Tests)"
     run_on: debian10-small
+    tags: ["nightly-driver"]
     tasks:
       - name: e2e_tests_linux_x64_60x
       - name: e2e_tests_linux_x64_openssl11_60x
   - name: e2e_debian11_x64
     display_name: "Debian 11 x64 (E2E Tests)"
     run_on: debian11-small
+    tags: ["nightly-driver"]
     tasks:
       - name: e2e_tests_linux_x64
       - name: e2e_tests_linux_x64_openssl11
   - name: e2e_amazon2_x64
     display_name: "Amazon Linux 2 x64 (E2E Tests)"
     run_on: amazon2-large
+    tags: ["nightly-driver"]
     tasks:
       - name: e2e_tests_linux_x64
   - name: e2e_amazon2023_x64
@@ -13507,16 +13526,19 @@ buildvariants:
     run_on: amazon2023.0-small
     expansions:
       disable_openssl_shared_config_for_bundled_openssl: true
+    tags: ["nightly-driver"]
     tasks:
       - name: e2e_tests_linux_x64
   - name: e2e_suse12_x64
     display_name: "SLES 12 x64 (E2E Tests)"
     run_on: suse12-sp5-large
+    tags: ["nightly-driver"]
     tasks:
       - name: e2e_tests_linux_x64
   - name: e2e_suse15_x64
     display_name: "SLES 15 x64 (E2E Tests)"
     run_on: suse15sp4-small
+    tags: ["nightly-driver"]
     tasks:
       - name: e2e_tests_linux_x64
   - name: e2e_ubuntu1804_arm64
@@ -13746,6 +13768,7 @@ buildvariants:
   - name: pkg_smoke_tests_docker_x64
     display_name: "package smoke (x64 Docker)"
     run_on: ubuntu2004-small
+    tags: ["nightly-driver"]
     tasks:
       - name: pkg_test_docker_linux_x64_ubuntu20_04_tgz
       - name: pkg_test_docker_deb_x64_ubuntu18_04_deb
@@ -13781,6 +13804,7 @@ buildvariants:
   - name: pkg_smoke_tests_docker_arm64
     display_name: "package smoke (arm64 Docker)"
     run_on: ubuntu2004-arm64-small
+    tags: ["nightly-driver"]
     tasks:
       - name: pkg_test_docker_linux_arm64_ubuntu20_04_tgz
       - name: pkg_test_docker_deb_arm64_ubuntu18_04_deb
@@ -13811,6 +13835,7 @@ buildvariants:
   - name: exec_connectitivty_tests_docker_x64_openssl11
     display_name: "executable connectivity tests (x64 Docker for OpenSSL 1.1 base OS)"
     run_on: ubuntu2004-small
+    tags: ["nightly-driver"]
     tasks:
       - name: executable_connectivity_test_linux_x64_rocky8
       - name: executable_connectivity_test_linux_x64_ubuntu2004
@@ -13833,6 +13858,7 @@ buildvariants:
   - name: exec_connectitivty_tests_docker_x64_openssl3
     display_name: "executable connectivity tests (x64 Docker for OpenSSL 3 base OS)"
     run_on: ubuntu2204-small
+    tags: ["nightly-driver"]
     tasks:
       - name: executable_connectivity_test_linux_x64_rocky8
       - name: executable_connectivity_test_linux_x64_ubuntu2004

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -1,6 +1,11 @@
 # Regenerate using `npm run update-evergreen-config`
 # https://jira.mongodb.org/browse/EVG-20276
 unset_function_vars: true
+
+patch_aliases:
+  - alias: "nightly-driver"
+    variant_tags: ["nightly-driver"]
+    task: ".*"
 exec_timeout_secs: 10800
 
 post_error_fails_task: true
@@ -13158,6 +13163,7 @@ buildvariants:
   - name: linux_unit
     display_name: "Ubuntu 18.04 x64 (Unit tests)"
     run_on: ubuntu2004-small
+    tags: ["driver-nightly"]
     tasks:
       - name: compile_ts
       - name: check

--- a/.evergreen/evergreen.yml.in
+++ b/.evergreen/evergreen.yml.in
@@ -2,6 +2,11 @@
 # https://jira.mongodb.org/browse/EVG-20276
 unset_function_vars: true
 
+patch_aliases:
+  - alias: "nightly-driver"
+    variant_tags: ["nightly-driver"]
+    task: ".*"
+
 <%
 const path = require('path');
 
@@ -1201,6 +1206,7 @@ buildvariants:
   - name: linux_unit
     display_name: "Ubuntu 18.04 x64 (Unit tests)"
     run_on: ubuntu2004-small
+    tags: ["nightly-driver"]
     tasks:
       - name: compile_ts
       - name: check

--- a/.evergreen/evergreen.yml.in
+++ b/.evergreen/evergreen.yml.in
@@ -2,11 +2,6 @@
 # https://jira.mongodb.org/browse/EVG-20276
 unset_function_vars: true
 
-patch_aliases:
-  - alias: "nightly-driver"
-    variant_tags: ["nightly-driver"]
-    task: ".*"
-
 <%
 const path = require('path');
 

--- a/.evergreen/evergreen.yml.in
+++ b/.evergreen/evergreen.yml.in
@@ -1219,6 +1219,7 @@ buildvariants:
   - name: linux_package
     display_name: "Ubuntu 18.04 x64 (Packaging)"
     run_on: ubuntu2004-small
+    tags: ["nightly-driver"]
     tasks:
       <% for (const { executableOsId, packages } of RELEASE_PACKAGE_MATRIX) {
           for (const { name: packageVariant } of packages) {
@@ -1230,6 +1231,7 @@ buildvariants:
     run_on: rhel70-build
     expansions:
       executable_os_id: linux-x64
+    tags: ["nightly-driver"]
     tasks:
       - name: compile_artifact
   - name: linux_x64_build_rhel8
@@ -1237,6 +1239,7 @@ buildvariants:
     run_on: rhel80-small
     expansions:
       executable_os_id: linux-x64
+    tags: ["nightly-driver"]
     tasks:
       - name: compile_artifact
   - name: linux_x64_build_openssl11
@@ -1245,6 +1248,7 @@ buildvariants:
     expansions:
       executable_os_id: linux-x64-openssl11
       mongosh_shared_openssl: openssl11
+    tags: ["nightly-driver"]
     tasks:
       - name: compile_artifact
   - name: linux_x64_build_openssl11_rhel8
@@ -1253,6 +1257,7 @@ buildvariants:
     expansions:
       executable_os_id: linux-x64-openssl11
       mongosh_shared_openssl: openssl11
+    tags: ["nightly-driver"]
     tasks:
       - name: compile_artifact
   - name: linux_x64_build_openssl3
@@ -1261,6 +1266,7 @@ buildvariants:
     expansions:
       executable_os_id: linux-x64-openssl3
       mongosh_shared_openssl: openssl3
+    tags: ["nightly-driver"]
     tasks:
       - name: compile_artifact
   - name: linux_x64_build_openssl3_rhel8
@@ -1269,6 +1275,7 @@ buildvariants:
     expansions:
       executable_os_id: linux-x64-openssl3
       mongosh_shared_openssl: openssl3
+    tags: ["nightly-driver"]
     tasks:
       - name: compile_artifact
   - name: linux_arm64_build
@@ -1312,16 +1319,19 @@ buildvariants:
   - name: e2e_rhel70_x64
     display_name: "RHEL 7.0 x64 (E2E Tests)"
     run_on: rhel70-large
+    tags: ["nightly-driver"]
     tasks:
       - name: e2e_tests_linux_x64
   - name: e2e_rhel76_x64
     display_name: "RHEL 7.6 x64 (E2E Tests)"
     run_on: rhel76-large
+    tags: ["nightly-driver"]
     tasks:
       - name: e2e_tests_linux_x64
   - name: e2e_rhel80_x64
     display_name: "RHEL 8.0 x64 (E2E Tests)"
     run_on: rhel80-small
+    tags: ["nightly-driver"]
     tasks:
       - name: e2e_tests_linux_x64
   - name: e2e_rhel90_x64
@@ -1329,11 +1339,13 @@ buildvariants:
     run_on: rhel90-small
     expansions:
       disable_openssl_shared_config_for_bundled_openssl: true
+    tags: ["nightly-driver"]
     tasks:
       - name: e2e_tests_linux_x64
   - name: e2e_rhel83_x64
     display_name: "RHEL 8.3 x64 (E2E Tests, FIPS-available OS)"
     run_on: rhel83-fips
+    tags: ["nightly-driver"]
     tasks:
       - name: e2e_tests_linux_x64
       - name: e2e_tests_linux_x64_openssl11
@@ -1341,6 +1353,7 @@ buildvariants:
   - name: e2e_rhel92_x64
     display_name: "RHEL 9.2 x64 (E2E Tests, FIPS-available OS)"
     run_on: rhel92-fips
+    tags: ["nightly-driver"]
     tasks:
       - name: e2e_tests_linux_x64
       - name: e2e_tests_linux_x64_openssl3
@@ -1348,35 +1361,41 @@ buildvariants:
   - name: e2e_ubuntu1804_x64
     display_name: "Ubuntu 18.04 x64 (E2E Tests)"
     run_on: ubuntu1804-large
+    tags: ["nightly-driver"]
     tasks:
       - name: e2e_tests_linux_x64_60x
   - name: e2e_ubuntu2004_x64
     display_name: "Ubuntu 20.04 x64 (E2E Tests)"
     run_on: ubuntu2004-small
+    tags: ["nightly-driver"]
     tasks:
       - name: e2e_tests_linux_x64
       - name: e2e_tests_linux_x64_openssl11
   - name: e2e_ubuntu2204_x64
     display_name: "Ubuntu 22.04 x64 (E2E Tests)"
     run_on: ubuntu2204-small
+    tags: ["nightly-driver"]
     tasks:
       - name: e2e_tests_linux_x64
       - name: e2e_tests_linux_x64_openssl3
   - name: e2e_debian10_x64
     display_name: "Debian 10 x64 (E2E Tests)"
     run_on: debian10-small
+    tags: ["nightly-driver"]
     tasks:
       - name: e2e_tests_linux_x64_60x
       - name: e2e_tests_linux_x64_openssl11_60x
   - name: e2e_debian11_x64
     display_name: "Debian 11 x64 (E2E Tests)"
     run_on: debian11-small
+    tags: ["nightly-driver"]
     tasks:
       - name: e2e_tests_linux_x64
       - name: e2e_tests_linux_x64_openssl11
   - name: e2e_amazon2_x64
     display_name: "Amazon Linux 2 x64 (E2E Tests)"
     run_on: amazon2-large
+    tags: ["nightly-driver"]
     tasks:
       - name: e2e_tests_linux_x64
   - name: e2e_amazon2023_x64
@@ -1384,16 +1403,19 @@ buildvariants:
     run_on: amazon2023.0-small
     expansions:
       disable_openssl_shared_config_for_bundled_openssl: true
+    tags: ["nightly-driver"]
     tasks:
       - name: e2e_tests_linux_x64
   - name: e2e_suse12_x64
     display_name: "SLES 12 x64 (E2E Tests)"
     run_on: suse12-sp5-large
+    tags: ["nightly-driver"]
     tasks:
       - name: e2e_tests_linux_x64
   - name: e2e_suse15_x64
     display_name: "SLES 15 x64 (E2E Tests)"
     run_on: suse15sp4-small
+    tags: ["nightly-driver"]
     tasks:
       - name: e2e_tests_linux_x64
   - name: e2e_ubuntu1804_arm64
@@ -1484,6 +1506,7 @@ buildvariants:
   - name: pkg_smoke_tests_docker_x64
     display_name: "package smoke (x64 Docker)"
     run_on: ubuntu2004-small
+    tags: ["nightly-driver"]
     tasks:
   <% for (const { taskName, executableOsId } of packageSmokeTestTasks) {
       if (executableOsId.includes('linux-x64')) { %>
@@ -1492,6 +1515,7 @@ buildvariants:
   - name: pkg_smoke_tests_docker_arm64
     display_name: "package smoke (arm64 Docker)"
     run_on: ubuntu2004-arm64-small
+    tags: ["nightly-driver"]
     tasks:
   <% for (const { taskName, executableOsId } of packageSmokeTestTasks) {
       if (executableOsId.includes('linux-arm64')) { %>
@@ -1500,6 +1524,7 @@ buildvariants:
   - name: exec_connectitivty_tests_docker_x64_openssl11
     display_name: "executable connectivity tests (x64 Docker for OpenSSL 1.1 base OS)"
     run_on: ubuntu2004-small
+    tags: ["nightly-driver"]
     tasks:
   <% for (const { taskName, executableOsId } of executableConnectivityTests) {
       if (executableOsId.includes('linux-x64') && !taskName.includes('openssl3')) { %>
@@ -1516,6 +1541,7 @@ buildvariants:
   - name: exec_connectitivty_tests_docker_x64_openssl3
     display_name: "executable connectivity tests (x64 Docker for OpenSSL 3 base OS)"
     run_on: ubuntu2204-small
+    tags: ["nightly-driver"]
     tasks:
   <% for (const { taskName, executableOsId } of executableConnectivityTests) {
       if (executableOsId.includes('linux-x64') && !taskName.includes('openssl11')) { %>

--- a/.evergreen/install-npm-deps.sh
+++ b/.evergreen/install-npm-deps.sh
@@ -9,7 +9,13 @@ echo "MONOGDB_DRIVER_VERSION_OVERRIDE:$MONOGDB_DRIVER_VERSION_OVERRIDE"
 if [[ -n "$MONOGDB_DRIVER_VERSION_OVERRIDE" ]]; then
   export REPLACE_PACKAGE="mongodb:$MONOGDB_DRIVER_VERSION_OVERRIDE"
   npm run replace-package
-  npm ci --verbose --force # force because of issues with peer deps and semver pre-releases
+  # force because of issues with peer deps and semver pre-releases,
+  # install rather than ci because `npm ci` can only install packages when your
+  # package.json and package-lock.json or npm-shrinkwrap.json are in sync.
+  # NOTE: this won't work on some more exotic platforms because not every dep
+  # can be installed on them. That's why we only run on linux x64 platforms when
+  # we set MONOGDB_DRIVER_VERSION_OVERRIDE=nightly in CI
+  npm i --verbose --force
 fi
 
 # if we rewrote this script in javascript using just builtin node modules we could skip the npm ci above


### PR DESCRIPTION
Replaces https://github.com/mongodb-js/mongosh/pull/1788, follow-up to https://github.com/mongodb-js/mongosh/pull/1780

See also https://spruce.mongodb.com/project/mongosh/settings/periodic-builds and https://spruce.mongodb.com/project/mongosh/settings/patch-aliases