### PR TITLE
chore: update node.js version to 20.11.0 MONGOSH-1648

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -6907,7 +6907,7 @@ tasks:
       - func: checkout
       - func: compile_ts
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
 
   - name: check
     depends_on:
@@ -6917,10 +6917,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: check
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
 
   - name: check_coverage
     depends_on:
@@ -6930,10 +6930,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: check_coverage
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
 
   ###
   # UNIT TESTS
@@ -6948,11 +6948,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: ""
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "n20_arg_parser"
           mongosh_run_only_in_package: "arg-parser"
@@ -6982,11 +6982,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: ""
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "n20_async_rewriter2"
           mongosh_run_only_in_package: "async-rewriter2"
@@ -7016,11 +7016,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: ""
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "n20_autocomplete"
           mongosh_run_only_in_package: "autocomplete"
@@ -7050,11 +7050,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: ""
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "n20_browser_repl"
           mongosh_run_only_in_package: "browser-repl"
@@ -7084,11 +7084,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: ""
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "n20_browser_runtime_core"
           mongosh_run_only_in_package: "browser-runtime-core"
@@ -7118,11 +7118,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: ""
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "n20_browser_runtime_electron"
           mongosh_run_only_in_package: "browser-runtime-electron"
@@ -7152,11 +7152,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: ""
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "n20_build"
           mongosh_run_only_in_package: "build"
@@ -7186,11 +7186,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.2.x"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m42xc_n20_cli_repl"
           mongosh_run_only_in_package: "cli-repl"
@@ -7203,11 +7203,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.2.x-enterprise"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m42xe_n20_cli_repl"
           mongosh_run_only_in_package: "cli-repl"
@@ -7220,11 +7220,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.4.x"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m44xc_n20_cli_repl"
           mongosh_run_only_in_package: "cli-repl"
@@ -7237,11 +7237,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.4.x-enterprise"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m44xe_n20_cli_repl"
           mongosh_run_only_in_package: "cli-repl"
@@ -7254,11 +7254,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "5.0.x"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m50xc_n20_cli_repl"
           mongosh_run_only_in_package: "cli-repl"
@@ -7271,11 +7271,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "5.0.x-enterprise"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m50xe_n20_cli_repl"
           mongosh_run_only_in_package: "cli-repl"
@@ -7288,11 +7288,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "6.0.x"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m60xc_n20_cli_repl"
           mongosh_run_only_in_package: "cli-repl"
@@ -7305,11 +7305,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "6.0.x-enterprise"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m60xe_n20_cli_repl"
           mongosh_run_only_in_package: "cli-repl"
@@ -7322,11 +7322,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "7.0.x"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m70xc_n20_cli_repl"
           mongosh_run_only_in_package: "cli-repl"
@@ -7339,11 +7339,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "7.0.x-enterprise"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m70xe_n20_cli_repl"
           mongosh_run_only_in_package: "cli-repl"
@@ -7356,11 +7356,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "latest-alpha-enterprise"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "mlatest_n20_cli_repl"
           mongosh_run_only_in_package: "cli-repl"
@@ -7560,11 +7560,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: ""
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "n20_connectivity_tests"
           mongosh_run_only_in_package: "connectivity-tests"
@@ -7594,11 +7594,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.2.x"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m42xc_n20_e2e_tests"
           mongosh_run_only_in_package: "e2e-tests"
@@ -7611,11 +7611,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.2.x-enterprise"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m42xe_n20_e2e_tests"
           mongosh_run_only_in_package: "e2e-tests"
@@ -7628,11 +7628,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.4.x"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m44xc_n20_e2e_tests"
           mongosh_run_only_in_package: "e2e-tests"
@@ -7645,11 +7645,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.4.x-enterprise"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m44xe_n20_e2e_tests"
           mongosh_run_only_in_package: "e2e-tests"
@@ -7662,11 +7662,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "5.0.x"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m50xc_n20_e2e_tests"
           mongosh_run_only_in_package: "e2e-tests"
@@ -7679,11 +7679,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "5.0.x-enterprise"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m50xe_n20_e2e_tests"
           mongosh_run_only_in_package: "e2e-tests"
@@ -7696,11 +7696,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "6.0.x"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m60xc_n20_e2e_tests"
           mongosh_run_only_in_package: "e2e-tests"
@@ -7713,11 +7713,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "6.0.x-enterprise"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m60xe_n20_e2e_tests"
           mongosh_run_only_in_package: "e2e-tests"
@@ -7730,11 +7730,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "7.0.x"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m70xc_n20_e2e_tests"
           mongosh_run_only_in_package: "e2e-tests"
@@ -7747,11 +7747,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "7.0.x-enterprise"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m70xe_n20_e2e_tests"
           mongosh_run_only_in_package: "e2e-tests"
@@ -7764,11 +7764,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "latest-alpha-enterprise"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "mlatest_n20_e2e_tests"
           mongosh_run_only_in_package: "e2e-tests"
@@ -7968,11 +7968,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: ""
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "n20_editor"
           mongosh_run_only_in_package: "editor"
@@ -8002,11 +8002,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: ""
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "n20_errors"
           mongosh_run_only_in_package: "errors"
@@ -8036,11 +8036,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: ""
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "n20_history"
           mongosh_run_only_in_package: "history"
@@ -8070,11 +8070,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: ""
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "n20_i18n"
           mongosh_run_only_in_package: "i18n"
@@ -8104,11 +8104,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.2.x"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m42xc_n20_java_shell"
           mongosh_run_only_in_package: "java-shell"
@@ -8121,11 +8121,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.2.x-enterprise"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m42xe_n20_java_shell"
           mongosh_run_only_in_package: "java-shell"
@@ -8138,11 +8138,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.4.x"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m44xc_n20_java_shell"
           mongosh_run_only_in_package: "java-shell"
@@ -8155,11 +8155,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.4.x-enterprise"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m44xe_n20_java_shell"
           mongosh_run_only_in_package: "java-shell"
@@ -8172,11 +8172,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "5.0.x"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m50xc_n20_java_shell"
           mongosh_run_only_in_package: "java-shell"
@@ -8189,11 +8189,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "5.0.x-enterprise"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m50xe_n20_java_shell"
           mongosh_run_only_in_package: "java-shell"
@@ -8206,11 +8206,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "6.0.x"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m60xc_n20_java_shell"
           mongosh_run_only_in_package: "java-shell"
@@ -8223,11 +8223,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "6.0.x-enterprise"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m60xe_n20_java_shell"
           mongosh_run_only_in_package: "java-shell"
@@ -8240,11 +8240,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "7.0.x"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m70xc_n20_java_shell"
           mongosh_run_only_in_package: "java-shell"
@@ -8257,11 +8257,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "7.0.x-enterprise"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m70xe_n20_java_shell"
           mongosh_run_only_in_package: "java-shell"
@@ -8274,11 +8274,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "latest-alpha-enterprise"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "mlatest_n20_java_shell"
           mongosh_run_only_in_package: "java-shell"
@@ -8478,11 +8478,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: ""
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "n20_js_multiline_to_singleline"
           mongosh_run_only_in_package: "js-multiline-to-singleline"
@@ -8512,11 +8512,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: ""
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "n20_logging"
           mongosh_run_only_in_package: "logging"
@@ -8546,11 +8546,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.2.x"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m42xc_n20_mongosh"
           mongosh_run_only_in_package: "mongosh"
@@ -8563,11 +8563,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.2.x-enterprise"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m42xe_n20_mongosh"
           mongosh_run_only_in_package: "mongosh"
@@ -8580,11 +8580,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.4.x"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m44xc_n20_mongosh"
           mongosh_run_only_in_package: "mongosh"
@@ -8597,11 +8597,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.4.x-enterprise"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m44xe_n20_mongosh"
           mongosh_run_only_in_package: "mongosh"
@@ -8614,11 +8614,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "5.0.x"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m50xc_n20_mongosh"
           mongosh_run_only_in_package: "mongosh"
@@ -8631,11 +8631,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "5.0.x-enterprise"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m50xe_n20_mongosh"
           mongosh_run_only_in_package: "mongosh"
@@ -8648,11 +8648,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "6.0.x"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m60xc_n20_mongosh"
           mongosh_run_only_in_package: "mongosh"
@@ -8665,11 +8665,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "6.0.x-enterprise"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m60xe_n20_mongosh"
           mongosh_run_only_in_package: "mongosh"
@@ -8682,11 +8682,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "7.0.x"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m70xc_n20_mongosh"
           mongosh_run_only_in_package: "mongosh"
@@ -8699,11 +8699,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "7.0.x-enterprise"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m70xe_n20_mongosh"
           mongosh_run_only_in_package: "mongosh"
@@ -8716,11 +8716,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "latest-alpha-enterprise"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "mlatest_n20_mongosh"
           mongosh_run_only_in_package: "mongosh"
@@ -8920,11 +8920,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.2.x"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m42xc_n20_node_runtime_worker_thread"
           mongosh_run_only_in_package: "node-runtime-worker-thread"
@@ -8937,11 +8937,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.2.x-enterprise"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m42xe_n20_node_runtime_worker_thread"
           mongosh_run_only_in_package: "node-runtime-worker-thread"
@@ -8954,11 +8954,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.4.x"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m44xc_n20_node_runtime_worker_thread"
           mongosh_run_only_in_package: "node-runtime-worker-thread"
@@ -8971,11 +8971,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.4.x-enterprise"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m44xe_n20_node_runtime_worker_thread"
           mongosh_run_only_in_package: "node-runtime-worker-thread"
@@ -8988,11 +8988,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "5.0.x"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m50xc_n20_node_runtime_worker_thread"
           mongosh_run_only_in_package: "node-runtime-worker-thread"
@@ -9005,11 +9005,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "5.0.x-enterprise"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m50xe_n20_node_runtime_worker_thread"
           mongosh_run_only_in_package: "node-runtime-worker-thread"
@@ -9022,11 +9022,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "6.0.x"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m60xc_n20_node_runtime_worker_thread"
           mongosh_run_only_in_package: "node-runtime-worker-thread"
@@ -9039,11 +9039,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "6.0.x-enterprise"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m60xe_n20_node_runtime_worker_thread"
           mongosh_run_only_in_package: "node-runtime-worker-thread"
@@ -9056,11 +9056,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "7.0.x"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m70xc_n20_node_runtime_worker_thread"
           mongosh_run_only_in_package: "node-runtime-worker-thread"
@@ -9073,11 +9073,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "7.0.x-enterprise"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m70xe_n20_node_runtime_worker_thread"
           mongosh_run_only_in_package: "node-runtime-worker-thread"
@@ -9090,11 +9090,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "latest-alpha-enterprise"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "mlatest_n20_node_runtime_worker_thread"
           mongosh_run_only_in_package: "node-runtime-worker-thread"
@@ -9294,11 +9294,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: ""
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "n20_service_provider_core"
           mongosh_run_only_in_package: "service-provider-core"
@@ -9328,11 +9328,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.2.x"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m42xc_n20_service_provider_server"
           mongosh_run_only_in_package: "service-provider-server"
@@ -9345,11 +9345,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.2.x-enterprise"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m42xe_n20_service_provider_server"
           mongosh_run_only_in_package: "service-provider-server"
@@ -9362,11 +9362,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.4.x"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m44xc_n20_service_provider_server"
           mongosh_run_only_in_package: "service-provider-server"
@@ -9379,11 +9379,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.4.x-enterprise"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m44xe_n20_service_provider_server"
           mongosh_run_only_in_package: "service-provider-server"
@@ -9396,11 +9396,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "5.0.x"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m50xc_n20_service_provider_server"
           mongosh_run_only_in_package: "service-provider-server"
@@ -9413,11 +9413,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "5.0.x-enterprise"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m50xe_n20_service_provider_server"
           mongosh_run_only_in_package: "service-provider-server"
@@ -9430,11 +9430,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "6.0.x"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m60xc_n20_service_provider_server"
           mongosh_run_only_in_package: "service-provider-server"
@@ -9447,11 +9447,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "6.0.x-enterprise"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m60xe_n20_service_provider_server"
           mongosh_run_only_in_package: "service-provider-server"
@@ -9464,11 +9464,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "7.0.x"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m70xc_n20_service_provider_server"
           mongosh_run_only_in_package: "service-provider-server"
@@ -9481,11 +9481,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "7.0.x-enterprise"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m70xe_n20_service_provider_server"
           mongosh_run_only_in_package: "service-provider-server"
@@ -9498,11 +9498,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "latest-alpha-enterprise"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "mlatest_n20_service_provider_server"
           mongosh_run_only_in_package: "service-provider-server"
@@ -9702,11 +9702,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.2.x"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m42xc_n20_shell_api"
           mongosh_run_only_in_package: "shell-api"
@@ -9719,11 +9719,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.2.x-enterprise"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m42xe_n20_shell_api"
           mongosh_run_only_in_package: "shell-api"
@@ -9736,11 +9736,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.4.x"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m44xc_n20_shell_api"
           mongosh_run_only_in_package: "shell-api"
@@ -9753,11 +9753,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "4.4.x-enterprise"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m44xe_n20_shell_api"
           mongosh_run_only_in_package: "shell-api"
@@ -9770,11 +9770,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "5.0.x"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m50xc_n20_shell_api"
           mongosh_run_only_in_package: "shell-api"
@@ -9787,11 +9787,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "5.0.x-enterprise"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m50xe_n20_shell_api"
           mongosh_run_only_in_package: "shell-api"
@@ -9804,11 +9804,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "6.0.x"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m60xc_n20_shell_api"
           mongosh_run_only_in_package: "shell-api"
@@ -9821,11 +9821,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "6.0.x-enterprise"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m60xe_n20_shell_api"
           mongosh_run_only_in_package: "shell-api"
@@ -9838,11 +9838,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "7.0.x"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m70xc_n20_shell_api"
           mongosh_run_only_in_package: "shell-api"
@@ -9855,11 +9855,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "7.0.x-enterprise"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "m70xe_n20_shell_api"
           mongosh_run_only_in_package: "shell-api"
@@ -9872,11 +9872,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: "latest-alpha-enterprise"
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "mlatest_n20_shell_api"
           mongosh_run_only_in_package: "shell-api"
@@ -10076,11 +10076,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: ""
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "n20_shell_evaluator"
           mongosh_run_only_in_package: "shell-evaluator"
@@ -10110,11 +10110,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: ""
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "n20_snippet_manager"
           mongosh_run_only_in_package: "snippet-manager"
@@ -10144,11 +10144,11 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test
         vars:
           mongosh_server_test_version: ""
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_skip_node_version_check: ""
           mongosh_test_id: "n20_types"
           mongosh_run_only_in_package: "types"
@@ -10182,10 +10182,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test_vscode
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
   - name: test_connectivity
     tags: ["extra-integration-test"]
     depends_on:
@@ -10195,10 +10195,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test_connectivity
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
   - name: test_apistrict
     tags: ["extra-integration-test"]
     depends_on:
@@ -10208,10 +10208,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test_apistrict
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_server_test_version: "latest-alpha-enterprise"
           mongosh_test_force_api_strict: "1"
   - name: compile_artifact
@@ -10222,10 +10222,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: compile_artifact
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
 
   - name: generate_license_and_vulnerability_report
     depends_on:
@@ -10235,10 +10235,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: generate_license_and_vulnerability_report
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
 
   ###
   # E2E TESTS
@@ -10252,13 +10252,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: darwin-x64
       - func: run_e2e_tests
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_server_test_version: "stable-enterprise"
           mongosh_test_e2e_force_fips: "1"
           disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
@@ -10271,13 +10271,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: darwin-x64
       - func: run_e2e_tests
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_server_test_version: "stable-enterprise"
           mongosh_test_e2e_force_fips: ""
           disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
@@ -10290,13 +10290,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: darwin-x64
       - func: run_e2e_tests
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_server_test_version: "6.0.x-enterprise"
           mongosh_test_e2e_force_fips: "1"
           disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
@@ -10309,13 +10309,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: darwin-x64
       - func: run_e2e_tests
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_server_test_version: "6.0.x-enterprise"
           mongosh_test_e2e_force_fips: ""
           disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
@@ -10328,13 +10328,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: darwin-arm64
       - func: run_e2e_tests
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_server_test_version: "stable-enterprise"
           mongosh_test_e2e_force_fips: "1"
           disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
@@ -10347,13 +10347,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: darwin-arm64
       - func: run_e2e_tests
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_server_test_version: "stable-enterprise"
           mongosh_test_e2e_force_fips: ""
           disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
@@ -10366,13 +10366,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: darwin-arm64
       - func: run_e2e_tests
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_server_test_version: "6.0.x-enterprise"
           mongosh_test_e2e_force_fips: "1"
           disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
@@ -10385,13 +10385,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: darwin-arm64
       - func: run_e2e_tests
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_server_test_version: "6.0.x-enterprise"
           mongosh_test_e2e_force_fips: ""
           disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
@@ -10404,13 +10404,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64
       - func: run_e2e_tests
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_server_test_version: "stable-enterprise"
           mongosh_test_e2e_force_fips: "1"
           disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
@@ -10423,13 +10423,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64
       - func: run_e2e_tests
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_server_test_version: "stable-enterprise"
           mongosh_test_e2e_force_fips: ""
           disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
@@ -10442,13 +10442,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64
       - func: run_e2e_tests
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_server_test_version: "6.0.x-enterprise"
           mongosh_test_e2e_force_fips: "1"
           disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
@@ -10461,13 +10461,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64
       - func: run_e2e_tests
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_server_test_version: "6.0.x-enterprise"
           mongosh_test_e2e_force_fips: ""
           disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
@@ -10480,13 +10480,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64-openssl11
       - func: run_e2e_tests
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_server_test_version: "stable-enterprise"
           mongosh_test_e2e_force_fips: "1"
           disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
@@ -10499,13 +10499,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64-openssl11
       - func: run_e2e_tests
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_server_test_version: "stable-enterprise"
           mongosh_test_e2e_force_fips: ""
           disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
@@ -10518,13 +10518,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64-openssl11
       - func: run_e2e_tests
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_server_test_version: "6.0.x-enterprise"
           mongosh_test_e2e_force_fips: "1"
           disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
@@ -10537,13 +10537,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64-openssl11
       - func: run_e2e_tests
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_server_test_version: "6.0.x-enterprise"
           mongosh_test_e2e_force_fips: ""
           disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
@@ -10556,13 +10556,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64-openssl3
       - func: run_e2e_tests
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_server_test_version: "stable-enterprise"
           mongosh_test_e2e_force_fips: "1"
           disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
@@ -10575,13 +10575,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64-openssl3
       - func: run_e2e_tests
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_server_test_version: "stable-enterprise"
           mongosh_test_e2e_force_fips: ""
           disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
@@ -10594,13 +10594,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64-openssl3
       - func: run_e2e_tests
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_server_test_version: "6.0.x-enterprise"
           mongosh_test_e2e_force_fips: "1"
           disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
@@ -10613,13 +10613,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64-openssl3
       - func: run_e2e_tests
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_server_test_version: "6.0.x-enterprise"
           mongosh_test_e2e_force_fips: ""
           disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
@@ -10632,13 +10632,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64
       - func: run_e2e_tests
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_server_test_version: "stable-enterprise"
           mongosh_test_e2e_force_fips: "1"
           disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
@@ -10651,13 +10651,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64
       - func: run_e2e_tests
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_server_test_version: "stable-enterprise"
           mongosh_test_e2e_force_fips: ""
           disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
@@ -10670,13 +10670,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64
       - func: run_e2e_tests
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_server_test_version: "6.0.x-enterprise"
           mongosh_test_e2e_force_fips: "1"
           disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
@@ -10689,13 +10689,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64
       - func: run_e2e_tests
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_server_test_version: "6.0.x-enterprise"
           mongosh_test_e2e_force_fips: ""
           disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
@@ -10708,13 +10708,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64-openssl11
       - func: run_e2e_tests
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_server_test_version: "stable-enterprise"
           mongosh_test_e2e_force_fips: "1"
           disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
@@ -10727,13 +10727,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64-openssl11
       - func: run_e2e_tests
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_server_test_version: "stable-enterprise"
           mongosh_test_e2e_force_fips: ""
           disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
@@ -10746,13 +10746,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64-openssl11
       - func: run_e2e_tests
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_server_test_version: "6.0.x-enterprise"
           mongosh_test_e2e_force_fips: "1"
           disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
@@ -10765,13 +10765,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64-openssl11
       - func: run_e2e_tests
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_server_test_version: "6.0.x-enterprise"
           mongosh_test_e2e_force_fips: ""
           disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
@@ -10784,13 +10784,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64-openssl3
       - func: run_e2e_tests
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_server_test_version: "stable-enterprise"
           mongosh_test_e2e_force_fips: "1"
           disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
@@ -10803,13 +10803,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64-openssl3
       - func: run_e2e_tests
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_server_test_version: "stable-enterprise"
           mongosh_test_e2e_force_fips: ""
           disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
@@ -10822,13 +10822,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64-openssl3
       - func: run_e2e_tests
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_server_test_version: "6.0.x-enterprise"
           mongosh_test_e2e_force_fips: "1"
           disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
@@ -10841,13 +10841,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64-openssl3
       - func: run_e2e_tests
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_server_test_version: "6.0.x-enterprise"
           mongosh_test_e2e_force_fips: ""
           disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
@@ -10860,13 +10860,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-ppc64le
       - func: run_e2e_tests
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_server_test_version: "stable-enterprise"
           mongosh_test_e2e_force_fips: "1"
           disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
@@ -10879,13 +10879,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-ppc64le
       - func: run_e2e_tests
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_server_test_version: "stable-enterprise"
           mongosh_test_e2e_force_fips: ""
           disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
@@ -10898,13 +10898,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-ppc64le
       - func: run_e2e_tests
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_server_test_version: "6.0.x-enterprise"
           mongosh_test_e2e_force_fips: "1"
           disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
@@ -10917,13 +10917,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-ppc64le
       - func: run_e2e_tests
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_server_test_version: "6.0.x-enterprise"
           mongosh_test_e2e_force_fips: ""
           disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
@@ -10936,13 +10936,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-s390x
       - func: run_e2e_tests
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_server_test_version: "stable-enterprise"
           mongosh_test_e2e_force_fips: "1"
           disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
@@ -10955,13 +10955,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-s390x
       - func: run_e2e_tests
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_server_test_version: "stable-enterprise"
           mongosh_test_e2e_force_fips: ""
           disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
@@ -10974,13 +10974,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-s390x
       - func: run_e2e_tests
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_server_test_version: "6.0.x-enterprise"
           mongosh_test_e2e_force_fips: "1"
           disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
@@ -10993,13 +10993,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-s390x
       - func: run_e2e_tests
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_server_test_version: "6.0.x-enterprise"
           mongosh_test_e2e_force_fips: ""
           disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
@@ -11012,13 +11012,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: win32
       - func: run_e2e_tests
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_server_test_version: "stable-enterprise"
           mongosh_test_e2e_force_fips: "1"
           disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
@@ -11031,13 +11031,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: win32
       - func: run_e2e_tests
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_server_test_version: "stable-enterprise"
           mongosh_test_e2e_force_fips: ""
           disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
@@ -11050,13 +11050,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: win32
       - func: run_e2e_tests
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_server_test_version: "6.0.x-enterprise"
           mongosh_test_e2e_force_fips: "1"
           disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
@@ -11069,13 +11069,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: win32
       - func: run_e2e_tests
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           mongosh_server_test_version: "6.0.x-enterprise"
           mongosh_test_e2e_force_fips: ""
           disable_openssl_shared_config_for_bundled_openssl: ${disable_openssl_shared_config_for_bundled_openssl|false}
@@ -11092,13 +11092,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64
       - func: test_connectivity
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           test_mongosh_executable: dist/mongosh
           kerberos_jumphost_dockerfile: "Dockerfile.rocky8"
   - name: executable_connectivity_test_linux_x64_ubuntu2004
@@ -11110,13 +11110,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64
       - func: test_connectivity
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           test_mongosh_executable: dist/mongosh
           kerberos_jumphost_dockerfile: "Dockerfile.ubuntu2004"
   - name: executable_connectivity_test_linux_x64_node20
@@ -11128,13 +11128,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64
       - func: test_connectivity
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           test_mongosh_executable: dist/mongosh
           kerberos_jumphost_dockerfile: "Dockerfile.node20"
   - name: executable_connectivity_test_linux_x64_rocky9
@@ -11146,13 +11146,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64
       - func: test_connectivity
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           test_mongosh_executable: dist/mongosh
           kerberos_jumphost_dockerfile: "Dockerfile.rocky9"
   - name: executable_connectivity_test_linux_x64_ubuntu2204
@@ -11164,13 +11164,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64
       - func: test_connectivity
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           test_mongosh_executable: dist/mongosh
           kerberos_jumphost_dockerfile: "Dockerfile.ubuntu2204"
   - name: executable_connectivity_test_linux_x64_openssl11_rocky8
@@ -11182,13 +11182,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64-openssl11
       - func: test_connectivity
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           test_mongosh_executable: dist/mongosh
           kerberos_jumphost_dockerfile: "Dockerfile.rocky8"
   - name: executable_connectivity_test_linux_x64_openssl11_ubuntu2004
@@ -11200,13 +11200,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64-openssl11
       - func: test_connectivity
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           test_mongosh_executable: dist/mongosh
           kerberos_jumphost_dockerfile: "Dockerfile.ubuntu2004"
   - name: executable_connectivity_test_linux_x64_openssl3_node20
@@ -11218,13 +11218,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64-openssl3
       - func: test_connectivity
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           test_mongosh_executable: dist/mongosh
           kerberos_jumphost_dockerfile: "Dockerfile.node20"
   - name: executable_connectivity_test_linux_x64_openssl3_rocky9
@@ -11236,13 +11236,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64-openssl3
       - func: test_connectivity
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           test_mongosh_executable: dist/mongosh
           kerberos_jumphost_dockerfile: "Dockerfile.rocky9"
   - name: executable_connectivity_test_linux_x64_openssl3_ubuntu2204
@@ -11254,13 +11254,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64-openssl3
       - func: test_connectivity
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           test_mongosh_executable: dist/mongosh
           kerberos_jumphost_dockerfile: "Dockerfile.ubuntu2204"
   - name: executable_connectivity_test_linux_arm64_rocky8
@@ -11272,13 +11272,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64
       - func: test_connectivity
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           test_mongosh_executable: dist/mongosh
           kerberos_jumphost_dockerfile: "Dockerfile.rocky8"
   - name: executable_connectivity_test_linux_arm64_ubuntu2004
@@ -11290,13 +11290,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64
       - func: test_connectivity
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           test_mongosh_executable: dist/mongosh
           kerberos_jumphost_dockerfile: "Dockerfile.ubuntu2004"
   - name: executable_connectivity_test_linux_arm64_node20
@@ -11308,13 +11308,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64
       - func: test_connectivity
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           test_mongosh_executable: dist/mongosh
           kerberos_jumphost_dockerfile: "Dockerfile.node20"
   - name: executable_connectivity_test_linux_arm64_rocky9
@@ -11326,13 +11326,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64
       - func: test_connectivity
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           test_mongosh_executable: dist/mongosh
           kerberos_jumphost_dockerfile: "Dockerfile.rocky9"
   - name: executable_connectivity_test_linux_arm64_ubuntu2204
@@ -11344,13 +11344,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64
       - func: test_connectivity
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           test_mongosh_executable: dist/mongosh
           kerberos_jumphost_dockerfile: "Dockerfile.ubuntu2204"
   - name: executable_connectivity_test_linux_arm64_openssl11_rocky8
@@ -11362,13 +11362,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64-openssl11
       - func: test_connectivity
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           test_mongosh_executable: dist/mongosh
           kerberos_jumphost_dockerfile: "Dockerfile.rocky8"
   - name: executable_connectivity_test_linux_arm64_openssl11_ubuntu2004
@@ -11380,13 +11380,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64-openssl11
       - func: test_connectivity
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           test_mongosh_executable: dist/mongosh
           kerberos_jumphost_dockerfile: "Dockerfile.ubuntu2004"
   - name: executable_connectivity_test_linux_arm64_openssl3_node20
@@ -11398,13 +11398,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64-openssl3
       - func: test_connectivity
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           test_mongosh_executable: dist/mongosh
           kerberos_jumphost_dockerfile: "Dockerfile.node20"
   - name: executable_connectivity_test_linux_arm64_openssl3_rocky9
@@ -11416,13 +11416,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64-openssl3
       - func: test_connectivity
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           test_mongosh_executable: dist/mongosh
           kerberos_jumphost_dockerfile: "Dockerfile.rocky9"
   - name: executable_connectivity_test_linux_arm64_openssl3_ubuntu2204
@@ -11434,13 +11434,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64-openssl3
       - func: test_connectivity
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           test_mongosh_executable: dist/mongosh
           kerberos_jumphost_dockerfile: "Dockerfile.ubuntu2204"
 
@@ -11455,10 +11455,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: package_and_upload_artifact
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           package_variant: darwin-x64
           executable_os_id: darwin-x64
   - name: package_and_upload_artifact_darwin_arm64
@@ -11469,10 +11469,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: package_and_upload_artifact
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           package_variant: darwin-arm64
           executable_os_id: darwin-arm64
   - name: package_and_upload_artifact_linux_x64
@@ -11483,10 +11483,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: package_and_upload_artifact
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           package_variant: linux-x64
           executable_os_id: linux-x64
   - name: package_and_upload_artifact_deb_x64
@@ -11497,10 +11497,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: package_and_upload_artifact
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           package_variant: deb-x64
           executable_os_id: linux-x64
   - name: package_and_upload_artifact_rpm_x64
@@ -11511,10 +11511,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: package_and_upload_artifact
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           package_variant: rpm-x64
           executable_os_id: linux-x64
   - name: package_and_upload_artifact_linux_x64_openssl11
@@ -11525,10 +11525,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: package_and_upload_artifact
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           package_variant: linux-x64-openssl11
           executable_os_id: linux-x64-openssl11
   - name: package_and_upload_artifact_deb_x64_openssl11
@@ -11539,10 +11539,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: package_and_upload_artifact
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           package_variant: deb-x64-openssl11
           executable_os_id: linux-x64-openssl11
   - name: package_and_upload_artifact_rpm_x64_openssl11
@@ -11553,10 +11553,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: package_and_upload_artifact
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           package_variant: rpm-x64-openssl11
           executable_os_id: linux-x64-openssl11
   - name: package_and_upload_artifact_linux_x64_openssl3
@@ -11567,10 +11567,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: package_and_upload_artifact
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           package_variant: linux-x64-openssl3
           executable_os_id: linux-x64-openssl3
   - name: package_and_upload_artifact_deb_x64_openssl3
@@ -11581,10 +11581,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: package_and_upload_artifact
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           package_variant: deb-x64-openssl3
           executable_os_id: linux-x64-openssl3
   - name: package_and_upload_artifact_rpm_x64_openssl3
@@ -11595,10 +11595,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: package_and_upload_artifact
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           package_variant: rpm-x64-openssl3
           executable_os_id: linux-x64-openssl3
   - name: package_and_upload_artifact_linux_arm64
@@ -11609,10 +11609,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: package_and_upload_artifact
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           package_variant: linux-arm64
           executable_os_id: linux-arm64
   - name: package_and_upload_artifact_deb_arm64
@@ -11623,10 +11623,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: package_and_upload_artifact
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           package_variant: deb-arm64
           executable_os_id: linux-arm64
   - name: package_and_upload_artifact_rpm_arm64
@@ -11637,10 +11637,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: package_and_upload_artifact
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           package_variant: rpm-arm64
           executable_os_id: linux-arm64
   - name: package_and_upload_artifact_linux_arm64_openssl11
@@ -11651,10 +11651,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: package_and_upload_artifact
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           package_variant: linux-arm64-openssl11
           executable_os_id: linux-arm64-openssl11
   - name: package_and_upload_artifact_deb_arm64_openssl11
@@ -11665,10 +11665,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: package_and_upload_artifact
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           package_variant: deb-arm64-openssl11
           executable_os_id: linux-arm64-openssl11
   - name: package_and_upload_artifact_rpm_arm64_openssl11
@@ -11679,10 +11679,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: package_and_upload_artifact
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           package_variant: rpm-arm64-openssl11
           executable_os_id: linux-arm64-openssl11
   - name: package_and_upload_artifact_linux_arm64_openssl3
@@ -11693,10 +11693,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: package_and_upload_artifact
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           package_variant: linux-arm64-openssl3
           executable_os_id: linux-arm64-openssl3
   - name: package_and_upload_artifact_deb_arm64_openssl3
@@ -11707,10 +11707,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: package_and_upload_artifact
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           package_variant: deb-arm64-openssl3
           executable_os_id: linux-arm64-openssl3
   - name: package_and_upload_artifact_rpm_arm64_openssl3
@@ -11721,10 +11721,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: package_and_upload_artifact
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           package_variant: rpm-arm64-openssl3
           executable_os_id: linux-arm64-openssl3
   - name: package_and_upload_artifact_linux_ppc64le
@@ -11735,10 +11735,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: package_and_upload_artifact
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           package_variant: linux-ppc64le
           executable_os_id: linux-ppc64le
   - name: package_and_upload_artifact_rpm_ppc64le
@@ -11749,10 +11749,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: package_and_upload_artifact
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           package_variant: rpm-ppc64le
           executable_os_id: linux-ppc64le
   - name: package_and_upload_artifact_linux_s390x
@@ -11763,10 +11763,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: package_and_upload_artifact
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           package_variant: linux-s390x
           executable_os_id: linux-s390x
   - name: package_and_upload_artifact_rpm_s390x
@@ -11777,10 +11777,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: package_and_upload_artifact
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           package_variant: rpm-s390x
           executable_os_id: linux-s390x
   - name: package_and_upload_artifact_win32_x64
@@ -11791,10 +11791,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: package_and_upload_artifact
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           package_variant: win32-x64
           executable_os_id: win32
   - name: package_and_upload_artifact_win32msi_x64
@@ -11805,10 +11805,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: package_and_upload_artifact
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           package_variant: win32msi-x64
           executable_os_id: win32
 
@@ -11852,10 +11852,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           dockerfile: ubuntu20.04-tgz
   - name: pkg_test_docker_deb_x64_ubuntu18_04_deb
     tags: ["smoke-test"]
@@ -11870,10 +11870,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           dockerfile: ubuntu18.04-deb
   - name: pkg_test_docker_deb_x64_ubuntu20_04_deb
     tags: ["smoke-test"]
@@ -11888,10 +11888,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           dockerfile: ubuntu20.04-deb
   - name: pkg_test_docker_deb_x64_ubuntu22_04_deb
     tags: ["smoke-test"]
@@ -11906,10 +11906,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           dockerfile: ubuntu22.04-deb
   - name: pkg_test_docker_deb_x64_ubuntu22_04_nohome_deb
     tags: ["smoke-test"]
@@ -11924,10 +11924,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           dockerfile: ubuntu22.04-nohome-deb
   - name: pkg_test_docker_deb_x64_debian10_deb
     tags: ["smoke-test"]
@@ -11942,10 +11942,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           dockerfile: debian10-deb
   - name: pkg_test_docker_deb_x64_debian11_deb
     tags: ["smoke-test"]
@@ -11960,10 +11960,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           dockerfile: debian11-deb
   - name: pkg_test_docker_deb_x64_debian12_deb
     tags: ["smoke-test"]
@@ -11978,10 +11978,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           dockerfile: debian12-deb
   - name: pkg_test_docker_rpm_x64_centos7_rpm
     tags: ["smoke-test"]
@@ -11996,10 +11996,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           dockerfile: centos7-rpm
   - name: pkg_test_docker_rpm_x64_amazonlinux2_rpm
     tags: ["smoke-test"]
@@ -12014,10 +12014,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           dockerfile: amazonlinux2-rpm
   - name: pkg_test_docker_rpm_x64_amazonlinux2023_rpm
     tags: ["smoke-test"]
@@ -12032,10 +12032,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           dockerfile: amazonlinux2023-rpm
   - name: pkg_test_docker_rpm_x64_rocky8_rpm
     tags: ["smoke-test"]
@@ -12050,10 +12050,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           dockerfile: rocky8-rpm
   - name: pkg_test_docker_rpm_x64_rocky9_rpm
     tags: ["smoke-test"]
@@ -12068,10 +12068,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           dockerfile: rocky9-rpm
   - name: pkg_test_docker_rpm_x64_fedora34_rpm
     tags: ["smoke-test"]
@@ -12086,10 +12086,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           dockerfile: fedora34-rpm
   - name: pkg_test_docker_rpm_x64_suse12_rpm
     tags: ["smoke-test"]
@@ -12104,10 +12104,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           dockerfile: suse12-rpm
   - name: pkg_test_docker_rpm_x64_suse15_rpm
     tags: ["smoke-test"]
@@ -12122,10 +12122,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           dockerfile: suse15-rpm
   - name: pkg_test_docker_deb_x64_openssl11_ubuntu20_04_deb
     tags: ["smoke-test"]
@@ -12140,10 +12140,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           dockerfile: ubuntu20.04-deb
   - name: pkg_test_docker_deb_x64_openssl11_debian10_deb
     tags: ["smoke-test"]
@@ -12158,10 +12158,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           dockerfile: debian10-deb
   - name: pkg_test_docker_deb_x64_openssl11_debian11_deb
     tags: ["smoke-test"]
@@ -12176,10 +12176,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           dockerfile: debian11-deb
   - name: pkg_test_docker_rpm_x64_openssl11_centos7_epel_rpm
     tags: ["smoke-test"]
@@ -12194,10 +12194,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           dockerfile: centos7-epel-rpm
   - name: pkg_test_docker_rpm_x64_openssl11_amazonlinux2_rpm
     tags: ["smoke-test"]
@@ -12212,10 +12212,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           dockerfile: amazonlinux2-rpm
   - name: pkg_test_docker_rpm_x64_openssl11_rocky8_rpm
     tags: ["smoke-test"]
@@ -12230,10 +12230,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           dockerfile: rocky8-rpm
   - name: pkg_test_docker_rpm_x64_openssl11_rocky9_rpm
     tags: ["smoke-test"]
@@ -12248,10 +12248,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           dockerfile: rocky9-rpm
   - name: pkg_test_docker_rpm_x64_openssl11_fedora34_rpm
     tags: ["smoke-test"]
@@ -12266,10 +12266,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           dockerfile: fedora34-rpm
   - name: pkg_test_docker_deb_x64_openssl3_ubuntu22_04_deb
     tags: ["smoke-test"]
@@ -12284,10 +12284,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           dockerfile: ubuntu22.04-deb
   - name: pkg_test_docker_deb_x64_openssl3_ubuntu22_04_fips_deb
     tags: ["smoke-test"]
@@ -12302,10 +12302,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           dockerfile: ubuntu22.04-fips-deb
   - name: pkg_test_docker_deb_x64_openssl3_debian12_deb
     tags: ["smoke-test"]
@@ -12320,10 +12320,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           dockerfile: debian12-deb
   - name: pkg_test_docker_rpm_x64_openssl3_rocky8_epel_rpm
     tags: ["smoke-test"]
@@ -12338,10 +12338,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           dockerfile: rocky8-epel-rpm
   - name: pkg_test_docker_rpm_x64_openssl3_rocky9_rpm
     tags: ["smoke-test"]
@@ -12356,10 +12356,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           dockerfile: rocky9-rpm
   - name: pkg_test_docker_rpm_x64_openssl3_rocky9_fips_rpm
     tags: ["smoke-test"]
@@ -12374,10 +12374,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           dockerfile: rocky9-fips-rpm
   - name: pkg_test_docker_rpm_x64_openssl3_amazonlinux2023_rpm
     tags: ["smoke-test"]
@@ -12392,10 +12392,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           dockerfile: amazonlinux2023-rpm
   - name: pkg_test_docker_linux_arm64_ubuntu20_04_tgz
     tags: ["smoke-test"]
@@ -12410,10 +12410,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           dockerfile: ubuntu20.04-tgz
   - name: pkg_test_docker_deb_arm64_ubuntu18_04_deb
     tags: ["smoke-test"]
@@ -12428,10 +12428,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           dockerfile: ubuntu18.04-deb
   - name: pkg_test_docker_deb_arm64_ubuntu20_04_deb
     tags: ["smoke-test"]
@@ -12446,10 +12446,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           dockerfile: ubuntu20.04-deb
   - name: pkg_test_docker_deb_arm64_ubuntu22_04_deb
     tags: ["smoke-test"]
@@ -12464,10 +12464,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           dockerfile: ubuntu22.04-deb
   - name: pkg_test_docker_deb_arm64_debian10_deb
     tags: ["smoke-test"]
@@ -12482,10 +12482,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           dockerfile: debian10-deb
   - name: pkg_test_docker_deb_arm64_debian11_deb
     tags: ["smoke-test"]
@@ -12500,10 +12500,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           dockerfile: debian11-deb
   - name: pkg_test_docker_deb_arm64_debian12_deb
     tags: ["smoke-test"]
@@ -12518,10 +12518,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           dockerfile: debian12-deb
   - name: pkg_test_docker_rpm_arm64_rocky8_rpm
     tags: ["smoke-test"]
@@ -12536,10 +12536,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           dockerfile: rocky8-rpm
   - name: pkg_test_docker_rpm_arm64_rocky9_rpm
     tags: ["smoke-test"]
@@ -12554,10 +12554,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           dockerfile: rocky9-rpm
   - name: pkg_test_docker_rpm_arm64_fedora34_rpm
     tags: ["smoke-test"]
@@ -12572,10 +12572,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           dockerfile: fedora34-rpm
   - name: pkg_test_docker_rpm_arm64_amazonlinux2_rpm
     tags: ["smoke-test"]
@@ -12590,10 +12590,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           dockerfile: amazonlinux2-rpm
   - name: pkg_test_docker_rpm_arm64_amazonlinux2023_rpm
     tags: ["smoke-test"]
@@ -12608,10 +12608,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           dockerfile: amazonlinux2023-rpm
   - name: pkg_test_docker_deb_arm64_openssl11_ubuntu20_04_deb
     tags: ["smoke-test"]
@@ -12626,10 +12626,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           dockerfile: ubuntu20.04-deb
   - name: pkg_test_docker_deb_arm64_openssl11_debian10_deb
     tags: ["smoke-test"]
@@ -12644,10 +12644,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           dockerfile: debian10-deb
   - name: pkg_test_docker_deb_arm64_openssl11_debian11_deb
     tags: ["smoke-test"]
@@ -12662,10 +12662,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           dockerfile: debian11-deb
   - name: pkg_test_docker_rpm_arm64_openssl11_rocky8_rpm
     tags: ["smoke-test"]
@@ -12680,10 +12680,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           dockerfile: rocky8-rpm
   - name: pkg_test_docker_rpm_arm64_openssl11_rocky9_rpm
     tags: ["smoke-test"]
@@ -12698,10 +12698,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           dockerfile: rocky9-rpm
   - name: pkg_test_docker_rpm_arm64_openssl11_fedora34_rpm
     tags: ["smoke-test"]
@@ -12716,10 +12716,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           dockerfile: fedora34-rpm
   - name: pkg_test_docker_rpm_arm64_openssl11_amazonlinux2_rpm
     tags: ["smoke-test"]
@@ -12734,10 +12734,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           dockerfile: amazonlinux2-rpm
   - name: pkg_test_docker_deb_arm64_openssl3_ubuntu22_04_deb
     tags: ["smoke-test"]
@@ -12752,10 +12752,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           dockerfile: ubuntu22.04-deb
   - name: pkg_test_docker_deb_arm64_openssl3_ubuntu22_04_fips_deb
     tags: ["smoke-test"]
@@ -12770,10 +12770,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           dockerfile: ubuntu22.04-fips-deb
   - name: pkg_test_docker_deb_arm64_openssl3_debian12_deb
     tags: ["smoke-test"]
@@ -12788,10 +12788,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           dockerfile: debian12-deb
   - name: pkg_test_docker_rpm_arm64_openssl3_rocky8_epel_rpm
     tags: ["smoke-test"]
@@ -12806,10 +12806,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           dockerfile: rocky8-epel-rpm
   - name: pkg_test_docker_rpm_arm64_openssl3_rocky9_rpm
     tags: ["smoke-test"]
@@ -12824,10 +12824,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           dockerfile: rocky9-rpm
   - name: pkg_test_docker_rpm_arm64_openssl3_rocky9_fips_rpm
     tags: ["smoke-test"]
@@ -12842,10 +12842,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           dockerfile: rocky9-fips-rpm
   - name: pkg_test_docker_rpm_arm64_openssl3_amazonlinux2023_rpm
     tags: ["smoke-test"]
@@ -12860,10 +12860,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
           dockerfile: amazonlinux2023-rpm
   - name: pkg_test_rpmextract_rpm_ppc64le
     tags: ["smoke-test"]
@@ -12950,10 +12950,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: release_draft
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
   - name: release_publish_dry_run
     git_tag_only: true
     exec_timeout_secs: 86400
@@ -12963,10 +12963,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: release_publish_dry_run
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
   - name: release_publish
     tags: ["publish"]
     git_tag_only: true
@@ -12978,10 +12978,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
       - func: release_publish
         vars:
-          node_js_version: "20.9.0"
+          node_js_version: "20.11.0"
 
 # Need to run builds for every possible build variant.
 buildvariants:

--- a/.evergreen/node-20-latest.json
+++ b/.evergreen/node-20-latest.json
@@ -1,7 +1,7 @@
 {
-  "version": "20.9.0",
+  "version": "20.11.0",
   "major": 20,
-  "minor": 9,
+  "minor": 11,
   "patch": 0,
   "tag": "",
   "codename": "iron",
@@ -10,7 +10,7 @@
   "lts": "2023-10-24T00:00:00.000Z",
   "maintenance": "2024-10-22T00:00:00.000Z",
   "end": "2026-04-30T00:00:00.000Z",
-  "releaseDate": "2023-10-24T00:00:00.000Z",
+  "releaseDate": "2024-01-09T00:00:00.000Z",
   "isLts": true,
   "files": [
     "aix-ppc64",
@@ -36,10 +36,10 @@
     "win-x86-zip"
   ],
   "dependencies": {
-    "npm": "10.1.0",
+    "npm": "10.2.4",
     "v8": "11.3.244.8",
     "uv": "1.46.0",
     "zlib": "1.2.13.1-motley",
-    "openssl": "3.0.10+quic"
+    "openssl": "3.0.12+quic"
   }
 }


### PR DESCRIPTION
Seems to work! This bumps Node.js to 20.11.0, but applies an additional dependency upgrade to c-ares, a DNS library used by Node.js, to fix compilation on Windows. 

(Patch created by cherry-picking nodejs/node@0090c107820 onto v20.11.0 tag, then `git diff HEAD~1 deps > ../mongosh/scripts/nodejs-patches/002-cares-1-25-commit-0090c107820.patch`)