### PR TITLE
chore(ci): use npm@10.x instead of npm@9.x

### DIFF
--- a/.evergreen/install-node.sh
+++ b/.evergreen/install-node.sh
@@ -5,7 +5,7 @@ export BASEDIR="$PWD/.evergreen"
 if [ "$OS" == "Windows_NT" ]; then
   powershell "$(cygpath -w "$BASEDIR")"/InstallNode.ps1
   . "$BASEDIR/setup-env.sh"
-  mkdir -p "$BASEDIR/npm-9" && (cd "$BASEDIR/npm-9" && echo '{}' > package.json && npm i npm@9.x)
+  mkdir -p "$BASEDIR/npm-10" && (cd "$BASEDIR/npm-10" && echo '{}' > package.json && npm i npm@10.x)
 
   curl -sSfLO https://raw.githubusercontent.com/mongodb-js/compass/42e6142ae08be6fec944b80ff6289e6bcd11badf/.evergreen/node-gyp-bug-workaround.sh && bash node-gyp-bug-workaround.sh
 else
@@ -58,7 +58,7 @@ else
   npm cache clear --force || true # Try to work around `Cannot read property 'pickAlgorithm' of null` errors in CI
   # Started observing CI failures on RHEL 7.2 (s390x) for installing npm, all
   # related to network issues hence adding a retry with backoff here.
-  bash "$BASEDIR/retry-with-backoff.sh" npm i -g npm@9.x
+  bash "$BASEDIR/retry-with-backoff.sh" npm i -g npm@10.x
 fi
 
 . "$BASEDIR/setup-env.sh"

--- a/.evergreen/install-node.sh
+++ b/.evergreen/install-node.sh
@@ -6,6 +6,7 @@ if [ "$OS" == "Windows_NT" ]; then
   powershell "$(cygpath -w "$BASEDIR")"/InstallNode.ps1
   . "$BASEDIR/setup-env.sh"
   mkdir -p "$BASEDIR/npm-10" && (cd "$BASEDIR/npm-10" && echo '{}' > package.json && npm i npm@10.x)
+  # using npm 10 because npm 9.9.3 does not install well on windows
 
   curl -sSfLO https://raw.githubusercontent.com/mongodb-js/compass/42e6142ae08be6fec944b80ff6289e6bcd11badf/.evergreen/node-gyp-bug-workaround.sh && bash node-gyp-bug-workaround.sh
 else
@@ -58,7 +59,7 @@ else
   npm cache clear --force || true # Try to work around `Cannot read property 'pickAlgorithm' of null` errors in CI
   # Started observing CI failures on RHEL 7.2 (s390x) for installing npm, all
   # related to network issues hence adding a retry with backoff here.
-  bash "$BASEDIR/retry-with-backoff.sh" npm i -g npm@10.x
+  bash "$BASEDIR/retry-with-backoff.sh" npm i -g npm@9.x
 fi
 
 . "$BASEDIR/setup-env.sh"

--- a/.evergreen/setup-env.sh
+++ b/.evergreen/setup-env.sh
@@ -1,7 +1,7 @@
 set -e
 set -x
 export BASEDIR="$PWD/.evergreen"
-export PATH="/cygdrive/c/python/Python311/Scripts:/cygdrive/c/python/Python311:/cygdrive/c/Python311/Scripts:/cygdrive/c/Python311:/opt/python/3.6/bin:$BASEDIR/mingit/cmd:$BASEDIR/mingit/mingw64/libexec/git-core:$BASEDIR/git-2:$BASEDIR/npm-9/node_modules/.bin:$BASEDIR/node-v$NODE_JS_VERSION-win-x64:/opt/java/jdk16/bin:/opt/chefdk/gitbin:/cygdrive/c/cmake/bin:/opt/mongodbtoolchain/v3/bin:$PATH"
+export PATH="/cygdrive/c/python/Python311/Scripts:/cygdrive/c/python/Python311:/cygdrive/c/Python311/Scripts:/cygdrive/c/Python311:/opt/python/3.6/bin:$BASEDIR/mingit/cmd:$BASEDIR/mingit/mingw64/libexec/git-core:$BASEDIR/git-2:$BASEDIR/npm-10/node_modules/.bin:$BASEDIR/node-v$NODE_JS_VERSION-win-x64:/opt/java/jdk16/bin:/opt/chefdk/gitbin:/cygdrive/c/cmake/bin:/opt/mongodbtoolchain/v3/bin:$PATH"
 export IS_MONGOSH_EVERGREEN_CI=1
 export DEBUG="mongodb*,$DEBUG"
 

--- a/scripts/docker/rocky8-package.Dockerfile
+++ b/scripts/docker/rocky8-package.Dockerfile
@@ -9,7 +9,7 @@ RUN dnf -y install python3 rpm-build dpkg-devel dpkg-dev git
 # Add Node.js
 RUN curl -sL https://rpm.nodesource.com/setup_20.x | bash -
 RUN dnf install -y nodejs
-RUN npm i -g npm@9.x
+RUN npm i -g npm@10.x
 # For some reason npm@8 failed silently (!) when $HOME was
 # set to /root and consequently $HOME/.npm was not writable
 RUN mkdir -p /tmp/home


### PR DESCRIPTION
npm 9.9.3 was released yesterday and broke Windows CI because it was not installable from the previous npm version. In a spawn host, using npm 10.x worked instead, so let’s go with that.