### PR TITLE
fix(e2e-tests): run in unit test suite MONGOSH-1716

### DIFF
--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -13,6 +13,8 @@
   "scripts": {
     "test": "cross-env TS_NODE_PROJECT=../../configs/tsconfig-mongosh/tsconfig.test.json mocha -r \"../../scripts/import-expansions.js\" --timeout 15000 --colors -r ts-node/register \"./test/e2e*.spec.ts\"",
     "test-ci": "node ../../scripts/run-if-package-requested.js npm test",
+    "test-coverage": "nyc --no-clean --cwd ../.. --reporter=none npm run test",
+    "test-ci-coverage": "nyc --no-clean --cwd ../.. --reporter=none npm run test-ci",
     "eslint": "eslint",
     "lint": "npm run eslint . && npm run prettier -- --check .",
     "check": "npm run lint && npm run depcheck",

--- a/packages/e2e-tests/test/e2e-auth.spec.ts
+++ b/packages/e2e-tests/test/e2e-auth.spec.ts
@@ -282,7 +282,7 @@ describe('Auth e2e', function () {
               shell.assertContainsOutput('{ n: 2, ok: 1 }');
             } catch {
               // The 5.0+ server responds with a Long.
-              shell.assertContainsOutput('{ n: Long("2"), ok: 1 }');
+              shell.assertContainsOutput("{ n: Long('2'), ok: 1 }");
             }
           });
           const result = await db.command({ usersInfo: 1 });
@@ -492,7 +492,7 @@ describe('Auth e2e', function () {
               shell.assertContainsOutput('{ n: 2, ok: 1 }');
             } catch {
               // The 5.0+ server responds with a Long.
-              shell.assertContainsOutput('{ n: Long("2"), ok: 1 }');
+              shell.assertContainsOutput("{ n: Long('2'), ok: 1 }");
             }
           });
           const result = await db.command({ rolesInfo: 1 });


### PR DESCRIPTION
3f55e4c02563a696 did not add a test-ci-coverage task to the e2e-test package, but changed the definition of the unit test tasks in CI to run the test-ci-coverage task, so that e2e tests wouldn't run as part of the unit test suite.