### PR TITLE
fix(ci): fix `release_publish(_dry_run)` parameters

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -6561,7 +6561,7 @@ functions:
 
   write_preload_script:
     - command: shell.exec
-      silent: true
+      # silent: true
       type: setup
       params:
         working_dir: src
@@ -6590,7 +6590,7 @@ functions:
         wait: true
   run_pkg_tests_through_ssh:
     - command: shell.exec
-      silent: true
+      # silent: true
       type: setup
       params:
         working_dir: src
@@ -6844,13 +6844,13 @@ functions:
         file: tmp/expansions.yaml
         redacted: true
     - command: shell.exec
-      silent: true
-      env:
-        devtoolsbot_npm_token: ${devtoolsbot_npm_token}
-        node_js_version: ${node_js_version}
+      # silent: true
       params:
         working_dir: src
         shell: bash
+        env:
+          devtoolsbot_npm_token: ${devtoolsbot_npm_token}
+          node_js_version: ${node_js_version}
         script: |
           set -e
           .evergreen/run-evergreen-release.sh -- --dry-run
@@ -6862,13 +6862,13 @@ functions:
         file: tmp/expansions.yaml
         redacted: true
     - command: shell.exec
-      silent: true
-      env:
-        devtoolsbot_npm_token: ${devtoolsbot_npm_token}
-        node_js_version: ${node_js_version}
+      # silent: true
       params:
         working_dir: src
         shell: bash
+        env:
+          devtoolsbot_npm_token: ${devtoolsbot_npm_token}
+          node_js_version: ${node_js_version}
         script: |
           set -e
           .evergreen/run-evergreen-release.sh

--- a/.evergreen/evergreen.yml.in
+++ b/.evergreen/evergreen.yml.in
@@ -513,7 +513,7 @@ functions:
 
   write_preload_script:
     - command: shell.exec
-      silent: true
+      # silent: true
       type: setup
       params:
         working_dir: src
@@ -542,7 +542,7 @@ functions:
         wait: true
   run_pkg_tests_through_ssh:
     - command: shell.exec
-      silent: true
+      # silent: true
       type: setup
       params:
         working_dir: src
@@ -796,13 +796,13 @@ functions:
         file: tmp/expansions.yaml
         redacted: true
     - command: shell.exec
-      silent: true
-      env:
-        devtoolsbot_npm_token: ${devtoolsbot_npm_token}
-        node_js_version: ${node_js_version}
+      # silent: true
       params:
         working_dir: src
         shell: bash
+        env:
+          devtoolsbot_npm_token: ${devtoolsbot_npm_token}
+          node_js_version: ${node_js_version}
         script: |
           set -e
           .evergreen/run-evergreen-release.sh -- --dry-run
@@ -814,13 +814,13 @@ functions:
         file: tmp/expansions.yaml
         redacted: true
     - command: shell.exec
-      silent: true
-      env:
-        devtoolsbot_npm_token: ${devtoolsbot_npm_token}
-        node_js_version: ${node_js_version}
+      # silent: true
       params:
         working_dir: src
         shell: bash
+        env:
+          devtoolsbot_npm_token: ${devtoolsbot_npm_token}
+          node_js_version: ${node_js_version}
         script: |
           set -e
           .evergreen/run-evergreen-release.sh


### PR DESCRIPTION
cbaeef2879d4c4 recently refactored the evergreen configuration file. This subtly introduced some breakage, because the `env` and `silent` options are not command options, but rather need to be nested under the `params` key.

I've intentionally left the `silent:` option disabled as this would hide genuinely valuable debug output otherwise.

This might be a good point to reconsider fixing the evergreen validation warnings that are displayed in CI; `evergreen validate .evergreen.yml` did catch these issues, but since there are a large number of existing warnings (around dependencies between tasks), these specific warnings were drowned out/not visible in the evergreen UI.