### PR TITLE
chore(shell-api): remove dropped timeseries collStats field from test MONGOSH-1763

### DIFF
--- a/packages/shell-api/src/integration.spec.ts
+++ b/packages/shell-api/src/integration.spec.ts
@@ -940,7 +940,6 @@ describe('Shell API (integration)', function () {
             'numBucketsClosedDueToCount',
             'numBucketsClosedDueToSize',
             'numBucketsClosedDueToTimeForward',
-            'numBucketsClosedDueToTimeBackward',
             'numBucketsClosedDueToMemoryThreshold',
             'numCommits',
             'numWaits',


### PR DESCRIPTION
This field is gone from most recent server versions. It's probably safe to just ignore this field altogether at this point instead of performing server version detection and adjusting the list of expected keys to account for that.