### PR TITLE
feat(cli-repl): make `--quiet` the default for non-interactive usage MONGOSH-1721

### DIFF
--- a/packages/cli-repl/src/cli-repl.spec.ts
+++ b/packages/cli-repl/src/cli-repl.spec.ts
@@ -609,6 +609,7 @@ describe('CliRepl', function () {
                 'hello1.js'
               );
               cliReplOptions.shellCliOptions.fileNames = [filename1];
+              cliReplOptions.shellCliOptions.quiet = false;
               cliRepl = new CliRepl(cliReplOptions);
               await startWithExpectedImmediateExit(cliRepl, '');
               expect(output).to.include(`Loading file: ${filename1}`);
@@ -634,6 +635,7 @@ describe('CliRepl', function () {
                 'hello2.js'
               );
               cliReplOptions.shellCliOptions.fileNames = [filename1, filename2];
+              cliReplOptions.shellCliOptions.quiet = false;
               cliRepl = new CliRepl(cliReplOptions);
               await startWithExpectedImmediateExit(cliRepl, '');
               expect(output).to.include(`Loading file: ${filename1}`);
@@ -643,7 +645,7 @@ describe('CliRepl', function () {
               expect(exitCode).to.equal(0);
             });
 
-            it('does not print filenames if --quiet is passed', async function () {
+            it('does not print filenames if --quiet is implied', async function () {
               const filename1 = path.resolve(
                 __dirname,
                 '..',
@@ -653,7 +655,6 @@ describe('CliRepl', function () {
                 'hello1.js'
               );
               cliReplOptions.shellCliOptions.fileNames = [filename1];
-              cliReplOptions.shellCliOptions.quiet = true;
               cliRepl = new CliRepl(cliReplOptions);
               await startWithExpectedImmediateExit(cliRepl, '');
               expect(output).not.to.include('Loading file');
@@ -671,6 +672,7 @@ describe('CliRepl', function () {
                 'throw.js'
               );
               cliReplOptions.shellCliOptions.fileNames = [filename1];
+              cliReplOptions.shellCliOptions.quiet = false;
               cliRepl = new CliRepl(cliReplOptions);
               try {
                 await cliRepl.start('', {});
@@ -1641,6 +1643,7 @@ describe('CliRepl', function () {
           'hello1.js'
         );
         cliReplOptions.shellCliOptions.fileNames = [filename1];
+        cliReplOptions.shellCliOptions.quiet = false;
         cliRepl = new CliRepl(cliReplOptions);
         await startWithExpectedImmediateExit(
           cliRepl,
@@ -1669,6 +1672,7 @@ describe('CliRepl', function () {
           'hello2.js'
         );
         cliReplOptions.shellCliOptions.fileNames = [filename1, filename2];
+        cliReplOptions.shellCliOptions.quiet = false;
         cliRepl = new CliRepl(cliReplOptions);
         await startWithExpectedImmediateExit(
           cliRepl,

--- a/packages/cli-repl/src/cli-repl.spec.ts
+++ b/packages/cli-repl/src/cli-repl.spec.ts
@@ -1204,6 +1204,16 @@ describe('CliRepl', function () {
     });
 
     it('has the full greeting if --quiet is not passed', async function () {
+      cliRepl = new CliRepl(cliReplOptions);
+      await cliRepl.start(await testServer.connectionString(), {});
+      // Full greeting:
+      expect(output).to.match(/Current Mongosh Log ID:/);
+      expect(output).to.match(/Connecting to:/);
+      expect(output).to.match(/Using MongoDB:/);
+      expect(output).to.match(/For mongosh info see:/);
+    });
+
+    it('has the full greeting if --quiet is set to false', async function () {
       cliReplOptions.shellCliOptions.quiet = false;
       cliRepl = new CliRepl(cliReplOptions);
       await cliRepl.start(await testServer.connectionString(), {});


### PR DESCRIPTION
This can be disabled through `--no-quiet` or `--verbose` (although `--verbose` may gain other meanings in the future depending on the outcome of MONGOSH-970).