### PR TITLE
chore(e2e-tests): account for upstream server TLS option changes MONGOSH-1718

### DIFF
--- a/packages/e2e-tests/test/e2e-tls.spec.ts
+++ b/packages/e2e-tests/test/e2e-tls.spec.ts
@@ -187,7 +187,7 @@ describe('e2e TLS', function () {
         const result = await shell.waitForPromptOrExit();
         expect(result.state).to.equal('exit');
         shell.assertContainsOutput(
-          /unable to verify the first certificate|self-signed certificate in certificate chain/
+          /unable to verify the first certificate|self[- ]signed certificate in certificate chain/
         );
       });
 
@@ -204,7 +204,7 @@ describe('e2e TLS', function () {
         const result = await shell.waitForPromptOrExit();
         expect(result.state).to.equal('exit');
         shell.assertContainsOutput(
-          /unable to verify the first certificate|self-signed certificate in certificate chain/
+          /unable to verify the first certificate|self[- ]signed certificate in certificate chain/
         );
       });
 

--- a/packages/e2e-tests/test/e2e-tls.spec.ts
+++ b/packages/e2e-tests/test/e2e-tls.spec.ts
@@ -115,6 +115,8 @@ describe('e2e TLS', function () {
           '--tlsCertificateKeyFile',
           SERVER_KEY,
           '--tlsAllowConnectionsWithoutCertificates',
+          '--tlsCAFile',
+          CA_CERT,
         ],
       });
 
@@ -184,7 +186,9 @@ describe('e2e TLS', function () {
         });
         const result = await shell.waitForPromptOrExit();
         expect(result.state).to.equal('exit');
-        shell.assertContainsOutput('unable to verify the first certificate');
+        shell.assertContainsOutput(
+          /unable to verify the first certificate|self-signed certificate in certificate chain/
+        );
       });
 
       it('fails with invalid CA (connection string)', async function () {
@@ -199,7 +203,9 @@ describe('e2e TLS', function () {
         });
         const result = await shell.waitForPromptOrExit();
         expect(result.state).to.equal('exit');
-        shell.assertContainsOutput('unable to verify the first certificate');
+        shell.assertContainsOutput(
+          /unable to verify the first certificate|self-signed certificate in certificate chain/
+        );
       });
 
       it('fails when providing a CRL including the servers cert', async function () {
@@ -640,6 +646,8 @@ describe('e2e TLS', function () {
         'requireTLS',
         '--tlsCertificateKeyFile',
         SERVER_INVALIDHOST_KEY,
+        '--tlsCAFile',
+        CA_CERT,
         '--tlsAllowConnectionsWithoutCertificates',
       ],
     });

--- a/packages/e2e-tests/test/test-shell.ts
+++ b/packages/e2e-tests/test/test-shell.ts
@@ -6,6 +6,7 @@ import type {
 } from 'child_process';
 import { spawn } from 'child_process';
 import { once } from 'events';
+import { inspect } from 'util';
 import path from 'path';
 import stripAnsi from 'strip-ansi';
 import { eventually } from '../../../testing/eventually';
@@ -245,9 +246,7 @@ export class TestShell {
     const onlyOutputLines = this._getOutputLines();
     if (!matches(onlyOutputLines.join('\n'), expectedOutput)) {
       throw new assert.AssertionError({
-        message: `Expected shell output to include ${JSON.stringify(
-          expectedOutput
-        )}`,
+        message: `Expected shell output to include ${inspect(expectedOutput)}`,
         actual: this._output,
         expected: expectedOutput,
       });
@@ -259,9 +258,7 @@ export class TestShell {
 
     if (!allErrors.find((error) => matches(error, expectedError))) {
       throw new assert.AssertionError({
-        message: `Expected shell errors to include ${JSON.stringify(
-          expectedError
-        )}`,
+        message: `Expected shell errors to include ${inspect(expectedError)}`,
         actual: this._output,
         expected: expectedError,
       });
@@ -272,7 +269,7 @@ export class TestShell {
     const onlyOutputLines = this._getOutputLines();
     if (matches(onlyOutputLines.join('\n'), unexpectedOutput)) {
       throw new assert.AssertionError({
-        message: `Expected shell output not  to include ${JSON.stringify(
+        message: `Expected shell output not  to include ${inspect(
           unexpectedOutput
         )}`,
         actual: this._output,


### PR DESCRIPTION
The server will no longer start when TLS is enabled without a CA certificate argument. This does not affect our tests’ functionality, only how we start the server in them.