### PR TITLE
chore(cli-repl): relax macOS `--tlsCertificateSelector` test expectations

### DIFF
--- a/packages/cli-repl/src/tls-certificate-selector.spec.ts
+++ b/packages/cli-repl/src/tls-certificate-selector.spec.ts
@@ -74,7 +74,7 @@ describe('arg-mapper.applyTlsCertificateSelector', function () {
         return this.skip();
       }
       expect(() => getTlsCertificateSelector('subject=Foo Bar')).to.throw(
-        /Could not find a matching certificate/
+        /Could not find a matching certificate|The specified item could not be found in the keychain/
       );
     });
   });

--- a/packages/e2e-tests/test/e2e-tls.spec.ts
+++ b/packages/e2e-tests/test/e2e-tls.spec.ts
@@ -601,7 +601,9 @@ describe('e2e TLS', function () {
           'Could not resolve certificate specification'
         );
       } else if (process.platform === 'darwin') {
-        shell.assertContainsOutput('Could not find a matching certificate');
+        shell.assertContainsOutput(
+          /Could not find a matching certificate|The specified item could not be found in the keychain/
+        );
       } else {
         shell.assertContainsOutput(
           'tlsCertificateSelector is not supported on this platform'


### PR DESCRIPTION
The actual error message we encounter in CI changed recently (from May 6 to May 7), likely as the result of changes to build hosts. Allow the more specific error message here as well, since it covers the same semantics.