### PR TITLE
chore: small fixes from perf investigation

### DIFF
--- a/packages/async-rewriter2/bin/async-rewrite.js
+++ b/packages/async-rewriter2/bin/async-rewrite.js
@@ -2,6 +2,6 @@
 'use strict';
 const AsyncWriter = require('../').default;
 const fs = require('fs');
-const input = fs.readFileSync(process.argv[2]);
+const input = fs.readFileSync(process.argv[2], 'utf8');
 const asyncWriter = new AsyncWriter();
 process.stdout.write(asyncWriter.process(input));

--- a/packages/shell-evaluator/src/shell-evaluator.ts
+++ b/packages/shell-evaluator/src/shell-evaluator.ts
@@ -25,7 +25,9 @@ try {
 }
 if (v8?.startupSnapshot?.isBuildingSnapshot?.()) {
   v8.startupSnapshot.addSerializeCallback(() => {
+    // Ensure that any lazy loading performed by Babel is part of the snapshot
     eval(new AsyncWriter().runtimeSupportCode());
+    eval(new AsyncWriter().process('1+1'));
     hasAlreadyRunGlobalRuntimeSupportEval = true;
   });
 }


### PR DESCRIPTION
No user-facing impact at this time, just two things that I noticed:
- We were consuming Buffers instead of strings in our example script
- We didn't actually run the async rewriter during startup snapshot building, so any lazy loading performed by babel was delayed until runtime; we can save ~75ms startup time by just doing this as part of the snapshot (this will only take effect once snapshots are enabled again, of course).