### PR TITLE
fix(ci): strip special characters from mongodb-runner tmp directories

### DIFF
--- a/testing/integration-testing-hooks.ts
+++ b/testing/integration-testing-hooks.ts
@@ -124,7 +124,7 @@ export class MongoRunnerSetup extends MongodSetup {
   private static _usedDirPrefix: Record<string, 0> = {};
 
   private static _buildDirPath(id: string, version?: string, topology?: string) {
-    const prefix = [id, version, topology].filter(Boolean).join('-').replace(/[^a-zA-Z0-9_-.]/g, '');
+    const prefix = [id, version, topology].filter(Boolean).join('-').replace(/[^a-zA-Z0-9_.-]/g, '');
 
     this._usedDirPrefix[prefix] ??= 0;
 

--- a/testing/integration-testing-hooks.ts
+++ b/testing/integration-testing-hooks.ts
@@ -3,12 +3,10 @@ import { promises as fs } from 'fs';
 import { MongoClient, MongoClientOptions } from 'mongodb';
 import path from 'path';
 import semver from 'semver';
-import { URL } from 'url';
 import { promisify } from 'util';
 import which from 'which';
 import { ConnectionString } from 'mongodb-connection-string-url';
 import { MongoCluster, MongoClusterOptions } from 'mongodb-runner';
-import { downloadMongoDb } from '@mongodb-js/mongodb-downloader';
 import { downloadCryptLibrary } from '../packages/build/src/packaging/download-crypt-library';
 
 const execFile = promisify(child_process.execFile);
@@ -126,7 +124,7 @@ export class MongoRunnerSetup extends MongodSetup {
   private static _usedDirPrefix: Record<string, 0> = {};
 
   private static _buildDirPath(id: string, version?: string, topology?: string) {
-    const prefix = [id, version, topology].filter(Boolean).join('-');
+    const prefix = [id, version, topology].filter(Boolean).join('-').replace(/[^a-zA-Z0-9_-.]/g, '');
 
     this._usedDirPrefix[prefix] ??= 0;
 


### PR DESCRIPTION
This fixes Windows CI, which has been buggy since 3851acb8efb6f4 (but not caught in the CI for that commit as it only took affect once GH actions automatically regenerated our evergreen config file).