### PR TITLE
feat: replace Node.js REPL with plain vm context for script usage MONGOSH-1720

### DIFF
--- a/packages/arg-parser/src/cli-options.ts
+++ b/packages/arg-parser/src/cli-options.ts
@@ -26,6 +26,7 @@ export interface CliOptions {
   help?: boolean;
   host?: string;
   ipv6?: boolean;
+  jsContext?: 'repl' | 'plain-vm' | 'auto';
   json?: boolean | 'canonical' | 'relaxed';
   keyVaultNamespace?: string;
   kmsURL?: string;

--- a/packages/cli-repl/src/arg-parser.ts
+++ b/packages/cli-repl/src/arg-parser.ts
@@ -31,6 +31,7 @@ const OPTIONS = {
     'gssapiServiceName',
     'sspiHostnameCanonicalization',
     'sspiRealmOverride',
+    'jsContext',
     'host',
     'keyVaultNamespace',
     'kmsURL',

--- a/packages/cli-repl/src/cli-repl.ts
+++ b/packages/cli-repl/src/cli-repl.ts
@@ -100,7 +100,7 @@ type CliUserConfigOnDisk = Partial<CliUserConfig> &
 export class CliRepl implements MongoshIOProvider {
   mongoshRepl: MongoshNodeRepl;
   bus: MongoshBus;
-  cliOptions: CliOptions;
+  cliOptions: Readonly<CliOptions>;
   getCryptLibraryPaths?: (bus: MongoshBus) => Promise<CryptLibraryPathResult>;
   cachedCryptLibraryPath?: Promise<CryptLibraryPathResult>;
   shellHomeDirectory: ShellHomeDirectory;
@@ -186,8 +186,17 @@ export class CliRepl implements MongoshIOProvider {
       this.bus.emit('mongosh:error', err, 'io');
     });
 
+    let jsContext = this.cliOptions.jsContext;
+    if (jsContext === 'auto' || !jsContext) {
+      jsContext = CliRepl.getFileAndEvalInfo(this.cliOptions)
+        .willEnterInteractiveMode
+        ? 'repl'
+        : 'plain-vm';
+    }
+
     this.mongoshRepl = new MongoshNodeRepl({
       ...options,
+      shellCliOptions: { ...this.cliOptions, jsContext },
       nodeReplOptions: options.nodeReplOptions ?? {
         terminal: process.env.MONGOSH_FORCE_TERMINAL ? true : undefined,
       },
@@ -373,12 +382,12 @@ export class CliRepl implements MongoshIOProvider {
     markTime(TimingCategories.REPLInstantiation, 'initialized mongosh repl');
     this.injectReplFunctions();
 
-    const commandLineLoadFiles = this.cliOptions.fileNames ?? [];
-    const evalScripts = this.cliOptions.eval ?? [];
-    const willExecuteCommandLineScripts =
-      commandLineLoadFiles.length > 0 || evalScripts.length > 0;
-    const willEnterInteractiveMode =
-      !willExecuteCommandLineScripts || !!this.cliOptions.shell;
+    const {
+      commandLineLoadFiles,
+      evalScripts,
+      willEnterInteractiveMode,
+      willExecuteCommandLineScripts,
+    } = CliRepl.getFileAndEvalInfo(this.cliOptions);
 
     if (
       (evalScripts.length === 0 ||
@@ -478,13 +487,33 @@ export class CliRepl implements MongoshIOProvider {
     });
   }
 
+  private static getFileAndEvalInfo(cliOptions: CliOptions): {
+    commandLineLoadFiles: string[];
+    evalScripts: string[];
+    willExecuteCommandLineScripts: boolean;
+    willEnterInteractiveMode: boolean;
+  } {
+    const commandLineLoadFiles = cliOptions.fileNames ?? [];
+    const evalScripts = cliOptions.eval ?? [];
+    const willExecuteCommandLineScripts =
+      commandLineLoadFiles.length > 0 || evalScripts.length > 0;
+    const willEnterInteractiveMode =
+      !willExecuteCommandLineScripts || !!cliOptions.shell;
+    return {
+      commandLineLoadFiles,
+      evalScripts,
+      willEnterInteractiveMode,
+      willExecuteCommandLineScripts,
+    };
+  }
+
   injectReplFunctions(): void {
     const functions = {
       async buildInfo() {
         return await buildInfo();
       },
     } as const;
-    const { context } = this.mongoshRepl.runtimeState().repl;
+    const { context } = this.mongoshRepl.runtimeState();
     for (const [name, impl] of Object.entries(functions)) {
       context[name] = (...args: Parameters<typeof impl>) => {
         return Object.assign(impl(...args), {

--- a/packages/cli-repl/src/cli-repl.ts
+++ b/packages/cli-repl/src/cli-repl.ts
@@ -425,6 +425,7 @@ export class CliRepl implements MongoshIOProvider {
 
       this.bus.emit('mongosh:start-session', {
         isInteractive: false,
+        jsContext: this.mongoshRepl.jsContext(),
         timings: summariseTimingData(getTimingData()),
       });
 
@@ -483,6 +484,7 @@ export class CliRepl implements MongoshIOProvider {
     await this.mongoshRepl.startRepl(initialized);
     this.bus.emit('mongosh:start-session', {
       isInteractive: true,
+      jsContext: this.mongoshRepl.jsContext(),
       timings: summariseTimingData(getTimingData()),
     });
   }

--- a/packages/cli-repl/src/mongosh-repl.ts
+++ b/packages/cli-repl/src/mongosh-repl.ts
@@ -1127,6 +1127,10 @@ class MongoshNodeRepl implements EvaluationListener {
     }
     return '> ';
   }
+
+  jsContext(): JSContext {
+    return this.runtimeState().repl ? 'repl' : 'plain-vm';
+  }
 }
 
 /**

--- a/packages/cli-repl/src/mongosh-repl.ts
+++ b/packages/cli-repl/src/mongosh-repl.ts
@@ -733,35 +733,35 @@ class MongoshNodeRepl implements EvaluationListener {
     const { repl, context } = this.runtimeState();
     if (repl) {
       return await promisify(repl.eval.bind(repl))(input, context, filename);
-    } else {
-      let asyncSigintHandler!: () => void;
-      const asyncSigintPromise = new Promise((resolve, reject) => {
-        asyncSigintHandler = () => {
-          void this.onAsyncSigint();
-          setImmediate(() =>
-            reject(
-              new Error('Asynchronous execution was interrupted by `SIGINT`')
-            )
-          );
-        };
-      });
-      try {
-        process.addListener('SIGINT', asyncSigintHandler);
-        return await Promise.race([
-          asyncSigintPromise,
-          this.eval(
-            (input, context, filename) =>
-              new Script(input, { filename }).runInContext(context, {
-                breakOnSigint: true,
-              }),
-            input,
-            context,
-            filename
-          ),
-        ]);
-      } finally {
-        process.removeListener('SIGINT', asyncSigintHandler);
-      }
+    }
+
+    let asyncSigintHandler!: () => void;
+    const asyncSigintPromise = new Promise((resolve, reject) => {
+      asyncSigintHandler = () => {
+        void this.onAsyncSigint();
+        setImmediate(() =>
+          reject(
+            new Error('Asynchronous execution was interrupted by `SIGINT`')
+          )
+        );
+      };
+    });
+    try {
+      process.addListener('SIGINT', asyncSigintHandler);
+      return await Promise.race([
+        asyncSigintPromise,
+        this.eval(
+          (input, context, filename) =>
+            new Script(input, { filename }).runInContext(context, {
+              breakOnSigint: true,
+            }),
+          input,
+          context,
+          filename
+        ),
+      ]);
+    } finally {
+      process.removeListener('SIGINT', asyncSigintHandler);
     }
   }
 

--- a/packages/cli-repl/src/mongosh-repl.ts
+++ b/packages/cli-repl/src/mongosh-repl.ts
@@ -968,11 +968,12 @@ class MongoshNodeRepl implements EvaluationListener {
    * Provides the current set of output formatting options used for this shell.
    */
   getFormatOptions(): FormatOptions {
-    const output = this.output as WriteStream;
+    const output: Writable &
+      Partial<Pick<WriteStream, 'isTTY' | 'getColorDepth'>> = this.output;
     return {
       colors:
         this._runtimeState?.repl?.useColors ??
-        (output.isTTY && output.getColorDepth() > 1),
+        !!(output.isTTY && (output?.getColorDepth?.() ?? 0) > 1),
       compact: this.inspectCompact,
       depth: this.inspectDepth,
       showStackTraces: this.showStackTraces,

--- a/packages/cli-repl/src/run.ts
+++ b/packages/cli-repl/src/run.ts
@@ -228,7 +228,10 @@ async function main() {
       ...connectionInfo.driverOptions,
     });
   } catch (e: any) {
-    console.error(`${e?.name}: ${e?.message}`);
+    // for debugging
+    if (process.env.MONGOSH_DISPLAY_STARTUP_STACK_TRACE)
+      console.error(e?.stack);
+    else console.error(`${e?.name}: ${e?.message}`);
     if (repl !== undefined) {
       repl.bus.emit('mongosh:error', e, 'startup');
     }

--- a/packages/cli-repl/src/smoke-tests.ts
+++ b/packages/cli-repl/src/smoke-tests.ts
@@ -54,6 +54,30 @@ export async function runSmokeTests(
       exitCode: 0,
     },
     {
+      input: '',
+      output: /Hello World!/,
+      includeStderr: false,
+      testArgs: [
+        '--nodb',
+        '--eval',
+        'print("He" + "llo" + " Wor" + "ld!")',
+        '--jsContext=plain-vm',
+      ],
+      exitCode: 0,
+    },
+    {
+      input: '',
+      output: /Hello World!/,
+      includeStderr: false,
+      testArgs: [
+        '--nodb',
+        '--eval',
+        'print("He" + "llo" + " Wor" + "ld!")',
+        '--jsContext=repl',
+      ],
+      exitCode: 0,
+    },
+    {
       input: 'crypto.createHash("md5").update("hello").digest("hex")',
       output: expectFipsSupport
         ? /disabled for FIPS|digital envelope routines::unsupported/i

--- a/packages/e2e-tests/test/test-shell.ts
+++ b/packages/e2e-tests/test/test-shell.ts
@@ -160,7 +160,7 @@ export class TestShell {
     return this._rawOutput;
   }
 
-  get process(): ChildProcess {
+  get process(): ChildProcessWithoutNullStreams {
     return this._process;
   }
 

--- a/packages/logging/src/setup-logger-and-telemetry.spec.ts
+++ b/packages/logging/src/setup-logger-and-telemetry.spec.ts
@@ -85,6 +85,7 @@ describe('setupLoggerAndTelemetry', function () {
     } as any);
     bus.emit('mongosh:start-session', {
       isInteractive: true,
+      jsContext: 'foo',
       timings: {
         'BoxedNode Bindings': 50,
         NodeREPL: 100,
@@ -418,6 +419,7 @@ describe('setupLoggerAndTelemetry', function () {
           event: 'Startup Time',
           properties: {
             is_interactive: true,
+            js_context: 'foo',
             boxed_node_bindings: 50,
             node_repl: 100,
             mongosh_version: '1.0.0',

--- a/packages/logging/src/setup-logger-and-telemetry.ts
+++ b/packages/logging/src/setup-logger-and-telemetry.ts
@@ -183,6 +183,7 @@ export function setupLoggerAndTelemetry(
       properties: {
         ...trackProperties,
         is_interactive: args.isInteractive,
+        js_context: args.jsContext,
         ...normalisedTimings,
       },
     });

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -176,6 +176,7 @@ export interface FetchingUpdateMetadataCompleteEvent {
 
 export interface SessionStartedEvent {
   isInteractive: boolean;
+  jsContext: string;
   timings: {
     [category: string]: number;
   };


### PR DESCRIPTION
[Definitely recommend viewing the diff in whitespace-changes-disabled mode :)]

- Allow running `MongoshNodeRepl` instances either based on:
  - The existing mechanism for running code, which is spinning up
    a Node.js REPL and using it to evaluate code; or
  - A more lightweight mechanism that only creates a `vm` context
    and then run code using that context directly.
- Introduce a new command-line switch, `--jsContext`, that can be
  used to explicitly select the desired behavior, with possible values
  of `repl`, `plain-vm` and `auto`. The default behavior is to switch
  depending on whether the CLI will enter interactive mode or not.

Running in `plain-vm` mode will significantly improve runtime
performance (a 6× reduction of script run time in local testing),
coming from the removal of async context tracking that the REPL
uses to identify async operations which were originally spawned
from the REPL instance in question.

This lack of async context tracking comes with some implications,
in particular asynchronously thrown errors (in the Node.js sense,
e.g. `setImmediate(() => { throw ... })`) will lead to slightly
different behavior (e.g. different error code and error output).
That is probably acceptable breakage in this context.