### PR TITLE
fix(shell-api): move subset of `validate` command tests to replset MONGOSH-1664

### DIFF
--- a/packages/shell-api/src/integration.spec.ts
+++ b/packages/shell-api/src/integration.spec.ts
@@ -1303,7 +1303,9 @@ describe('Shell API (integration)', function () {
       });
     });
 
-    describe('validate', function () {
+    describe('validate [standalone mode]', function () {
+      // other options are tested in the ReplicaSet suite because they are not available
+      // in standalone mode
       skipIfApiStrict();
       skipIfServerVersion(testServer, '< 5.0');
 
@@ -1321,21 +1323,6 @@ describe('Shell API (integration)', function () {
         expect(
           (await collection.validate({ full: true, repair: true })).valid
         ).to.equal(true);
-      });
-
-      it('validate accepts a background option', async function () {
-        expect(
-          (await collection.validate({ full: false, background: true })).valid
-        ).to.equal(true);
-      });
-
-      it('validate fails with background: true and full: true', async function () {
-        try {
-          await collection.validate({ full: true, background: true });
-          expect.fail('missed exception');
-        } catch (err: any) {
-          expect(err.name).to.equal('MongoServerError');
-        }
       });
     });
   });

--- a/packages/shell-api/src/replica-set.spec.ts
+++ b/packages/shell-api/src/replica-set.spec.ts
@@ -1122,7 +1122,9 @@ describe('ReplicaSet', function () {
           expect.fail('missed exception');
         } catch (err: any) {
           expect(err.name).to.equal('MongoServerError');
-          expect(err.codeName).to.equal('InvalidOptions');
+          expect(err.codeName).to.match(
+            /^(CommandNotSupported|InvalidOptions)$/
+          );
         }
       });
     });


### PR DESCRIPTION
Since the 7.3 server, the `validate` command rejects the `background` option in standalone setups, so we move the corresponding integration tests to the replica set integration test section. (We keep the `repair` option test in the core integration test section since it only works on standalone nodes.)