### PR TITLE
fix(autocomplete): handle missing `buildInfo` well MONGOSH-1792

### DIFF
--- a/packages/autocomplete/src/index.spec.ts
+++ b/packages/autocomplete/src/index.spec.ts
@@ -92,7 +92,7 @@ const localAtlas600 = {
 };
 
 const noParams = {
-  topology: () => Topologies.Standalone,
+  topology: () => undefined,
   apiVersionInfo: () => undefined,
   connectionInfo: () => undefined,
   getCollectionCompletionsForCurrentDb: () => collections,

--- a/packages/autocomplete/src/index.ts
+++ b/packages/autocomplete/src/index.ts
@@ -17,7 +17,7 @@ import {
 type TypeSignatureAttributes = { [key: string]: TypeSignature };
 
 export interface AutocompleteParameters {
-  topology: () => Topologies;
+  topology: () => Topologies | undefined;
   connectionInfo: () =>
     | undefined
     | {
@@ -373,18 +373,20 @@ function filterShellAPI(
         +apiVersionInfo.version <= acceptableApiVersions[1];
     } else {
       const serverVersion = params.connectionInfo()?.server_version;
-      if (!serverVersion) return true;
-
       const acceptableVersions = completions[c].serverVersions;
       isAcceptableVersion =
         !acceptableVersions ||
+        !serverVersion ||
         (semver.gte(serverVersion, acceptableVersions[0]) &&
           semver.lte(serverVersion, acceptableVersions[1]));
     }
 
     const acceptableTopologies = completions[c].topologies;
+    const topology = params.topology();
     const isAcceptableTopology =
-      !acceptableTopologies || acceptableTopologies.includes(params.topology());
+      !acceptableTopologies ||
+      !topology ||
+      acceptableTopologies.includes(topology);
 
     return isAcceptableVersion && isAcceptableTopology;
   });

--- a/packages/shell-api/src/shell-instance-state.ts
+++ b/packages/shell-api/src/shell-instance-state.ts
@@ -49,7 +49,7 @@ export interface ShellCliOptions {
  * from the autocompleter implementation.
  */
 export interface AutocompleteParameters {
-  topology: () => Topologies;
+  topology: () => Topologies | undefined;
   apiVersionInfo: () => Required<ServerApi> | undefined;
   connectionInfo: () => ConnectionExtraInfo | undefined;
   getCollectionCompletionsForCurrentDb: (collName: string) => Promise<string[]>;
@@ -394,7 +394,8 @@ export default class ShellInstanceState {
       topology: () => {
         let topology: Topologies;
         const topologyDescription = this.currentServiceProvider.getTopology()
-          ?.description as TopologyDescription;
+          ?.description as TopologyDescription | undefined;
+        if (!topologyDescription) return undefined;
         // TODO: once a driver with NODE-3011 is available set type to TopologyType | undefined
         const topologyType: string | undefined = topologyDescription?.type;
         switch (topologyType) {
@@ -413,8 +414,8 @@ export default class ShellInstanceState {
             // We're connected to a single server, but that doesn't necessarily
             // mean that that server isn't part of a replset or sharding setup
             // if we're using directConnection=true (which we do by default).
-            if (topologyDescription.servers.size === 1) {
-              const [server] = topologyDescription.servers.values();
+            if (topologyDescription?.servers.size === 1) {
+              const [server] = topologyDescription?.servers.values();
               switch (server.type) {
                 case 'Mongos':
                   topology = Topologies.Sharded;


### PR DESCRIPTION
Recent server source changes put the `buildInfo` command behind authentication. We previously assumed that this information would always be available (and, as a corollary, that if the information from `buildInfo` was absent, topology information would also be absent), and should stop assuming this.

Long-term, it is probably desirable to rely on `buildInfo` as little as possible – for example, most of our version checks for autocompletion should probably be wire version checks instead of server release version checks.

This should address some failures occuring in the latest-alpha CI jobs.