### PR TITLE
fix(ci): remove unused licenses.json entry

### DIFF
--- a/licenses.json
+++ b/licenses.json
@@ -1,7 +1,5 @@
 {
   "ignoredOrgs": ["@mongodb-js", "@leafygreen-ui"],
   "doNotValidatePackages": ["argparse@2.0.1"],
-  "licenseOverrides": {
-    "@segment/loosely-validate-event@2.0.0": "MIT"
-  }
+  "licenseOverrides": {}
 }


### PR DESCRIPTION
This is no longer necessary since 20df659f9ae0 and made our vuln scan CI job and the GH actions runs for `main` commits fail since then.