### PR TITLE
chore(MONGOSH-1808): migrate mongosh to new mongodb-client-encryption repository

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -22876,18 +22876,46 @@
       }
     },
     "node_modules/mongodb-client-encryption": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-6.0.0.tgz",
-      "integrity": "sha512-GtqkqlSq19acX006/U1odA3l+gwhvABeoTUlvvgtvSs6qcN3qSHPnur3Z5N4oKOv6fZ7EtT8rIsWP2riI0+Eyg==",
+      "version": "6.1.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-6.1.0-alpha.0.tgz",
+      "integrity": "sha512-pcypn4m2EdAYPkfw0V4cfu64E5spJDHJTVSiIU8ErNbiIk+zJe1HcnfMRbyiXsulI4B46aWoOzNNd7NUGUBRwg==",
       "hasInstallScript": true,
+      "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "bindings": "^1.5.0",
         "node-addon-api": "^4.3.0",
-        "prebuild-install": "^7.1.1"
+        "prebuild-install": "^7.1.2"
       },
       "engines": {
         "node": ">=16.20.1"
+      }
+    },
+    "node_modules/mongodb-client-encryption/node_modules/prebuild-install": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.2.tgz",
+      "integrity": "sha512-UnNke3IQb6sgarcZIDU3gbMeTp/9SSU1DAIkil7PrqG1vZlBtY5msYccSKSHDqa3hNg436IXK+SNImReuA1wEQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^1.0.1",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/mongodb-connection-string-url": {
@@ -31652,49 +31680,6 @@
         "mongodb-client-encryption": "^6.1.0-alpha.0"
       }
     },
-    "packages/service-provider-core/node_modules/mongodb-client-encryption": {
-      "version": "6.1.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-6.1.0-alpha.0.tgz",
-      "integrity": "sha512-pcypn4m2EdAYPkfw0V4cfu64E5spJDHJTVSiIU8ErNbiIk+zJe1HcnfMRbyiXsulI4B46aWoOzNNd7NUGUBRwg==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "node-addon-api": "^4.3.0",
-        "prebuild-install": "^7.1.2"
-      },
-      "engines": {
-        "node": ">=16.20.1"
-      }
-    },
-    "packages/service-provider-core/node_modules/prebuild-install": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.2.tgz",
-      "integrity": "sha512-UnNke3IQb6sgarcZIDU3gbMeTp/9SSU1DAIkil7PrqG1vZlBtY5msYccSKSHDqa3hNg436IXK+SNImReuA1wEQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "detect-libc": "^2.0.0",
-        "expand-template": "^2.0.3",
-        "github-from-package": "0.0.0",
-        "minimist": "^1.2.3",
-        "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^1.0.1",
-        "node-abi": "^3.3.0",
-        "pump": "^3.0.0",
-        "rc": "^1.2.7",
-        "simple-get": "^4.0.0",
-        "tar-fs": "^2.0.0",
-        "tunnel-agent": "^0.6.0"
-      },
-      "bin": {
-        "prebuild-install": "bin.js"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "packages/service-provider-server": {
       "name": "@mongosh/service-provider-server",
       "version": "0.0.0-dev.0",
@@ -31724,50 +31709,7 @@
       },
       "optionalDependencies": {
         "kerberos": "^2.1.0",
-        "mongodb-client-encryption": "6.1.0-alpha.0"
-      }
-    },
-    "packages/service-provider-server/node_modules/mongodb-client-encryption": {
-      "version": "6.1.0-alpha.0",
-      "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-6.1.0-alpha.0.tgz",
-      "integrity": "sha512-pcypn4m2EdAYPkfw0V4cfu64E5spJDHJTVSiIU8ErNbiIk+zJe1HcnfMRbyiXsulI4B46aWoOzNNd7NUGUBRwg==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "bindings": "^1.5.0",
-        "node-addon-api": "^4.3.0",
-        "prebuild-install": "^7.1.2"
-      },
-      "engines": {
-        "node": ">=16.20.1"
-      }
-    },
-    "packages/service-provider-server/node_modules/prebuild-install": {
-      "version": "7.1.2",
-      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.2.tgz",
-      "integrity": "sha512-UnNke3IQb6sgarcZIDU3gbMeTp/9SSU1DAIkil7PrqG1vZlBtY5msYccSKSHDqa3hNg436IXK+SNImReuA1wEQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "detect-libc": "^2.0.0",
-        "expand-template": "^2.0.3",
-        "github-from-package": "0.0.0",
-        "minimist": "^1.2.3",
-        "mkdirp-classic": "^0.5.3",
-        "napi-build-utils": "^1.0.1",
-        "node-abi": "^3.3.0",
-        "pump": "^3.0.0",
-        "rc": "^1.2.7",
-        "simple-get": "^4.0.0",
-        "tar-fs": "^2.0.0",
-        "tunnel-agent": "^0.6.0"
-      },
-      "bin": {
-        "prebuild-install": "bin.js"
-      },
-      "engines": {
-        "node": ">=10"
+        "mongodb-client-encryption": "^6.1.0-alpha.0"
       }
     },
     "packages/shell-api": {
@@ -36980,7 +36922,7 @@
         "@mongodb-js/oidc-http-server-pages": "1.1.1",
         "kerberos": "^2.1.0",
         "lodash.merge": "^4.6.2",
-        "mongodb-client-encryption": "^6.0.0",
+        "mongodb-client-encryption": "^6.1.0-alpha.0",
         "mongodb-connection-string-url": "^3.0.0",
         "os-dns-native": "^1.2.0",
         "resolve-mongodb-srv": "^1.1.1",
@@ -37957,39 +37899,6 @@
         "mongodb-build-info": "^1.7.2",
         "mongodb-client-encryption": "^6.1.0-alpha.0",
         "prettier": "^2.8.8"
-      },
-      "dependencies": {
-        "mongodb-client-encryption": {
-          "version": "6.1.0-alpha.0",
-          "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-6.1.0-alpha.0.tgz",
-          "integrity": "sha512-pcypn4m2EdAYPkfw0V4cfu64E5spJDHJTVSiIU8ErNbiIk+zJe1HcnfMRbyiXsulI4B46aWoOzNNd7NUGUBRwg==",
-          "optional": true,
-          "requires": {
-            "bindings": "^1.5.0",
-            "node-addon-api": "^4.3.0",
-            "prebuild-install": "^7.1.2"
-          }
-        },
-        "prebuild-install": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.2.tgz",
-          "integrity": "sha512-UnNke3IQb6sgarcZIDU3gbMeTp/9SSU1DAIkil7PrqG1vZlBtY5msYccSKSHDqa3hNg436IXK+SNImReuA1wEQ==",
-          "optional": true,
-          "requires": {
-            "detect-libc": "^2.0.0",
-            "expand-template": "^2.0.3",
-            "github-from-package": "0.0.0",
-            "minimist": "^1.2.3",
-            "mkdirp-classic": "^0.5.3",
-            "napi-build-utils": "^1.0.1",
-            "node-abi": "^3.3.0",
-            "pump": "^3.0.0",
-            "rc": "^1.2.7",
-            "simple-get": "^4.0.0",
-            "tar-fs": "^2.0.0",
-            "tunnel-agent": "^0.6.0"
-          }
-        }
       }
     },
     "@mongosh/service-provider-server": {
@@ -38009,43 +37918,10 @@
         "eslint": "^7.25.0",
         "kerberos": "^2.1.0",
         "mongodb": "^6.7.0",
-        "mongodb-client-encryption": "6.1.0-alpha.0",
+        "mongodb-client-encryption": "^6.1.0-alpha.0",
         "mongodb-connection-string-url": "^3.0.1",
         "prettier": "^2.8.8",
         "socks": "^2.8.3"
-      },
-      "dependencies": {
-        "mongodb-client-encryption": {
-          "version": "6.1.0-alpha.0",
-          "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-6.1.0-alpha.0.tgz",
-          "integrity": "sha512-pcypn4m2EdAYPkfw0V4cfu64E5spJDHJTVSiIU8ErNbiIk+zJe1HcnfMRbyiXsulI4B46aWoOzNNd7NUGUBRwg==",
-          "optional": true,
-          "requires": {
-            "bindings": "^1.5.0",
-            "node-addon-api": "^4.3.0",
-            "prebuild-install": "^7.1.2"
-          }
-        },
-        "prebuild-install": {
-          "version": "7.1.2",
-          "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.2.tgz",
-          "integrity": "sha512-UnNke3IQb6sgarcZIDU3gbMeTp/9SSU1DAIkil7PrqG1vZlBtY5msYccSKSHDqa3hNg436IXK+SNImReuA1wEQ==",
-          "optional": true,
-          "requires": {
-            "detect-libc": "^2.0.0",
-            "expand-template": "^2.0.3",
-            "github-from-package": "0.0.0",
-            "minimist": "^1.2.3",
-            "mkdirp-classic": "^0.5.3",
-            "napi-build-utils": "^1.0.1",
-            "node-abi": "^3.3.0",
-            "pump": "^3.0.0",
-            "rc": "^1.2.7",
-            "simple-get": "^4.0.0",
-            "tar-fs": "^2.0.0",
-            "tunnel-agent": "^0.6.0"
-          }
-        }
       }
     },
     "@mongosh/shell-api": {
@@ -50526,14 +50402,36 @@
       }
     },
     "mongodb-client-encryption": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-6.0.0.tgz",
-      "integrity": "sha512-GtqkqlSq19acX006/U1odA3l+gwhvABeoTUlvvgtvSs6qcN3qSHPnur3Z5N4oKOv6fZ7EtT8rIsWP2riI0+Eyg==",
+      "version": "6.1.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-6.1.0-alpha.0.tgz",
+      "integrity": "sha512-pcypn4m2EdAYPkfw0V4cfu64E5spJDHJTVSiIU8ErNbiIk+zJe1HcnfMRbyiXsulI4B46aWoOzNNd7NUGUBRwg==",
       "optional": true,
       "requires": {
         "bindings": "^1.5.0",
         "node-addon-api": "^4.3.0",
-        "prebuild-install": "^7.1.1"
+        "prebuild-install": "^7.1.2"
+      },
+      "dependencies": {
+        "prebuild-install": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.2.tgz",
+          "integrity": "sha512-UnNke3IQb6sgarcZIDU3gbMeTp/9SSU1DAIkil7PrqG1vZlBtY5msYccSKSHDqa3hNg436IXK+SNImReuA1wEQ==",
+          "optional": true,
+          "requires": {
+            "detect-libc": "^2.0.0",
+            "expand-template": "^2.0.3",
+            "github-from-package": "0.0.0",
+            "minimist": "^1.2.3",
+            "mkdirp-classic": "^0.5.3",
+            "napi-build-utils": "^1.0.1",
+            "node-abi": "^3.3.0",
+            "pump": "^3.0.0",
+            "rc": "^1.2.7",
+            "simple-get": "^4.0.0",
+            "tar-fs": "^2.0.0",
+            "tunnel-agent": "^0.6.0"
+          }
+        }
       }
     },
     "mongodb-connection-string-url": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -31674,13 +31674,13 @@
         "node": ">=14.15.1"
       },
       "optionalDependencies": {
-        "mongodb-client-encryption": "^6.1.0-alpha"
+        "mongodb-client-encryption": "^6.1.0-alpha.0"
       }
     },
     "packages/service-provider-core/node_modules/mongodb-client-encryption": {
-      "version": "6.1.0-alpha",
-      "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-6.1.0-alpha.tgz",
-      "integrity": "sha512-JMXPabcr5P8WybMBDjjSENkc0t3SxyqtumMxjj2BgcwpcvpmP4mQGA22offJCBMBiNXdc6Zdcmh63mH+OCwgZA==",
+      "version": "6.1.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-6.1.0-alpha.0.tgz",
+      "integrity": "sha512-pcypn4m2EdAYPkfw0V4cfu64E5spJDHJTVSiIU8ErNbiIk+zJe1HcnfMRbyiXsulI4B46aWoOzNNd7NUGUBRwg==",
       "hasInstallScript": true,
       "optional": true,
       "dependencies": {
@@ -31747,7 +31747,7 @@
       },
       "optionalDependencies": {
         "kerberos": "^2.1.0",
-        "mongodb-client-encryption": "6.1.0-alpha"
+        "mongodb-client-encryption": "6.1.0-alpha.0"
       }
     },
     "packages/service-provider-server/node_modules/@mongodb-js/devtools-connect": {
@@ -31773,10 +31773,25 @@
         "mongodb-log-writer": "^1.4.2"
       }
     },
+    "packages/service-provider-server/node_modules/@mongodb-js/devtools-connect/node_modules/mongodb-client-encryption": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-6.0.1.tgz",
+      "integrity": "sha512-u6pKu9plR7hQH6VtsfYonC9dwWAM3HFEpi+Xy3EJIdUyoH6dlFgaxX8TnKx/Ycfi2I1cxTXq2IbhSpg157vVgg==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "node-addon-api": "^4.3.0",
+        "prebuild-install": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      }
+    },
     "packages/service-provider-server/node_modules/mongodb-client-encryption": {
-      "version": "6.1.0-alpha",
-      "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-6.1.0-alpha.tgz",
-      "integrity": "sha512-JMXPabcr5P8WybMBDjjSENkc0t3SxyqtumMxjj2BgcwpcvpmP4mQGA22offJCBMBiNXdc6Zdcmh63mH+OCwgZA==",
+      "version": "6.1.0-alpha.0",
+      "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-6.1.0-alpha.0.tgz",
+      "integrity": "sha512-pcypn4m2EdAYPkfw0V4cfu64E5spJDHJTVSiIU8ErNbiIk+zJe1HcnfMRbyiXsulI4B46aWoOzNNd7NUGUBRwg==",
       "hasInstallScript": true,
       "optional": true,
       "dependencies": {
@@ -38043,14 +38058,14 @@
         "eslint": "^7.25.0",
         "mongodb": "^6.7.0",
         "mongodb-build-info": "^1.7.2",
-        "mongodb-client-encryption": "^6.1.0-alpha",
+        "mongodb-client-encryption": "^6.1.0-alpha.0",
         "prettier": "^2.8.8"
       },
       "dependencies": {
         "mongodb-client-encryption": {
-          "version": "6.1.0-alpha",
-          "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-6.1.0-alpha.tgz",
-          "integrity": "sha512-JMXPabcr5P8WybMBDjjSENkc0t3SxyqtumMxjj2BgcwpcvpmP4mQGA22offJCBMBiNXdc6Zdcmh63mH+OCwgZA==",
+          "version": "6.1.0-alpha.0",
+          "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-6.1.0-alpha.0.tgz",
+          "integrity": "sha512-pcypn4m2EdAYPkfw0V4cfu64E5spJDHJTVSiIU8ErNbiIk+zJe1HcnfMRbyiXsulI4B46aWoOzNNd7NUGUBRwg==",
           "optional": true,
           "requires": {
             "bindings": "^1.5.0",
@@ -38097,7 +38112,7 @@
         "eslint": "^7.25.0",
         "kerberos": "^2.1.0",
         "mongodb": "^6.7.0",
-        "mongodb-client-encryption": "6.1.0-alpha",
+        "mongodb-client-encryption": "6.1.0-alpha.0",
         "mongodb-connection-string-url": "^3.0.1",
         "prettier": "^2.8.8",
         "socks": "^2.8.3"
@@ -38117,12 +38132,25 @@
             "resolve-mongodb-srv": "^1.1.1",
             "socks": "^2.7.3",
             "system-ca": "^1.0.2"
+          },
+          "dependencies": {
+            "mongodb-client-encryption": {
+              "version": "6.0.1",
+              "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-6.0.1.tgz",
+              "integrity": "sha512-u6pKu9plR7hQH6VtsfYonC9dwWAM3HFEpi+Xy3EJIdUyoH6dlFgaxX8TnKx/Ycfi2I1cxTXq2IbhSpg157vVgg==",
+              "optional": true,
+              "requires": {
+                "bindings": "^1.5.0",
+                "node-addon-api": "^4.3.0",
+                "prebuild-install": "^7.1.2"
+              }
+            }
           }
         },
         "mongodb-client-encryption": {
-          "version": "6.1.0-alpha",
-          "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-6.1.0-alpha.tgz",
-          "integrity": "sha512-JMXPabcr5P8WybMBDjjSENkc0t3SxyqtumMxjj2BgcwpcvpmP4mQGA22offJCBMBiNXdc6Zdcmh63mH+OCwgZA==",
+          "version": "6.1.0-alpha.0",
+          "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-6.1.0-alpha.0.tgz",
+          "integrity": "sha512-pcypn4m2EdAYPkfw0V4cfu64E5spJDHJTVSiIU8ErNbiIk+zJe1HcnfMRbyiXsulI4B46aWoOzNNd7NUGUBRwg==",
           "optional": true,
           "requires": {
             "bindings": "^1.5.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -31674,7 +31674,48 @@
         "node": ">=14.15.1"
       },
       "optionalDependencies": {
-        "mongodb-client-encryption": "^6.0.0"
+        "mongodb-client-encryption": "^6.1.0-alpha"
+      }
+    },
+    "packages/service-provider-core/node_modules/mongodb-client-encryption": {
+      "version": "6.1.0-alpha",
+      "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-6.1.0-alpha.tgz",
+      "integrity": "sha512-JMXPabcr5P8WybMBDjjSENkc0t3SxyqtumMxjj2BgcwpcvpmP4mQGA22offJCBMBiNXdc6Zdcmh63mH+OCwgZA==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "node-addon-api": "^4.3.0",
+        "prebuild-install": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      }
+    },
+    "packages/service-provider-core/node_modules/prebuild-install": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.2.tgz",
+      "integrity": "sha512-UnNke3IQb6sgarcZIDU3gbMeTp/9SSU1DAIkil7PrqG1vZlBtY5msYccSKSHDqa3hNg436IXK+SNImReuA1wEQ==",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^1.0.1",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "packages/service-provider-server": {
@@ -31706,7 +31747,7 @@
       },
       "optionalDependencies": {
         "kerberos": "^2.1.0",
-        "mongodb-client-encryption": "^6.0.0"
+        "mongodb-client-encryption": "6.1.0-alpha"
       }
     },
     "packages/service-provider-server/node_modules/@mongodb-js/devtools-connect": {
@@ -31730,6 +31771,47 @@
         "@mongodb-js/oidc-plugin": "^1.0.0",
         "mongodb": "^5.8.1 || ^6.0.0",
         "mongodb-log-writer": "^1.4.2"
+      }
+    },
+    "packages/service-provider-server/node_modules/mongodb-client-encryption": {
+      "version": "6.1.0-alpha",
+      "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-6.1.0-alpha.tgz",
+      "integrity": "sha512-JMXPabcr5P8WybMBDjjSENkc0t3SxyqtumMxjj2BgcwpcvpmP4mQGA22offJCBMBiNXdc6Zdcmh63mH+OCwgZA==",
+      "hasInstallScript": true,
+      "optional": true,
+      "dependencies": {
+        "bindings": "^1.5.0",
+        "node-addon-api": "^4.3.0",
+        "prebuild-install": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=16.20.1"
+      }
+    },
+    "packages/service-provider-server/node_modules/prebuild-install": {
+      "version": "7.1.2",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.2.tgz",
+      "integrity": "sha512-UnNke3IQb6sgarcZIDU3gbMeTp/9SSU1DAIkil7PrqG1vZlBtY5msYccSKSHDqa3hNg436IXK+SNImReuA1wEQ==",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^1.0.1",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "packages/shell-api": {
@@ -37961,8 +38043,41 @@
         "eslint": "^7.25.0",
         "mongodb": "^6.7.0",
         "mongodb-build-info": "^1.7.2",
-        "mongodb-client-encryption": "^6.0.0",
+        "mongodb-client-encryption": "^6.1.0-alpha",
         "prettier": "^2.8.8"
+      },
+      "dependencies": {
+        "mongodb-client-encryption": {
+          "version": "6.1.0-alpha",
+          "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-6.1.0-alpha.tgz",
+          "integrity": "sha512-JMXPabcr5P8WybMBDjjSENkc0t3SxyqtumMxjj2BgcwpcvpmP4mQGA22offJCBMBiNXdc6Zdcmh63mH+OCwgZA==",
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "node-addon-api": "^4.3.0",
+            "prebuild-install": "^7.1.2"
+          }
+        },
+        "prebuild-install": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.2.tgz",
+          "integrity": "sha512-UnNke3IQb6sgarcZIDU3gbMeTp/9SSU1DAIkil7PrqG1vZlBtY5msYccSKSHDqa3hNg436IXK+SNImReuA1wEQ==",
+          "optional": true,
+          "requires": {
+            "detect-libc": "^2.0.0",
+            "expand-template": "^2.0.3",
+            "github-from-package": "0.0.0",
+            "minimist": "^1.2.3",
+            "mkdirp-classic": "^0.5.3",
+            "napi-build-utils": "^1.0.1",
+            "node-abi": "^3.3.0",
+            "pump": "^3.0.0",
+            "rc": "^1.2.7",
+            "simple-get": "^4.0.0",
+            "tar-fs": "^2.0.0",
+            "tunnel-agent": "^0.6.0"
+          }
+        }
       }
     },
     "@mongosh/service-provider-server": {
@@ -37982,7 +38097,7 @@
         "eslint": "^7.25.0",
         "kerberos": "^2.1.0",
         "mongodb": "^6.7.0",
-        "mongodb-client-encryption": "^6.0.0",
+        "mongodb-client-encryption": "6.1.0-alpha",
         "mongodb-connection-string-url": "^3.0.1",
         "prettier": "^2.8.8",
         "socks": "^2.8.3"
@@ -38002,6 +38117,37 @@
             "resolve-mongodb-srv": "^1.1.1",
             "socks": "^2.7.3",
             "system-ca": "^1.0.2"
+          }
+        },
+        "mongodb-client-encryption": {
+          "version": "6.1.0-alpha",
+          "resolved": "https://registry.npmjs.org/mongodb-client-encryption/-/mongodb-client-encryption-6.1.0-alpha.tgz",
+          "integrity": "sha512-JMXPabcr5P8WybMBDjjSENkc0t3SxyqtumMxjj2BgcwpcvpmP4mQGA22offJCBMBiNXdc6Zdcmh63mH+OCwgZA==",
+          "optional": true,
+          "requires": {
+            "bindings": "^1.5.0",
+            "node-addon-api": "^4.3.0",
+            "prebuild-install": "^7.1.2"
+          }
+        },
+        "prebuild-install": {
+          "version": "7.1.2",
+          "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.2.tgz",
+          "integrity": "sha512-UnNke3IQb6sgarcZIDU3gbMeTp/9SSU1DAIkil7PrqG1vZlBtY5msYccSKSHDqa3hNg436IXK+SNImReuA1wEQ==",
+          "optional": true,
+          "requires": {
+            "detect-libc": "^2.0.0",
+            "expand-template": "^2.0.3",
+            "github-from-package": "0.0.0",
+            "minimist": "^1.2.3",
+            "mkdirp-classic": "^0.5.3",
+            "napi-build-utils": "^1.0.1",
+            "node-abi": "^3.3.0",
+            "pump": "^3.0.0",
+            "rc": "^1.2.7",
+            "simple-get": "^4.0.0",
+            "tar-fs": "^2.0.0",
+            "tunnel-agent": "^0.6.0"
           }
         }
       }

--- a/package.json
+++ b/package.json
@@ -92,6 +92,14 @@
   "engines": {
     "node": ">=12.18.4"
   },
+  "overrides": {
+    "@mongodb-js/devtools-connect": {
+      "mongodb-client-encryption": "^6.1.0-alpha.0"
+    },
+    "mongodb": {
+      "mongodb-client-encryption": "^6.1.0-alpha.0"
+    }
+  },
   "devDependencies": {
     "@babel/compat-data": "^7.9.0",
     "@mongodb-js/monorepo-tools": "^1.1.10",

--- a/packages/arg-parser/package.json
+++ b/packages/arg-parser/package.json
@@ -48,5 +48,10 @@
     "eslint": "^7.25.0",
     "mongodb": "^6.7.0",
     "prettier": "^2.8.8"
+  },
+  "overrides": {
+    "@mongodb-js/devtools-connect": {
+      "mongodb-client-encryption": "^6.1.0-alpha.0"
+    }
   }
 }

--- a/packages/build/src/compile/signable-compiler.ts
+++ b/packages/build/src/compile/signable-compiler.ts
@@ -32,7 +32,7 @@ async function preCompileHook(nodeSourceTree: string) {
       env: {
         ...process.env,
         FLE_NODE_SOURCE_PATH: nodeSourceTree,
-        LIBMONGOCRYPT_VERSION: `node-v${fleAddonVersion}`,
+        MONGODB_CLIENT_ENCRYPTION_VERSION: `v${fleAddonVersion}`,
       },
       stdio: 'inherit',
     }

--- a/packages/e2e-tests/test/e2e-fle.spec.ts
+++ b/packages/e2e-tests/test/e2e-fle.spec.ts
@@ -716,8 +716,8 @@ describe('FLE tests', function () {
       expect(parseInt(dekCount.trim(), 10)).to.equal(1);
     });
 
-    context('using rangePreview algorithm', function () {
-      // TODO(MONGOSH-1742): Server 8.0 drops "rangePreview" algorithm and adds
+    context('using range algorithm', function () {
+      // TODO(MONGOSH-1742): Server 8.0 drops "range" algorithm and adds
       // "range". Re-enable these when the change is finalized
       skipIfServerVersion(testServer, '>= 8.0.0-alpha');
 
@@ -734,13 +734,13 @@ describe('FLE tests', function () {
             kmsProviders: { local: { key: 'A'.repeat(128) } },
             bypassQueryAnalysis: true
           });
-  
+
           keyVault = client.getKeyVault();
           clientEncryption = client.getClientEncryption();
-  
+
           // Create necessary data key
           dataKey = keyVault.createKey('local');
-  
+
           rangeOptions = {
             sparsity: Long(1),
             min: new Date('1970'),
@@ -754,21 +754,21 @@ describe('FLE tests', function () {
                 path: 'v',
                 bsonType: 'date',
                 queries: [{
-                  queryType: 'rangePreview',
+                  queryType: 'range',
                   contention: 4,
                   ...rangeOptions
                 }]
               }]
             }
           });
-  
+
           // Encrypt and insert data encrypted with specified data key
           for (let year = 1990; year < 2010; year++) {
             const insertPayload = clientEncryption.encrypt(
               dataKey,
               new Date(year + '-02-02T12:45:16.277Z'),
               {
-                algorithm: 'RangePreview',
+                algorithm: 'range',
                 contentionFactor: 4,
                 rangeOptions
               });
@@ -783,8 +783,8 @@ describe('FLE tests', function () {
         findPayload = clientEncryption.encryptExpression(dataKey, {
           $and: [ { v: {$gt: new Date('1992')} }, { v: {$lt: new Date('1999')} } ]
         }, {
-          algorithm: 'RangePreview',
-          queryType: 'rangePreview',
+          algorithm: 'Range',
+          queryType: 'range',
           contentionFactor: 4,
           rangeOptions
         });
@@ -804,7 +804,7 @@ describe('FLE tests', function () {
 
       it('allows automatic range encryption', async function () {
         // TODO(MONGOSH-1550): On s390x, we are using the 6.0.x RHEL7 shared library,
-        // which does not support QE rangePreview. That's just fine for preview, but
+        // which does not support QE range. That's just fine for preview, but
         // we should switch to the 7.0.x RHEL8 shared library for Range GA.
         if (process.arch === 's390x') {
           return this.skip();
@@ -822,9 +822,9 @@ describe('FLE tests', function () {
             keyVaultNamespace: '${dbname}.keyVault',
             kmsProviders: { local: { key: 'A'.repeat(128) } }
           });
-  
+
           dataKey = client.getKeyVault().createKey('local');
-  
+
           coll = client.getDB('${dbname}').encryptiontest;
           client.getDB('${dbname}').createCollection('encryptiontest', {
             encryptedFields: {
@@ -833,7 +833,7 @@ describe('FLE tests', function () {
                 path: 'v',
                 bsonType: 'date',
                 queries: [{
-                  queryType: 'rangePreview',
+                  queryType: 'range',
                   contention: 4,
                   sparsity: 1,
                   min: new Date('1970'),
@@ -842,7 +842,7 @@ describe('FLE tests', function () {
               }]
             }
           });
-  
+
           for (let year = 1990; year < 2010; year++) {
             coll.insertOne({ v: new Date(year + '-02-02T12:45:16.277Z'), year })
           }

--- a/packages/logging/package.json
+++ b/packages/logging/package.json
@@ -32,6 +32,11 @@
     "eslint": "^7.25.0",
     "prettier": "^2.8.8"
   },
+  "overrides": {
+    "@mongodb-js/devtools-connect": {
+      "mongodb-client-encryption": "^6.1.0-alpha.0"
+    }
+  },
   "scripts": {
     "test": "mocha -r \"../../scripts/import-expansions.js\" --timeout 15000 -r ts-node/register \"./src/**/*.spec.ts\"",
     "test-ci": "node ../../scripts/run-if-package-requested.js npm test",

--- a/packages/service-provider-core/package.json
+++ b/packages/service-provider-core/package.json
@@ -50,7 +50,7 @@
     "mongodb-build-info": "^1.7.2"
   },
   "optionalDependencies": {
-    "mongodb-client-encryption": "^6.0.0"
+    "mongodb-client-encryption": "^6.1.0-alpha"
   },
   "devDependencies": {
     "@mongodb-js/eslint-config-mongosh": "^1.0.0",

--- a/packages/service-provider-core/package.json
+++ b/packages/service-provider-core/package.json
@@ -50,7 +50,7 @@
     "mongodb-build-info": "^1.7.2"
   },
   "optionalDependencies": {
-    "mongodb-client-encryption": "^6.1.0-alpha"
+    "mongodb-client-encryption": "^6.1.0-alpha.0"
   },
   "devDependencies": {
     "@mongodb-js/eslint-config-mongosh": "^1.0.0",

--- a/packages/service-provider-server/package.json
+++ b/packages/service-provider-server/package.json
@@ -59,7 +59,7 @@
   },
   "optionalDependencies": {
     "kerberos": "^2.1.0",
-    "mongodb-client-encryption": "6.1.0-alpha.0"
+    "mongodb-client-encryption": "^6.1.0-alpha.0"
   },
   "devDependencies": {
     "@mongodb-js/eslint-config-mongosh": "^1.0.0",
@@ -69,5 +69,10 @@
     "depcheck": "^1.4.3",
     "eslint": "^7.25.0",
     "prettier": "^2.8.8"
+  },
+  "overrides": {
+    "@mongodb-js/devtools-connect": {
+      "mongodb-client-encryption": "^6.1.0-alpha.0"
+    }
   }
 }

--- a/packages/service-provider-server/package.json
+++ b/packages/service-provider-server/package.json
@@ -59,7 +59,7 @@
   },
   "optionalDependencies": {
     "kerberos": "^2.1.0",
-    "mongodb-client-encryption": "^6.0.0"
+    "mongodb-client-encryption": "6.1.0-alpha"
   },
   "devDependencies": {
     "@mongodb-js/eslint-config-mongosh": "^1.0.0",

--- a/packages/service-provider-server/package.json
+++ b/packages/service-provider-server/package.json
@@ -59,7 +59,7 @@
   },
   "optionalDependencies": {
     "kerberos": "^2.1.0",
-    "mongodb-client-encryption": "6.1.0-alpha"
+    "mongodb-client-encryption": "6.1.0-alpha.0"
   },
   "devDependencies": {
     "@mongodb-js/eslint-config-mongosh": "^1.0.0",

--- a/packages/shell-api/src/field-level-encryption.spec.ts
+++ b/packages/shell-api/src/field-level-encryption.spec.ts
@@ -275,7 +275,7 @@ describe('Field Level Encryption', function () {
         rangeOptions: {
           sparsity: new bson.Long(1),
         },
-      } as const;
+      } as any; // TODO Needs a driver update to get correct types.
 
       it('calls encryptExpression with algorithm on libmongoc', async function () {
         libmongoc.encryptExpression.resolves();

--- a/packages/shell-api/src/field-level-encryption.spec.ts
+++ b/packages/shell-api/src/field-level-encryption.spec.ts
@@ -269,8 +269,8 @@ describe('Field Level Encryption', function () {
       };
 
       const options = {
-        algorithm: 'RangePreview',
-        queryType: 'rangePreview',
+        algorithm: 'Range',
+        queryType: 'range',
         contentionFactor: 0,
         rangeOptions: {
           sparsity: new bson.Long(1),

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -40,6 +40,11 @@
   "dependencies": {
     "@mongodb-js/devtools-connect": "^3.0.2"
   },
+  "overrides": {
+    "@mongodb-js/devtools-connect": {
+      "mongodb-client-encryption": "^6.1.0-alpha.0"
+    }
+  },
   "devDependencies": {
     "@mongodb-js/eslint-config-mongosh": "^1.0.0",
     "@mongodb-js/prettier-config-devtools": "^1.0.1",

--- a/scripts/prep-fle-addon.sh
+++ b/scripts/prep-fle-addon.sh
@@ -31,7 +31,7 @@ cd "$BUILDROOT"
 
 echo Using mongodb-client-encryption at git tag "$MONGODB_CLIENT_ENCRYPTION_VERSION"
 
-git clone https://github.com/mongodb-js/mongodb-client-encryption --branch "$MONGODB_CLIENT_ENCRYPTION_VERSION" --depth 2
+git clone https://github.com/mongodb-js/mongodb-client-encryption --branch chore-fix-build-on-intel-mac --depth 2
 
 cd mongodb-client-encryption
 
@@ -42,8 +42,7 @@ esac
 
 # The script in `mongodb-js/mongodb-client-encryption` will download or build the libmongocrypt version specified in
 # mongodb-client-encryption's package.json at "mongodb:libmongocrypt"
-npm run install:libmongocrypt -- ${IS_WINDOWS:+--build}
-npm run prepare
+npm run install:libmongocrypt -- --no-macos-universal ${IS_WINDOWS:+--build}
 
 # The "deps" directory will be populated
 # Structure:

--- a/scripts/prep-fle-addon.sh
+++ b/scripts/prep-fle-addon.sh
@@ -31,7 +31,7 @@ cd "$BUILDROOT"
 
 echo Using mongodb-client-encryption at git tag "$MONGODB_CLIENT_ENCRYPTION_VERSION"
 
-git clone https://github.com/mongodb-js/mongodb-client-encryption --depth 2
+git clone https://github.com/mongodb-js/mongodb-client-encryption --branch "$MONGODB_CLIENT_ENCRYPTION_VERSION" --depth 2
 
 cd mongodb-client-encryption
 

--- a/scripts/prep-fle-addon.sh
+++ b/scripts/prep-fle-addon.sh
@@ -43,6 +43,7 @@ esac
 # The script in `mongodb-js/mongodb-client-encryption` will download or build the libmongocrypt version specified in
 # mongodb-client-encryption's package.json at "mongodb:libmongocrypt"
 npm run install:libmongocrypt ${IS_WINDOWS:+--build}
+npm run prepare
 
 # The "deps" directory will be populated
 # Structure:

--- a/scripts/prep-fle-addon.sh
+++ b/scripts/prep-fle-addon.sh
@@ -26,69 +26,33 @@ BUILDROOT="$MONGOSH_ROOT_DIR"/tmp/fle-buildroot
 rm -rf "$BUILDROOT"
 mkdir -p "$BUILDROOT"
 cd "$BUILDROOT"
-PREBUILT_OSNAME=''
 
-[ -z "$LIBMONGOCRYPT_VERSION" ] && LIBMONGOCRYPT_VERSION=latest
+[ -z "$MONGODB_CLIENT_ENCRYPTION_VERSION" ] && MONGODB_CLIENT_ENCRYPTION_VERSION=main
 
-echo Using libmongocrypt at git tag "$LIBMONGOCRYPT_VERSION"
+echo Using mongodb-client-encryption at git tag "$MONGODB_CLIENT_ENCRYPTION_VERSION"
 
-if [ x"$FLE_NODE_SOURCE_PATH" != x"" -a -z "$BUILD_FLE_FROM_SOURCE" ]; then
-  # Use prebuilt binaries where available.
-  case `uname -a` in
-      Darwin*x86_64*)                   PREBUILT_OSNAME=macos;;
-      Linux*x86_64*)                    PREBUILT_OSNAME=rhel-70-64-bit;;
-      Linux*s390x*)                     PREBUILT_OSNAME=rhel72-zseries-test;;
-      Linux*aarch64*)                   PREBUILT_OSNAME=ubuntu1804-arm64;;
-      Linux*ppc64le*)                   PREBUILT_OSNAME=rhel-71-ppc64el;;
-      CYGWIN*|MINGW32*|MSYS*|MINGW*)    PREBUILT_OSNAME=windows-test;;
-  esac
-fi
+git clone https://github.com/mongodb-js/mongodb-client-encryption --branch "$MONGODB_CLIENT_ENCRYPTION_VERSION" --depth 2
 
-if [ x"$PREBUILT_OSNAME" != x"" ]; then
-  if [ $LIBMONGOCRYPT_VERSION != latest ]; then
-    # Replace LIBMONGOCRYPT_VERSION through its git SHA
-    git clone https://github.com/mongodb/libmongocrypt --branch $LIBMONGOCRYPT_VERSION --depth 2
-    LIBMONGOCRYPT_VERSION=$(cd libmongocrypt && git rev-parse HEAD)
-    rm -rf libmongocrypt
-  fi
+cd mongodb-client-encryption
 
-  # Download and extract prebuilt binaries.
-  curl -sSfLO https://s3.amazonaws.com/mciuploads/libmongocrypt/$PREBUILT_OSNAME/master/$LIBMONGOCRYPT_VERSION/libmongocrypt.tar.gz
-  if tar -tzf libmongocrypt.tar.gz lib64; then LIB=lib64; else LIB=lib; fi
-  mkdir -p prebuilts
-  tar -xzvf libmongocrypt.tar.gz -C prebuilts nocrypto/ $LIB/
-  mkdir -p lib
-  mv -v prebuilts/nocrypto/$LIB/* lib
-  mv -v prebuilts/nocrypto/include include
-  mv -v prebuilts/$LIB/*bson* lib
-  rm -rf prebuilts
-else
-  if [ `uname` = Darwin ]; then
-    export CFLAGS="-mmacosx-version-min=10.15";
-  fi
+# The script in `mongodb-js/mongodb-client-encryption` will download or build the libmongocrypt version specified in
+# mongodb-client-encryption's package.json at "mongodb:libmongocrypt"
+npm run install:libmongocrypt
 
-  if [ -z "$CMAKE" ]; then CMAKE=cmake; fi
-
-  # libmongocrypt currently determines its own version at build time by using
-  # `git describe`, so there's no way to do anything but a full checkout of the
-  # repository at this point.
-  git clone https://github.com/mongodb/libmongocrypt
-  if [ $LIBMONGOCRYPT_VERSION != "latest" ]; then
-    (cd libmongocrypt && git checkout $LIBMONGOCRYPT_VERSION)
-  fi
-
-  # build libmongocrypt
-  cd libmongocrypt
-  mkdir -p cmake-build
-  cd cmake-build
-  "$CMAKE" -DCMAKE_INSTALL_PREFIX="$BUILDROOT" -DCMAKE_PREFIX_PATH="$BUILDROOT" -DDISABLE_NATIVE_CRYPTO=1 ..
-  make -j8 install
-  cd ../../
-fi
+# The "deps" directory will be populated
+# Structure:
+# deps/
+#   include/kms_message
+#   include/mongocrypt
+# lib/
+#   libbson-static-for-libmongocrypt.a
+#   libkms_message-static.a
+#   libmongocrypt-static.a
 
 if [ x"$FLE_NODE_SOURCE_PATH" != x"" ]; then
   mkdir -p "$FLE_NODE_SOURCE_PATH"/deps/lib
   mkdir -p "$FLE_NODE_SOURCE_PATH"/deps/include
-  cp -rv "$BUILDROOT"/lib*/*-static* "$FLE_NODE_SOURCE_PATH"/deps/lib
-  cp -rv "$BUILDROOT"/include/*{kms,mongocrypt}* "$FLE_NODE_SOURCE_PATH"/deps/include
+  cp -rv ./deps/lib*/*-static* "$FLE_NODE_SOURCE_PATH"/deps/lib
+  cp -rv ./deps/include/*kms* "$FLE_NODE_SOURCE_PATH"/deps/include
+  cp -rv ./deps/include/*mongocrypt* "$FLE_NODE_SOURCE_PATH"/deps/include
 fi

--- a/scripts/prep-fle-addon.sh
+++ b/scripts/prep-fle-addon.sh
@@ -59,7 +59,7 @@ fi
 
 # The script in `mongodb-js/mongodb-client-encryption` will download or build the libmongocrypt version specified in
 # mongodb-client-encryption's package.json at "mongodb:libmongocrypt"
-npm run install:libmongocrypt -- --no-macos-universal ${IS_WINDOWS:+--build}
+npm run install:libmongocrypt -- --skip-bindings ${IS_WINDOWS:+--build}
 
 # The "deps" directory will be populated
 # Structure:

--- a/scripts/prep-fle-addon.sh
+++ b/scripts/prep-fle-addon.sh
@@ -40,6 +40,23 @@ case $(uname -a) in
   CYGWIN*|MINGW32*|MSYS*|MINGW*) IS_WINDOWS="true";;
 esac
 
+if [[ $IS_WINDOWS == "true" ]]; then
+  CMAKE_VERSION="3.25.1"
+  archive="cmake-$CMAKE_VERSION-windows-x86_64.zip"
+  url="https://github.com/Kitware/CMake/releases/download/v$CMAKE_VERSION/cmake-$CMAKE_VERSION-windows-x86_64.zip"
+  extract_dir="cmake_$CMAKE_VERSION"
+  curl --retry 5 -LsS --max-time 120 --fail --output "$archive" "$url"
+  unzip -o -qq "$archive" -d "cmake_$CMAKE_VERSION"
+  mv -- $extract_dir/cmake-$CMAKE_VERSION-*/* "$extract_dir"
+  chmod +x $extract_dir/bin/*
+
+  PATH=$PWD/$extract_dir/bin:$PATH
+  export PATH
+  hash -r
+  which cmake
+  cmake --version
+fi
+
 # The script in `mongodb-js/mongodb-client-encryption` will download or build the libmongocrypt version specified in
 # mongodb-client-encryption's package.json at "mongodb:libmongocrypt"
 npm run install:libmongocrypt -- --no-macos-universal ${IS_WINDOWS:+--build}

--- a/scripts/prep-fle-addon.sh
+++ b/scripts/prep-fle-addon.sh
@@ -31,7 +31,7 @@ cd "$BUILDROOT"
 
 echo Using mongodb-client-encryption at git tag "$MONGODB_CLIENT_ENCRYPTION_VERSION"
 
-git clone https://github.com/mongodb-js/mongodb-client-encryption --branch chore-fix-build-on-intel-mac --depth 2
+git clone https://github.com/mongodb-js/mongodb-client-encryption --depth 2
 
 cd mongodb-client-encryption
 

--- a/scripts/prep-fle-addon.sh
+++ b/scripts/prep-fle-addon.sh
@@ -42,7 +42,7 @@ esac
 
 # The script in `mongodb-js/mongodb-client-encryption` will download or build the libmongocrypt version specified in
 # mongodb-client-encryption's package.json at "mongodb:libmongocrypt"
-npm run install:libmongocrypt ${IS_WINDOWS:+--build}
+npm run install:libmongocrypt -- ${IS_WINDOWS:+--build}
 npm run prepare
 
 # The "deps" directory will be populated

--- a/scripts/prep-fle-addon.sh
+++ b/scripts/prep-fle-addon.sh
@@ -35,9 +35,14 @@ git clone https://github.com/mongodb-js/mongodb-client-encryption --branch "$MON
 
 cd mongodb-client-encryption
 
+unset IS_WINDOWS
+case $(uname -a) in
+  CYGWIN*|MINGW32*|MSYS*|MINGW*) IS_WINDOWS="true";;
+esac
+
 # The script in `mongodb-js/mongodb-client-encryption` will download or build the libmongocrypt version specified in
 # mongodb-client-encryption's package.json at "mongodb:libmongocrypt"
-npm run install:libmongocrypt
+npm run install:libmongocrypt ${IS_WINDOWS:+--build}
 
 # The "deps" directory will be populated
 # Structure:


### PR DESCRIPTION
Changes prep-fle-addon script to use new repo and depend on new repo's script for downloading/building bindings. The version of libmongocrypt is now determined by the binding's package.json file.