### PR TITLE
fix(cli-repl): do not use process.report() to get glibc version MONGOSH-1754

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -16871,6 +16871,29 @@
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
       "optional": true
     },
+    "node_modules/glibc-version": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/glibc-version/-/glibc-version-1.0.0.tgz",
+      "integrity": "sha512-nK5/mgMuxS3ScqKLCvPfZxl4Mmj1seHZiuURC21BtOC0utC/rNWsU0q5uWHOAwqwQLQg9sAcQVXxhrv6pDi4+A==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "node-addon-api": "^8.0.0"
+      },
+      "bin": {
+        "glibc-version": "bin/glibc-version.js"
+      }
+    },
+    "node_modules/glibc-version/node_modules/node-addon-api": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.0.0.tgz",
+      "integrity": "sha512-ipO7rsHEBqa9STO5C5T10fj732ml+5kLN1cAG8/jdHd56ldQeGj3Q7+scUS+VHK/qy1zLEwC4wMK5+yM0btPvw==",
+      "optional": true,
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
     "node_modules/glob": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.2.0.tgz",
@@ -31269,6 +31292,7 @@
       },
       "optionalDependencies": {
         "get-console-process-list": "^1.0.4",
+        "glibc-version": "^1.0.0",
         "macos-export-certificate-and-key": "^1.1.1",
         "mongodb-crypt-library-version": "^1.0.3",
         "win-export-certificate-and-key": "^1.1.1"
@@ -37636,6 +37660,7 @@
         "escape-string-regexp": "^4.0.0",
         "eslint": "^7.25.0",
         "get-console-process-list": "^1.0.4",
+        "glibc-version": "^1.0.0",
         "is-recoverable-error": "^1.0.3",
         "js-yaml": "^4.1.0",
         "macos-export-certificate-and-key": "^1.1.1",
@@ -45855,6 +45880,24 @@
       "resolved": "https://registry.npmjs.org/github-from-package/-/github-from-package-0.0.0.tgz",
       "integrity": "sha512-SyHy3T1v2NUXn29OsWdxmK6RwHD+vkj3v8en8AOBZ1wBQ/hCAQ5bAQTD02kW4W9tUp/3Qh6J8r9EvntiyCmOOw==",
       "optional": true
+    },
+    "glibc-version": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/glibc-version/-/glibc-version-1.0.0.tgz",
+      "integrity": "sha512-nK5/mgMuxS3ScqKLCvPfZxl4Mmj1seHZiuURC21BtOC0utC/rNWsU0q5uWHOAwqwQLQg9sAcQVXxhrv6pDi4+A==",
+      "optional": true,
+      "requires": {
+        "bindings": "^1.5.0",
+        "node-addon-api": "^8.0.0"
+      },
+      "dependencies": {
+        "node-addon-api": {
+          "version": "8.0.0",
+          "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.0.0.tgz",
+          "integrity": "sha512-ipO7rsHEBqa9STO5C5T10fj732ml+5kLN1cAG8/jdHd56ldQeGj3Q7+scUS+VHK/qy1zLEwC4wMK5+yM0btPvw==",
+          "optional": true
+        }
+      }
     },
     "glob": {
       "version": "7.2.0",

--- a/packages/build/src/compile/signable-compiler.ts
+++ b/packages/build/src/compile/signable-compiler.ts
@@ -125,6 +125,10 @@ export class SignableCompiler {
       path: await findModulePath('cli-repl', 'mongodb-crypt-library-version'),
       requireRegexp: /\bmongodb_crypt_library_version\.node$/,
     };
+    const glibcVersionAddon = {
+      path: await findModulePath('cli-repl', 'glibc-version'),
+      requireRegexp: /\bglibc_version\.node$/,
+    };
     // Warning! Until https://jira.mongodb.org/browse/MONGOSH-990,
     // packages/service-provider-server *also* has a copy of these.
     // We use the versions included in packages/cli-repl here, so these
@@ -173,7 +177,13 @@ export class SignableCompiler {
           GYP_DEFINES: 'kerberos_use_rtld=true',
         }),
       },
-      addons: [fleAddon, osDnsAddon, kerberosAddon, cryptLibraryVersionAddon]
+      addons: [
+        fleAddon,
+        osDnsAddon,
+        kerberosAddon,
+        cryptLibraryVersionAddon,
+        glibcVersionAddon,
+      ]
         .concat(winCAAddon ? [winCAAddon] : [])
         .concat(winConsoleProcessListAddon ? [winConsoleProcessListAddon] : [])
         .concat(macKeychainAddon ? [macKeychainAddon] : []),

--- a/packages/cli-repl/package.json
+++ b/packages/cli-repl/package.json
@@ -54,6 +54,9 @@
       ],
       "get-console-process-list": [
         "win32"
+      ],
+      "glibc-version": [
+        "linux"
       ]
     }
   },

--- a/packages/cli-repl/package.json
+++ b/packages/cli-repl/package.json
@@ -111,6 +111,7 @@
   },
   "optionalDependencies": {
     "get-console-process-list": "^1.0.4",
+    "glibc-version": "^1.0.0",
     "macos-export-certificate-and-key": "^1.1.1",
     "mongodb-crypt-library-version": "^1.0.3",
     "win-export-certificate-and-key": "^1.1.1"

--- a/packages/cli-repl/src/build-info.ts
+++ b/packages/cli-repl/src/build-info.ts
@@ -15,6 +15,7 @@ export interface BuildInfo {
   opensslVersion: string;
   sharedOpenssl: boolean;
   segmentApiKey?: string;
+  runtimeGlibcVersion: string;
   deps: ReturnType<typeof CliServiceProvider.getVersionInformation>;
 }
 
@@ -44,7 +45,7 @@ export function baseBuildInfo(): Omit<BuildInfo, 'deps'> {
     // Runtime platform can differ e.g. because homebrew on macOS uses
     // npm packages published from Linux
     runtimePlatform: process.platform,
-    runtimeGlibcVersion: getGlibcVersion(),
+    runtimeGlibcVersion: getGlibcVersion() ?? 'N/A',
   };
 
   try {

--- a/packages/cli-repl/src/build-info.ts
+++ b/packages/cli-repl/src/build-info.ts
@@ -44,6 +44,7 @@ export function baseBuildInfo(): Omit<BuildInfo, 'deps'> {
     // Runtime platform can differ e.g. because homebrew on macOS uses
     // npm packages published from Linux
     runtimePlatform: process.platform,
+    runtimeGlibcVersion: getGlibcVersion(),
   };
 
   try {
@@ -85,4 +86,15 @@ export async function buildInfo({
     delete buildInfo.segmentApiKey;
   }
   return buildInfo;
+}
+
+let cachedGlibcVersion: string | undefined | null = null;
+export function getGlibcVersion(): string | undefined {
+  if (process.platform !== 'linux') return undefined;
+  if (cachedGlibcVersion !== null) return cachedGlibcVersion;
+  try {
+    return (cachedGlibcVersion = require('glibc-version')());
+  } catch {
+    return (cachedGlibcVersion = undefined);
+  }
 }

--- a/packages/e2e-tests/test/e2e-snapshot.spec.ts
+++ b/packages/e2e-tests/test/e2e-snapshot.spec.ts
@@ -132,7 +132,7 @@ describe('e2e startup banners', function () {
       );
       verifyAllInCategoryMatch(
         'nodb-eval',
-        /^node_modules\/(kerberos|mongodb-client-encryption)\//
+        /^node_modules\/(kerberos|mongodb-client-encryption|glibc-version)\//
       );
       verifyAllThatMatchAreInCategory(
         'not-loaded',

--- a/packages/e2e-tests/test/e2e.spec.ts
+++ b/packages/e2e-tests/test/e2e.spec.ts
@@ -102,7 +102,7 @@ describe('e2e', function () {
         processReport = JSON.parse(shell.output);
       }
       expect(data.runtimeGlibcVersion).to.equal(
-        processReport.header.glibcVersionRuntime
+        processReport.header.glibcVersionRuntime ?? 'N/A'
       );
     });
 

--- a/packages/e2e-tests/test/e2e.spec.ts
+++ b/packages/e2e-tests/test/e2e.spec.ts
@@ -61,6 +61,7 @@ describe('e2e', function () {
         'sharedOpenssl',
         'runtimeArch',
         'runtimePlatform',
+        'runtimeGlibcVersion',
         'deps',
       ]);
       expect(data.version).to.be.a('string');
@@ -85,6 +86,24 @@ describe('e2e', function () {
       expect(data.deps.nodeDriverVersion).to.be.a('string');
       expect(data.deps.libmongocryptVersion).to.be.a('string');
       expect(data.deps.libmongocryptNodeBindingsVersion).to.be.a('string');
+
+      let processReport: any;
+      {
+        const shell = TestShell.start({
+          args: [
+            '--quiet',
+            '--nodb',
+            '--json=relaxed',
+            '--eval',
+            'process.report.getReport()',
+          ],
+        });
+        await shell.waitForExit();
+        processReport = JSON.parse(shell.output);
+      }
+      expect(data.runtimeGlibcVersion).to.equal(
+        processReport.header.glibcVersionRuntime
+      );
     });
 
     it('provides build info via the buildInfo() builtin', async function () {

--- a/packages/e2e-tests/test/e2e.spec.ts
+++ b/packages/e2e-tests/test/e2e.spec.ts
@@ -87,6 +87,8 @@ describe('e2e', function () {
       expect(data.deps.libmongocryptVersion).to.be.a('string');
       expect(data.deps.libmongocryptNodeBindingsVersion).to.be.a('string');
 
+      if (process.version.startsWith('v16.')) return;
+
       let processReport: any;
       {
         const shell = TestShell.start({


### PR DESCRIPTION
Instead, use a native addon (https://github.com/mongodb-js/glibc-version) to get the glibc version number.
