### PR TITLE
chore(ci): small evergreen config cleanups

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -6937,6 +6937,7 @@ functions:
           node_js_version: ${node_js_version}
         script: |
           set -e
+          export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD="true"
           .evergreen/run-evergreen-release.sh -- --dry-run
 
   release_publish:
@@ -6955,6 +6956,7 @@ functions:
           node_js_version: ${node_js_version}
         script: |
           set -e
+          export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD="true"
           .evergreen/run-evergreen-release.sh
 
   run_perf_tests:
@@ -10299,7 +10301,6 @@ tasks:
   # INTEGRATION TESTS
   ###
   - name: test_vscode
-    tags: ["extra-integration-test"]
     depends_on:
       - name: compile_ts
         variant: linux_unit
@@ -10353,6 +10354,7 @@ tasks:
           node_js_version: "20.11.1"
 
   - name: generate_license_and_vulnerability_report
+    tags: ["extra-integration-test"]
     depends_on:
       - name: compile_ts
         variant: linux_unit

--- a/.evergreen/evergreen.yml.in
+++ b/.evergreen/evergreen.yml.in
@@ -805,6 +805,7 @@ functions:
           node_js_version: ${node_js_version}
         script: |
           set -e
+          export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD="true"
           .evergreen/run-evergreen-release.sh -- --dry-run
 
   release_publish:
@@ -823,6 +824,7 @@ functions:
           node_js_version: ${node_js_version}
         script: |
           set -e
+          export PUPPETEER_SKIP_CHROMIUM_DOWNLOAD="true"
           .evergreen/run-evergreen-release.sh
 
   run_perf_tests:
@@ -922,7 +924,6 @@ tasks:
   # INTEGRATION TESTS
   ###
   - name: test_vscode
-    tags: ["extra-integration-test"]
     depends_on:
       - name: compile_ts
         variant: linux_unit
@@ -976,6 +977,7 @@ tasks:
           node_js_version: "<% out(NODE_JS_VERSION_20) %>"
 
   - name: generate_license_and_vulnerability_report
+    tags: ["extra-integration-test"]
     depends_on:
       - name: compile_ts
         variant: linux_unit


### PR DESCRIPTION
- Do not label the VSCode integration test as required for `release_draft`
- *Do* label the vulnerability check task as required for it
- Do not download Chrome for browser testing in the release tasks to reduce run time a bit