### PR TITLE
MONGOSH-1661: Add autocomplete for streams commands

### DIFF
--- a/packages/autocomplete/src/index.spec.ts
+++ b/packages/autocomplete/src/index.spec.ts
@@ -836,4 +836,22 @@ describe('completer.completer', function () {
       expect(await completer(apiStrictParams, i)).to.deep.equal([[], i]);
     });
   });
+
+  context('with stream processing sp', function () {
+    it('completes supported methods sp.listStreamProcessor', async function () {
+      const i = 'sp.listS';
+      expect(await completer(apiStrictParams, i)).to.deep.equal([
+        ['sp.listStreamProcessors'],
+        i,
+      ]);
+    });
+
+    it('completes methods on processors like sp.name.drop', async function () {
+      const i = 'sp.processorName.d';
+      expect(await completer(apiStrictParams, i)).to.deep.equal([
+        ['sp.processorName.drop'],
+        i,
+      ]);
+    });
+  });
 });

--- a/packages/autocomplete/src/index.ts
+++ b/packages/autocomplete/src/index.ts
@@ -98,6 +98,10 @@ async function completer(
     .attributes as TypeSignatureAttributes;
   const SHARD_COMPLETE = shellSignatures.Shard
     .attributes as TypeSignatureAttributes;
+  const SP_COMPLETIONS = shellSignatures.Streams
+    .attributes as TypeSignatureAttributes;
+  const SP_INSTANCE_COMPLETIONS = shellSignatures.StreamProcessor
+    .attributes as TypeSignatureAttributes;
 
   // Split at space-to-non-space transitions when looking at this as a command,
   // because multiple spaces (e.g. 'show  collections') are valid in commands.
@@ -265,6 +269,20 @@ async function completer(
       splitLine
     );
     return [hits.length ? hits : [], line];
+  } else if (/\bsp\b/.exec(firstLineEl)) {
+    let expressions: TypeSignatureAttributes | undefined;
+    if (splitLine.length === 2) {
+      expressions = SP_COMPLETIONS;
+    } else if (splitLine.length === 3) {
+      // something like sp.spName.start()
+      expressions = SP_INSTANCE_COMPLETIONS;
+    }
+
+    const hits =
+      expressions &&
+      filterShellAPI(params, expressions, elToComplete, splitLine);
+
+    return [hits?.length ? hits : [], line];
   }
 
   return [[], line];


### PR DESCRIPTION
## Description
[MONGOSH-1661](https://jira.mongodb.org/browse/MONGOSH-1661): Adds autocomplete for `sp.` commands. 
- Works for `sp.` prompts and autocompletes for all standard commands - but not names of stream processors
- Autocompletes when command is in that format: `sp.name.` with standard commands like `start()`, `stop()` etc.


https://github.com/mongodb-js/mongosh/assets/156152710/9c5f699f-9e25-4660-a355-ff27b210d148



## Testing
Unit test

