### PR TITLE
chore(ci): add qemu-based regression test for architecture minima

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -11918,6 +11918,24 @@ tasks:
         vars:
           node_js_version: "20.11.1"
           dockerfile: ubuntu22.04-nohome-deb
+  - name: pkg_test_docker_deb_x64_ubuntu22_04_qemu_deb
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_deb_x64
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: deb-x64
+      - func: write_preload_script
+      - func: install
+        vars:
+          node_js_version: "20.11.1"
+      - func: test_artifact_docker
+        vars:
+          node_js_version: "20.11.1"
+          dockerfile: ubuntu22.04-qemu-deb
   - name: pkg_test_docker_deb_x64_debian10_deb
     tags: ["smoke-test"]
     depends_on:
@@ -12458,6 +12476,42 @@ tasks:
         vars:
           node_js_version: "20.11.1"
           dockerfile: ubuntu22.04-deb
+  - name: pkg_test_docker_deb_arm64_ubuntu22_04_nohome_deb
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_deb_arm64
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: deb-arm64
+      - func: write_preload_script
+      - func: install
+        vars:
+          node_js_version: "20.11.1"
+      - func: test_artifact_docker
+        vars:
+          node_js_version: "20.11.1"
+          dockerfile: ubuntu22.04-nohome-deb
+  - name: pkg_test_docker_deb_arm64_ubuntu22_04_qemu_deb
+    tags: ["smoke-test"]
+    depends_on:
+      - name: package_and_upload_artifact_deb_arm64
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: get_artifact_url
+        vars:
+          source_package_variant: deb-arm64
+      - func: write_preload_script
+      - func: install
+        vars:
+          node_js_version: "20.11.1"
+      - func: test_artifact_docker
+        vars:
+          node_js_version: "20.11.1"
+          dockerfile: ubuntu22.04-qemu-deb
   - name: pkg_test_docker_deb_arm64_debian10_deb
     tags: ["smoke-test"]
     depends_on:
@@ -13764,6 +13818,7 @@ buildvariants:
       - name: pkg_test_docker_deb_x64_ubuntu20_04_deb
       - name: pkg_test_docker_deb_x64_ubuntu22_04_deb
       - name: pkg_test_docker_deb_x64_ubuntu22_04_nohome_deb
+      - name: pkg_test_docker_deb_x64_ubuntu22_04_qemu_deb
       - name: pkg_test_docker_deb_x64_debian10_deb
       - name: pkg_test_docker_deb_x64_debian11_deb
       - name: pkg_test_docker_deb_x64_debian12_deb
@@ -13799,6 +13854,8 @@ buildvariants:
       - name: pkg_test_docker_deb_arm64_ubuntu18_04_deb
       - name: pkg_test_docker_deb_arm64_ubuntu20_04_deb
       - name: pkg_test_docker_deb_arm64_ubuntu22_04_deb
+      - name: pkg_test_docker_deb_arm64_ubuntu22_04_nohome_deb
+      - name: pkg_test_docker_deb_arm64_ubuntu22_04_qemu_deb
       - name: pkg_test_docker_deb_arm64_debian10_deb
       - name: pkg_test_docker_deb_arm64_debian11_deb
       - name: pkg_test_docker_deb_arm64_debian12_deb

--- a/config/release-package-matrix.js
+++ b/config/release-package-matrix.js
@@ -48,7 +48,7 @@ exports.RELEASE_PACKAGE_MATRIX = [
     kerberosConnectivityTestDockerfiles: [...krbConnTestsOpenSSL11, ...krbConnTestsOpenSSL3],
     packages: [
       { name: 'linux-x64', description: publicDescriptions.linux_x64, packageType: 'tgz', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['ubuntu20.04-tgz'], serverLikeTargetList: [...allLinux] },
-      { name: 'deb-x64', description: publicDescriptions.debian_x64, packageType: 'deb', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['ubuntu18.04-deb', 'ubuntu20.04-deb', 'ubuntu22.04-deb', 'ubuntu22.04-nohome-deb', 'debian10-deb', 'debian11-deb', 'debian12-deb'], serverLikeTargetList: [...ubuntu1804AndAboveAndDebBased] },
+      { name: 'deb-x64', description: publicDescriptions.debian_x64, packageType: 'deb', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['ubuntu18.04-deb', 'ubuntu20.04-deb', 'ubuntu22.04-deb', 'ubuntu22.04-nohome-deb', 'ubuntu22.04-qemu-deb', 'debian10-deb', 'debian11-deb', 'debian12-deb'], serverLikeTargetList: [...ubuntu1804AndAboveAndDebBased] },
       { name: 'rpm-x64', description: publicDescriptions.rhel_x64, packageType: 'rpm', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['centos7-rpm', 'amazonlinux2-rpm', 'amazonlinux2023-rpm', 'rocky8-rpm', 'rocky9-rpm', 'fedora34-rpm', 'suse12-rpm', 'suse15-rpm'], serverLikeTargetList: [...rhel70AndAboveAndRpmBased] }
     ]
   },
@@ -78,7 +78,7 @@ exports.RELEASE_PACKAGE_MATRIX = [
     kerberosConnectivityTestDockerfiles: [...krbConnTestsOpenSSL11, ...krbConnTestsOpenSSL3],
     packages: [
       { name: 'linux-arm64', description: publicDescriptions.linux_arm64, packageType: 'tgz', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['ubuntu20.04-tgz'], serverLikeTargetList: [...al2AndAbove] },
-      { name: 'deb-arm64', description: publicDescriptions.debian_arm64, packageType: 'deb', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['ubuntu18.04-deb', 'ubuntu20.04-deb', 'ubuntu22.04-deb', 'debian10-deb', 'debian11-deb', 'debian12-deb'], serverLikeTargetList: [...ubuntu1804AndAboveAndDebBased] },
+      { name: 'deb-arm64', description: publicDescriptions.debian_arm64, packageType: 'deb', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['ubuntu18.04-deb', 'ubuntu20.04-deb', 'ubuntu22.04-deb', 'ubuntu22.04-nohome-deb', 'ubuntu22.04-qemu-deb', 'debian10-deb', 'debian11-deb', 'debian12-deb'], serverLikeTargetList: [...ubuntu1804AndAboveAndDebBased] },
       { name: 'rpm-arm64', description: publicDescriptions.rhel_arm64, packageType: 'rpm', packageOn: 'linux_package', smokeTestKind: 'docker', smokeTestDockerfiles: ['rocky8-rpm', 'rocky9-rpm', 'fedora34-rpm', 'amazonlinux2-rpm', 'amazonlinux2023-rpm'], serverLikeTargetList: [...al2AndAbove] }
     ]
   },

--- a/scripts/docker/qemu-wrap.sh
+++ b/scripts/docker/qemu-wrap.sh
@@ -1,0 +1,24 @@
+#!/bin/bash
+set -e
+set -x
+TARGET="$1"
+PROC="$(uname -p)"
+
+case "$PROC" in
+  "aarch64")
+    QEMU_CPU=cortex-a53
+    ;;
+  "x86_64")
+    QEMU_CPU=qemu64
+    ;;
+  *)
+    echo "Unknown processor type '$PROC'"
+    exit 1
+esac
+
+mv -vn "$TARGET" "$TARGET.original"
+cat << EOF > "$TARGET"
+#!/bin/bash
+exec "qemu-$PROC" -cpu "$QEMU_CPU" "$TARGET.original" "\$@"
+EOF
+chmod +x "$TARGET"

--- a/scripts/docker/ubuntu22.04-qemu-deb.Dockerfile
+++ b/scripts/docker/ubuntu22.04-qemu-deb.Dockerfile
@@ -1,0 +1,15 @@
+FROM ubuntu:22.04
+
+ARG artifact_url=""
+ADD ${artifact_url} /tmp
+ADD node_modules /usr/share/mongodb-crypt-library-version/node_modules
+ADD qemu-wrap.sh /tmp
+RUN apt-get update
+RUN yes | unminimize
+RUN apt-get install -y man-db qemu-user
+RUN apt-get install -y /tmp/*mongosh*.deb
+RUN /tmp/qemu-wrap.sh /usr/bin/mongosh
+RUN /usr/bin/mongosh --build-info
+RUN env MONGOSH_RUN_NODE_SCRIPT=1 mongosh /usr/share/mongodb-crypt-library-version/node_modules/.bin/mongodb-crypt-library-version /usr/lib/mongosh_crypt_v1.so | grep -Eq '^mongo_(crypt|csfle)_v1-'
+RUN man mongosh | grep -q tlsAllowInvalidCertificates
+ENTRYPOINT [ "mongosh" ]


### PR DESCRIPTION
To fix MONGOSH-1604, we temporarily disabled startup snapshots in cd6e6af174b. As we are now starting to look into re-enabling this feature again soon, we should have a regression test in place if it’s possible.

This commits adds a docker imagine within which we install qemu-user to emulate the minimum requirements for our supported architectures on arm64 and x64.

(So if this works, we'll be running an emulator inside of a docker container inside of evergreen hosts in CI... 🙂)