### PR TITLE
chore(service-provider-core): remove `CloseOptions` COMPASS-7754

### DIFF
--- a/packages/service-provider-core/src/all-transport-types.ts
+++ b/packages/service-provider-core/src/all-transport-types.ts
@@ -8,7 +8,6 @@ export type {
   ChangeStream,
   ChangeStreamOptions,
   ClientSession,
-  CloseOptions,
   CollationOptions,
   Collection,
   CommandOperationOptions,


### PR DESCRIPTION
This type is unused and will be removed from the driver in the future.