### PR TITLE
fix(shell-api): do not test `validate` command background option MONGOSH-1664

### DIFF
--- a/packages/shell-api/src/integration.spec.ts
+++ b/packages/shell-api/src/integration.spec.ts
@@ -1323,18 +1323,18 @@ describe('Shell API (integration)', function () {
         ).to.equal(true);
       });
 
-      it('validate accepts a background option', async function () {
-        expect(
-          (await collection.validate({ full: false, background: true })).valid
-        ).to.equal(true);
-      });
-
+      // We cannot positively test background: true since it may take a while for
+      // the collection can be 'ready' to be validated on recent (7.3+) server versions,
+      // but we can test that specific argument combinations will be rejected.
       it('validate fails with background: true and full: true', async function () {
         try {
           await collection.validate({ full: true, background: true });
           expect.fail('missed exception');
         } catch (err: any) {
           expect(err.name).to.equal('MongoServerError');
+          expect(err.codeName).to.match(
+            /^(CommandNotSupported|InvalidOptions)$/
+          );
         }
       });
     });


### PR DESCRIPTION
It turns out that actually testing that this option works on latest-alpha builds of the server is pretty tricky. Since we do not actually touch the options in any way in mongosh and just pass them through to the server, it should be okay to drop this test.