### PR TITLE
chore: retry docker build MONGOSH-1644

### DIFF
--- a/.evergreen/package-and-upload-artifact.sh
+++ b/.evergreen/package-and-upload-artifact.sh
@@ -11,7 +11,7 @@ tar xvzf dist.tgz
 if [ "$(uname)" == Linux ]; then
   mkdir -p tmp
   cp "$(pwd)/../tmp/expansions.yaml" tmp/expansions.yaml
-  (cd scripts/docker && docker build -t rocky8-package -f rocky8-package.Dockerfile .)
+  (cd scripts/docker && bash "$BASEDIR/retry-with-backoff.sh" docker build -t rocky8-package -f rocky8-package.Dockerfile .)
   echo Starting Docker container packaging
   docker run -e PUPPETEER_SKIP_CHROMIUM_DOWNLOAD \
     -e EVERGREEN_EXPANSIONS_PATH=/tmp/build/tmp/expansions.yaml \


### PR DESCRIPTION
https://jira.mongodb.org/browse/MONGOSH-1644

Retry placements considered (ordered by scope):
1. retry the evergreen command
2. retry docker build
3. retry the individual package installs (either via bash script or package manager configuration)

Decided against 1. because evergreen only has a boolean `retry_on_failure`, so it doesn't look like we can control the number of retries.
2. was chosen over 3. because of complexity.

Note: I'm unsure how to test this change locally