### PR TITLE
fix(build): fix tests for new platforms MONGOSH-1806

### DIFF
--- a/config/release-package-matrix.js
+++ b/config/release-package-matrix.js
@@ -4,7 +4,7 @@ const rhel81AndAbove = ['rhel81', 'rhel82', 'rhel83', 'rhel90']
 const rhel80AndAbove = ['rhel80', ...rhel81AndAbove]
 const rhel72AndAbove = ['rhel72', ...rhel80AndAbove]
 const al2AndAbove = ['amazon2', 'amazon2023', ...rhel81AndAbove]
-const rhel70AndAboveAndRpmBased = ['rhel70', 'rhel71', ...rhel72AndAbove, 'amazon', ...al2AndAbove, 'suse12', 'suse15', 'oraclelinux9']
+const rhel70AndAboveAndRpmBased = ['rhel70', 'rhel71', ...rhel72AndAbove, 'amazon', ...al2AndAbove, 'suse12', 'suse15']
 const ubuntu1804AndAboveAndDebBased = ['ubuntu1804', 'ubuntu1804', 'ubuntu2004', 'ubuntu2204', 'ubuntu2404', 'debian10', 'debian11', 'debian12']
 const allLinux = [...rhel70AndAboveAndRpmBased, ...ubuntu1804AndAboveAndDebBased]
 

--- a/packages/build/src/download-center/config.spec.ts
+++ b/packages/build/src/download-center/config.spec.ts
@@ -522,7 +522,7 @@ describe('DownloadCenter config', function () {
       ];
       const mongoshTargets = [
         ...new Set(mongoshJsonFeedEntry.downloads.flatMap((d) => d.targets)),
-      ].filter((t) => t !== 'debian12'); // debian12 is not part of the server platform list at the time of writing
+      ].filter((t) => t !== 'ubuntu2404'); // ubuntu2404 is not part of the server platform list at the time of writing
 
       for (const arch of mongoshArchs) expect(serverArchs).to.include(arch);
       for (const target of mongoshTargets)


### PR DESCRIPTION
Our `build` package tests have been failing since 904162f5e89f8. This commit fixes:

- Ubuntu 24.04 is not known as part of the server distro list yet, but we can reliably infer its name tag based on the format used for existing Ubuntu distros
- Oracle Linux 9 is not known as a server distro and will likely never be.