### PR TITLE
fix(shell-api): improve error message on reading from secondary via runCommand MONGOSH-1679

### DIFF
--- a/packages/shell-api/src/database.spec.ts
+++ b/packages/shell-api/src/database.spec.ts
@@ -323,6 +323,21 @@ describe('Database', function () {
           }
         );
       });
+
+      it('rephrases the "NotPrimaryNoSecondaryOk" error (version 2)', async function () {
+        const originalError = {
+          message: 'old message',
+          codeName: 'NotPrimaryNoSecondaryOk',
+          code: 13435,
+        }; // Partial<MongoServerError>
+        serviceProvider.runCommandWithCheck.rejects(originalError);
+        const caughtError = await database
+          .runCommand({ someCommand: 'someCollection' })
+          .catch((e) => e);
+        expect(caughtError.message).to.contain(
+          'e.g. db.runCommand({command}, { readPreference: "secondaryPreferred"})'
+        );
+      });
     });
 
     describe('adminCommand', function () {

--- a/packages/shell-api/src/database.spec.ts
+++ b/packages/shell-api/src/database.spec.ts
@@ -31,6 +31,8 @@ import {
   MongoshUnimplementedError,
 } from '@mongosh/errors';
 import type { ClientEncryption } from './field-level-encryption';
+import type { MongoServerError } from 'mongodb';
+
 chai.use(sinonChai);
 
 describe('Database', function () {
@@ -325,11 +327,11 @@ describe('Database', function () {
       });
 
       it('rephrases the "NotPrimaryNoSecondaryOk" error (version 2)', async function () {
-        const originalError = {
+        const originalError: Partial<MongoServerError> = {
           message: 'old message',
           codeName: 'NotPrimaryNoSecondaryOk',
           code: 13435,
-        }; // Partial<MongoServerError>
+        };
         serviceProvider.runCommandWithCheck.rejects(originalError);
         const caughtError = await database
           .runCommand({ someCommand: 'someCollection' })

--- a/packages/shell-api/src/database.spec.ts
+++ b/packages/shell-api/src/database.spec.ts
@@ -326,7 +326,7 @@ describe('Database', function () {
         );
       });
 
-      it('rephrases the "NotPrimaryNoSecondaryOk" error (version 2)', async function () {
+      it('rephrases the "NotPrimaryNoSecondaryOk" error', async function () {
         const originalError: Partial<MongoServerError> = {
           message: 'old message',
           codeName: 'NotPrimaryNoSecondaryOk',
@@ -337,7 +337,7 @@ describe('Database', function () {
           .runCommand({ someCommand: 'someCollection' })
           .catch((e) => e);
         expect(caughtError.message).to.contain(
-          'e.g. db.runCommand({command}, { readPreference: "secondaryPreferred"})'
+          'e.g. db.runCommand({ command }, { readPreference: "secondaryPreferred" })'
         );
       });
     });

--- a/packages/shell-api/src/database.ts
+++ b/packages/shell-api/src/database.ts
@@ -373,7 +373,7 @@ export default class Database extends ShellApiWithMongoClass {
       return await this._runCommand(cmd, options);
     } catch (error: any) {
       if (error.codeName === 'NotPrimaryNoSecondaryOk') {
-        const message = `not primary - consider passing the readPreference option e.g. db.runCommand({ command }, { readPreference: 'secondaryPreferred' })`;
+        const message = `not primary - consider passing the readPreference option e.g. db.runCommand({ command }, { readPreference: "secondaryPreferred" })`;
         (error as Error).message = message;
       }
       throw error;

--- a/packages/shell-api/src/database.ts
+++ b/packages/shell-api/src/database.ts
@@ -52,7 +52,6 @@ import type {
   CheckMetadataConsistencyOptions,
   RunCommandOptions,
 } from '@mongosh/service-provider-core';
-import { MongoServerError } from 'mongodb';
 
 export type CollectionNamesWithTypes = {
   name: string;
@@ -366,7 +365,6 @@ export default class Database extends ShellApiWithMongoClass {
       cmd = { [cmd]: 1 };
     }
 
-    // TODO paula
     try {
       const hiddenCommands = new RegExp(HIDDEN_COMMANDS);
       if (!Object.keys(cmd).some((k) => hiddenCommands.test(k))) {
@@ -375,9 +373,8 @@ export default class Database extends ShellApiWithMongoClass {
       return await this._runCommand(cmd, options);
     } catch (error: any) {
       if (error.codeName === 'NotPrimaryNoSecondaryOk') {
-        const message = `MongoServerError: not primary - consider passing the readPreference option e.g. db.runCommand({command}, { readPreference: "secondaryPreferred"})`;
+        const message = `not primary - consider passing the readPreference option e.g. db.runCommand({command}, { readPreference: "secondaryPreferred"})`;
         (error as Error).message = message;
-        // throw new MongoServerError({ message });
       }
       throw error;
     }

--- a/packages/shell-api/src/database.ts
+++ b/packages/shell-api/src/database.ts
@@ -373,7 +373,7 @@ export default class Database extends ShellApiWithMongoClass {
       return await this._runCommand(cmd, options);
     } catch (error: any) {
       if (error.codeName === 'NotPrimaryNoSecondaryOk') {
-        const message = `not primary - consider passing the readPreference option e.g. db.runCommand({command}, { readPreference: "secondaryPreferred"})`;
+        const message = `not primary - consider passing the readPreference option e.g. db.runCommand({ command }, { readPreference: 'secondaryPreferred' })`;
         (error as Error).message = message;
       }
       throw error;

--- a/packages/shell-api/src/database.ts
+++ b/packages/shell-api/src/database.ts
@@ -52,6 +52,7 @@ import type {
   CheckMetadataConsistencyOptions,
   RunCommandOptions,
 } from '@mongosh/service-provider-core';
+import { MongoServerError } from 'mongodb';
 
 export type CollectionNamesWithTypes = {
   name: string;
@@ -365,11 +366,21 @@ export default class Database extends ShellApiWithMongoClass {
       cmd = { [cmd]: 1 };
     }
 
-    const hiddenCommands = new RegExp(HIDDEN_COMMANDS);
-    if (!Object.keys(cmd).some((k) => hiddenCommands.test(k))) {
-      this._emitDatabaseApiCall('runCommand', { cmd, options });
+    // TODO paula
+    try {
+      const hiddenCommands = new RegExp(HIDDEN_COMMANDS);
+      if (!Object.keys(cmd).some((k) => hiddenCommands.test(k))) {
+        this._emitDatabaseApiCall('runCommand', { cmd, options });
+      }
+      return await this._runCommand(cmd, options);
+    } catch (error: any) {
+      if (error.codeName === 'NotPrimaryNoSecondaryOk') {
+        const message = `MongoServerError: not primary - consider passing the readPreference option e.g. db.runCommand({command}, { readPreference: "secondaryPreferred"})`;
+        (error as Error).message = message;
+        // throw new MongoServerError({ message });
+      }
+      throw error;
     }
-    return this._runCommand(cmd, options);
   }
 
   /**

--- a/packages/shell-api/src/mongo-errors.spec.ts
+++ b/packages/shell-api/src/mongo-errors.spec.ts
@@ -61,6 +61,17 @@ describe('mongo-errors', function () {
         expect(r.code).to.equal(13435);
         expect(r.message).to.contain('setReadPref');
       });
+
+      it('does not rephrase a NotPrimaryNoSecondaryOk error with db.runCommand example', function () {
+        const e = new MongoError(
+          'not primary - consider passing the readPreference option e.g. db.runCommand({command}, { readPreference: "secondaryPreferred"})'
+        );
+        e.code = 13435;
+        const r = rephraseMongoError(e);
+        expect(r).to.equal(e);
+        expect(r.code).to.equal(13435);
+        expect(r.message).not.to.contain('setReadPref');
+      });
     });
   });
 

--- a/packages/shell-api/src/mongo-errors.spec.ts
+++ b/packages/shell-api/src/mongo-errors.spec.ts
@@ -64,7 +64,7 @@ describe('mongo-errors', function () {
 
       it('does not rephrase a NotPrimaryNoSecondaryOk error with db.runCommand example', function () {
         const e = new MongoError(
-          'not primary - consider passing the readPreference option e.g. db.runCommand({command}, { readPreference: "secondaryPreferred"})'
+          'not primary - consider passing the readPreference option e.g. db.runCommand({ command }, { readPreference: "secondaryPreferred" })'
         );
         e.code = 13435;
         const r = rephraseMongoError(e);
@@ -112,7 +112,7 @@ describe('mongo-errors', function () {
         expect.fail('expected error');
       } catch (e: any) {
         expect(e).to.equal(error);
-        expect(e.message).to.contain('not primary and secondaryOk=false');
+        expect(e.message).to.contain('not primary');
         expect(e.message).to.contain('db.getMongo().setReadPref()');
         expect(e.message).to.contain('readPreference');
       }

--- a/packages/shell-api/src/mongo-errors.ts
+++ b/packages/shell-api/src/mongo-errors.ts
@@ -9,8 +9,10 @@ const ERROR_REPHRASES: MongoErrorRephrase[] = [
   {
     // NotPrimaryNoSecondaryOk (also used for old terminology)
     code: 13435,
-    replacement:
-      'not primary and secondaryOk=false - consider using db.getMongo().setReadPref() or readPreference in the connection string',
+    replacement: (message) =>
+      message.includes('db.runCommand')
+        ? message
+        : 'not primary and secondaryOk=false - consider using db.getMongo().setReadPref() or readPreference in the connection string',
   },
 ];
 

--- a/packages/shell-api/src/mongo-errors.ts
+++ b/packages/shell-api/src/mongo-errors.ts
@@ -12,7 +12,7 @@ const ERROR_REPHRASES: MongoErrorRephrase[] = [
     replacement: (message) =>
       message.includes('db.runCommand')
         ? message
-        : 'not primary and secondaryOk=false - consider using db.getMongo().setReadPref() or readPreference in the connection string',
+        : 'not primary - consider using db.getMongo().setReadPref() or readPreference in the connection string',
   },
 ];
 


### PR DESCRIPTION
https://jira.mongodb.org/browse/MONGOSH-1679

Changes:
- `runCommand` in the `shell-api` catches `NotPrimaryNoSecondaryOk` and applies a custom message
- the custom `runCommand` message is ignored in the `mongo-errors` post-processing

Note: I used `codeName` instead of `code` in the new part for readability - I hope it's okay. Let me know if you think it's safe to switch the `mongo-errors` section to also use `codeName`.