### PR TITLE
chore(ci): use `docker compose` over `docker-compose`

### DIFF
--- a/packages/connectivity-tests/test/kerberos.sh
+++ b/packages/connectivity-tests/test/kerberos.sh
@@ -5,13 +5,13 @@ set -x
 export KERBEROS_JUMPHOST_DOCKERFILE=${KERBEROS_JUMPHOST_DOCKERFILE:-Dockerfile.node20}
 
 FAILED=no
-docker-compose \
+docker compose \
   -f "$TEST_TMPDIR/test-envs/docker/kerberos/docker-compose.yaml" \
   -f "$CONNECTIVITY_TEST_SOURCE_DIR/kerberos/docker-compose.kerberos.yaml" \
   --no-ansi \
   up --build --exit-code-from kerberos_jumphost --abort-on-container-exit || FAILED=yes
 
-docker-compose \
+docker compose \
   -f "$TEST_TMPDIR/test-envs/docker/kerberos/docker-compose.yaml" \
   -f "$CONNECTIVITY_TEST_SOURCE_DIR/kerberos/docker-compose.kerberos.yaml" \
   --no-ansi \

--- a/packages/connectivity-tests/test/ldap.sh
+++ b/packages/connectivity-tests/test/ldap.sh
@@ -20,13 +20,13 @@ function try_connect_connection_string() {
 }
 
 function test_for_version() {
-  MONGODB_VERSION="$1" docker-compose -f docker/ldap/docker-compose.yaml up -d
+  MONGODB_VERSION="$1" docker compose -f docker/ldap/docker-compose.yaml up -d
 
   sleep 10 # let mongod start up
   FAILED_EXPLICIT=$(try_connect_explicit 'writer@EXAMPLE.COM' 'Password1!')
   FAILED_CONNECTION_STRING=$(try_connect_connection_string 'mongodb://writer%40EXAMPLE.COM:Password1!@localhost:30017/$external?authMechanism=PLAIN' 'writer@EXAMPLE.COM')
 
-  MONGODB_VERSION="$1" docker-compose -f docker/ldap/docker-compose.yaml down
+  MONGODB_VERSION="$1" docker compose -f docker/ldap/docker-compose.yaml down
 
   if [ $FAILED_EXPLICIT = yes ]; then
     ANY_FAILED=yes

--- a/packages/connectivity-tests/test/localhost.sh
+++ b/packages/connectivity-tests/test/localhost.sh
@@ -13,13 +13,13 @@ function try_connect_connection_string() {
 }
 
 function test_for_version() {
-  MONGODB_VERSION="$1" docker-compose -f docker/enterprise/docker-compose.yaml up -d
+  MONGODB_VERSION="$1" docker compose -f docker/enterprise/docker-compose.yaml up -d
 
   sleep 10 # let mongod start up
   FAILED_EXPLICIT=$(try_connect_explicit)
   FAILED_CONNECTION_STRING=$(try_connect_connection_string)
 
-  MONGODB_VERSION="$1" docker-compose -f docker/enterprise/docker-compose.yaml down
+  MONGODB_VERSION="$1" docker compose -f docker/enterprise/docker-compose.yaml down
 
   if [ $FAILED_EXPLICIT = yes ]; then
     ANY_FAILED=yes
@@ -41,7 +41,7 @@ function try_connect_ipv4only_dualstackhostname() {
   else
     INNER_MONGOSH="/host/${MONGOSH}"
   fi
-  MONGODB_VERSION="5.0" docker-compose -f docker/enterprise/docker-compose.yaml up -d
+  MONGODB_VERSION="5.0" docker compose -f docker/enterprise/docker-compose.yaml up -d
 
   DOCKER_BASE_IMG=ubuntu:$("${MONGOSH}" --quiet --nodb --eval 'b = buildInfo(); b.sharedOpenssl && b.opensslVersion.startsWith("1.") ? "20.04" : "22.04"')
   # Use a second docker container to be able to modify /etc/hosts easily
@@ -63,7 +63,7 @@ EOF
     echo "Localhost test with ipv4-only access failed"
   fi
 
-  MONGODB_VERSION="5.0" docker-compose -f docker/enterprise/docker-compose.yaml down
+  MONGODB_VERSION="5.0" docker compose -f docker/enterprise/docker-compose.yaml down
 }
 
 ANY_FAILED=no


### PR DESCRIPTION
This should hopefully fix some CI breakage for us, same as in Compass.

Refs: https://github.com/mongodb-js/compass/commit/a322429f4a970695629242657427ce4ff8ecfa43