### PR TITLE
fix(shell-evaluator): fix exposed asyncRewrite fn for benchmarks

### DIFF
--- a/packages/cli-repl/src/smoke-tests.ts
+++ b/packages/cli-repl/src/smoke-tests.ts
@@ -176,9 +176,9 @@ export async function runSmokeTests({
       perfTestIterations: 0,
     },
     {
-      name: 'async_rewrite',
+      name: 'async_rewrite_foreach',
       input:
-        'for (let i = 0; i < 100; i++) __asyncRewrite(String([].forEach)); print("done")',
+        'for (let i = 0; i < 100; i++) __asyncRewrite(String([].forEach).replace("function", "function forEach")); print("done")',
       output: /done/,
       includeStderr: false,
       testArgs: ['--exposeAsyncRewriter', '--nodb'],

--- a/packages/shell-evaluator/src/shell-evaluator.ts
+++ b/packages/shell-evaluator/src/shell-evaluator.ts
@@ -93,8 +93,8 @@ class ShellEvaluator<EvaluationResultType = ShellResult> {
     }
 
     if (this.exposeAsyncRewriter) {
-      (context as any).__asyncRewrite = (input: string) =>
-        this.asyncWriter.process(input);
+      (context as any).__asyncRewrite = (rewriteInput: string) =>
+        this.asyncWriter.process(rewriteInput);
     }
 
     this.markTime?.(TimingCategories.AsyncRewrite, 'start async rewrite');

--- a/packages/shell-evaluator/src/shell-evaluator.ts
+++ b/packages/shell-evaluator/src/shell-evaluator.ts
@@ -93,7 +93,8 @@ class ShellEvaluator<EvaluationResultType = ShellResult> {
     }
 
     if (this.exposeAsyncRewriter) {
-      (context as any).__asyncRewrite = () => this.asyncWriter.process(input);
+      (context as any).__asyncRewrite = (input: string) =>
+        this.asyncWriter.process(input);
     }
 
     this.markTime?.(TimingCategories.AsyncRewrite, 'start async rewrite');


### PR DESCRIPTION
Painfully obvious bug in 0491491ce96b :) Renamed the benchmark test and fixed it to account for the (now very) different performance measurements after the fix.