### PR TITLE
fix(cli-repl): redact for all lines, add e2e test MONGOSH-1682

### DIFF
--- a/packages/cli-repl/src/mongosh-repl.ts
+++ b/packages/cli-repl/src/mongosh-repl.ts
@@ -451,7 +451,7 @@ class MongoshNodeRepl implements EvaluationListener {
       // repl.history is an array of previous commands. We need to hijack the
       // value we just typed, and shift it off the history array if the info is
       // sensitive.
-      repl.on('flushHistory', () => {
+      repl.on('line', () => {
         if (this.redactHistory !== 'keep') {
           const history: string[] = (repl as any).history;
           changeHistory(

--- a/packages/e2e-tests/test/e2e.spec.ts
+++ b/packages/e2e-tests/test/e2e.spec.ts
@@ -1486,6 +1486,19 @@ describe('e2e', function () {
 
           expect((await fs.stat(historyPath)).mode & 0o077).to.equal(0);
         });
+
+        it('redacts secrets', async function () {
+          await shell.executeLine('db.auth("myusername", "mypassword")');
+          await shell.executeLine('a = 42');
+          await shell.executeLine('foo = "bar"');
+          shell.writeInput('.exit\n');
+          await shell.waitForExit();
+
+          const contents = await fs.readFile(historyPath, 'utf8');
+          expect(contents).to.not.match(/mypassword/);
+          expect(contents).to.match(/^a = 42$/m);
+          expect(contents).to.match(/^foo = "bar"$/m);
+        });
       });
 
       describe('mongoshrc', function () {


### PR DESCRIPTION
Looking at node's [repl history code](https://github.com/nodejs/node/blob/312ebd97c21dc94b8e6456fcf29799b3c5bf8f65/lib/internal/repl/history.js#L127) you can see that flushHistory does not always precede a write. ie. sometimes it would have already written the file before we had a chance to redact the line. The 'line' event seems to always be emitted on repl first, though. So that appears to be safer to use.

I added an e2e test for this as well.
