### PR TITLE
feat(ci): add SBOM file to release artifacts

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -6530,10 +6530,6 @@ functions:
           DISTRO_ID: ${distro_id}
           NODE_JS_VERSION: ${node_js_version}
           MONGOSH_SHARED_OPENSSL: ${mongosh_shared_openssl}
-    - command: expansions.update
-      params:
-        ignore_missing_file: false
-        file: tmp/compiling-context.yml
   upload_sbom:
     - command: s3.put
       params:
@@ -6554,6 +6550,20 @@ functions:
         permissions: public-read
         content_type: text/plain
   upload_compiled_artifact:
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        env:
+          DISTRO_ID: ${distro_id}
+        script: |
+          set -e
+          set -x
+          bash .evergreen/compilation-context-expansions.sh
+    - command: expansions.update
+      params:
+        ignore_missing_file: false
+        file: tmp/compiling-context.yml
     - command: s3.put
       params:
         aws_key: ${aws_key}

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -6559,6 +6559,7 @@ functions:
         script: |
           set -e
           set -x
+          tar cvzf dist.tgz dist
           bash .evergreen/compilation-context-expansions.sh
     - command: expansions.update
       params:

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -6534,6 +6534,26 @@ functions:
       params:
         ignore_missing_file: false
         file: tmp/compiling-context.yml
+  upload_sbom:
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/dist/.sbom.json
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/mongosh-${executable_os_id}${extra_upload_tag}-sbom.json
+        bucket: mciuploads
+        permissions: public-read
+        content_type: application/json
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/dist/.purls.txt
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/mongosh-${executable_os_id}${extra_upload_tag}-purls.txt
+        bucket: mciuploads
+        permissions: public-read
+        content_type: text/plain
+  upload_compiled_artifact:
     - command: s3.put
       params:
         aws_key: ${aws_key}
@@ -6601,6 +6621,17 @@ functions:
   # - package_variant
   # - signature_tag (either 'signed' or 'unsigned')
   ###
+  add_crypt_shared_and_sbom:
+    - command: subprocess.exec
+      params:
+        working_dir: src
+        binary: bash .evergreen/download-crypt-shared-and-generate-sbom.sh
+        env:
+          NODE_JS_VERSION: ${node_js_version}
+          DISTRO_ID_OVERRIDE: ${distro_id}
+          PACKAGE_VARIANT: ${package_variant}
+          ARTIFACTORY_USERNAME: ${artifactory_username}
+          ARTIFACTORY_PASSWORD: ${artifactory_password}
   package_artifact:
     - command: expansions.write
       type: setup
@@ -6822,11 +6853,6 @@ functions:
           }
 
   generate_license_and_vulnerability_report:
-    - command: expansions.write
-      type: system
-      params:
-        file: tmp/expansions.yaml
-        redacted: true
     - command: shell.exec
       params:
         working_dir: src
@@ -6839,7 +6865,6 @@ functions:
           JIRA_API_TOKEN: ${jira_api_token}
         script: |
           set -e
-          export NODE_JS_VERSION=${node_js_version}
           source .evergreen/setup-env.sh
 
           # validate licenses, we first remove THIRD_PARTY_NOTICES.md, so we are sure
@@ -10434,6 +10459,9 @@ tasks:
       - func: compile_artifact
         vars:
           node_js_version: "20.12.2"
+      - func: upload_compiled_artifact
+        vars:
+          node_js_version: "20.12.2"
 
   - name: generate_license_and_vulnerability_report
     tags: ["extra-integration-test"]
@@ -11810,7 +11838,7 @@ tasks:
   ###
   # PACKAGING
   ###
-  - name: package_artifact_darwin_x64
+  - name: add_crypt_shared_and_sbom_darwin_x64
     depends_on:
       - name: compile_artifact
         variant: darwin
@@ -11822,6 +11850,31 @@ tasks:
       - func: download_compiled_artifact
         vars:
           executable_os_id: darwin-x64
+      - func: add_crypt_shared_and_sbom
+        vars:
+          package_variant: darwin-x64
+          executable_os_id: darwin-x64
+      - func: upload_sbom
+        vars:
+          executable_os_id: darwin-x64
+          extra_upload_tag: -darwin-x64-sbom
+      - func: upload_compiled_artifact
+        vars:
+          executable_os_id: darwin-x64
+          extra_upload_tag: -darwin-x64-complete
+  - name: package_artifact_darwin_x64
+    depends_on:
+      - name: add_crypt_shared_and_sbom_darwin_x64
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.12.2"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: darwin-x64
+          extra_upload_tag: -darwin-x64-complete
       - func: package_artifact
         vars:
           node_js_version: "20.12.2"
@@ -11867,7 +11920,7 @@ tasks:
           package_variant: darwin-x64
           signature_tag: signed
       - func: verify_artifact
-  - name: package_artifact_darwin_arm64
+  - name: add_crypt_shared_and_sbom_darwin_arm64
     depends_on:
       - name: compile_artifact
         variant: darwin_arm64
@@ -11879,6 +11932,31 @@ tasks:
       - func: download_compiled_artifact
         vars:
           executable_os_id: darwin-arm64
+      - func: add_crypt_shared_and_sbom
+        vars:
+          package_variant: darwin-arm64
+          executable_os_id: darwin-arm64
+      - func: upload_sbom
+        vars:
+          executable_os_id: darwin-arm64
+          extra_upload_tag: -darwin-arm64-sbom
+      - func: upload_compiled_artifact
+        vars:
+          executable_os_id: darwin-arm64
+          extra_upload_tag: -darwin-arm64-complete
+  - name: package_artifact_darwin_arm64
+    depends_on:
+      - name: add_crypt_shared_and_sbom_darwin_arm64
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.12.2"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: darwin-arm64
+          extra_upload_tag: -darwin-arm64-complete
       - func: package_artifact
         vars:
           node_js_version: "20.12.2"
@@ -11924,7 +12002,7 @@ tasks:
           package_variant: darwin-arm64
           signature_tag: signed
       - func: verify_artifact
-  - name: package_artifact_linux_x64
+  - name: add_crypt_shared_and_sbom_linux_x64
     depends_on:
       - name: compile_artifact
         variant: linux_x64_build
@@ -11936,6 +12014,31 @@ tasks:
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64
+      - func: add_crypt_shared_and_sbom
+        vars:
+          package_variant: linux-x64
+          executable_os_id: linux-x64
+      - func: upload_sbom
+        vars:
+          executable_os_id: linux-x64
+          extra_upload_tag: -linux-x64-sbom
+      - func: upload_compiled_artifact
+        vars:
+          executable_os_id: linux-x64
+          extra_upload_tag: -linux-x64-complete
+  - name: package_artifact_linux_x64
+    depends_on:
+      - name: add_crypt_shared_and_sbom_linux_x64
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.12.2"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-x64
+          extra_upload_tag: -linux-x64-complete
       - func: package_artifact
         vars:
           node_js_version: "20.12.2"
@@ -11981,7 +12084,7 @@ tasks:
           package_variant: linux-x64
           signature_tag: signed
       - func: verify_artifact
-  - name: package_artifact_deb_x64
+  - name: add_crypt_shared_and_sbom_deb_x64
     depends_on:
       - name: compile_artifact
         variant: linux_x64_build
@@ -11993,6 +12096,31 @@ tasks:
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64
+      - func: add_crypt_shared_and_sbom
+        vars:
+          package_variant: deb-x64
+          executable_os_id: linux-x64
+      - func: upload_sbom
+        vars:
+          executable_os_id: linux-x64
+          extra_upload_tag: -deb-x64-sbom
+      - func: upload_compiled_artifact
+        vars:
+          executable_os_id: linux-x64
+          extra_upload_tag: -deb-x64-complete
+  - name: package_artifact_deb_x64
+    depends_on:
+      - name: add_crypt_shared_and_sbom_deb_x64
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.12.2"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-x64
+          extra_upload_tag: -deb-x64-complete
       - func: package_artifact
         vars:
           node_js_version: "20.12.2"
@@ -12038,7 +12166,7 @@ tasks:
           package_variant: deb-x64
           signature_tag: signed
       - func: verify_artifact
-  - name: package_artifact_rpm_x64
+  - name: add_crypt_shared_and_sbom_rpm_x64
     depends_on:
       - name: compile_artifact
         variant: linux_x64_build
@@ -12050,6 +12178,31 @@ tasks:
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64
+      - func: add_crypt_shared_and_sbom
+        vars:
+          package_variant: rpm-x64
+          executable_os_id: linux-x64
+      - func: upload_sbom
+        vars:
+          executable_os_id: linux-x64
+          extra_upload_tag: -rpm-x64-sbom
+      - func: upload_compiled_artifact
+        vars:
+          executable_os_id: linux-x64
+          extra_upload_tag: -rpm-x64-complete
+  - name: package_artifact_rpm_x64
+    depends_on:
+      - name: add_crypt_shared_and_sbom_rpm_x64
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.12.2"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-x64
+          extra_upload_tag: -rpm-x64-complete
       - func: package_artifact
         vars:
           node_js_version: "20.12.2"
@@ -12095,7 +12248,7 @@ tasks:
           package_variant: rpm-x64
           signature_tag: signed
       - func: verify_artifact
-  - name: package_artifact_linux_x64_openssl11
+  - name: add_crypt_shared_and_sbom_linux_x64_openssl11
     depends_on:
       - name: compile_artifact
         variant: linux_x64_build_openssl11
@@ -12107,6 +12260,31 @@ tasks:
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64-openssl11
+      - func: add_crypt_shared_and_sbom
+        vars:
+          package_variant: linux-x64-openssl11
+          executable_os_id: linux-x64-openssl11
+      - func: upload_sbom
+        vars:
+          executable_os_id: linux-x64-openssl11
+          extra_upload_tag: -linux-x64-openssl11-sbom
+      - func: upload_compiled_artifact
+        vars:
+          executable_os_id: linux-x64-openssl11
+          extra_upload_tag: -linux-x64-openssl11-complete
+  - name: package_artifact_linux_x64_openssl11
+    depends_on:
+      - name: add_crypt_shared_and_sbom_linux_x64_openssl11
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.12.2"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-x64-openssl11
+          extra_upload_tag: -linux-x64-openssl11-complete
       - func: package_artifact
         vars:
           node_js_version: "20.12.2"
@@ -12152,7 +12330,7 @@ tasks:
           package_variant: linux-x64-openssl11
           signature_tag: signed
       - func: verify_artifact
-  - name: package_artifact_deb_x64_openssl11
+  - name: add_crypt_shared_and_sbom_deb_x64_openssl11
     depends_on:
       - name: compile_artifact
         variant: linux_x64_build_openssl11
@@ -12164,6 +12342,31 @@ tasks:
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64-openssl11
+      - func: add_crypt_shared_and_sbom
+        vars:
+          package_variant: deb-x64-openssl11
+          executable_os_id: linux-x64-openssl11
+      - func: upload_sbom
+        vars:
+          executable_os_id: linux-x64-openssl11
+          extra_upload_tag: -deb-x64-openssl11-sbom
+      - func: upload_compiled_artifact
+        vars:
+          executable_os_id: linux-x64-openssl11
+          extra_upload_tag: -deb-x64-openssl11-complete
+  - name: package_artifact_deb_x64_openssl11
+    depends_on:
+      - name: add_crypt_shared_and_sbom_deb_x64_openssl11
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.12.2"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-x64-openssl11
+          extra_upload_tag: -deb-x64-openssl11-complete
       - func: package_artifact
         vars:
           node_js_version: "20.12.2"
@@ -12209,7 +12412,7 @@ tasks:
           package_variant: deb-x64-openssl11
           signature_tag: signed
       - func: verify_artifact
-  - name: package_artifact_rpm_x64_openssl11
+  - name: add_crypt_shared_and_sbom_rpm_x64_openssl11
     depends_on:
       - name: compile_artifact
         variant: linux_x64_build_openssl11
@@ -12221,6 +12424,31 @@ tasks:
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64-openssl11
+      - func: add_crypt_shared_and_sbom
+        vars:
+          package_variant: rpm-x64-openssl11
+          executable_os_id: linux-x64-openssl11
+      - func: upload_sbom
+        vars:
+          executable_os_id: linux-x64-openssl11
+          extra_upload_tag: -rpm-x64-openssl11-sbom
+      - func: upload_compiled_artifact
+        vars:
+          executable_os_id: linux-x64-openssl11
+          extra_upload_tag: -rpm-x64-openssl11-complete
+  - name: package_artifact_rpm_x64_openssl11
+    depends_on:
+      - name: add_crypt_shared_and_sbom_rpm_x64_openssl11
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.12.2"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-x64-openssl11
+          extra_upload_tag: -rpm-x64-openssl11-complete
       - func: package_artifact
         vars:
           node_js_version: "20.12.2"
@@ -12266,7 +12494,7 @@ tasks:
           package_variant: rpm-x64-openssl11
           signature_tag: signed
       - func: verify_artifact
-  - name: package_artifact_linux_x64_openssl3
+  - name: add_crypt_shared_and_sbom_linux_x64_openssl3
     depends_on:
       - name: compile_artifact
         variant: linux_x64_build_openssl3
@@ -12278,6 +12506,31 @@ tasks:
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64-openssl3
+      - func: add_crypt_shared_and_sbom
+        vars:
+          package_variant: linux-x64-openssl3
+          executable_os_id: linux-x64-openssl3
+      - func: upload_sbom
+        vars:
+          executable_os_id: linux-x64-openssl3
+          extra_upload_tag: -linux-x64-openssl3-sbom
+      - func: upload_compiled_artifact
+        vars:
+          executable_os_id: linux-x64-openssl3
+          extra_upload_tag: -linux-x64-openssl3-complete
+  - name: package_artifact_linux_x64_openssl3
+    depends_on:
+      - name: add_crypt_shared_and_sbom_linux_x64_openssl3
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.12.2"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-x64-openssl3
+          extra_upload_tag: -linux-x64-openssl3-complete
       - func: package_artifact
         vars:
           node_js_version: "20.12.2"
@@ -12323,7 +12576,7 @@ tasks:
           package_variant: linux-x64-openssl3
           signature_tag: signed
       - func: verify_artifact
-  - name: package_artifact_deb_x64_openssl3
+  - name: add_crypt_shared_and_sbom_deb_x64_openssl3
     depends_on:
       - name: compile_artifact
         variant: linux_x64_build_openssl3
@@ -12335,6 +12588,31 @@ tasks:
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64-openssl3
+      - func: add_crypt_shared_and_sbom
+        vars:
+          package_variant: deb-x64-openssl3
+          executable_os_id: linux-x64-openssl3
+      - func: upload_sbom
+        vars:
+          executable_os_id: linux-x64-openssl3
+          extra_upload_tag: -deb-x64-openssl3-sbom
+      - func: upload_compiled_artifact
+        vars:
+          executable_os_id: linux-x64-openssl3
+          extra_upload_tag: -deb-x64-openssl3-complete
+  - name: package_artifact_deb_x64_openssl3
+    depends_on:
+      - name: add_crypt_shared_and_sbom_deb_x64_openssl3
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.12.2"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-x64-openssl3
+          extra_upload_tag: -deb-x64-openssl3-complete
       - func: package_artifact
         vars:
           node_js_version: "20.12.2"
@@ -12380,7 +12658,7 @@ tasks:
           package_variant: deb-x64-openssl3
           signature_tag: signed
       - func: verify_artifact
-  - name: package_artifact_rpm_x64_openssl3
+  - name: add_crypt_shared_and_sbom_rpm_x64_openssl3
     depends_on:
       - name: compile_artifact
         variant: linux_x64_build_openssl3
@@ -12392,6 +12670,31 @@ tasks:
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64-openssl3
+      - func: add_crypt_shared_and_sbom
+        vars:
+          package_variant: rpm-x64-openssl3
+          executable_os_id: linux-x64-openssl3
+      - func: upload_sbom
+        vars:
+          executable_os_id: linux-x64-openssl3
+          extra_upload_tag: -rpm-x64-openssl3-sbom
+      - func: upload_compiled_artifact
+        vars:
+          executable_os_id: linux-x64-openssl3
+          extra_upload_tag: -rpm-x64-openssl3-complete
+  - name: package_artifact_rpm_x64_openssl3
+    depends_on:
+      - name: add_crypt_shared_and_sbom_rpm_x64_openssl3
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.12.2"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-x64-openssl3
+          extra_upload_tag: -rpm-x64-openssl3-complete
       - func: package_artifact
         vars:
           node_js_version: "20.12.2"
@@ -12437,7 +12740,7 @@ tasks:
           package_variant: rpm-x64-openssl3
           signature_tag: signed
       - func: verify_artifact
-  - name: package_artifact_linux_arm64
+  - name: add_crypt_shared_and_sbom_linux_arm64
     depends_on:
       - name: compile_artifact
         variant: linux_arm64_build
@@ -12449,6 +12752,31 @@ tasks:
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64
+      - func: add_crypt_shared_and_sbom
+        vars:
+          package_variant: linux-arm64
+          executable_os_id: linux-arm64
+      - func: upload_sbom
+        vars:
+          executable_os_id: linux-arm64
+          extra_upload_tag: -linux-arm64-sbom
+      - func: upload_compiled_artifact
+        vars:
+          executable_os_id: linux-arm64
+          extra_upload_tag: -linux-arm64-complete
+  - name: package_artifact_linux_arm64
+    depends_on:
+      - name: add_crypt_shared_and_sbom_linux_arm64
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.12.2"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-arm64
+          extra_upload_tag: -linux-arm64-complete
       - func: package_artifact
         vars:
           node_js_version: "20.12.2"
@@ -12494,7 +12822,7 @@ tasks:
           package_variant: linux-arm64
           signature_tag: signed
       - func: verify_artifact
-  - name: package_artifact_deb_arm64
+  - name: add_crypt_shared_and_sbom_deb_arm64
     depends_on:
       - name: compile_artifact
         variant: linux_arm64_build
@@ -12506,6 +12834,31 @@ tasks:
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64
+      - func: add_crypt_shared_and_sbom
+        vars:
+          package_variant: deb-arm64
+          executable_os_id: linux-arm64
+      - func: upload_sbom
+        vars:
+          executable_os_id: linux-arm64
+          extra_upload_tag: -deb-arm64-sbom
+      - func: upload_compiled_artifact
+        vars:
+          executable_os_id: linux-arm64
+          extra_upload_tag: -deb-arm64-complete
+  - name: package_artifact_deb_arm64
+    depends_on:
+      - name: add_crypt_shared_and_sbom_deb_arm64
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.12.2"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-arm64
+          extra_upload_tag: -deb-arm64-complete
       - func: package_artifact
         vars:
           node_js_version: "20.12.2"
@@ -12551,7 +12904,7 @@ tasks:
           package_variant: deb-arm64
           signature_tag: signed
       - func: verify_artifact
-  - name: package_artifact_rpm_arm64
+  - name: add_crypt_shared_and_sbom_rpm_arm64
     depends_on:
       - name: compile_artifact
         variant: linux_arm64_build
@@ -12563,6 +12916,31 @@ tasks:
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64
+      - func: add_crypt_shared_and_sbom
+        vars:
+          package_variant: rpm-arm64
+          executable_os_id: linux-arm64
+      - func: upload_sbom
+        vars:
+          executable_os_id: linux-arm64
+          extra_upload_tag: -rpm-arm64-sbom
+      - func: upload_compiled_artifact
+        vars:
+          executable_os_id: linux-arm64
+          extra_upload_tag: -rpm-arm64-complete
+  - name: package_artifact_rpm_arm64
+    depends_on:
+      - name: add_crypt_shared_and_sbom_rpm_arm64
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.12.2"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-arm64
+          extra_upload_tag: -rpm-arm64-complete
       - func: package_artifact
         vars:
           node_js_version: "20.12.2"
@@ -12608,7 +12986,7 @@ tasks:
           package_variant: rpm-arm64
           signature_tag: signed
       - func: verify_artifact
-  - name: package_artifact_linux_arm64_openssl11
+  - name: add_crypt_shared_and_sbom_linux_arm64_openssl11
     depends_on:
       - name: compile_artifact
         variant: linux_arm64_build_openssl11
@@ -12620,6 +12998,31 @@ tasks:
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64-openssl11
+      - func: add_crypt_shared_and_sbom
+        vars:
+          package_variant: linux-arm64-openssl11
+          executable_os_id: linux-arm64-openssl11
+      - func: upload_sbom
+        vars:
+          executable_os_id: linux-arm64-openssl11
+          extra_upload_tag: -linux-arm64-openssl11-sbom
+      - func: upload_compiled_artifact
+        vars:
+          executable_os_id: linux-arm64-openssl11
+          extra_upload_tag: -linux-arm64-openssl11-complete
+  - name: package_artifact_linux_arm64_openssl11
+    depends_on:
+      - name: add_crypt_shared_and_sbom_linux_arm64_openssl11
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.12.2"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-arm64-openssl11
+          extra_upload_tag: -linux-arm64-openssl11-complete
       - func: package_artifact
         vars:
           node_js_version: "20.12.2"
@@ -12665,7 +13068,7 @@ tasks:
           package_variant: linux-arm64-openssl11
           signature_tag: signed
       - func: verify_artifact
-  - name: package_artifact_deb_arm64_openssl11
+  - name: add_crypt_shared_and_sbom_deb_arm64_openssl11
     depends_on:
       - name: compile_artifact
         variant: linux_arm64_build_openssl11
@@ -12677,6 +13080,31 @@ tasks:
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64-openssl11
+      - func: add_crypt_shared_and_sbom
+        vars:
+          package_variant: deb-arm64-openssl11
+          executable_os_id: linux-arm64-openssl11
+      - func: upload_sbom
+        vars:
+          executable_os_id: linux-arm64-openssl11
+          extra_upload_tag: -deb-arm64-openssl11-sbom
+      - func: upload_compiled_artifact
+        vars:
+          executable_os_id: linux-arm64-openssl11
+          extra_upload_tag: -deb-arm64-openssl11-complete
+  - name: package_artifact_deb_arm64_openssl11
+    depends_on:
+      - name: add_crypt_shared_and_sbom_deb_arm64_openssl11
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.12.2"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-arm64-openssl11
+          extra_upload_tag: -deb-arm64-openssl11-complete
       - func: package_artifact
         vars:
           node_js_version: "20.12.2"
@@ -12722,7 +13150,7 @@ tasks:
           package_variant: deb-arm64-openssl11
           signature_tag: signed
       - func: verify_artifact
-  - name: package_artifact_rpm_arm64_openssl11
+  - name: add_crypt_shared_and_sbom_rpm_arm64_openssl11
     depends_on:
       - name: compile_artifact
         variant: linux_arm64_build_openssl11
@@ -12734,6 +13162,31 @@ tasks:
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64-openssl11
+      - func: add_crypt_shared_and_sbom
+        vars:
+          package_variant: rpm-arm64-openssl11
+          executable_os_id: linux-arm64-openssl11
+      - func: upload_sbom
+        vars:
+          executable_os_id: linux-arm64-openssl11
+          extra_upload_tag: -rpm-arm64-openssl11-sbom
+      - func: upload_compiled_artifact
+        vars:
+          executable_os_id: linux-arm64-openssl11
+          extra_upload_tag: -rpm-arm64-openssl11-complete
+  - name: package_artifact_rpm_arm64_openssl11
+    depends_on:
+      - name: add_crypt_shared_and_sbom_rpm_arm64_openssl11
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.12.2"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-arm64-openssl11
+          extra_upload_tag: -rpm-arm64-openssl11-complete
       - func: package_artifact
         vars:
           node_js_version: "20.12.2"
@@ -12779,7 +13232,7 @@ tasks:
           package_variant: rpm-arm64-openssl11
           signature_tag: signed
       - func: verify_artifact
-  - name: package_artifact_linux_arm64_openssl3
+  - name: add_crypt_shared_and_sbom_linux_arm64_openssl3
     depends_on:
       - name: compile_artifact
         variant: linux_arm64_build_openssl3
@@ -12791,6 +13244,31 @@ tasks:
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64-openssl3
+      - func: add_crypt_shared_and_sbom
+        vars:
+          package_variant: linux-arm64-openssl3
+          executable_os_id: linux-arm64-openssl3
+      - func: upload_sbom
+        vars:
+          executable_os_id: linux-arm64-openssl3
+          extra_upload_tag: -linux-arm64-openssl3-sbom
+      - func: upload_compiled_artifact
+        vars:
+          executable_os_id: linux-arm64-openssl3
+          extra_upload_tag: -linux-arm64-openssl3-complete
+  - name: package_artifact_linux_arm64_openssl3
+    depends_on:
+      - name: add_crypt_shared_and_sbom_linux_arm64_openssl3
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.12.2"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-arm64-openssl3
+          extra_upload_tag: -linux-arm64-openssl3-complete
       - func: package_artifact
         vars:
           node_js_version: "20.12.2"
@@ -12836,7 +13314,7 @@ tasks:
           package_variant: linux-arm64-openssl3
           signature_tag: signed
       - func: verify_artifact
-  - name: package_artifact_deb_arm64_openssl3
+  - name: add_crypt_shared_and_sbom_deb_arm64_openssl3
     depends_on:
       - name: compile_artifact
         variant: linux_arm64_build_openssl3
@@ -12848,6 +13326,31 @@ tasks:
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64-openssl3
+      - func: add_crypt_shared_and_sbom
+        vars:
+          package_variant: deb-arm64-openssl3
+          executable_os_id: linux-arm64-openssl3
+      - func: upload_sbom
+        vars:
+          executable_os_id: linux-arm64-openssl3
+          extra_upload_tag: -deb-arm64-openssl3-sbom
+      - func: upload_compiled_artifact
+        vars:
+          executable_os_id: linux-arm64-openssl3
+          extra_upload_tag: -deb-arm64-openssl3-complete
+  - name: package_artifact_deb_arm64_openssl3
+    depends_on:
+      - name: add_crypt_shared_and_sbom_deb_arm64_openssl3
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.12.2"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-arm64-openssl3
+          extra_upload_tag: -deb-arm64-openssl3-complete
       - func: package_artifact
         vars:
           node_js_version: "20.12.2"
@@ -12893,7 +13396,7 @@ tasks:
           package_variant: deb-arm64-openssl3
           signature_tag: signed
       - func: verify_artifact
-  - name: package_artifact_rpm_arm64_openssl3
+  - name: add_crypt_shared_and_sbom_rpm_arm64_openssl3
     depends_on:
       - name: compile_artifact
         variant: linux_arm64_build_openssl3
@@ -12905,6 +13408,31 @@ tasks:
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64-openssl3
+      - func: add_crypt_shared_and_sbom
+        vars:
+          package_variant: rpm-arm64-openssl3
+          executable_os_id: linux-arm64-openssl3
+      - func: upload_sbom
+        vars:
+          executable_os_id: linux-arm64-openssl3
+          extra_upload_tag: -rpm-arm64-openssl3-sbom
+      - func: upload_compiled_artifact
+        vars:
+          executable_os_id: linux-arm64-openssl3
+          extra_upload_tag: -rpm-arm64-openssl3-complete
+  - name: package_artifact_rpm_arm64_openssl3
+    depends_on:
+      - name: add_crypt_shared_and_sbom_rpm_arm64_openssl3
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.12.2"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-arm64-openssl3
+          extra_upload_tag: -rpm-arm64-openssl3-complete
       - func: package_artifact
         vars:
           node_js_version: "20.12.2"
@@ -12950,7 +13478,7 @@ tasks:
           package_variant: rpm-arm64-openssl3
           signature_tag: signed
       - func: verify_artifact
-  - name: package_artifact_linux_ppc64le
+  - name: add_crypt_shared_and_sbom_linux_ppc64le
     depends_on:
       - name: compile_artifact
         variant: linux_ppc64le_build
@@ -12962,6 +13490,31 @@ tasks:
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-ppc64le
+      - func: add_crypt_shared_and_sbom
+        vars:
+          package_variant: linux-ppc64le
+          executable_os_id: linux-ppc64le
+      - func: upload_sbom
+        vars:
+          executable_os_id: linux-ppc64le
+          extra_upload_tag: -linux-ppc64le-sbom
+      - func: upload_compiled_artifact
+        vars:
+          executable_os_id: linux-ppc64le
+          extra_upload_tag: -linux-ppc64le-complete
+  - name: package_artifact_linux_ppc64le
+    depends_on:
+      - name: add_crypt_shared_and_sbom_linux_ppc64le
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.12.2"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-ppc64le
+          extra_upload_tag: -linux-ppc64le-complete
       - func: package_artifact
         vars:
           node_js_version: "20.12.2"
@@ -13007,7 +13560,7 @@ tasks:
           package_variant: linux-ppc64le
           signature_tag: signed
       - func: verify_artifact
-  - name: package_artifact_rpm_ppc64le
+  - name: add_crypt_shared_and_sbom_rpm_ppc64le
     depends_on:
       - name: compile_artifact
         variant: linux_ppc64le_build
@@ -13019,6 +13572,31 @@ tasks:
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-ppc64le
+      - func: add_crypt_shared_and_sbom
+        vars:
+          package_variant: rpm-ppc64le
+          executable_os_id: linux-ppc64le
+      - func: upload_sbom
+        vars:
+          executable_os_id: linux-ppc64le
+          extra_upload_tag: -rpm-ppc64le-sbom
+      - func: upload_compiled_artifact
+        vars:
+          executable_os_id: linux-ppc64le
+          extra_upload_tag: -rpm-ppc64le-complete
+  - name: package_artifact_rpm_ppc64le
+    depends_on:
+      - name: add_crypt_shared_and_sbom_rpm_ppc64le
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.12.2"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-ppc64le
+          extra_upload_tag: -rpm-ppc64le-complete
       - func: package_artifact
         vars:
           node_js_version: "20.12.2"
@@ -13064,7 +13642,7 @@ tasks:
           package_variant: rpm-ppc64le
           signature_tag: signed
       - func: verify_artifact
-  - name: package_artifact_linux_s390x
+  - name: add_crypt_shared_and_sbom_linux_s390x
     depends_on:
       - name: compile_artifact
         variant: linux_s390x_build
@@ -13076,6 +13654,31 @@ tasks:
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-s390x
+      - func: add_crypt_shared_and_sbom
+        vars:
+          package_variant: linux-s390x
+          executable_os_id: linux-s390x
+      - func: upload_sbom
+        vars:
+          executable_os_id: linux-s390x
+          extra_upload_tag: -linux-s390x-sbom
+      - func: upload_compiled_artifact
+        vars:
+          executable_os_id: linux-s390x
+          extra_upload_tag: -linux-s390x-complete
+  - name: package_artifact_linux_s390x
+    depends_on:
+      - name: add_crypt_shared_and_sbom_linux_s390x
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.12.2"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-s390x
+          extra_upload_tag: -linux-s390x-complete
       - func: package_artifact
         vars:
           node_js_version: "20.12.2"
@@ -13121,7 +13724,7 @@ tasks:
           package_variant: linux-s390x
           signature_tag: signed
       - func: verify_artifact
-  - name: package_artifact_rpm_s390x
+  - name: add_crypt_shared_and_sbom_rpm_s390x
     depends_on:
       - name: compile_artifact
         variant: linux_s390x_build
@@ -13133,6 +13736,31 @@ tasks:
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-s390x
+      - func: add_crypt_shared_and_sbom
+        vars:
+          package_variant: rpm-s390x
+          executable_os_id: linux-s390x
+      - func: upload_sbom
+        vars:
+          executable_os_id: linux-s390x
+          extra_upload_tag: -rpm-s390x-sbom
+      - func: upload_compiled_artifact
+        vars:
+          executable_os_id: linux-s390x
+          extra_upload_tag: -rpm-s390x-complete
+  - name: package_artifact_rpm_s390x
+    depends_on:
+      - name: add_crypt_shared_and_sbom_rpm_s390x
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.12.2"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-s390x
+          extra_upload_tag: -rpm-s390x-complete
       - func: package_artifact
         vars:
           node_js_version: "20.12.2"
@@ -13178,7 +13806,7 @@ tasks:
           package_variant: rpm-s390x
           signature_tag: signed
       - func: verify_artifact
-  - name: package_artifact_win32_x64
+  - name: add_crypt_shared_and_sbom_win32_x64
     depends_on:
       - name: compile_artifact
         variant: win32_build
@@ -13190,6 +13818,31 @@ tasks:
       - func: download_compiled_artifact
         vars:
           executable_os_id: win32
+      - func: add_crypt_shared_and_sbom
+        vars:
+          package_variant: win32-x64
+          executable_os_id: win32
+      - func: upload_sbom
+        vars:
+          executable_os_id: win32
+          extra_upload_tag: -win32-x64-sbom
+      - func: upload_compiled_artifact
+        vars:
+          executable_os_id: win32
+          extra_upload_tag: -win32-x64-complete
+  - name: package_artifact_win32_x64
+    depends_on:
+      - name: add_crypt_shared_and_sbom_win32_x64
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.12.2"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: win32
+          extra_upload_tag: -win32-x64-complete
       - func: package_artifact
         vars:
           node_js_version: "20.12.2"
@@ -13235,7 +13888,7 @@ tasks:
           package_variant: win32-x64
           signature_tag: signed
       - func: verify_artifact
-  - name: package_artifact_win32msi_x64
+  - name: add_crypt_shared_and_sbom_win32msi_x64
     depends_on:
       - name: compile_artifact
         variant: win32_build
@@ -13247,6 +13900,31 @@ tasks:
       - func: download_compiled_artifact
         vars:
           executable_os_id: win32
+      - func: add_crypt_shared_and_sbom
+        vars:
+          package_variant: win32msi-x64
+          executable_os_id: win32
+      - func: upload_sbom
+        vars:
+          executable_os_id: win32
+          extra_upload_tag: -win32msi-x64-sbom
+      - func: upload_compiled_artifact
+        vars:
+          executable_os_id: win32
+          extra_upload_tag: -win32msi-x64-complete
+  - name: package_artifact_win32msi_x64
+    depends_on:
+      - name: add_crypt_shared_and_sbom_win32msi_x64
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "20.12.2"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: win32
+          extra_upload_tag: -win32msi-x64-complete
       - func: package_artifact
         vars:
           node_js_version: "20.12.2"
@@ -14946,56 +15624,82 @@ buildvariants:
     run_on: ubuntu2004-small
     tags: ["nightly-driver"]
     tasks:
+      - name: add_crypt_shared_and_sbom_darwin_x64
+      - name: add_crypt_shared_and_sbom_darwin_arm64
+      - name: add_crypt_shared_and_sbom_linux_x64
       - name: package_artifact_linux_x64
       - name: sign_artifact_linux_x64
+      - name: add_crypt_shared_and_sbom_deb_x64
       - name: package_artifact_deb_x64
       - name: sign_artifact_deb_x64
       - name: verify_artifact_deb_x64
+      - name: add_crypt_shared_and_sbom_rpm_x64
       - name: package_artifact_rpm_x64
       - name: sign_artifact_rpm_x64
+      - name: add_crypt_shared_and_sbom_linux_x64_openssl11
       - name: package_artifact_linux_x64_openssl11
       - name: sign_artifact_linux_x64_openssl11
+      - name: add_crypt_shared_and_sbom_deb_x64_openssl11
       - name: package_artifact_deb_x64_openssl11
       - name: sign_artifact_deb_x64_openssl11
       - name: verify_artifact_deb_x64_openssl11
+      - name: add_crypt_shared_and_sbom_rpm_x64_openssl11
       - name: package_artifact_rpm_x64_openssl11
       - name: sign_artifact_rpm_x64_openssl11
+      - name: add_crypt_shared_and_sbom_linux_x64_openssl3
       - name: package_artifact_linux_x64_openssl3
       - name: sign_artifact_linux_x64_openssl3
+      - name: add_crypt_shared_and_sbom_deb_x64_openssl3
       - name: package_artifact_deb_x64_openssl3
       - name: sign_artifact_deb_x64_openssl3
       - name: verify_artifact_deb_x64_openssl3
+      - name: add_crypt_shared_and_sbom_rpm_x64_openssl3
       - name: package_artifact_rpm_x64_openssl3
       - name: sign_artifact_rpm_x64_openssl3
+      - name: add_crypt_shared_and_sbom_linux_arm64
       - name: package_artifact_linux_arm64
       - name: sign_artifact_linux_arm64
+      - name: add_crypt_shared_and_sbom_deb_arm64
       - name: package_artifact_deb_arm64
       - name: sign_artifact_deb_arm64
       - name: verify_artifact_deb_arm64
+      - name: add_crypt_shared_and_sbom_rpm_arm64
       - name: package_artifact_rpm_arm64
       - name: sign_artifact_rpm_arm64
+      - name: add_crypt_shared_and_sbom_linux_arm64_openssl11
       - name: package_artifact_linux_arm64_openssl11
       - name: sign_artifact_linux_arm64_openssl11
+      - name: add_crypt_shared_and_sbom_deb_arm64_openssl11
       - name: package_artifact_deb_arm64_openssl11
       - name: sign_artifact_deb_arm64_openssl11
       - name: verify_artifact_deb_arm64_openssl11
+      - name: add_crypt_shared_and_sbom_rpm_arm64_openssl11
       - name: package_artifact_rpm_arm64_openssl11
       - name: sign_artifact_rpm_arm64_openssl11
+      - name: add_crypt_shared_and_sbom_linux_arm64_openssl3
       - name: package_artifact_linux_arm64_openssl3
       - name: sign_artifact_linux_arm64_openssl3
+      - name: add_crypt_shared_and_sbom_deb_arm64_openssl3
       - name: package_artifact_deb_arm64_openssl3
       - name: sign_artifact_deb_arm64_openssl3
       - name: verify_artifact_deb_arm64_openssl3
+      - name: add_crypt_shared_and_sbom_rpm_arm64_openssl3
       - name: package_artifact_rpm_arm64_openssl3
       - name: sign_artifact_rpm_arm64_openssl3
+      - name: add_crypt_shared_and_sbom_linux_ppc64le
       - name: package_artifact_linux_ppc64le
       - name: sign_artifact_linux_ppc64le
+      - name: add_crypt_shared_and_sbom_rpm_ppc64le
       - name: package_artifact_rpm_ppc64le
       - name: sign_artifact_rpm_ppc64le
+      - name: add_crypt_shared_and_sbom_linux_s390x
       - name: package_artifact_linux_s390x
       - name: sign_artifact_linux_s390x
+      - name: add_crypt_shared_and_sbom_rpm_s390x
       - name: package_artifact_rpm_s390x
       - name: sign_artifact_rpm_s390x
+      - name: add_crypt_shared_and_sbom_win32_x64
+      - name: add_crypt_shared_and_sbom_win32msi_x64
       - name: sign_artifact_win32_x64
       - name: sign_artifact_win32msi_x64
   - name: verify_rhel_artifact

--- a/.evergreen/compile-artifact.sh
+++ b/.evergreen/compile-artifact.sh
@@ -91,7 +91,3 @@ if uname -a | grep -q 'Linux.*x86_64'; then
   # accidentally raised hardware requirements by changing how we compile mongosh.
   test $(objdump -d dist/mongosh | grep '\bvmovd\b' | wc -l) -lt 1250
 fi
-
-tar cvzf dist.tgz dist
-
-source .evergreen/compilation-context-expansions.sh

--- a/.evergreen/compile-artifact.sh
+++ b/.evergreen/compile-artifact.sh
@@ -6,6 +6,9 @@ cd $(pwd)
 
 source .evergreen/setup-env.sh
 
+# make sure our .sbom files are freshly created
+rm -vrf .sbom && mkdir -vp .sbom
+
 if uname -a | grep -q 'Linux.*x86_64'; then
   rm -rf "tmp/.sccache"
   mkdir -p "tmp/.sccache"
@@ -91,3 +94,9 @@ if uname -a | grep -q 'Linux.*x86_64'; then
   # accidentally raised hardware requirements by changing how we compile mongosh.
   test $(objdump -d dist/mongosh | grep '\bvmovd\b' | wc -l) -lt 1250
 fi
+
+npm run write-node-js-dep
+npm run create-purls-file
+cp .sbom/purls.txt dist/.purls.txt
+
+cat dist/.purls.txt

--- a/.evergreen/download-crypt-shared-and-generate-sbom.sh
+++ b/.evergreen/download-crypt-shared-and-generate-sbom.sh
@@ -2,10 +2,6 @@
 set -e
 set -x
 npm run evergreen-release download-crypt-shared-library
-rm -vrf .sbom && mkdir -vp .sbom
-npm run write-node-js-dep
-npm run create-purls-file
-cp .sbom/purls.txt dist/.purls.txt
 echo "pkg:generic/mongo_crypt_shared@$(cat dist/.mongo_crypt_*.version)" >> dist/.purls.txt
 
 cat dist/.purls.txt

--- a/.evergreen/download-crypt-shared-and-generate-sbom.sh
+++ b/.evergreen/download-crypt-shared-and-generate-sbom.sh
@@ -2,7 +2,9 @@
 set -e
 set -x
 npm run evergreen-release download-crypt-shared-library
-echo "pkg:generic/mongo_crypt_shared@$(cat dist/.mongo_crypt_*.version)" >> dist/.purls.txt
+
+ls -lhA dist
+echo "pkg:generic/mongo_crypt_shared@$(cat dist/.mongosh_crypt_*.version)" >> dist/.purls.txt
 
 cat dist/.purls.txt
 

--- a/.evergreen/download-crypt-shared-and-generate-sbom.sh
+++ b/.evergreen/download-crypt-shared-and-generate-sbom.sh
@@ -2,6 +2,7 @@
 set -e
 set -x
 npm run evergreen-release download-crypt-shared-library
+rm -vrf .sbom && mkdir -vp .sbom
 npm run write-node-js-dep
 npm run create-purls-file
 cp .sbom/purls.txt dist/.purls.txt

--- a/.evergreen/download-crypt-shared-and-generate-sbom.sh
+++ b/.evergreen/download-crypt-shared-and-generate-sbom.sh
@@ -15,5 +15,5 @@ docker login artifactory.corp.mongodb.com --username ${ARTIFACTORY_USERNAME} --p
 set -x
 
 docker pull artifactory.corp.mongodb.com/release-tools-container-registry-public-local/silkbomb:1.0
-docker run -it --rm -v ${PWD}:/pwd artifactory.corp.mongodb.com/release-tools-container-registry-public-local/silkbomb:1.0 update \
+docker run --rm -v ${PWD}:/pwd artifactory.corp.mongodb.com/release-tools-container-registry-public-local/silkbomb:1.0 update \
   --purls /pwd/dist/.purls.txt --sbom_out /pwd/dist/.sbom.json

--- a/.evergreen/download-crypt-shared-and-generate-sbom.sh
+++ b/.evergreen/download-crypt-shared-and-generate-sbom.sh
@@ -1,0 +1,18 @@
+#!/bin/bash
+set -e
+set -x
+npm run evergreen-release download-crypt-shared-library
+npm run write-node-js-dep
+npm run create-purls-file
+cp .sbom/purls.txt dist/.purls.txt
+echo "pkg:generic/mongo_crypt_shared@$(cat dist/.mongo_crypt_*.version)" >> dist/.purls.txt
+
+cat dist/.purls.txt
+
+set +x
+docker login artifactory.corp.mongodb.com --username ${ARTIFACTORY_USERNAME} --password ${ARTIFACTORY_PASSWORD}
+set -x
+
+docker pull artifactory.corp.mongodb.com/release-tools-container-registry-public-local/silkbomb:1.0
+docker run -it --rm -v ${PWD}:/pwd artifactory.corp.mongodb.com/release-tools-container-registry-public-local/silkbomb:1.0 update \
+  --purls /pwd/dist/.purls.txt --sbom_out /pwd/dist/.sbom.json

--- a/.evergreen/evergreen.yml.in
+++ b/.evergreen/evergreen.yml.in
@@ -425,6 +425,7 @@ functions:
         script: |
           set -e
           set -x
+          tar cvzf dist.tgz dist
           bash .evergreen/compilation-context-expansions.sh
     - command: expansions.update
       params:

--- a/.evergreen/evergreen.yml.in
+++ b/.evergreen/evergreen.yml.in
@@ -400,6 +400,26 @@ functions:
       params:
         ignore_missing_file: false
         file: tmp/compiling-context.yml
+  upload_sbom:
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/dist/.sbom.json
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/mongosh-${executable_os_id}${extra_upload_tag}-sbom.json
+        bucket: mciuploads
+        permissions: public-read
+        content_type: application/json
+    - command: s3.put
+      params:
+        aws_key: ${aws_key}
+        aws_secret: ${aws_secret}
+        local_file: src/dist/.purls.txt
+        remote_file: mongosh/binaries/${revision}/${revision_order_id}/mongosh-${executable_os_id}${extra_upload_tag}-purls.txt
+        bucket: mciuploads
+        permissions: public-read
+        content_type: text/plain
+  upload_compiled_artifact:
     - command: s3.put
       params:
         aws_key: ${aws_key}
@@ -467,6 +487,17 @@ functions:
   # - package_variant
   # - signature_tag (either 'signed' or 'unsigned')
   ###
+  add_crypt_shared_and_sbom:
+    - command: subprocess.exec
+      params:
+        working_dir: src
+        binary: bash .evergreen/download-crypt-shared-and-generate-sbom.sh
+        env:
+          NODE_JS_VERSION: ${node_js_version}
+          DISTRO_ID_OVERRIDE: ${distro_id}
+          PACKAGE_VARIANT: ${package_variant}
+          ARTIFACTORY_USERNAME: ${artifactory_username}
+          ARTIFACTORY_PASSWORD: ${artifactory_password}
   package_artifact:
     - command: expansions.write
       type: setup
@@ -688,11 +719,6 @@ functions:
           }
 
   generate_license_and_vulnerability_report:
-    - command: expansions.write
-      type: system
-      params:
-        file: tmp/expansions.yaml
-        redacted: true
     - command: shell.exec
       params:
         working_dir: src
@@ -705,7 +731,6 @@ functions:
           JIRA_API_TOKEN: ${jira_api_token}
         script: |
           set -e
-          export NODE_JS_VERSION=${node_js_version}
           source .evergreen/setup-env.sh
 
           # validate licenses, we first remove THIRD_PARTY_NOTICES.md, so we are sure
@@ -1055,6 +1080,9 @@ tasks:
       - func: compile_artifact
         vars:
           node_js_version: "<% out(NODE_JS_VERSION_20) %>"
+      - func: upload_compiled_artifact
+        vars:
+          node_js_version: "<% out(NODE_JS_VERSION_20) %>"
 
   - name: generate_license_and_vulnerability_report
     tags: ["extra-integration-test"]
@@ -1147,7 +1175,7 @@ tasks:
   ###
   <% for (const { executableOsId, compileBuildVariant, packages } of RELEASE_PACKAGE_MATRIX) {
        for (const { name: packageVariant } of packages) { %>
-  - name: package_artifact_<% out(packageVariant.replace(/-/g, '_')) %>
+  - name: add_crypt_shared_and_sbom_<% out(packageVariant.replace(/-/g, '_')) %>
     depends_on:
       - name: compile_artifact
         variant: <% out(compileBuildVariant) %>
@@ -1159,6 +1187,31 @@ tasks:
       - func: download_compiled_artifact
         vars:
           executable_os_id: <% out(executableOsId) %>
+      - func: add_crypt_shared_and_sbom
+        vars:
+          package_variant: <% out(packageVariant) %>
+          executable_os_id: <% out(executableOsId) %>
+      - func: upload_sbom
+        vars:
+          executable_os_id: <% out(executableOsId) %>
+          extra_upload_tag: -<% out(packageVariant) %>-sbom
+      - func: upload_compiled_artifact
+        vars:
+          executable_os_id: <% out(executableOsId) %>
+          extra_upload_tag: -<% out(packageVariant) %>-complete
+  - name: package_artifact_<% out(packageVariant.replace(/-/g, '_')) %>
+    depends_on:
+      - name: add_crypt_shared_and_sbom_<% out(packageVariant.replace(/-/g, '_')) %>
+        variant: linux_package
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: "<% out(NODE_JS_VERSION_20) %>"
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: <% out(executableOsId) %>
+          extra_upload_tag: -<% out(packageVariant) %>-complete
       - func: package_artifact
         vars:
           node_js_version: "<% out(NODE_JS_VERSION_20) %>"
@@ -1384,7 +1437,9 @@ buildvariants:
     tags: ["nightly-driver"]
     tasks:
       <% for (const { executableOsId, packages } of RELEASE_PACKAGE_MATRIX) {
-          for (const { name: packageVariant } of packages) {
+          for (const { name: packageVariant } of packages) { %>
+      - name: add_crypt_shared_and_sbom_<% out(packageVariant.replace(/-/g, '_')) %>
+      <%
             if (executableOsId.startsWith('linux')) { %>
       - name: package_artifact_<% out(packageVariant.replace(/-/g, '_')) %>
       - name: sign_artifact_<% out(packageVariant.replace(/-/g, '_')) %>

--- a/.evergreen/evergreen.yml.in
+++ b/.evergreen/evergreen.yml.in
@@ -396,10 +396,6 @@ functions:
           DISTRO_ID: ${distro_id}
           NODE_JS_VERSION: ${node_js_version}
           MONGOSH_SHARED_OPENSSL: ${mongosh_shared_openssl}
-    - command: expansions.update
-      params:
-        ignore_missing_file: false
-        file: tmp/compiling-context.yml
   upload_sbom:
     - command: s3.put
       params:
@@ -420,6 +416,20 @@ functions:
         permissions: public-read
         content_type: text/plain
   upload_compiled_artifact:
+    - command: shell.exec
+      params:
+        working_dir: src
+        shell: bash
+        env:
+          DISTRO_ID: ${distro_id}
+        script: |
+          set -e
+          set -x
+          bash .evergreen/compilation-context-expansions.sh
+    - command: expansions.update
+      params:
+        ignore_missing_file: false
+        file: tmp/compiling-context.yml
     - command: s3.put
       params:
         aws_key: ${aws_key}

--- a/config/build.conf.js
+++ b/config/build.conf.js
@@ -48,7 +48,7 @@ const EXECUTABLE_PATH = path.join(OUTPUT_DIR, process.platform === 'win32' ? 'mo
  * We use the name mongosh_crypt_v1 to avoid conflicts with users
  * potentially installing the 'proper' crypt shared library.
  */
-const CRYPT_LIBRARY_PATH = path.resolve(TMP_DIR, 'mongosh_crypt_v1.' + SHARED_LIBRARY_SUFFIX);
+const CRYPT_LIBRARY_PATH = path.resolve(OUTPUT_DIR, 'mongosh_crypt_v1.' + SHARED_LIBRARY_SUFFIX);
 
 /**
  * Build info JSON data file.
@@ -148,7 +148,11 @@ module.exports = {
         {
           sourceFilePath: path.resolve(__dirname, '..', 'THIRD_PARTY_NOTICES.md'),
           packagedFilePath: 'THIRD_PARTY_NOTICES'
-        }
+        },
+        {
+          sourceFilePath: path.resolve(EXECUTABLE_PATH, '.sbom.json'),
+          packagedFilePath: '.sbom.json'
+        },
       ],
       manpage: {
         sourceFilePath: path.resolve(TMP_DIR, 'manpage', MANPAGE_NAME),

--- a/config/build.conf.js
+++ b/config/build.conf.js
@@ -4,8 +4,8 @@ const path = require('path');
 const os = require('os');
 
 const SHARED_LIBRARY_SUFFIX =
-  process.platform === 'win32' ? 'dll' :
-  process.platform === 'darwin' ? 'dylib' : 'so';
+  (process.env.PACKAGE_VARIANT ?? process.platform).startsWith('win32') ? 'dll' :
+  (process.env.PACKAGE_VARIANT ?? process.platform).startsWith('darwin') ? 'dylib' : 'so';
 
 /**
  * The project root.

--- a/config/build.conf.js
+++ b/config/build.conf.js
@@ -150,7 +150,7 @@ module.exports = {
           packagedFilePath: 'THIRD_PARTY_NOTICES'
         },
         {
-          sourceFilePath: path.resolve(EXECUTABLE_PATH, '.sbom.json'),
+          sourceFilePath: path.resolve(path.dirname(EXECUTABLE_PATH), '.sbom.json'),
           packagedFilePath: '.sbom.json'
         },
       ],

--- a/package-lock.json
+++ b/package-lock.json
@@ -38,6 +38,10 @@
         "packages/browser-repl",
         "packages/connectivity-tests"
       ],
+      "dependencies": {
+        "@cyclonedx/cyclonedx-library": "^6.6.0",
+        "npm-package-arg": "^11.0.2"
+      },
       "bin": {
         "mongosh": "packages/cli-repl/bin/mongosh.js"
       },
@@ -2940,6 +2944,70 @@
         "@jridgewell/resolve-uri": "^3.0.3",
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
+    },
+    "node_modules/@cyclonedx/cyclonedx-library": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@cyclonedx/cyclonedx-library/-/cyclonedx-library-6.6.0.tgz",
+      "integrity": "sha512-1d9gWCE+yrBICRxrPMZqDoPlQGng0Z08WGMz87wAHwiUFkmLlW8gQTGbPTGHUIgLg7mp2zYNo+eyE4VlWetBWg==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://owasp.org/donate/?reponame=www-project-cyclonedx&title=OWASP+CycloneDX"
+        }
+      ],
+      "dependencies": {
+        "packageurl-js": ">=0.0.6 <0.0.8 || ^1",
+        "spdx-expression-parse": "^3.0.1 || ^4"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "optionalDependencies": {
+        "ajv": "^8.12.0",
+        "ajv-formats": "^3.0.1",
+        "ajv-formats-draft2019": "^1.6.1",
+        "libxmljs2": "^0.31 || ^0.32 || ^0.33",
+        "xmlbuilder2": "^3.0.2"
+      }
+    },
+    "node_modules/@cyclonedx/cyclonedx-library/node_modules/ajv": {
+      "version": "8.13.0",
+      "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.13.0.tgz",
+      "integrity": "sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==",
+      "optional": true,
+      "dependencies": {
+        "fast-deep-equal": "^3.1.3",
+        "json-schema-traverse": "^1.0.0",
+        "require-from-string": "^2.0.2",
+        "uri-js": "^4.4.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/@cyclonedx/cyclonedx-library/node_modules/ajv-formats": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+      "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+      "optional": true,
+      "dependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependencies": {
+        "ajv": "^8.0.0"
+      },
+      "peerDependenciesMeta": {
+        "ajv": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@cyclonedx/cyclonedx-library/node_modules/json-schema-traverse": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+      "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+      "optional": true
     },
     "node_modules/@discoveryjs/json-ext": {
       "version": "0.5.7",
@@ -6226,27 +6294,6 @@
         "uuid": "dist/bin/uuid"
       }
     },
-    "node_modules/@lerna/create/node_modules/validate-npm-package-name": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.0.tgz",
-      "integrity": "sha512-YuKoXDAhBYxY7SfOKxHBDoSyENFeW5VvIIQp2TGQuit8gpK6MnWaQelBKxso72DoxTZfZdcP3W90LqpSkgPzLQ==",
-      "optional": true,
-      "dependencies": {
-        "builtins": "^5.0.0"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/@lerna/create/node_modules/validate-npm-package-name/node_modules/builtins": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/builtins/-/builtins-5.0.1.tgz",
-      "integrity": "sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==",
-      "optional": true,
-      "dependencies": {
-        "semver": "^7.0.0"
-      }
-    },
     "node_modules/@lerna/create/node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -6364,6 +6411,109 @@
       },
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz",
+      "integrity": "sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "make-dir": "^3.1.0",
+        "node-fetch": "^2.6.7",
+        "nopt": "^5.0.0",
+        "npmlog": "^5.0.1",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
+        "tar": "^6.1.11"
+      },
+      "bin": {
+        "node-pre-gyp": "bin/node-pre-gyp"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/are-we-there-yet": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
+      "integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
+      "optional": true,
+      "dependencies": {
+        "delegates": "^1.0.0",
+        "readable-stream": "^3.6.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/gauge": {
+      "version": "3.0.2",
+      "resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
+      "integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
+      "optional": true,
+      "dependencies": {
+        "aproba": "^1.0.3 || ^2.0.0",
+        "color-support": "^1.1.2",
+        "console-control-strings": "^1.0.0",
+        "has-unicode": "^2.0.1",
+        "object-assign": "^4.1.1",
+        "signal-exit": "^3.0.0",
+        "string-width": "^4.2.3",
+        "strip-ansi": "^6.0.1",
+        "wide-align": "^1.1.2"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+      "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+      "optional": true,
+      "dependencies": {
+        "semver": "^6.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/make-dir/node_modules/semver": {
+      "version": "6.3.1",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+      "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+      "optional": true,
+      "bin": {
+        "semver": "bin/semver.js"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/npmlog": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
+      "integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
+      "optional": true,
+      "dependencies": {
+        "are-we-there-yet": "^2.0.0",
+        "console-control-strings": "^1.1.0",
+        "gauge": "^3.0.0",
+        "set-blocking": "^2.0.0"
+      }
+    },
+    "node_modules/@mapbox/node-pre-gyp/node_modules/readable-stream": {
+      "version": "3.6.2",
+      "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+      "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+      "optional": true,
+      "dependencies": {
+        "inherits": "^2.0.3",
+        "string_decoder": "^1.1.1",
+        "util-deprecate": "^1.0.1"
+      },
+      "engines": {
+        "node": ">= 6"
       }
     },
     "node_modules/@mongodb-js/compass-components": {
@@ -6586,6 +6736,7 @@
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/@mongodb-js/mongodb-downloader/-/mongodb-downloader-0.2.9.tgz",
       "integrity": "sha512-RaTqbRkBSuB4ixo9c8BbImEET0HuK3j0F+Y429rD22TiOCozUNxM26OmOydNE3Fb8A4C/ble1BCRFv78J7X6Nw==",
+      "dev": true,
       "dependencies": {
         "debug": "^4.3.4",
         "decompress": "^4.2.1",
@@ -8307,6 +8458,54 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@one-ini/wasm/-/wasm-0.1.1.tgz",
       "integrity": "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw=="
+    },
+    "node_modules/@oozcitak/dom": {
+      "version": "1.15.10",
+      "resolved": "https://registry.npmjs.org/@oozcitak/dom/-/dom-1.15.10.tgz",
+      "integrity": "sha512-0JT29/LaxVgRcGKvHmSrUTEvZ8BXvZhGl2LASRUgHqDTC1M5g1pLmVv56IYNyt3bG2CUjDkc67wnyZC14pbQrQ==",
+      "optional": true,
+      "dependencies": {
+        "@oozcitak/infra": "1.0.8",
+        "@oozcitak/url": "1.0.4",
+        "@oozcitak/util": "8.3.8"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/@oozcitak/infra": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@oozcitak/infra/-/infra-1.0.8.tgz",
+      "integrity": "sha512-JRAUc9VR6IGHOL7OGF+yrvs0LO8SlqGnPAMqyzOuFZPSZSXI7Xf2O9+awQPSMXgIWGtgUf/dA6Hs6X6ySEaWTg==",
+      "optional": true,
+      "dependencies": {
+        "@oozcitak/util": "8.3.8"
+      },
+      "engines": {
+        "node": ">=6.0"
+      }
+    },
+    "node_modules/@oozcitak/url": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@oozcitak/url/-/url-1.0.4.tgz",
+      "integrity": "sha512-kDcD8y+y3FCSOvnBI6HJgl00viO/nGbQoCINmQ0h98OhnGITrWR3bOGfwYCthgcrV8AnTJz8MzslTQbC3SOAmw==",
+      "optional": true,
+      "dependencies": {
+        "@oozcitak/infra": "1.0.8",
+        "@oozcitak/util": "8.3.8"
+      },
+      "engines": {
+        "node": ">=8.0"
+      }
+    },
+    "node_modules/@oozcitak/util": {
+      "version": "8.3.8",
+      "resolved": "https://registry.npmjs.org/@oozcitak/util/-/util-8.3.8.tgz",
+      "integrity": "sha512-T8TbSnGsxo6TDBJx/Sgv/BlVJL3tshxZP7Aq5R1mSnM5OcHY2dQaxLMu2+E8u3gN0MLOzdjurqN4ZRVuzQycOQ==",
+      "optional": true,
+      "engines": {
+        "node": ">=8.0"
+      }
     },
     "node_modules/@parcel/watcher": {
       "version": "2.0.4",
@@ -11201,6 +11400,21 @@
         "ajv": {
           "optional": true
         }
+      }
+    },
+    "node_modules/ajv-formats-draft2019": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats-draft2019/-/ajv-formats-draft2019-1.6.1.tgz",
+      "integrity": "sha512-JQPvavpkWDvIsBp2Z33UkYCtXCSpW4HD3tAZ+oL4iEFOk9obQZffx0yANwECt6vzr6ET+7HN5czRyqXbnq/u0Q==",
+      "optional": true,
+      "dependencies": {
+        "punycode": "^2.1.1",
+        "schemes": "^1.4.0",
+        "smtp-address-parser": "^1.0.3",
+        "uri-js": "^4.4.1"
+      },
+      "peerDependencies": {
+        "ajv": "*"
       }
     },
     "node_modules/ajv-formats/node_modules/ajv": {
@@ -14374,7 +14588,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
       "integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/dns-equal": {
       "version": "1.0.0",
@@ -15847,7 +16061,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/external-editor": {
       "version": "3.1.0",
@@ -17946,15 +18160,6 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
-    "node_modules/init-package-json/node_modules/builtins": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/builtins/-/builtins-5.0.1.tgz",
-      "integrity": "sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==",
-      "optional": true,
-      "dependencies": {
-        "semver": "^7.0.0"
-      }
-    },
     "node_modules/init-package-json/node_modules/hosted-git-info": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-6.1.1.tgz",
@@ -17986,18 +18191,6 @@
         "proc-log": "^3.0.0",
         "semver": "^7.3.5",
         "validate-npm-package-name": "^5.0.0"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/init-package-json/node_modules/validate-npm-package-name": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.0.tgz",
-      "integrity": "sha512-YuKoXDAhBYxY7SfOKxHBDoSyENFeW5VvIIQp2TGQuit8gpK6MnWaQelBKxso72DoxTZfZdcP3W90LqpSkgPzLQ==",
-      "optional": true,
-      "dependencies": {
-        "builtins": "^5.0.0"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -21228,27 +21421,6 @@
         "uuid": "dist/bin/uuid"
       }
     },
-    "node_modules/lerna/node_modules/validate-npm-package-name": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.0.tgz",
-      "integrity": "sha512-YuKoXDAhBYxY7SfOKxHBDoSyENFeW5VvIIQp2TGQuit8gpK6MnWaQelBKxso72DoxTZfZdcP3W90LqpSkgPzLQ==",
-      "optional": true,
-      "dependencies": {
-        "builtins": "^5.0.0"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/lerna/node_modules/validate-npm-package-name/node_modules/builtins": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/builtins/-/builtins-5.0.1.tgz",
-      "integrity": "sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==",
-      "optional": true,
-      "dependencies": {
-        "semver": "^7.0.0"
-      }
-    },
     "node_modules/lerna/node_modules/webidl-conversions": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -21330,15 +21502,6 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
-    "node_modules/libnpmaccess/node_modules/builtins": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/builtins/-/builtins-5.0.1.tgz",
-      "integrity": "sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==",
-      "optional": true,
-      "dependencies": {
-        "semver": "^7.0.0"
-      }
-    },
     "node_modules/libnpmaccess/node_modules/hosted-git-info": {
       "version": "6.1.1",
       "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-6.1.1.tgz",
@@ -21375,18 +21538,6 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
-    "node_modules/libnpmaccess/node_modules/validate-npm-package-name": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.0.tgz",
-      "integrity": "sha512-YuKoXDAhBYxY7SfOKxHBDoSyENFeW5VvIIQp2TGQuit8gpK6MnWaQelBKxso72DoxTZfZdcP3W90LqpSkgPzLQ==",
-      "optional": true,
-      "dependencies": {
-        "builtins": "^5.0.0"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
     "node_modules/libnpmpublish": {
       "version": "7.3.0",
       "resolved": "https://registry.npmjs.org/libnpmpublish/-/libnpmpublish-7.3.0.tgz",
@@ -21404,15 +21555,6 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/libnpmpublish/node_modules/builtins": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/builtins/-/builtins-5.0.1.tgz",
-      "integrity": "sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==",
-      "optional": true,
-      "dependencies": {
-        "semver": "^7.0.0"
       }
     },
     "node_modules/libnpmpublish/node_modules/hosted-git-info": {
@@ -21487,17 +21629,26 @@
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
-    "node_modules/libnpmpublish/node_modules/validate-npm-package-name": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.0.tgz",
-      "integrity": "sha512-YuKoXDAhBYxY7SfOKxHBDoSyENFeW5VvIIQp2TGQuit8gpK6MnWaQelBKxso72DoxTZfZdcP3W90LqpSkgPzLQ==",
+    "node_modules/libxmljs2": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/libxmljs2/-/libxmljs2-0.33.0.tgz",
+      "integrity": "sha512-Hw74f2/3rbpxc6tkTqe3yrs4v2Tx0rEukrYxaNkXSVKK540i2eqlQxzf1jjG+RlwMuv66WxkkuZHM/OQq6km4w==",
+      "hasInstallScript": true,
       "optional": true,
       "dependencies": {
-        "builtins": "^5.0.0"
+        "@mapbox/node-pre-gyp": "^1.0.11",
+        "bindings": "~1.5.0",
+        "nan": "~2.18.0"
       },
       "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+        "node": ">=18"
       }
+    },
+    "node_modules/libxmljs2/node_modules/nan": {
+      "version": "2.18.0",
+      "resolved": "https://registry.npmjs.org/nan/-/nan-2.18.0.tgz",
+      "integrity": "sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w==",
+      "optional": true
     },
     "node_modules/lines-and-columns": {
       "version": "1.2.4",
@@ -23095,7 +23246,7 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.2.tgz",
       "integrity": "sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/mrmime": {
       "version": "1.0.1",
@@ -23242,7 +23393,7 @@
       "version": "2.20.1",
       "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
       "integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "commander": "^2.19.0",
         "moo": "^0.5.0",
@@ -23689,17 +23840,44 @@
       "devOptional": true
     },
     "node_modules/npm-package-arg": {
-      "version": "8.1.5",
-      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-8.1.5.tgz",
-      "integrity": "sha512-LhgZrg0n0VgvzVdSm1oiZworPbTxYHUJCgtsJW8mGvlDpxTM1vSJc3m5QZeUkhAHIzbz3VCHd/R4osi1L1Tg/Q==",
-      "dev": true,
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-11.0.2.tgz",
+      "integrity": "sha512-IGN0IAwmhDJwy13Wc8k+4PEbTPhpJnMtfR53ZbOyjkvmEcLS4nCwp6mvMWjS5sUjeiW3mpx6cHmuhKEu9XmcQw==",
       "dependencies": {
-        "hosted-git-info": "^4.0.1",
-        "semver": "^7.3.4",
-        "validate-npm-package-name": "^3.0.0"
+        "hosted-git-info": "^7.0.0",
+        "proc-log": "^4.0.0",
+        "semver": "^7.3.5",
+        "validate-npm-package-name": "^5.0.0"
       },
       "engines": {
-        "node": ">=10"
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm-package-arg/node_modules/hosted-git-info": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.1.tgz",
+      "integrity": "sha512-+K84LB1DYwMHoHSgaOY/Jfhw3ucPmSET5v98Ke/HdNSw4a0UktWzyW1mjhjpuxxTqOOsfWT/7iVshHmVZ4IpOA==",
+      "dependencies": {
+        "lru-cache": "^10.0.1"
+      },
+      "engines": {
+        "node": "^16.14.0 || >=18.0.0"
+      }
+    },
+    "node_modules/npm-package-arg/node_modules/lru-cache": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.2.tgz",
+      "integrity": "sha512-9hp3Vp2/hFQUiIwKo8XCeFVnrg8Pk3TYNPIR7tJADKi5YfcF7vEaK7avFHTlSy3kOKYaJQaalfEo6YuXdceBOQ==",
+      "engines": {
+        "node": "14 || >=16.14"
+      }
+    },
+    "node_modules/npm-package-arg/node_modules/proc-log": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-4.2.0.tgz",
+      "integrity": "sha512-g8+OnU/L2v+wyiVK+D5fA34J7EH8jZ8DDlvwhRCMxmMj7UCBvxiO1mGeN+36JXIKF4zevU4kRBd8lVgG9vLelA==",
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
     },
     "node_modules/npm-packlist": {
@@ -23752,6 +23930,29 @@
         "semver": "^7.3.4"
       }
     },
+    "node_modules/npm-pick-manifest/node_modules/npm-package-arg": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-8.1.5.tgz",
+      "integrity": "sha512-LhgZrg0n0VgvzVdSm1oiZworPbTxYHUJCgtsJW8mGvlDpxTM1vSJc3m5QZeUkhAHIzbz3VCHd/R4osi1L1Tg/Q==",
+      "dev": true,
+      "dependencies": {
+        "hosted-git-info": "^4.0.1",
+        "semver": "^7.3.4",
+        "validate-npm-package-name": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
+    "node_modules/npm-pick-manifest/node_modules/validate-npm-package-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
+      "integrity": "sha512-M6w37eVCMMouJ9V/sdPGnC5H4uDr73/+xdq0FBLO3TFFX1+7wiUY6Es328NN+y43tmY+doUdN9g9J21vqB7iLw==",
+      "dev": true,
+      "dependencies": {
+        "builtins": "^1.0.3"
+      }
+    },
     "node_modules/npm-registry-fetch": {
       "version": "14.0.5",
       "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-14.0.5.tgz",
@@ -23768,15 +23969,6 @@
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm-registry-fetch/node_modules/builtins": {
-      "version": "5.0.1",
-      "resolved": "https://registry.npmjs.org/builtins/-/builtins-5.0.1.tgz",
-      "integrity": "sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==",
-      "optional": true,
-      "dependencies": {
-        "semver": "^7.0.0"
       }
     },
     "node_modules/npm-registry-fetch/node_modules/hosted-git-info": {
@@ -23845,18 +24037,6 @@
         "proc-log": "^3.0.0",
         "semver": "^7.3.5",
         "validate-npm-package-name": "^5.0.0"
-      },
-      "engines": {
-        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
-      }
-    },
-    "node_modules/npm-registry-fetch/node_modules/validate-npm-package-name": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.0.tgz",
-      "integrity": "sha512-YuKoXDAhBYxY7SfOKxHBDoSyENFeW5VvIIQp2TGQuit8gpK6MnWaQelBKxso72DoxTZfZdcP3W90LqpSkgPzLQ==",
-      "optional": true,
-      "dependencies": {
-        "builtins": "^5.0.0"
       },
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
@@ -24829,6 +25009,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/packageurl-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/packageurl-js/-/packageurl-js-1.2.1.tgz",
+      "integrity": "sha512-cZ6/MzuXaoFd16/k0WnwtI298UCaDHe/XlSh85SeOKbGZ1hq0xvNbx3ILyCMyk7uFQxl6scF3Aucj6/EO9NwcA=="
+    },
     "node_modules/pacote": {
       "version": "11.3.5",
       "resolved": "https://registry.npmjs.org/pacote/-/pacote-11.3.5.tgz",
@@ -24924,6 +25109,20 @@
         "node": ">=10"
       }
     },
+    "node_modules/pacote/node_modules/npm-package-arg": {
+      "version": "8.1.5",
+      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-8.1.5.tgz",
+      "integrity": "sha512-LhgZrg0n0VgvzVdSm1oiZworPbTxYHUJCgtsJW8mGvlDpxTM1vSJc3m5QZeUkhAHIzbz3VCHd/R4osi1L1Tg/Q==",
+      "dev": true,
+      "dependencies": {
+        "hosted-git-info": "^4.0.1",
+        "semver": "^7.3.4",
+        "validate-npm-package-name": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/pacote/node_modules/npm-registry-fetch": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-11.0.0.tgz",
@@ -24953,6 +25152,15 @@
       },
       "engines": {
         "node": ">= 10"
+      }
+    },
+    "node_modules/pacote/node_modules/validate-npm-package-name": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
+      "integrity": "sha512-M6w37eVCMMouJ9V/sdPGnC5H4uDr73/+xdq0FBLO3TFFX1+7wiUY6Es328NN+y43tmY+doUdN9g9J21vqB7iLw==",
+      "dev": true,
+      "dependencies": {
+        "builtins": "^1.0.3"
       }
     },
     "node_modules/pad": {
@@ -26035,7 +26243,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
       "integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==",
-      "dev": true
+      "devOptional": true
     },
     "node_modules/ramda": {
       "version": "0.27.2",
@@ -26046,7 +26254,7 @@
       "version": "0.4.6",
       "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
       "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
-      "dev": true,
+      "devOptional": true,
       "dependencies": {
         "discontinuous-range": "1.0.0",
         "ret": "~0.1.10"
@@ -27013,7 +27221,7 @@
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
-      "dev": true,
+      "devOptional": true,
       "engines": {
         "node": ">=0.12"
       }
@@ -27239,6 +27447,15 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/schemes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/schemes/-/schemes-1.4.0.tgz",
+      "integrity": "sha512-ImFy9FbCsQlVgnE3TCWmLPCFnVzx0lHL/l+umHplDqAKd0dzFpnS6lFZIpagBlYhKwzVmlV36ec0Y1XTu8JBAQ==",
+      "optional": true,
+      "dependencies": {
+        "extend": "^3.0.0"
       }
     },
     "node_modules/scss-parser": {
@@ -27757,6 +27974,18 @@
         "npm": ">= 3.0.0"
       }
     },
+    "node_modules/smtp-address-parser": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/smtp-address-parser/-/smtp-address-parser-1.0.10.tgz",
+      "integrity": "sha512-Osg9LmvGeAG/hyao4mldbflLOkkr3a+h4m1lwKCK5U8M6ZAr7tdXEz/+/vr752TSGE4MNUlUl9cIK2cB8cgzXg==",
+      "optional": true,
+      "dependencies": {
+        "nearley": "^2.20.1"
+      },
+      "engines": {
+        "node": ">=0.10"
+      }
+    },
     "node_modules/snyk-module": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/snyk-module/-/snyk-module-3.2.0.tgz",
@@ -28076,14 +28305,12 @@
     "node_modules/spdx-exceptions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
-      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
-      "devOptional": true
+      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A=="
     },
     "node_modules/spdx-expression-parse": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
       "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
-      "devOptional": true,
       "dependencies": {
         "spdx-exceptions": "^2.1.0",
         "spdx-license-ids": "^3.0.0"
@@ -28092,8 +28319,7 @@
     "node_modules/spdx-license-ids": {
       "version": "3.0.11",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz",
-      "integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==",
-      "devOptional": true
+      "integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g=="
     },
     "node_modules/spdx-ranges": {
       "version": "2.1.1",
@@ -29695,12 +29921,22 @@
       }
     },
     "node_modules/validate-npm-package-name": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
-      "integrity": "sha512-M6w37eVCMMouJ9V/sdPGnC5H4uDr73/+xdq0FBLO3TFFX1+7wiUY6Es328NN+y43tmY+doUdN9g9J21vqB7iLw==",
-      "dev": true,
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.0.tgz",
+      "integrity": "sha512-YuKoXDAhBYxY7SfOKxHBDoSyENFeW5VvIIQp2TGQuit8gpK6MnWaQelBKxso72DoxTZfZdcP3W90LqpSkgPzLQ==",
       "dependencies": {
-        "builtins": "^1.0.3"
+        "builtins": "^5.0.0"
+      },
+      "engines": {
+        "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
+      }
+    },
+    "node_modules/validate-npm-package-name/node_modules/builtins": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/builtins/-/builtins-5.1.0.tgz",
+      "integrity": "sha512-SW9lzGTLvWTP1AY8xeAMZimqDrIaSdLQUcVr9DMef51niJ022Ri87SwRRKYm4A6iHfkPaiVUu/Duw2Wc4J7kKg==",
+      "dependencies": {
+        "semver": "^7.0.0"
       }
     },
     "node_modules/vary": {
@@ -30744,6 +30980,21 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/xmlbuilder2": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder2/-/xmlbuilder2-3.1.1.tgz",
+      "integrity": "sha512-WCSfbfZnQDdLQLiMdGUQpMxxckeQ4oZNMNhLVkcekTu7xhD4tuUDyAPoY8CwXvBYE6LwBHd6QW2WZXlOWr1vCw==",
+      "optional": true,
+      "dependencies": {
+        "@oozcitak/dom": "1.15.10",
+        "@oozcitak/infra": "1.0.8",
+        "@oozcitak/util": "8.3.8",
+        "js-yaml": "3.14.1"
+      },
+      "engines": {
+        "node": ">=12.0"
+      }
+    },
     "node_modules/xtend": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
@@ -31159,7 +31410,7 @@
       "dependencies": {
         "@mongodb-js/devtools-github-repo": "^1.0.1",
         "@mongodb-js/dl-center": "^1.1.1",
-        "@mongodb-js/mongodb-downloader": "^0.2.7",
+        "@mongodb-js/mongodb-downloader": "^0.3.0",
         "@mongodb-js/signing-utils": "^0.3.3",
         "@octokit/rest": "^17.9.0",
         "aws-sdk": "^2.674.0",
@@ -31199,6 +31450,18 @@
       },
       "engines": {
         "node": ">=14.15.1"
+      }
+    },
+    "packages/build/node_modules/@mongodb-js/mongodb-downloader": {
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/mongodb-downloader/-/mongodb-downloader-0.3.0.tgz",
+      "integrity": "sha512-VXEDPI7tnzZyIZhWNJwPM3kHForiiWaGx7+ufaS/ElhdjBBoq/6wxFfw59wp25Uj8mc9JhPYGiGmBblBbaL1IA==",
+      "dependencies": {
+        "debug": "^4.3.4",
+        "decompress": "^4.2.1",
+        "mongodb-download-url": "^1.3.0",
+        "node-fetch": "^2.6.11",
+        "tar": "^6.1.15"
       }
     },
     "packages/build/node_modules/yaml": {
@@ -34014,6 +34277,49 @@
         }
       }
     },
+    "@cyclonedx/cyclonedx-library": {
+      "version": "6.6.0",
+      "resolved": "https://registry.npmjs.org/@cyclonedx/cyclonedx-library/-/cyclonedx-library-6.6.0.tgz",
+      "integrity": "sha512-1d9gWCE+yrBICRxrPMZqDoPlQGng0Z08WGMz87wAHwiUFkmLlW8gQTGbPTGHUIgLg7mp2zYNo+eyE4VlWetBWg==",
+      "requires": {
+        "ajv": "^8.12.0",
+        "ajv-formats": "^3.0.1",
+        "ajv-formats-draft2019": "^1.6.1",
+        "libxmljs2": "^0.31 || ^0.32 || ^0.33",
+        "packageurl-js": ">=0.0.6 <0.0.8 || ^1",
+        "spdx-expression-parse": "^3.0.1 || ^4",
+        "xmlbuilder2": "^3.0.2"
+      },
+      "dependencies": {
+        "ajv": {
+          "version": "8.13.0",
+          "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.13.0.tgz",
+          "integrity": "sha512-PRA911Blj99jR5RMeTunVbNXMF6Lp4vZXnk5GQjcnUWUTsrXtekg/pnmFFI2u/I36Y/2bITGS30GZCXei6uNkA==",
+          "optional": true,
+          "requires": {
+            "fast-deep-equal": "^3.1.3",
+            "json-schema-traverse": "^1.0.0",
+            "require-from-string": "^2.0.2",
+            "uri-js": "^4.4.1"
+          }
+        },
+        "ajv-formats": {
+          "version": "3.0.1",
+          "resolved": "https://registry.npmjs.org/ajv-formats/-/ajv-formats-3.0.1.tgz",
+          "integrity": "sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==",
+          "optional": true,
+          "requires": {
+            "ajv": "^8.0.0"
+          }
+        },
+        "json-schema-traverse": {
+          "version": "1.0.0",
+          "resolved": "https://registry.npmjs.org/json-schema-traverse/-/json-schema-traverse-1.0.0.tgz",
+          "integrity": "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==",
+          "optional": true
+        }
+      }
+    },
     "@discoveryjs/json-ext": {
       "version": "0.5.7",
       "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
@@ -36734,26 +37040,6 @@
           "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
           "optional": true
         },
-        "validate-npm-package-name": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.0.tgz",
-          "integrity": "sha512-YuKoXDAhBYxY7SfOKxHBDoSyENFeW5VvIIQp2TGQuit8gpK6MnWaQelBKxso72DoxTZfZdcP3W90LqpSkgPzLQ==",
-          "optional": true,
-          "requires": {
-            "builtins": "^5.0.0"
-          },
-          "dependencies": {
-            "builtins": {
-              "version": "5.0.1",
-              "resolved": "https://registry.npmjs.org/builtins/-/builtins-5.0.1.tgz",
-              "integrity": "sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==",
-              "optional": true,
-              "requires": {
-                "semver": "^7.0.0"
-              }
-            }
-          }
-        },
         "webidl-conversions": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -36854,6 +37140,92 @@
       "integrity": "sha512-qC72D4+CDdjGqJvkFMMEAtancHUQ7/d/tAiHf64z8MopFDmcrtbcJuerDtFceuAfQJ2pDSfCKCtbqoGBNnwg0w==",
       "requires": {
         "@lukeed/csprng": "^1.1.0"
+      }
+    },
+    "@mapbox/node-pre-gyp": {
+      "version": "1.0.11",
+      "resolved": "https://registry.npmjs.org/@mapbox/node-pre-gyp/-/node-pre-gyp-1.0.11.tgz",
+      "integrity": "sha512-Yhlar6v9WQgUp/He7BdgzOz8lqMQ8sU+jkCq7Wx8Myc5YFJLbEe7lgui/V7G1qB1DJykHSGwreceSaD60Y0PUQ==",
+      "optional": true,
+      "requires": {
+        "detect-libc": "^2.0.0",
+        "https-proxy-agent": "^5.0.0",
+        "make-dir": "^3.1.0",
+        "node-fetch": "^2.6.7",
+        "nopt": "^5.0.0",
+        "npmlog": "^5.0.1",
+        "rimraf": "^3.0.2",
+        "semver": "^7.3.5",
+        "tar": "^6.1.11"
+      },
+      "dependencies": {
+        "are-we-there-yet": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/are-we-there-yet/-/are-we-there-yet-2.0.0.tgz",
+          "integrity": "sha512-Ci/qENmwHnsYo9xKIcUJN5LeDKdJ6R1Z1j9V/J5wyq8nh/mYPEpIKJbBZXtZjG04HiK7zV/p6Vs9952MrMeUIw==",
+          "optional": true,
+          "requires": {
+            "delegates": "^1.0.0",
+            "readable-stream": "^3.6.0"
+          }
+        },
+        "gauge": {
+          "version": "3.0.2",
+          "resolved": "https://registry.npmjs.org/gauge/-/gauge-3.0.2.tgz",
+          "integrity": "sha512-+5J6MS/5XksCuXq++uFRsnUd7Ovu1XenbeuIuNRJxYWjgQbPuFhT14lAvsWfqfAmnwluf1OwMjz39HjfLPci0Q==",
+          "optional": true,
+          "requires": {
+            "aproba": "^1.0.3 || ^2.0.0",
+            "color-support": "^1.1.2",
+            "console-control-strings": "^1.0.0",
+            "has-unicode": "^2.0.1",
+            "object-assign": "^4.1.1",
+            "signal-exit": "^3.0.0",
+            "string-width": "^4.2.3",
+            "strip-ansi": "^6.0.1",
+            "wide-align": "^1.1.2"
+          }
+        },
+        "make-dir": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
+          "integrity": "sha512-g3FeP20LNwhALb/6Cz6Dd4F2ngze0jz7tbzrD2wAV+o9FeNHe4rL+yK2md0J/fiSf1sa1ADhXqi5+oVwOM/eGw==",
+          "optional": true,
+          "requires": {
+            "semver": "^6.0.0"
+          },
+          "dependencies": {
+            "semver": {
+              "version": "6.3.1",
+              "resolved": "https://registry.npmjs.org/semver/-/semver-6.3.1.tgz",
+              "integrity": "sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==",
+              "optional": true
+            }
+          }
+        },
+        "npmlog": {
+          "version": "5.0.1",
+          "resolved": "https://registry.npmjs.org/npmlog/-/npmlog-5.0.1.tgz",
+          "integrity": "sha512-AqZtDUWOMKs1G/8lwylVjrdYgqA4d9nu8hc+0gzRxlDb1I10+FHBGMXs6aiQHFdCUUlqH99MUMuLfzWDNDtfxw==",
+          "optional": true,
+          "requires": {
+            "are-we-there-yet": "^2.0.0",
+            "console-control-strings": "^1.1.0",
+            "gauge": "^3.0.0",
+            "set-blocking": "^2.0.0"
+          }
+        },
+        "readable-stream": {
+          "version": "3.6.2",
+          "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-3.6.2.tgz",
+          "integrity": "sha512-9u/sniCrY3D5WdsERHzHE4G2YCXqoG5FTHUiCC4SIbr6XcLZBY05ya9EKjYek9O5xOAwjGq+1JdGBAS7Q9ScoA==",
+          "optional": true,
+          "requires": {
+            "inherits": "^2.0.3",
+            "string_decoder": "^1.1.1",
+            "util-deprecate": "^1.0.1"
+          }
+        }
       }
     },
     "@mongodb-js/compass-components": {
@@ -37055,6 +37427,7 @@
       "version": "0.2.9",
       "resolved": "https://registry.npmjs.org/@mongodb-js/mongodb-downloader/-/mongodb-downloader-0.2.9.tgz",
       "integrity": "sha512-RaTqbRkBSuB4ixo9c8BbImEET0HuK3j0F+Y429rD22TiOCozUNxM26OmOydNE3Fb8A4C/ble1BCRFv78J7X6Nw==",
+      "dev": true,
       "requires": {
         "debug": "^4.3.4",
         "decompress": "^4.2.1",
@@ -37507,7 +37880,7 @@
         "@mongodb-js/devtools-github-repo": "^1.0.1",
         "@mongodb-js/dl-center": "^1.1.1",
         "@mongodb-js/eslint-config-mongosh": "^1.0.0",
-        "@mongodb-js/mongodb-downloader": "^0.2.7",
+        "@mongodb-js/mongodb-downloader": "^0.3.0",
         "@mongodb-js/monorepo-tools": "^1.1.10",
         "@mongodb-js/prettier-config-devtools": "^1.0.1",
         "@mongodb-js/signing-utils": "^0.3.3",
@@ -37543,6 +37916,18 @@
         "yaml": "^2.3.1"
       },
       "dependencies": {
+        "@mongodb-js/mongodb-downloader": {
+          "version": "0.3.0",
+          "resolved": "https://registry.npmjs.org/@mongodb-js/mongodb-downloader/-/mongodb-downloader-0.3.0.tgz",
+          "integrity": "sha512-VXEDPI7tnzZyIZhWNJwPM3kHForiiWaGx7+ufaS/ElhdjBBoq/6wxFfw59wp25Uj8mc9JhPYGiGmBblBbaL1IA==",
+          "requires": {
+            "debug": "^4.3.4",
+            "decompress": "^4.2.1",
+            "mongodb-download-url": "^1.3.0",
+            "node-fetch": "^2.6.11",
+            "tar": "^6.1.15"
+          }
+        },
         "yaml": {
           "version": "2.3.1",
           "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.1.tgz",
@@ -39006,6 +39391,42 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/@one-ini/wasm/-/wasm-0.1.1.tgz",
       "integrity": "sha512-XuySG1E38YScSJoMlqovLru4KTUNSjgVTIjyh7qMX6aNN5HY5Ct5LhRJdxO79JtTzKfzV/bnWpz+zquYrISsvw=="
+    },
+    "@oozcitak/dom": {
+      "version": "1.15.10",
+      "resolved": "https://registry.npmjs.org/@oozcitak/dom/-/dom-1.15.10.tgz",
+      "integrity": "sha512-0JT29/LaxVgRcGKvHmSrUTEvZ8BXvZhGl2LASRUgHqDTC1M5g1pLmVv56IYNyt3bG2CUjDkc67wnyZC14pbQrQ==",
+      "optional": true,
+      "requires": {
+        "@oozcitak/infra": "1.0.8",
+        "@oozcitak/url": "1.0.4",
+        "@oozcitak/util": "8.3.8"
+      }
+    },
+    "@oozcitak/infra": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@oozcitak/infra/-/infra-1.0.8.tgz",
+      "integrity": "sha512-JRAUc9VR6IGHOL7OGF+yrvs0LO8SlqGnPAMqyzOuFZPSZSXI7Xf2O9+awQPSMXgIWGtgUf/dA6Hs6X6ySEaWTg==",
+      "optional": true,
+      "requires": {
+        "@oozcitak/util": "8.3.8"
+      }
+    },
+    "@oozcitak/url": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@oozcitak/url/-/url-1.0.4.tgz",
+      "integrity": "sha512-kDcD8y+y3FCSOvnBI6HJgl00viO/nGbQoCINmQ0h98OhnGITrWR3bOGfwYCthgcrV8AnTJz8MzslTQbC3SOAmw==",
+      "optional": true,
+      "requires": {
+        "@oozcitak/infra": "1.0.8",
+        "@oozcitak/util": "8.3.8"
+      }
+    },
+    "@oozcitak/util": {
+      "version": "8.3.8",
+      "resolved": "https://registry.npmjs.org/@oozcitak/util/-/util-8.3.8.tgz",
+      "integrity": "sha512-T8TbSnGsxo6TDBJx/Sgv/BlVJL3tshxZP7Aq5R1mSnM5OcHY2dQaxLMu2+E8u3gN0MLOzdjurqN4ZRVuzQycOQ==",
+      "optional": true
     },
     "@parcel/watcher": {
       "version": "2.0.4",
@@ -41516,6 +41937,18 @@
         }
       }
     },
+    "ajv-formats-draft2019": {
+      "version": "1.6.1",
+      "resolved": "https://registry.npmjs.org/ajv-formats-draft2019/-/ajv-formats-draft2019-1.6.1.tgz",
+      "integrity": "sha512-JQPvavpkWDvIsBp2Z33UkYCtXCSpW4HD3tAZ+oL4iEFOk9obQZffx0yANwECt6vzr6ET+7HN5czRyqXbnq/u0Q==",
+      "optional": true,
+      "requires": {
+        "punycode": "^2.1.1",
+        "schemes": "^1.4.0",
+        "smtp-address-parser": "^1.0.3",
+        "uri-js": "^4.4.1"
+      }
+    },
     "ajv-keywords": {
       "version": "3.5.2",
       "resolved": "https://registry.npmjs.org/ajv-keywords/-/ajv-keywords-3.5.2.tgz",
@@ -43976,7 +44409,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/discontinuous-range/-/discontinuous-range-1.0.0.tgz",
       "integrity": "sha512-c68LpLbO+7kP/b1Hr1qs8/BJ09F5khZGTxqxZuhzxpmwJKOgRFHJWIb9/KmqnqHhLdO55aOxFH/EGBvUQbL/RQ==",
-      "dev": true
+      "devOptional": true
     },
     "dns-equal": {
       "version": "1.0.0",
@@ -45103,7 +45536,7 @@
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
       "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g==",
-      "dev": true
+      "devOptional": true
     },
     "external-editor": {
       "version": "3.1.0",
@@ -46686,15 +47119,6 @@
         "validate-npm-package-name": "^5.0.0"
       },
       "dependencies": {
-        "builtins": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/builtins/-/builtins-5.0.1.tgz",
-          "integrity": "sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==",
-          "optional": true,
-          "requires": {
-            "semver": "^7.0.0"
-          }
-        },
         "hosted-git-info": {
           "version": "6.1.1",
           "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-6.1.1.tgz",
@@ -46720,15 +47144,6 @@
             "proc-log": "^3.0.0",
             "semver": "^7.3.5",
             "validate-npm-package-name": "^5.0.0"
-          }
-        },
-        "validate-npm-package-name": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.0.tgz",
-          "integrity": "sha512-YuKoXDAhBYxY7SfOKxHBDoSyENFeW5VvIIQp2TGQuit8gpK6MnWaQelBKxso72DoxTZfZdcP3W90LqpSkgPzLQ==",
-          "optional": true,
-          "requires": {
-            "builtins": "^5.0.0"
           }
         }
       }
@@ -49173,26 +49588,6 @@
           "integrity": "sha512-MXcSTerfPa4uqyzStbRoTgt5XIe3x5+42+q1sDuy3R5MDk66URdLMOZe5aPX/SQd+kuYAh0FdP/pO28IkQyTeg==",
           "optional": true
         },
-        "validate-npm-package-name": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.0.tgz",
-          "integrity": "sha512-YuKoXDAhBYxY7SfOKxHBDoSyENFeW5VvIIQp2TGQuit8gpK6MnWaQelBKxso72DoxTZfZdcP3W90LqpSkgPzLQ==",
-          "optional": true,
-          "requires": {
-            "builtins": "^5.0.0"
-          },
-          "dependencies": {
-            "builtins": {
-              "version": "5.0.1",
-              "resolved": "https://registry.npmjs.org/builtins/-/builtins-5.0.1.tgz",
-              "integrity": "sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==",
-              "optional": true,
-              "requires": {
-                "semver": "^7.0.0"
-              }
-            }
-          }
-        },
         "webidl-conversions": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-3.0.1.tgz",
@@ -49257,15 +49652,6 @@
         "npm-registry-fetch": "^14.0.3"
       },
       "dependencies": {
-        "builtins": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/builtins/-/builtins-5.0.1.tgz",
-          "integrity": "sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==",
-          "optional": true,
-          "requires": {
-            "semver": "^7.0.0"
-          }
-        },
         "hosted-git-info": {
           "version": "6.1.1",
           "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-6.1.1.tgz",
@@ -49292,15 +49678,6 @@
             "semver": "^7.3.5",
             "validate-npm-package-name": "^5.0.0"
           }
-        },
-        "validate-npm-package-name": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.0.tgz",
-          "integrity": "sha512-YuKoXDAhBYxY7SfOKxHBDoSyENFeW5VvIIQp2TGQuit8gpK6MnWaQelBKxso72DoxTZfZdcP3W90LqpSkgPzLQ==",
-          "optional": true,
-          "requires": {
-            "builtins": "^5.0.0"
-          }
         }
       }
     },
@@ -49320,15 +49697,6 @@
         "ssri": "^10.0.1"
       },
       "dependencies": {
-        "builtins": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/builtins/-/builtins-5.0.1.tgz",
-          "integrity": "sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==",
-          "optional": true,
-          "requires": {
-            "semver": "^7.0.0"
-          }
-        },
         "hosted-git-info": {
           "version": "6.1.1",
           "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-6.1.1.tgz",
@@ -49382,15 +49750,25 @@
           "requires": {
             "minipass": "^7.0.3"
           }
-        },
-        "validate-npm-package-name": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.0.tgz",
-          "integrity": "sha512-YuKoXDAhBYxY7SfOKxHBDoSyENFeW5VvIIQp2TGQuit8gpK6MnWaQelBKxso72DoxTZfZdcP3W90LqpSkgPzLQ==",
-          "optional": true,
-          "requires": {
-            "builtins": "^5.0.0"
-          }
+        }
+      }
+    },
+    "libxmljs2": {
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/libxmljs2/-/libxmljs2-0.33.0.tgz",
+      "integrity": "sha512-Hw74f2/3rbpxc6tkTqe3yrs4v2Tx0rEukrYxaNkXSVKK540i2eqlQxzf1jjG+RlwMuv66WxkkuZHM/OQq6km4w==",
+      "optional": true,
+      "requires": {
+        "@mapbox/node-pre-gyp": "^1.0.11",
+        "bindings": "~1.5.0",
+        "nan": "~2.18.0"
+      },
+      "dependencies": {
+        "nan": {
+          "version": "2.18.0",
+          "resolved": "https://registry.npmjs.org/nan/-/nan-2.18.0.tgz",
+          "integrity": "sha512-W7tfG7vMOGtD30sHoZSSc/JVYiyDPEyQVso/Zz+/uQd0B0L46gtC+pHha5FFMRpil6fm/AoEcRWyOVi4+E/f8w==",
+          "optional": true
         }
       }
     },
@@ -50628,7 +51006,7 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/moo/-/moo-0.5.2.tgz",
       "integrity": "sha512-iSAJLHYKnX41mKcJKjqvnAN9sf0LMDTXDEvFv+ffuRR9a1MIuXLjMNL6EsnDHSkKLTWNqQQ5uo61P4EbU4NU+Q==",
-      "dev": true
+      "devOptional": true
     },
     "mrmime": {
       "version": "1.0.1",
@@ -50756,7 +51134,7 @@
       "version": "2.20.1",
       "resolved": "https://registry.npmjs.org/nearley/-/nearley-2.20.1.tgz",
       "integrity": "sha512-+Mc8UaAebFzgV+KpI5n7DasuuQCHA89dmwm7JXw3TV43ukfNQ9DnBH3Mdb2g/I4Fdxc26pwimBWvjIw0UAILSQ==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "commander": "^2.19.0",
         "moo": "^0.5.0",
@@ -51095,14 +51473,34 @@
       "devOptional": true
     },
     "npm-package-arg": {
-      "version": "8.1.5",
-      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-8.1.5.tgz",
-      "integrity": "sha512-LhgZrg0n0VgvzVdSm1oiZworPbTxYHUJCgtsJW8mGvlDpxTM1vSJc3m5QZeUkhAHIzbz3VCHd/R4osi1L1Tg/Q==",
-      "dev": true,
+      "version": "11.0.2",
+      "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-11.0.2.tgz",
+      "integrity": "sha512-IGN0IAwmhDJwy13Wc8k+4PEbTPhpJnMtfR53ZbOyjkvmEcLS4nCwp6mvMWjS5sUjeiW3mpx6cHmuhKEu9XmcQw==",
       "requires": {
-        "hosted-git-info": "^4.0.1",
-        "semver": "^7.3.4",
-        "validate-npm-package-name": "^3.0.0"
+        "hosted-git-info": "^7.0.0",
+        "proc-log": "^4.0.0",
+        "semver": "^7.3.5",
+        "validate-npm-package-name": "^5.0.0"
+      },
+      "dependencies": {
+        "hosted-git-info": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-7.0.1.tgz",
+          "integrity": "sha512-+K84LB1DYwMHoHSgaOY/Jfhw3ucPmSET5v98Ke/HdNSw4a0UktWzyW1mjhjpuxxTqOOsfWT/7iVshHmVZ4IpOA==",
+          "requires": {
+            "lru-cache": "^10.0.1"
+          }
+        },
+        "lru-cache": {
+          "version": "10.2.2",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.2.2.tgz",
+          "integrity": "sha512-9hp3Vp2/hFQUiIwKo8XCeFVnrg8Pk3TYNPIR7tJADKi5YfcF7vEaK7avFHTlSy3kOKYaJQaalfEo6YuXdceBOQ=="
+        },
+        "proc-log": {
+          "version": "4.2.0",
+          "resolved": "https://registry.npmjs.org/proc-log/-/proc-log-4.2.0.tgz",
+          "integrity": "sha512-g8+OnU/L2v+wyiVK+D5fA34J7EH8jZ8DDlvwhRCMxmMj7UCBvxiO1mGeN+36JXIKF4zevU4kRBd8lVgG9vLelA=="
+        }
       }
     },
     "npm-packlist": {
@@ -51143,6 +51541,28 @@
         "npm-normalize-package-bin": "^1.0.1",
         "npm-package-arg": "^8.1.2",
         "semver": "^7.3.4"
+      },
+      "dependencies": {
+        "npm-package-arg": {
+          "version": "8.1.5",
+          "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-8.1.5.tgz",
+          "integrity": "sha512-LhgZrg0n0VgvzVdSm1oiZworPbTxYHUJCgtsJW8mGvlDpxTM1vSJc3m5QZeUkhAHIzbz3VCHd/R4osi1L1Tg/Q==",
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "^4.0.1",
+            "semver": "^7.3.4",
+            "validate-npm-package-name": "^3.0.0"
+          }
+        },
+        "validate-npm-package-name": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
+          "integrity": "sha512-M6w37eVCMMouJ9V/sdPGnC5H4uDr73/+xdq0FBLO3TFFX1+7wiUY6Es328NN+y43tmY+doUdN9g9J21vqB7iLw==",
+          "dev": true,
+          "requires": {
+            "builtins": "^1.0.3"
+          }
+        }
       }
     },
     "npm-registry-fetch": {
@@ -51160,15 +51580,6 @@
         "proc-log": "^3.0.0"
       },
       "dependencies": {
-        "builtins": {
-          "version": "5.0.1",
-          "resolved": "https://registry.npmjs.org/builtins/-/builtins-5.0.1.tgz",
-          "integrity": "sha512-qwVpFEHNfhYJIzNRBvd2C1kyo6jz3ZSMPyyuR47OPdiKWlbYnZNyDWuyR175qDnAJLiCo5fBBqPb3RiXgWlkOQ==",
-          "optional": true,
-          "requires": {
-            "semver": "^7.0.0"
-          }
-        },
         "hosted-git-info": {
           "version": "6.1.1",
           "resolved": "https://registry.npmjs.org/hosted-git-info/-/hosted-git-info-6.1.1.tgz",
@@ -51220,15 +51631,6 @@
             "proc-log": "^3.0.0",
             "semver": "^7.3.5",
             "validate-npm-package-name": "^5.0.0"
-          }
-        },
-        "validate-npm-package-name": {
-          "version": "5.0.0",
-          "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.0.tgz",
-          "integrity": "sha512-YuKoXDAhBYxY7SfOKxHBDoSyENFeW5VvIIQp2TGQuit8gpK6MnWaQelBKxso72DoxTZfZdcP3W90LqpSkgPzLQ==",
-          "optional": true,
-          "requires": {
-            "builtins": "^5.0.0"
           }
         }
       }
@@ -51940,6 +52342,11 @@
         "release-zalgo": "^1.0.0"
       }
     },
+    "packageurl-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/packageurl-js/-/packageurl-js-1.2.1.tgz",
+      "integrity": "sha512-cZ6/MzuXaoFd16/k0WnwtI298UCaDHe/XlSh85SeOKbGZ1hq0xvNbx3ILyCMyk7uFQxl6scF3Aucj6/EO9NwcA=="
+    },
     "pacote": {
       "version": "11.3.5",
       "resolved": "https://registry.npmjs.org/pacote/-/pacote-11.3.5.tgz",
@@ -52014,6 +52421,17 @@
           "integrity": "sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==",
           "dev": true
         },
+        "npm-package-arg": {
+          "version": "8.1.5",
+          "resolved": "https://registry.npmjs.org/npm-package-arg/-/npm-package-arg-8.1.5.tgz",
+          "integrity": "sha512-LhgZrg0n0VgvzVdSm1oiZworPbTxYHUJCgtsJW8mGvlDpxTM1vSJc3m5QZeUkhAHIzbz3VCHd/R4osi1L1Tg/Q==",
+          "dev": true,
+          "requires": {
+            "hosted-git-info": "^4.0.1",
+            "semver": "^7.3.4",
+            "validate-npm-package-name": "^3.0.0"
+          }
+        },
         "npm-registry-fetch": {
           "version": "11.0.0",
           "resolved": "https://registry.npmjs.org/npm-registry-fetch/-/npm-registry-fetch-11.0.0.tgz",
@@ -52037,6 +52455,15 @@
             "agent-base": "^6.0.2",
             "debug": "^4.3.3",
             "socks": "^2.6.2"
+          }
+        },
+        "validate-npm-package-name": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
+          "integrity": "sha512-M6w37eVCMMouJ9V/sdPGnC5H4uDr73/+xdq0FBLO3TFFX1+7wiUY6Es328NN+y43tmY+doUdN9g9J21vqB7iLw==",
+          "dev": true,
+          "requires": {
+            "builtins": "^1.0.3"
           }
         }
       }
@@ -52863,7 +53290,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/railroad-diagrams/-/railroad-diagrams-1.0.0.tgz",
       "integrity": "sha512-cz93DjNeLY0idrCNOH6PviZGRN9GJhsdm9hpn1YCS879fj4W+x5IFJhhkRZcwVgMmFF7R82UA/7Oh+R8lLZg6A==",
-      "dev": true
+      "devOptional": true
     },
     "ramda": {
       "version": "0.27.2",
@@ -52874,7 +53301,7 @@
       "version": "0.4.6",
       "resolved": "https://registry.npmjs.org/randexp/-/randexp-0.4.6.tgz",
       "integrity": "sha512-80WNmd9DA0tmZrw9qQa62GPPWfuXJknrmVmLcxvq4uZBdYqb1wYoKTmnlGUchvVWe0XiLupYkBoXVOxz3C8DYQ==",
-      "dev": true,
+      "devOptional": true,
       "requires": {
         "discontinuous-range": "1.0.0",
         "ret": "~0.1.10"
@@ -53640,7 +54067,7 @@
       "version": "0.1.15",
       "resolved": "https://registry.npmjs.org/ret/-/ret-0.1.15.tgz",
       "integrity": "sha512-TTlYpa+OL+vMMNG24xSlQGEJ3B/RzEfUlLct7b5G/ytav+wPrplCpVMFuwzXbkecJrb6IYo1iFb0S9v37754mg==",
-      "dev": true
+      "devOptional": true
     },
     "retry": {
       "version": "0.12.0",
@@ -53795,6 +54222,15 @@
         "@types/json-schema": "^7.0.8",
         "ajv": "^6.12.5",
         "ajv-keywords": "^3.5.2"
+      }
+    },
+    "schemes": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/schemes/-/schemes-1.4.0.tgz",
+      "integrity": "sha512-ImFy9FbCsQlVgnE3TCWmLPCFnVzx0lHL/l+umHplDqAKd0dzFpnS6lFZIpagBlYhKwzVmlV36ec0Y1XTu8JBAQ==",
+      "optional": true,
+      "requires": {
+        "extend": "^3.0.0"
       }
     },
     "scss-parser": {
@@ -54193,6 +54629,15 @@
       "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
       "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="
     },
+    "smtp-address-parser": {
+      "version": "1.0.10",
+      "resolved": "https://registry.npmjs.org/smtp-address-parser/-/smtp-address-parser-1.0.10.tgz",
+      "integrity": "sha512-Osg9LmvGeAG/hyao4mldbflLOkkr3a+h4m1lwKCK5U8M6ZAr7tdXEz/+/vr752TSGE4MNUlUl9cIK2cB8cgzXg==",
+      "optional": true,
+      "requires": {
+        "nearley": "^2.20.1"
+      }
+    },
     "snyk-module": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/snyk-module/-/snyk-module-3.2.0.tgz",
@@ -54465,14 +54910,12 @@
     "spdx-exceptions": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
-      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
-      "devOptional": true
+      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A=="
     },
     "spdx-expression-parse": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
       "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
-      "devOptional": true,
       "requires": {
         "spdx-exceptions": "^2.1.0",
         "spdx-license-ids": "^3.0.0"
@@ -54481,8 +54924,7 @@
     "spdx-license-ids": {
       "version": "3.0.11",
       "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.11.tgz",
-      "integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g==",
-      "devOptional": true
+      "integrity": "sha512-Ctl2BrFiM0X3MANYgj3CkygxhRmr9mi6xhejbdO960nF6EDJApTYpn0BQnDKlnNBULKiCN1n3w9EBkHK8ZWg+g=="
     },
     "spdx-ranges": {
       "version": "2.1.1",
@@ -55703,12 +56145,21 @@
       }
     },
     "validate-npm-package-name": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-3.0.0.tgz",
-      "integrity": "sha512-M6w37eVCMMouJ9V/sdPGnC5H4uDr73/+xdq0FBLO3TFFX1+7wiUY6Es328NN+y43tmY+doUdN9g9J21vqB7iLw==",
-      "dev": true,
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/validate-npm-package-name/-/validate-npm-package-name-5.0.0.tgz",
+      "integrity": "sha512-YuKoXDAhBYxY7SfOKxHBDoSyENFeW5VvIIQp2TGQuit8gpK6MnWaQelBKxso72DoxTZfZdcP3W90LqpSkgPzLQ==",
       "requires": {
-        "builtins": "^1.0.3"
+        "builtins": "^5.0.0"
+      },
+      "dependencies": {
+        "builtins": {
+          "version": "5.1.0",
+          "resolved": "https://registry.npmjs.org/builtins/-/builtins-5.1.0.tgz",
+          "integrity": "sha512-SW9lzGTLvWTP1AY8xeAMZimqDrIaSdLQUcVr9DMef51niJ022Ri87SwRRKYm4A6iHfkPaiVUu/Duw2Wc4J7kKg==",
+          "requires": {
+            "semver": "^7.0.0"
+          }
+        }
       }
     },
     "vary": {
@@ -56457,6 +56908,18 @@
       "version": "11.0.1",
       "resolved": "https://registry.npmjs.org/xmlbuilder/-/xmlbuilder-11.0.1.tgz",
       "integrity": "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="
+    },
+    "xmlbuilder2": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/xmlbuilder2/-/xmlbuilder2-3.1.1.tgz",
+      "integrity": "sha512-WCSfbfZnQDdLQLiMdGUQpMxxckeQ4oZNMNhLVkcekTu7xhD4tuUDyAPoY8CwXvBYE6LwBHd6QW2WZXlOWr1vCw==",
+      "optional": true,
+      "requires": {
+        "@oozcitak/dom": "1.15.10",
+        "@oozcitak/infra": "1.0.8",
+        "@oozcitak/util": "8.3.8",
+        "js-yaml": "3.14.1"
+      }
     },
     "xtend": {
       "version": "4.0.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -64,7 +64,7 @@
         "husky": "^8.0.3",
         "mocha": "^10.2.0",
         "mongodb": "^6.5.0",
-        "mongodb-runner": "^5.4.6",
+        "mongodb-runner": "^5.6.1",
         "node-gyp": "^9.0.0",
         "nyc": "^15.1.0",
         "pkg-up": "^3.1.0",
@@ -6733,10 +6733,9 @@
       }
     },
     "node_modules/@mongodb-js/mongodb-downloader": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/mongodb-downloader/-/mongodb-downloader-0.2.9.tgz",
-      "integrity": "sha512-RaTqbRkBSuB4ixo9c8BbImEET0HuK3j0F+Y429rD22TiOCozUNxM26OmOydNE3Fb8A4C/ble1BCRFv78J7X6Nw==",
-      "dev": true,
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/mongodb-downloader/-/mongodb-downloader-0.3.1.tgz",
+      "integrity": "sha512-kIl/clNwacFdzkBjacb1NoWIlNPn4kO8H61iT8gAGK1v/LLjekz5i3hOhrOVGIjzdpIItELXM/RxFFuR2+N5Ig==",
       "dependencies": {
         "debug": "^4.3.4",
         "decompress": "^4.2.1",
@@ -6931,9 +6930,9 @@
       }
     },
     "node_modules/@mongodb-js/saslprep": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.5.tgz",
-      "integrity": "sha512-XLNOMH66KhJzUJNwT/qlMnS4WsNDWD5ASdyaSH3EtK+F4r/CFGa3jT4GNi4mfOitGvWXtdLgQJkQjxSVrio+jA==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.6.tgz",
+      "integrity": "sha512-jqTTXQ46H8cAxmXBu8wm1HTSIMBMrIcoVrsjdQkKdMBj3il/fSCgWyya4P2I1xjPBl69mw+nRphrPlcIqBd20Q==",
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
       }
@@ -10607,16 +10606,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
       "integrity": "sha512-xTE1E+YF4aWPJJeUzaZI5DRntlkY3+BCVJi0axFptnjGmAoWxkyREIh/XMrfxVLejwQxMCfDXdICo0VLxThrog=="
-    },
-    "node_modules/@types/whatwg-url": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
-      "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
-      "dev": true,
-      "dependencies": {
-        "@types/node": "*",
-        "@types/webidl-conversions": "*"
-      }
     },
     "node_modules/@types/which": {
       "version": "1.3.2",
@@ -23066,28 +23055,20 @@
       }
     },
     "node_modules/mongodb-runner": {
-      "version": "5.4.6",
-      "resolved": "https://registry.npmjs.org/mongodb-runner/-/mongodb-runner-5.4.6.tgz",
-      "integrity": "sha512-9En4HuM9YmngsTMHgSXuK4eLTSLpdXiki3QLikABKQH+UL+wa8kvyZnhZtaachD8fL+rVHfMcVMbFzepLwlEkQ==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/mongodb-runner/-/mongodb-runner-5.6.1.tgz",
+      "integrity": "sha512-avPly0y9g4CNCnmwRY0VH+gQqnn95NcjTeucTPV/OgGJJAilOqJVHRTyeSVke44tIbvJ65k8AHxYpirKN80QgQ==",
       "dev": true,
       "dependencies": {
-        "@mongodb-js/mongodb-downloader": "^0.2.9",
+        "@mongodb-js/mongodb-downloader": "^0.3.1",
+        "@mongodb-js/saslprep": "^1.1.6",
         "debug": "^4.3.4",
-        "mongodb": "^5.6.0",
+        "mongodb": "^6.3.0",
         "mongodb-connection-string-url": "^3.0.0",
         "yargs": "^17.7.2"
       },
       "bin": {
         "mongodb-runner": "bin/runner.js"
-      }
-    },
-    "node_modules/mongodb-runner/node_modules/bson": {
-      "version": "5.4.0",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-5.4.0.tgz",
-      "integrity": "sha512-WRZ5SQI5GfUuKnPTNmAYPiKIof3ORXAF4IRU5UcgmivNIon01rWQlw5RUH954dpu8yGL8T59YShVddIPaU/gFA==",
-      "dev": true,
-      "engines": {
-        "node": ">=14.20.1"
       }
     },
     "node_modules/mongodb-runner/node_modules/cliui": {
@@ -23099,113 +23080,6 @@
         "string-width": "^4.2.0",
         "strip-ansi": "^6.0.1",
         "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/mongodb-runner/node_modules/mongodb": {
-      "version": "5.8.1",
-      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.8.1.tgz",
-      "integrity": "sha512-wKyh4kZvm6NrCPH8AxyzXm3JBoEf4Xulo0aUWh3hCgwgYJxyQ1KLST86ZZaSWdj6/kxYUA3+YZuyADCE61CMSg==",
-      "dev": true,
-      "dependencies": {
-        "bson": "^5.4.0",
-        "mongodb-connection-string-url": "^2.6.0",
-        "socks": "^2.7.1"
-      },
-      "engines": {
-        "node": ">=14.20.1"
-      },
-      "optionalDependencies": {
-        "@mongodb-js/saslprep": "^1.1.0"
-      },
-      "peerDependencies": {
-        "@aws-sdk/credential-providers": "^3.188.0",
-        "@mongodb-js/zstd": "^1.0.0",
-        "kerberos": "^1.0.0 || ^2.0.0",
-        "mongodb-client-encryption": ">=2.3.0 <3",
-        "snappy": "^7.2.2"
-      },
-      "peerDependenciesMeta": {
-        "@aws-sdk/credential-providers": {
-          "optional": true
-        },
-        "@mongodb-js/zstd": {
-          "optional": true
-        },
-        "kerberos": {
-          "optional": true
-        },
-        "mongodb-client-encryption": {
-          "optional": true
-        },
-        "snappy": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/mongodb-runner/node_modules/mongodb-client-encryption": {
-      "version": "2.9.0",
-      "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-2.9.0.tgz",
-      "integrity": "sha512-OGMfTnS+JJ49ksWdExQ5048ynaQJLhPjbOi3i44PbU2sdufKH0Z4YZqn1pvd/eQ4WgLfbmSws3u9kAiFNFxpOg==",
-      "dev": true,
-      "hasInstallScript": true,
-      "optional": true,
-      "peer": true,
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "node-addon-api": "^4.3.0",
-        "prebuild-install": "^7.1.1",
-        "socks": "^2.7.1"
-      },
-      "engines": {
-        "node": ">=12.9.0"
-      },
-      "peerDependencies": {
-        "@aws-sdk/credential-providers": "^3.186.0",
-        "gcp-metadata": "^5.2.0",
-        "mongodb": ">=3.4.0"
-      },
-      "peerDependenciesMeta": {
-        "@aws-sdk/credential-providers": {
-          "optional": true
-        },
-        "gcp-metadata": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/mongodb-runner/node_modules/mongodb/node_modules/mongodb-connection-string-url": {
-      "version": "2.6.0",
-      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
-      "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
-      "dev": true,
-      "dependencies": {
-        "@types/whatwg-url": "^8.2.1",
-        "whatwg-url": "^11.0.0"
-      }
-    },
-    "node_modules/mongodb-runner/node_modules/tr46": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
-      "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
-      "dev": true,
-      "dependencies": {
-        "punycode": "^2.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/mongodb-runner/node_modules/whatwg-url": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
-      "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
-      "dev": true,
-      "dependencies": {
-        "tr46": "^3.0.0",
-        "webidl-conversions": "^7.0.0"
       },
       "engines": {
         "node": ">=12"
@@ -31410,7 +31284,7 @@
       "dependencies": {
         "@mongodb-js/devtools-github-repo": "^1.0.1",
         "@mongodb-js/dl-center": "^1.1.1",
-        "@mongodb-js/mongodb-downloader": "^0.3.0",
+        "@mongodb-js/mongodb-downloader": "^0.3.1",
         "@mongodb-js/signing-utils": "^0.3.3",
         "@octokit/rest": "^17.9.0",
         "aws-sdk": "^2.674.0",
@@ -31450,18 +31324,6 @@
       },
       "engines": {
         "node": ">=14.15.1"
-      }
-    },
-    "packages/build/node_modules/@mongodb-js/mongodb-downloader": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/mongodb-downloader/-/mongodb-downloader-0.3.0.tgz",
-      "integrity": "sha512-VXEDPI7tnzZyIZhWNJwPM3kHForiiWaGx7+ufaS/ElhdjBBoq/6wxFfw59wp25Uj8mc9JhPYGiGmBblBbaL1IA==",
-      "dependencies": {
-        "debug": "^4.3.4",
-        "decompress": "^4.2.1",
-        "mongodb-download-url": "^1.3.0",
-        "node-fetch": "^2.6.11",
-        "tar": "^6.1.15"
       }
     },
     "packages/build/node_modules/yaml": {
@@ -37424,10 +37286,9 @@
       }
     },
     "@mongodb-js/mongodb-downloader": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/mongodb-downloader/-/mongodb-downloader-0.2.9.tgz",
-      "integrity": "sha512-RaTqbRkBSuB4ixo9c8BbImEET0HuK3j0F+Y429rD22TiOCozUNxM26OmOydNE3Fb8A4C/ble1BCRFv78J7X6Nw==",
-      "dev": true,
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/mongodb-downloader/-/mongodb-downloader-0.3.1.tgz",
+      "integrity": "sha512-kIl/clNwacFdzkBjacb1NoWIlNPn4kO8H61iT8gAGK1v/LLjekz5i3hOhrOVGIjzdpIItELXM/RxFFuR2+N5Ig==",
       "requires": {
         "debug": "^4.3.4",
         "decompress": "^4.2.1",
@@ -37578,9 +37439,9 @@
       "requires": {}
     },
     "@mongodb-js/saslprep": {
-      "version": "1.1.5",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.5.tgz",
-      "integrity": "sha512-XLNOMH66KhJzUJNwT/qlMnS4WsNDWD5ASdyaSH3EtK+F4r/CFGa3jT4GNi4mfOitGvWXtdLgQJkQjxSVrio+jA==",
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.6.tgz",
+      "integrity": "sha512-jqTTXQ46H8cAxmXBu8wm1HTSIMBMrIcoVrsjdQkKdMBj3il/fSCgWyya4P2I1xjPBl69mw+nRphrPlcIqBd20Q==",
       "requires": {
         "sparse-bitfield": "^3.0.3"
       }
@@ -37880,7 +37741,7 @@
         "@mongodb-js/devtools-github-repo": "^1.0.1",
         "@mongodb-js/dl-center": "^1.1.1",
         "@mongodb-js/eslint-config-mongosh": "^1.0.0",
-        "@mongodb-js/mongodb-downloader": "^0.3.0",
+        "@mongodb-js/mongodb-downloader": "^0.3.1",
         "@mongodb-js/monorepo-tools": "^1.1.10",
         "@mongodb-js/prettier-config-devtools": "^1.0.1",
         "@mongodb-js/signing-utils": "^0.3.3",
@@ -37916,18 +37777,6 @@
         "yaml": "^2.3.1"
       },
       "dependencies": {
-        "@mongodb-js/mongodb-downloader": {
-          "version": "0.3.0",
-          "resolved": "https://registry.npmjs.org/@mongodb-js/mongodb-downloader/-/mongodb-downloader-0.3.0.tgz",
-          "integrity": "sha512-VXEDPI7tnzZyIZhWNJwPM3kHForiiWaGx7+ufaS/ElhdjBBoq/6wxFfw59wp25Uj8mc9JhPYGiGmBblBbaL1IA==",
-          "requires": {
-            "debug": "^4.3.4",
-            "decompress": "^4.2.1",
-            "mongodb-download-url": "^1.3.0",
-            "node-fetch": "^2.6.11",
-            "tar": "^6.1.15"
-          }
-        },
         "yaml": {
           "version": "2.3.1",
           "resolved": "https://registry.npmjs.org/yaml/-/yaml-2.3.1.tgz",
@@ -41308,16 +41157,6 @@
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
       "integrity": "sha512-xTE1E+YF4aWPJJeUzaZI5DRntlkY3+BCVJi0axFptnjGmAoWxkyREIh/XMrfxVLejwQxMCfDXdICo0VLxThrog=="
-    },
-    "@types/whatwg-url": {
-      "version": "8.2.2",
-      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.2.tgz",
-      "integrity": "sha512-FtQu10RWgn3D9U4aazdwIE2yzphmTJREDqNdODHrbrZmmMqI0vMheC/6NE/J1Yveaj8H+ela+YwWTjq5PGmuhA==",
-      "dev": true,
-      "requires": {
-        "@types/node": "*",
-        "@types/webidl-conversions": "*"
-      }
     },
     "@types/which": {
       "version": "1.3.2",
@@ -50887,24 +50726,19 @@
       }
     },
     "mongodb-runner": {
-      "version": "5.4.6",
-      "resolved": "https://registry.npmjs.org/mongodb-runner/-/mongodb-runner-5.4.6.tgz",
-      "integrity": "sha512-9En4HuM9YmngsTMHgSXuK4eLTSLpdXiki3QLikABKQH+UL+wa8kvyZnhZtaachD8fL+rVHfMcVMbFzepLwlEkQ==",
+      "version": "5.6.1",
+      "resolved": "https://registry.npmjs.org/mongodb-runner/-/mongodb-runner-5.6.1.tgz",
+      "integrity": "sha512-avPly0y9g4CNCnmwRY0VH+gQqnn95NcjTeucTPV/OgGJJAilOqJVHRTyeSVke44tIbvJ65k8AHxYpirKN80QgQ==",
       "dev": true,
       "requires": {
-        "@mongodb-js/mongodb-downloader": "^0.2.9",
+        "@mongodb-js/mongodb-downloader": "^0.3.1",
+        "@mongodb-js/saslprep": "^1.1.6",
         "debug": "^4.3.4",
-        "mongodb": "^5.6.0",
+        "mongodb": "^6.3.0",
         "mongodb-connection-string-url": "^3.0.0",
         "yargs": "^17.7.2"
       },
       "dependencies": {
-        "bson": {
-          "version": "5.4.0",
-          "resolved": "https://registry.npmjs.org/bson/-/bson-5.4.0.tgz",
-          "integrity": "sha512-WRZ5SQI5GfUuKnPTNmAYPiKIof3ORXAF4IRU5UcgmivNIon01rWQlw5RUH954dpu8yGL8T59YShVddIPaU/gFA==",
-          "dev": true
-        },
         "cliui": {
           "version": "8.0.1",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -50914,63 +50748,6 @@
             "string-width": "^4.2.0",
             "strip-ansi": "^6.0.1",
             "wrap-ansi": "^7.0.0"
-          }
-        },
-        "mongodb": {
-          "version": "5.8.1",
-          "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-5.8.1.tgz",
-          "integrity": "sha512-wKyh4kZvm6NrCPH8AxyzXm3JBoEf4Xulo0aUWh3hCgwgYJxyQ1KLST86ZZaSWdj6/kxYUA3+YZuyADCE61CMSg==",
-          "dev": true,
-          "requires": {
-            "@mongodb-js/saslprep": "^1.1.0",
-            "bson": "^5.4.0",
-            "mongodb-connection-string-url": "^2.6.0",
-            "socks": "^2.7.1"
-          },
-          "dependencies": {
-            "mongodb-connection-string-url": {
-              "version": "2.6.0",
-              "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.6.0.tgz",
-              "integrity": "sha512-WvTZlI9ab0QYtTYnuMLgobULWhokRjtC7db9LtcVfJ+Hsnyr5eo6ZtNAt3Ly24XZScGMelOcGtm7lSn0332tPQ==",
-              "dev": true,
-              "requires": {
-                "@types/whatwg-url": "^8.2.1",
-                "whatwg-url": "^11.0.0"
-              }
-            }
-          }
-        },
-        "mongodb-client-encryption": {
-          "version": "2.9.0",
-          "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-2.9.0.tgz",
-          "integrity": "sha512-OGMfTnS+JJ49ksWdExQ5048ynaQJLhPjbOi3i44PbU2sdufKH0Z4YZqn1pvd/eQ4WgLfbmSws3u9kAiFNFxpOg==",
-          "dev": true,
-          "optional": true,
-          "peer": true,
-          "requires": {
-            "bindings": "^1.5.0",
-            "node-addon-api": "^4.3.0",
-            "prebuild-install": "^7.1.1",
-            "socks": "^2.7.1"
-          }
-        },
-        "tr46": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
-          "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
-          "dev": true,
-          "requires": {
-            "punycode": "^2.1.1"
-          }
-        },
-        "whatwg-url": {
-          "version": "11.0.0",
-          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
-          "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
-          "dev": true,
-          "requires": {
-            "tr46": "^3.0.0",
-            "webidl-conversions": "^7.0.0"
           }
         },
         "yargs": {

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     "generate-error-overview": "npm run generate-error-overview --workspace @mongosh/errors",
     "update-authors": "ts-node -P configs/tsconfig-mongosh/tsconfig.common.json scripts/generate-authors.ts",
     "create-dependency-sbom-lists": "npm run webpack-build -w packages/cli-repl && npm run write-node-js-dep && npm run create-purls-file",
-    "create-purls-file": "cat .sbom/dependencies.json .sbom/node-js-dep.json | jq -r '.[] | if .name != \".node.js\" then \"pkg:npm/\" + .name + \"@\" + .version else \"pkg:generic/node@\" + .version end' > .sbom/purls.txt",
+    "create-purls-file": "node scripts/create-purls.js .sbom/dependencies.json .sbom/node-js-dep.json > .sbom/purls.txt",
     "preupdate-third-party-notices": "npm run create-dependency-sbom-lists",
     "update-third-party-notices": "mongodb-sbom-tools generate-3rd-party-notices --product='mongosh' --dependencies=.sbom/dependencies.json > THIRD_PARTY_NOTICES.md",
     "update-node-js-versions": "npx @pkgjs/nv ls v20 > .evergreen/node-20-latest.json && npx @pkgjs/nv ls v16 > .evergreen/node-16-latest.json",

--- a/package.json
+++ b/package.json
@@ -106,7 +106,7 @@
     "husky": "^8.0.3",
     "mocha": "^10.2.0",
     "mongodb": "^6.5.0",
-    "mongodb-runner": "^5.4.6",
+    "mongodb-runner": "^5.6.1",
     "node-gyp": "^9.0.0",
     "nyc": "^15.1.0",
     "pkg-up": "^3.1.0",

--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "update-node-js-versions": "npx @pkgjs/nv ls v20 > .evergreen/node-20-latest.json && npx @pkgjs/nv ls v16 > .evergreen/node-16-latest.json",
     "update-evergreen-config": "npm run test-evergreen-expansions && node .evergreen/generate-evergreen-yml.js .evergreen/evergreen.yml.in > .evergreen.yml",
     "mark-ci-required-optional-dependencies": "ts-node scripts/mark-ci-required-optional-dependencies.ts",
-    "write-node-js-dep": "echo '[{\"name\": \".node.js\", \"version\":\"'\"$NODE_JS_VERSION\"'\"}]' > .sbom/node-js-dep.json",
+    "write-node-js-dep": "node scripts/write-nodejs-dep > .sbom/node-js-dep.json",
     "scan-node-js": "mongodb-sbom-tools scan-node-js --version=$NODE_JS_VERSION > .sbom/node-js-vuln.json",
     "snyk-test": "node scripts/snyk-test.js",
     "pregenerate-vulnerability-report": "npm run create-dependency-sbom-lists && npm run snyk-test && npm run scan-node-js",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,9 @@
     "check-coverage": "nyc check-coverage --lines=90",
     "generate-error-overview": "npm run generate-error-overview --workspace @mongosh/errors",
     "update-authors": "ts-node -P configs/tsconfig-mongosh/tsconfig.common.json scripts/generate-authors.ts",
-    "preupdate-third-party-notices": "npm run webpack-build -w packages/cli-repl",
+    "create-dependency-sbom-lists": "npm run webpack-build -w packages/cli-repl && npm run write-node-js-dep && npm run create-purls-file",
+    "create-purls-file": "cat .sbom/dependencies.json .sbom/node-js-dep.json | jq -r '.[] | if .name != \".node.js\" then \"pkg:npm/\" + .name + \"@\" + .version else \"pkg:generic/node@\" + .version end' > .sbom/purls.txt",
+    "preupdate-third-party-notices": "npm run create-dependency-sbom-lists",
     "update-third-party-notices": "mongodb-sbom-tools generate-3rd-party-notices --product='mongosh' --dependencies=.sbom/dependencies.json > THIRD_PARTY_NOTICES.md",
     "update-node-js-versions": "npx @pkgjs/nv ls v20 > .evergreen/node-20-latest.json && npx @pkgjs/nv ls v16 > .evergreen/node-16-latest.json",
     "update-evergreen-config": "npm run test-evergreen-expansions && node .evergreen/generate-evergreen-yml.js .evergreen/evergreen.yml.in > .evergreen.yml",
@@ -54,7 +56,7 @@
     "write-node-js-dep": "echo '[{\"name\": \".node.js\", \"version\":\"'\"$NODE_JS_VERSION\"'\"}]' > .sbom/node-js-dep.json",
     "scan-node-js": "mongodb-sbom-tools scan-node-js --version=$NODE_JS_VERSION > .sbom/node-js-vuln.json",
     "snyk-test": "node scripts/snyk-test.js",
-    "pregenerate-vulnerability-report": "npm run webpack-build -w packages/cli-repl && npm run snyk-test && npm run scan-node-js && npm run write-node-js-dep",
+    "pregenerate-vulnerability-report": "npm run create-dependency-sbom-lists && npm run snyk-test && npm run scan-node-js",
     "generate-vulnerability-report": "mongodb-sbom-tools generate-vulnerability-report --snyk-reports=.sbom/snyk-test-result.json,.sbom/node-js-vuln.json --dependencies=.sbom/dependencies.json,.sbom/node-js-dep.json --fail-on=high > .sbom/vulnerability-report.md",
     "create-vulnerability-tickets": "mongodb-sbom-tools generate-vulnerability-report --snyk-reports=.sbom/snyk-test-result.json,.sbom/node-js-vuln.json --dependencies=.sbom/dependencies.json,.sbom/node-js-dep.json --create-jira-issues",
     "where": "monorepo-where",
@@ -156,5 +158,9 @@
     "packages/node-runtime-worker-thread",
     "packages/browser-repl",
     "packages/connectivity-tests"
-  ]
+  ],
+  "dependencies": {
+    "@cyclonedx/cyclonedx-library": "^6.6.0",
+    "npm-package-arg": "^11.0.2"
+  }
 }

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -62,7 +62,7 @@
   "dependencies": {
     "@mongodb-js/devtools-github-repo": "^1.0.1",
     "@mongodb-js/dl-center": "^1.1.1",
-    "@mongodb-js/mongodb-downloader": "^0.2.7",
+    "@mongodb-js/mongodb-downloader": "^0.3.0",
     "@mongodb-js/signing-utils": "^0.3.3",
     "@octokit/rest": "^17.9.0",
     "aws-sdk": "^2.674.0",

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -62,7 +62,7 @@
   "dependencies": {
     "@mongodb-js/devtools-github-repo": "^1.0.1",
     "@mongodb-js/dl-center": "^1.1.1",
-    "@mongodb-js/mongodb-downloader": "^0.3.0",
+    "@mongodb-js/mongodb-downloader": "^0.3.1",
     "@mongodb-js/signing-utils": "^0.3.3",
     "@octokit/rest": "^17.9.0",
     "aws-sdk": "^2.674.0",

--- a/packages/build/src/index.ts
+++ b/packages/build/src/index.ts
@@ -17,6 +17,7 @@ const validCommands: (ReleaseCommand | 'trigger-release')[] = [
   'draft',
   'publish',
   'sign',
+  'download-crypt-shared-library',
   'download-and-list-artifacts',
   'trigger-release',
 ] as const;

--- a/packages/build/src/packaging/run-download-crypt-library.ts
+++ b/packages/build/src/packaging/run-download-crypt-library.ts
@@ -17,7 +17,10 @@ export async function runDownloadCryptLibrary(config: Config): Promise<void> {
     fsConstants.COPYFILE_FICLONE
   );
   await fs.writeFile(
-    path.join(path.dirname(cryptLibrary), `.${cryptLibrary}.version`),
+    path.join(
+      path.dirname(cryptLibrary),
+      `.${path.basename(cryptLibrary)}.version`
+    ),
     cryptLibraryVersion
   );
 }

--- a/packages/build/src/packaging/run-download-crypt-library.ts
+++ b/packages/build/src/packaging/run-download-crypt-library.ts
@@ -1,0 +1,20 @@
+import { constants as fsConstants, promises as fs } from 'fs';
+import path from 'path';
+import type { Config } from '../config';
+import { validatePackageVariant } from '../config';
+import { downloadCryptLibrary } from './download-crypt-library';
+
+export async function runDownloadCryptLibrary(config: Config): Promise<void> {
+  const packageVariant = config.packageVariant;
+  validatePackageVariant(packageVariant);
+
+  await fs.mkdir(path.dirname(config.cryptSharedLibPath), { recursive: true });
+  const { cryptLibrary, version: cryptLibraryVersion } =
+    await downloadCryptLibrary(packageVariant);
+  await fs.copyFile(
+    cryptLibrary,
+    config.cryptSharedLibPath,
+    fsConstants.COPYFILE_FICLONE
+  );
+  await fs.writeFile(`.${cryptLibrary}.version`, cryptLibraryVersion);
+}

--- a/packages/build/src/packaging/run-download-crypt-library.ts
+++ b/packages/build/src/packaging/run-download-crypt-library.ts
@@ -18,8 +18,8 @@ export async function runDownloadCryptLibrary(config: Config): Promise<void> {
   );
   await fs.writeFile(
     path.join(
-      path.dirname(cryptLibrary),
-      `.${path.basename(cryptLibrary)}.version`
+      path.dirname(config.cryptSharedLibPath),
+      `.${path.basename(config.cryptSharedLibPath)}.version`
     ),
     cryptLibraryVersion
   );

--- a/packages/build/src/packaging/run-download-crypt-library.ts
+++ b/packages/build/src/packaging/run-download-crypt-library.ts
@@ -16,5 +16,8 @@ export async function runDownloadCryptLibrary(config: Config): Promise<void> {
     config.cryptSharedLibPath,
     fsConstants.COPYFILE_FICLONE
   );
-  await fs.writeFile(`.${cryptLibrary}.version`, cryptLibraryVersion);
+  await fs.writeFile(
+    path.join(path.dirname(cryptLibrary), `.${cryptLibrary}.version`),
+    cryptLibraryVersion
+  );
 }

--- a/packages/build/src/packaging/run-package.ts
+++ b/packages/build/src/packaging/run-package.ts
@@ -1,8 +1,5 @@
-import { constants as fsConstants, promises as fs } from 'fs';
-import path from 'path';
 import type { Config } from '../config';
 import { validatePackageVariant } from '../config';
-import { downloadCryptLibrary } from './download-crypt-library';
 import { downloadManpage } from './download-manpage';
 import type { PackageFile } from './package';
 import { createPackage } from './package';
@@ -10,13 +7,6 @@ import { createPackage } from './package';
 export async function runPackage(config: Config): Promise<PackageFile> {
   const packageVariant = config.packageVariant;
   validatePackageVariant(packageVariant);
-
-  await fs.mkdir(path.dirname(config.cryptSharedLibPath), { recursive: true });
-  await fs.copyFile(
-    await downloadCryptLibrary(packageVariant),
-    config.cryptSharedLibPath,
-    fsConstants.COPYFILE_FICLONE
-  );
 
   const { manpage } = config;
   if (manpage) {

--- a/packages/build/src/release.ts
+++ b/packages/build/src/release.ts
@@ -21,6 +21,7 @@ import { runPublish } from './run-publish';
 import { runUpload } from './run-upload';
 import { runSign } from './packaging/run-sign';
 import { runDownloadAndListArtifacts } from './run-download-and-list-artifacts';
+import { runDownloadCryptLibrary } from './packaging/run-download-crypt-library';
 
 export type ReleaseCommand =
   | 'bump'
@@ -28,6 +29,7 @@ export type ReleaseCommand =
   | 'package'
   | 'sign'
   | 'upload'
+  | 'download-crypt-shared-library'
   | 'download-and-list-artifacts'
   | 'draft'
   | 'publish';
@@ -92,6 +94,8 @@ export async function release(
     await runCompile(config);
   } else if (command === 'package') {
     await runPackage(config);
+  } else if (command === 'download-crypt-shared-library') {
+    await runDownloadCryptLibrary(config);
   } else if (command === 'sign') {
     await runSign(config);
   } else if (command === 'upload') {

--- a/scripts/create-purls.js
+++ b/scripts/create-purls.js
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+'use strict';
+const fs = require('fs');
+for (const file of process.argv.slice(2)) {
+  for (const { name, version } of JSON.parse(fs.readFileSync(file, 'utf8'))) {
+    if (name === '.node.js') {
+      console.log(`pkg:generic/node@${encodeURIComponent(version)}`);
+    } else {
+      console.log(`pkg:npm/${encodeURIComponent(name)}@${encodeURIComponent(version)}`);
+    }
+  }
+}

--- a/scripts/write-nodejs-dep.js
+++ b/scripts/write-nodejs-dep.js
@@ -1,0 +1,6 @@
+#!/usr/bin/env node
+'use strict';
+console.log(JSON.stringify([{
+  name: '.node.js',
+  version: process.env.NODE_JS_VERSION
+}]));

--- a/testing/integration-testing-hooks.ts
+++ b/testing/integration-testing-hooks.ts
@@ -178,9 +178,9 @@ async function getInstalledMongodVersion(): Promise<string> {
 
 export async function downloadCurrentCryptSharedLibrary(): Promise<string> {
   if (process.platform === 'linux') {
-    return await downloadCryptLibrary(`linux-${process.arch.replace('ppc64', 'ppc64le')}` as any);
+    return (await downloadCryptLibrary(`linux-${process.arch.replace('ppc64', 'ppc64le')}` as any)).cryptLibrary;
   }
-  return downloadCryptLibrary('host');
+  return (await downloadCryptLibrary('host')).cryptLibrary;
 }
 
 /**


### PR DESCRIPTION
Add generation of [`purls.txt`](https://docs.devprod.prod.corp.mongodb.com/mms/python/src/sbom/silkbomb/docs/PURLS/) and [Silkbomb](https://docs.devprod.prod.corp.mongodb.com/mms/python/src/sbom/silkbomb/docs/SILK)-generated `sbom.json` files to our CI/release infrastructure.

Like the corresponding [Compass PR](https://github.com/mongodb-js/compass/pull/5770), this PR:

- Modifies our crypt_shared-library bundling/downloading step so that we store the version of the crypt_shared library we're bundling
- Generates a list of PURLs and then uses the SilkBomb tool to generate a SBOM file that we can share with DevProd 
(and later turn into its 'augmented' version with vulnerability information)

Unlike the Compass PR, this PR:
- Bundles the generated sbom.json file in existing release artifacts (i.e. .rpm/.deb/.zip/.tgz files)
- Introduces a new CI step, combining the partial PURLs file with the PURL (or, rather, _a_ PURL – we'll probably need to clarify how exactly to specify this) for the crypt_shared library while also downloading it (instead of doing that in the other packaging steps)
- Fixes some existing inaccuracies around crypt_shared library downloading that never surfaced as real issues because we mostly just used the "host" OS/architecture combination for downloading the file (not it always happens on x64 Ubuntu)
