### PR TITLE
Revert "chore(ci): disables test_vscode task (#1888)"

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -13653,8 +13653,7 @@ buildvariants:
       - name: test_n16_snippet_manager
       - name: test_n20_types
       - name: test_n16_types
-      # TODO: (MONGOSH-1740) Re-enable this after fixing the linked ticket
-      # - name: test_vscode
+      - name: test_vscode
       - name: test_connectivity
       - name: test_apistrict
   - name: linux_coverage

--- a/.evergreen/evergreen.yml.in
+++ b/.evergreen/evergreen.yml.in
@@ -1232,8 +1232,7 @@ buildvariants:
       <% for (const test of ALL_UNIT_TESTS.filter(t => t.variants.includes('linux'))) { %>
       - name: test_<% out(test.id) %>
       <% } %>
-      # TODO: (MONGOSH-1740) Re-enable this after fixing the linked ticket
-      # - name: test_vscode
+      - name: test_vscode
       - name: test_connectivity
       - name: test_apistrict
   - name: linux_coverage


### PR DESCRIPTION
This reverts commit 773eee6fd002aa020be37e43fc24f69159ecf3e2.

These are failures that we should keep being aware of, but the VSCode tests *are* still useful regardless of the failing OIDC tests.

I assume this was disabled for a release, but 97d8c2e966f029699356ed70efc9328b397f6887 already removed this task from the list of tasks required for releases.