### PR TITLE
fix(cli-repl): use JS Proxy for forwarding lazy-loaded webpack function exports

### DIFF
--- a/packages/e2e-tests/test/e2e-oidc.spec.ts
+++ b/packages/e2e-tests/test/e2e-oidc.spec.ts
@@ -38,10 +38,6 @@ describe('OIDC auth e2e', function () {
       process.platform !== 'linux' ||
       !process.env.MONGOSH_SERVER_TEST_VERSION ||
       !process.env.MONGOSH_SERVER_TEST_VERSION.includes('-enterprise') ||
-      !(
-        process.env.MONGOSH_SERVER_TEST_VERSION.includes('latest-alpha') ||
-        +process.env.MONGOSH_SERVER_TEST_VERSION.split('.')[0] >= 7
-      ) ||
       +process.version.slice(1).split('.')[0] < 16
     ) {
       // OIDC is only supported on Linux in the 7.0+ enterprise server,


### PR DESCRIPTION
This fixes OIDC for compiled executables, because class exports like the `Issuer` class from `openid-client` or `IncomingMessage` from `http` did not fully have properties on the function and/or its prototype forwarded, effectively breaking the feature.

This was not caught by our e2e tests because they were first written before the 7.x+ server was the default stable one, and therefore additional checks needed to be added to the test conditions for it.

It is now safe to remove those checks, which will make the OIDC e2e tests run as part of our regular e2e test suite for compiled executables (on systems that support 7.x+ servers).