### PR TITLE
fix(build): fix hash file parsing

### DIFF
--- a/packages/build/src/download-center/config.ts
+++ b/packages/build/src/download-center/config.ts
@@ -293,13 +293,13 @@ async function getHashes(
         );
         const line = content
           .split('\n')
-          .find((line) => line.endsWith(packagedFilename));
+          .find((line) => line.trim().startsWith(packagedFilename));
         if (!line) {
           throw new Error(
             `Could not find entry for ${packagedFilename} in ${filename}`
           );
         }
-        return [hash, line.trim().split(/\s/)[0]] as const;
+        return [hash, line.trim().split(/\s+/)[1]] as const;
       })
     )
   ) as { sha1: string; sha256: string };

--- a/packages/build/src/run-download-and-list-artifacts.ts
+++ b/packages/build/src/run-download-and-list-artifacts.ts
@@ -17,7 +17,8 @@ export const hashListFiles = [
 
 export async function runDownloadAndListArtifacts(
   config: Config,
-  publicArtifactBaseUrl: string = ARTIFACTS_URL_PUBLIC_BASE
+  publicArtifactBaseUrl: string = ARTIFACTS_URL_PUBLIC_BASE,
+  hashFileWriteMode: 'normal' | 'append-to-hash-file-for-testing' = 'normal'
 ): Promise<void> {
   const requiredConfigKeys: (keyof Config)[] = ['outputDir'];
   for (const key of requiredConfigKeys) {
@@ -66,7 +67,10 @@ export async function runDownloadAndListArtifacts(
         .filter(Boolean)
         .map((file) => `${file?.filename}  ${file?.[hash]}`)
         .join('\n') + '\n';
-    await fs.writeFile(filepath, contents);
+    await (hashFileWriteMode === 'normal' ? fs.writeFile : fs.appendFile)(
+      filepath,
+      contents
+    );
     console.log('wrote hash list to', filepath);
   }
 }


### PR DESCRIPTION
In 2da3c3159545e, we moved file hash computation for our produced artifacts from the JSON feed generation step to the newly introduced "download artifacts" step of the `release_publish` tasks (because we need to download artifacts before we can submit them to the papertrail service). We used the standard-ish SHASUMS format (output of `sha256sum`/input of `sha256sum -c`) for that, but failed to parse it properly when consuming it.

This fixes that and extends the download center config tests to also perform the full "download artifacts" step as part of the test setup, to ensure that the two parts work together properly.