### PR TITLE
fix(cli-repl): fix prompt TTY raw mode toggling MONGOSH-1667

### DIFF
--- a/packages/cli-repl/src/mongosh-repl.spec.ts
+++ b/packages/cli-repl/src/mongosh-repl.spec.ts
@@ -898,6 +898,7 @@ describe('MongoshNodeRepl', function () {
         input.write('const pw = passwordPrompt()\n');
         await tick();
         expect(output).to.include('Enter password');
+        expect((input as any).isRaw).to.equal(true); // MONGOSH-1667
 
         output = '';
         input.write('hello!\n');
@@ -914,6 +915,7 @@ describe('MongoshNodeRepl', function () {
         input.write('pw = passwordPrompt(); 0\n');
         await tick();
         expect(output).to.include('Enter password');
+        expect((input as any).isRaw).to.equal(true);
 
         output = '';
         input.write('hello!\u0003'); // Ctrl+C
@@ -932,6 +934,7 @@ describe('MongoshNodeRepl', function () {
         input.write('const answer = booleanPrompt("shall we play a game?")\n');
         await tick();
         expect(output).to.include('shall we play a game?:');
+        expect((input as any).isRaw).to.equal(true);
 
         input.write('Y');
         await waitEval(bus);
@@ -948,6 +951,7 @@ describe('MongoshNodeRepl', function () {
         input.write('const answer = booleanPrompt("shall we play a game?")\n');
         await tick();
         expect(output).to.include('shall we play a game?:');
+        expect((input as any).isRaw).to.equal(true);
 
         input.write('q');
         await tick();
@@ -972,6 +976,7 @@ describe('MongoshNodeRepl', function () {
         input.write('const answer = booleanPrompt("shall we play a game?")\n');
         await tick();
         expect(output).to.include('shall we play a game?:');
+        expect((input as any).isRaw).to.equal(true);
 
         input.write('\n');
         await waitEval(bus);
@@ -986,6 +991,7 @@ describe('MongoshNodeRepl', function () {
         input.write('answer = booleanPrompt("shall we play a game?")\n');
         await tick();
         expect(output).to.include('shall we play a game?:');
+        expect((input as any).isRaw).to.equal(true);
 
         input.write('\u0003'); // Ctrl+C
         await waitEval(bus);

--- a/packages/cli-repl/test/repl-helpers.ts
+++ b/packages/cli-repl/test/repl-helpers.ts
@@ -7,6 +7,7 @@ import sinon from 'sinon';
 import sinonChai from 'sinon-chai';
 import chaiAsPromised from 'chai-as-promised';
 import type { MongoshBus, MongoshBusEventsMap } from '@mongosh/types';
+import type { ReadStream, WriteStream } from 'tty';
 
 chai.use(sinonChai);
 chai.use(chaiAsPromised);
@@ -74,11 +75,12 @@ async function waitCompletion(bus: MongoshBus) {
   await tick();
 }
 
-const fakeTTYProps = {
+const fakeTTYProps: Partial<ReadStream & WriteStream> = {
   isTTY: true,
   isRaw: true,
-  setRawMode() {
-    return false;
+  setRawMode(newValue: boolean) {
+    this.isRaw = newValue;
+    return this;
   },
   getColorDepth() {
     return 256;


### PR DESCRIPTION
Avoid interaction between TTY raw mode toggling done by the prompt and TTY raw mode toggling done by our/the Node.js REPL implementation by ensuring that prompts always run in the fully asynchronous part of REPL evaluation.