### PR TITLE
chore(service-provider-core): explicitly define cursor types in service-provider-core

### DIFF
--- a/packages/service-provider-core/src/cursors.ts
+++ b/packages/service-provider-core/src/cursors.ts
@@ -38,6 +38,7 @@ export interface ServiceProviderAggregationOrFindCursor<TSchema = Document>
   withReadConcern(readConcern: ReadConcernLike): this;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface ServiceProviderRunCommandCursor<TSchema = Document>
   extends ServiceProviderAbstractCursor<TSchema> {}
 
@@ -57,6 +58,7 @@ export interface ServiceProviderFindCursor<TSchema = Document>
   showRecordId(value: boolean): void;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-empty-interface
 export interface ServiceProviderAggregationCursor<TSchema = Document>
   extends ServiceProviderAggregationOrFindCursor<TSchema> {}
 

--- a/packages/service-provider-core/src/cursors.ts
+++ b/packages/service-provider-core/src/cursors.ts
@@ -1,0 +1,67 @@
+import type {
+  CollationOptions,
+  CountOptions,
+  CursorFlag,
+  Document,
+  ExplainVerbosityLike,
+  ReadConcernLike,
+  ReadPreferenceLike,
+  ResumeToken,
+} from './all-transport-types';
+
+interface ServiceProviderBaseCursor<TSchema = Document> {
+  close(): Promise<void>;
+  hasNext(): Promise<boolean>;
+  next(): Promise<TSchema | null>;
+  tryNext(): Promise<TSchema | null>;
+  readonly closed: boolean;
+  [Symbol.asyncIterator](): AsyncGenerator<TSchema, void, void>;
+}
+
+export interface ServiceProviderAbstractCursor<TSchema = Document>
+  extends ServiceProviderBaseCursor<TSchema> {
+  batchSize(number: number): void;
+  maxTimeMS(value: number): void;
+  bufferedCount(): number;
+  readBufferedDocuments(number?: number): TSchema[];
+  toArray(): Promise<TSchema[]>;
+}
+
+export interface ServiceProviderAggregationOrFindCursor<TSchema = Document>
+  extends ServiceProviderAbstractCursor<TSchema> {
+  project($project: Document): void;
+  skip($skip: number): void;
+  sort($sort: Document): void;
+  explain(verbosity?: ExplainVerbosityLike): Promise<Document>;
+  addCursorFlag(flag: CursorFlag, value: boolean): void;
+  withReadPreference(readPreference: ReadPreferenceLike): this;
+  withReadConcern(readConcern: ReadConcernLike): this;
+}
+
+export interface ServiceProviderRunCommandCursor<TSchema = Document>
+  extends ServiceProviderAbstractCursor<TSchema> {}
+
+export interface ServiceProviderFindCursor<TSchema = Document>
+  extends ServiceProviderAggregationOrFindCursor<TSchema> {
+  allowDiskUse(allow?: boolean): void;
+  collation(value: CollationOptions): void;
+  comment(value: string): void;
+  maxAwaitTimeMS(value: number): void;
+  count(options?: CountOptions): Promise<number>;
+  hint(hint: string | Document): void;
+  max(max: Document): void;
+  min(min: Document): void;
+  limit(value: number): void;
+  skip(value: number): void;
+  returnKey(value: boolean): void;
+  showRecordId(value: boolean): void;
+}
+
+export interface ServiceProviderAggregationCursor<TSchema = Document>
+  extends ServiceProviderAggregationOrFindCursor<TSchema> {}
+
+export interface ServiceProviderChangeStream<TSchema = Document>
+  extends ServiceProviderBaseCursor<TSchema> {
+  next(): Promise<TSchema>;
+  readonly resumeToken: ResumeToken;
+}

--- a/packages/service-provider-core/src/index.ts
+++ b/packages/service-provider-core/src/index.ts
@@ -19,6 +19,14 @@ export {
 export { bson } from './bson-export';
 
 export {
+  ServiceProviderAbstractCursor,
+  ServiceProviderAggregationCursor,
+  ServiceProviderFindCursor,
+  ServiceProviderRunCommandCursor,
+  ServiceProviderChangeStream,
+} from './cursors';
+
+export {
   ServiceProvider,
   ShellAuthOptions,
   getConnectExtraInfo,

--- a/packages/service-provider-core/src/readable.ts
+++ b/packages/service-provider-core/src/readable.ts
@@ -8,13 +8,16 @@ import type {
   FindOptions,
   ListCollectionsOptions,
   ListIndexesOptions,
-  AggregationCursor,
-  FindCursor,
   DbOptions,
   ReadPreferenceFromOptions,
   ReadPreferenceLike,
 } from './all-transport-types';
-import type { ChangeStream, ChangeStreamOptions } from './all-transport-types';
+import type { ChangeStreamOptions } from './all-transport-types';
+import {
+  ServiceProviderAggregationCursor,
+  ServiceProviderChangeStream,
+  ServiceProviderFindCursor,
+} from './cursors';
 
 /**
  * Interface for read operations in the CRUD specification.
@@ -37,7 +40,7 @@ export default interface Readable {
     pipeline: Document[],
     options?: AggregateOptions,
     dbOptions?: DbOptions
-  ): AggregationCursor;
+  ): ServiceProviderAggregationCursor;
 
   /**
    * Run an aggregation pipeline on the DB.
@@ -54,7 +57,7 @@ export default interface Readable {
     pipeline: Document[],
     options?: AggregateOptions,
     dbOptions?: DbOptions
-  ): AggregationCursor;
+  ): ServiceProviderAggregationCursor;
 
   /**
    * Returns the count of documents that would match a find() query for the
@@ -152,7 +155,7 @@ export default interface Readable {
     filter?: Document,
     options?: FindOptions,
     dbOptions?: DbOptions
-  ): FindCursor;
+  ): ServiceProviderFindCursor;
 
   /**
    * Get currently known topology information.
@@ -215,7 +218,7 @@ export default interface Readable {
     dbOptions?: DbOptions,
     db?: string,
     coll?: string
-  ): ChangeStream<Document>;
+  ): ServiceProviderChangeStream;
 
   /**
    * Returns an array of documents that identify and describe the existing

--- a/packages/service-provider-core/src/readable.ts
+++ b/packages/service-provider-core/src/readable.ts
@@ -13,7 +13,7 @@ import type {
   ReadPreferenceLike,
 } from './all-transport-types';
 import type { ChangeStreamOptions } from './all-transport-types';
-import {
+import type {
   ServiceProviderAggregationCursor,
   ServiceProviderChangeStream,
   ServiceProviderFindCursor,

--- a/packages/service-provider-core/src/writable.ts
+++ b/packages/service-provider-core/src/writable.ts
@@ -1,4 +1,4 @@
-import type { RunCommandCursor, RunCursorCommandOptions } from 'mongodb';
+import type { RunCursorCommandOptions } from 'mongodb';
 import type {
   Document,
   InsertOneOptions,
@@ -25,7 +25,7 @@ import type {
   OrderedBulkOperation,
   UnorderedBulkOperation,
 } from './all-transport-types';
-import { ServiceProviderRunCommandCursor } from './cursors';
+import type { ServiceProviderRunCommandCursor } from './cursors';
 
 /**
  * Interface for write operations in the CRUD specification.

--- a/packages/service-provider-core/src/writable.ts
+++ b/packages/service-provider-core/src/writable.ts
@@ -25,6 +25,7 @@ import type {
   OrderedBulkOperation,
   UnorderedBulkOperation,
 } from './all-transport-types';
+import { ServiceProviderRunCommandCursor } from './cursors';
 
 /**
  * Interface for write operations in the CRUD specification.
@@ -70,7 +71,7 @@ export default interface Writable {
     spec: Document,
     options: RunCursorCommandOptions,
     dbOptions?: DbOptions
-  ): RunCommandCursor;
+  ): ServiceProviderRunCommandCursor;
 
   /**
    * Drop a database

--- a/packages/shell-api/src/abstract-cursor.ts
+++ b/packages/shell-api/src/abstract-cursor.ts
@@ -8,9 +8,9 @@ import {
 import type Mongo from './mongo';
 import type {
   Document,
-  FindCursor as ServiceProviderCursor,
-  AggregationCursor as ServiceProviderAggregationCursor,
-  RunCommandCursor as ServiceProviderRunCommandCursor,
+  ServiceProviderFindCursor,
+  ServiceProviderAggregationCursor,
+  ServiceProviderRunCommandCursor,
 } from '@mongosh/service-provider-core';
 import { asPrintable } from './enums';
 import { CursorIterationResult } from './result';
@@ -20,7 +20,7 @@ import { iterate } from './helpers';
 export abstract class AbstractCursor<
   CursorType extends
     | ServiceProviderAggregationCursor
-    | ServiceProviderCursor
+    | ServiceProviderFindCursor
     | ServiceProviderRunCommandCursor
 > extends ShellApiWithMongoClass {
   _mongo: Mongo;

--- a/packages/shell-api/src/abstract-cursor.ts
+++ b/packages/shell-api/src/abstract-cursor.ts
@@ -78,7 +78,7 @@ export abstract class AbstractCursor<
 
   @returnsPromise
   async hasNext(): Promise<boolean> {
-    return this._cursor.hasNext();
+    return await this._cursor.hasNext();
   }
 
   @returnsPromise

--- a/packages/shell-api/src/aggregate-or-find-cursor.ts
+++ b/packages/shell-api/src/aggregate-or-find-cursor.ts
@@ -7,15 +7,17 @@ import {
 import type {
   Document,
   ExplainVerbosityLike,
-  FindCursor as ServiceProviderCursor,
-  AggregationCursor as ServiceProviderAggregationCursor,
+  ServiceProviderFindCursor,
+  ServiceProviderAggregationCursor,
 } from '@mongosh/service-provider-core';
 import { validateExplainableVerbosity, markAsExplainOutput } from './helpers';
 import { AbstractCursor } from './abstract-cursor';
 
 @shellApiClassNoHelp
 export abstract class AggregateOrFindCursor<
-  CursorType extends ServiceProviderAggregationCursor | ServiceProviderCursor
+  CursorType extends
+    | ServiceProviderAggregationCursor
+    | ServiceProviderFindCursor
 > extends AbstractCursor<CursorType> {
   @returnType('this')
   projection(spec: Document): this {

--- a/packages/shell-api/src/aggregation-cursor.ts
+++ b/packages/shell-api/src/aggregation-cursor.ts
@@ -1,6 +1,6 @@
 import type Mongo from './mongo';
 import { shellApiClassDefault } from './decorators';
-import type { AggregationCursor as ServiceProviderAggregationCursor } from '@mongosh/service-provider-core';
+import type { ServiceProviderAggregationCursor } from '@mongosh/service-provider-core';
 import { AggregateOrFindCursor } from './aggregate-or-find-cursor';
 
 @shellApiClassDefault

--- a/packages/shell-api/src/change-stream-cursor.ts
+++ b/packages/shell-api/src/change-stream-cursor.ts
@@ -6,7 +6,7 @@ import {
   ShellApiWithMongoClass,
 } from './decorators';
 import type {
-  ChangeStream,
+  ServiceProviderChangeStream,
   Document,
   ResumeToken,
 } from '@mongosh/service-provider-core';
@@ -23,11 +23,15 @@ import type Mongo from './mongo';
 @shellApiClassDefault
 export default class ChangeStreamCursor extends ShellApiWithMongoClass {
   _mongo: Mongo;
-  _cursor: ChangeStream<Document>;
+  _cursor: ServiceProviderChangeStream<Document>;
   _currentIterationResult: CursorIterationResult | null = null;
   _on: string;
 
-  constructor(cursor: ChangeStream<Document>, on: string, mongo: Mongo) {
+  constructor(
+    cursor: ServiceProviderChangeStream<Document>,
+    on: string,
+    mongo: Mongo
+  ) {
     super();
     this._cursor = cursor;
     this._on = on;

--- a/packages/shell-api/src/cursor.ts
+++ b/packages/shell-api/src/cursor.ts
@@ -14,7 +14,7 @@ import {
 } from './decorators';
 import { ServerVersions, CURSOR_FLAGS } from './enums';
 import type {
-  FindCursor as ServiceProviderCursor,
+  ServiceProviderFindCursor,
   CursorFlag,
   Document,
   CollationOptions,
@@ -27,10 +27,10 @@ import type Mongo from './mongo';
 import { AggregateOrFindCursor } from './aggregate-or-find-cursor';
 
 @shellApiClassDefault
-export default class Cursor extends AggregateOrFindCursor<ServiceProviderCursor> {
+export default class Cursor extends AggregateOrFindCursor<ServiceProviderFindCursor> {
   _tailable = false;
 
-  constructor(mongo: Mongo, cursor: ServiceProviderCursor) {
+  constructor(mongo: Mongo, cursor: ServiceProviderFindCursor) {
     super(mongo, cursor);
   }
 

--- a/packages/shell-api/src/cursor.ts
+++ b/packages/shell-api/src/cursor.ts
@@ -100,7 +100,7 @@ export default class Cursor extends AggregateOrFindCursor<ServiceProviderFindCur
   @returnsPromise
   @deprecated
   async count(): Promise<number> {
-    return this._cursor.count();
+    return await this._cursor.count();
   }
 
   @returnsPromise
@@ -199,7 +199,7 @@ export default class Cursor extends AggregateOrFindCursor<ServiceProviderFindCur
 
   @returnsPromise
   async size(): Promise<number> {
-    return this._cursor.count();
+    return await this._cursor.count();
   }
 
   @returnType('Cursor')

--- a/packages/shell-api/src/run-command-cursor.ts
+++ b/packages/shell-api/src/run-command-cursor.ts
@@ -1,6 +1,6 @@
 import type Mongo from './mongo';
 import { shellApiClassDefault } from './decorators';
-import type { RunCommandCursor as ServiceProviderRunCommandCursor } from '@mongosh/service-provider-core';
+import type { ServiceProviderRunCommandCursor } from '@mongosh/service-provider-core';
 import { AbstractCursor } from './abstract-cursor';
 
 @shellApiClassDefault


### PR DESCRIPTION
Instead of directly using driver types, only define the types required for the Shell API, and define them separately from the driver.

This addresses part of MONGOSH-915 and is likely to help pave the way for things like MONGOSH-1285.