### PR TITLE
fix(shell-api): sh.status() should show full list of tag ranges in verbose mode only MONGOSH-1327

### DIFF
--- a/packages/shell-api/src/helpers.ts
+++ b/packages/shell-api/src/helpers.ts
@@ -611,6 +611,7 @@ export async function getPrintableShardStatus(
                 chunksRes.push(
                   'too many chunks to print, use verbose if you want to force print'
                 );
+                break;
               }
             }
 
@@ -631,6 +632,7 @@ export async function getPrintableShardStatus(
                 tagsRes.push(
                   'too many tags to print, use verbose if you want to force print'
                 );
+                break;
               }
             }
             collRes.chunks = chunksRes;

--- a/packages/shell-api/src/helpers.ts
+++ b/packages/shell-api/src/helpers.ts
@@ -614,18 +614,30 @@ export async function getPrintableShardStatus(
               );
             }
 
-            const tagsRes: any[] = [];
-            for await (const tag of (
+            const tags = await (
               await configDB.getCollection('tags').find({
                 ns: coll._id,
               })
-            ).sort({ min: 1 })) {
-              tagsRes.push({
-                tag: tag.tag,
-                min: tag.min,
-                max: tag.max,
-              });
+            )
+              .sort({ min: 1 })
+              .toArray();
+            const tagsRes: any[] = [];
+
+            // NOTE: this will return tags as a string, and will print ugly BSON
+            if (tags.length < 20 || verbose) {
+              for (const tag of tags) {
+                tagsRes.push({
+                  tag: tag.tag,
+                  min: tag.min,
+                  max: tag.max,
+                });
+              }
+            } else {
+              tagsRes.push(
+                'too many tags to print, use verbose if you want to force print'
+              );
             }
+
             collRes.chunks = chunksRes;
             collRes.tags = tagsRes;
             return [coll._id, collRes] as const;

--- a/packages/shell-api/src/shard.spec.ts
+++ b/packages/shell-api/src/shard.spec.ts
@@ -2093,6 +2093,7 @@ describe('Shard', function () {
       });
     });
     describe('chunks', function () {
+      skipIfServerVersion(mongos, '<= 6.0');
       it('shows a full chunk list when there are 20 or less chunks', async function () {
         for (let i = 0; i < 19; i++) {
           await sh.splitAt(ns, { key: i + 1 });

--- a/packages/shell-api/src/shard.spec.ts
+++ b/packages/shell-api/src/shard.spec.ts
@@ -2040,8 +2040,8 @@ describe('Shard', function () {
           await sh.addShardToZone(`${shardId}-0`, `zone${i}`);
           await sh.updateZoneKeyRange(
             ns,
-            { key: i * 10 - 10 },
             { key: i * 10 },
+            { key: i * 10 + 10 },
             `zone${i}`
           );
           await sh.addShardTag(`${shardId}-0`, `zone${i}`);
@@ -2054,7 +2054,7 @@ describe('Shard', function () {
       });
       it('shows tags as a string when there are too many', async function () {
         await sh.addShardToZone(`${shardId}-0`, 'zone19');
-        await sh.updateZoneKeyRange(ns, { key: 180 }, { key: 190 }, 'zone19');
+        await sh.updateZoneKeyRange(ns, { key: 190 }, { key: 200 }, 'zone19');
         await sh.addShardTag(`${shardId}-0`, 'zone19');
 
         const databases = (await sh.status()).value.databases;

--- a/packages/shell-api/src/shard.spec.ts
+++ b/packages/shell-api/src/shard.spec.ts
@@ -2071,6 +2071,25 @@ describe('Shard', function () {
               'too many tags to print, use verbose if you want to force print'
           )
         ).to.equal(true);
+
+        for (let i = 0; i < 20; i++) {
+          expect(
+            (
+              await sh.removeRangeFromZone(
+                ns,
+                { key: i * 10 },
+                { key: i * 10 + 10 }
+              )
+            ).ok
+          ).to.equal(1);
+        }
+
+        const db = instanceState.currentDb.getSiblingDB(dbName);
+        await db.getCollection('coll').deleteMany({});
+
+        expect(
+          (await sh.removeShardFromZone(`${shardId}-0`, 'zone0')).ok
+        ).to.equal(1);
       });
     });
     describe('chunks', function () {

--- a/packages/shell-api/src/shard.spec.ts
+++ b/packages/shell-api/src/shard.spec.ts
@@ -2084,7 +2084,16 @@ describe('Shard', function () {
     });
     describe('chunks', function () {
       it('shows a full chunk list when there are 20 or less chunks', async function () {
-        for (let i = 1000; i < 1019; i++) {
+        const chunks0 = (await sh.status()).value.databases.find(
+          (d) => d.database._id === 'test'
+        ).collections[ns].chunks;
+        // eslint-disable-next-line no-console
+        console.log('chunks0----------------------');
+        // eslint-disable-next-line no-console
+        console.log(chunks0);
+        // eslint-disable-next-line no-console
+        console.log('----------------------');
+        for (let i = 1000; i < 1019 - chunks0.length; i++) {
           await sh.splitAt(ns, { key: i + 1 });
         }
         const chunks = (await sh.status()).value.databases.find(

--- a/packages/shell-api/src/shard.spec.ts
+++ b/packages/shell-api/src/shard.spec.ts
@@ -2061,12 +2061,10 @@ describe('Shard', function () {
         ).collections[ns].tags;
         expect(tags.length).to.equal(21);
         expect(
-          !!tags.find(
-            (tag) =>
-              tag ===
-              'too many tags to print, use verbose if you want to force print'
+          tags.indexOf(
+            'too many tags to print, use verbose if you want to force print'
           )
-        ).to.equal(true);
+        ).to.equal(20);
 
         // Cleanup.
         const db = instanceState.currentDb.getSiblingDB(dbName);
@@ -2755,12 +2753,10 @@ describe('Shard', function () {
       ).collections[ns].chunks;
       expect(chunks.length).to.equal(21);
       expect(
-        !!chunks.find(
-          (tag) =>
-            tag ===
-            'too many chunks to print, use verbose if you want to force print'
+        chunks.indexOf(
+          'too many chunks to print, use verbose if you want to force print'
         )
-      ).to.equal(true);
+      ).to.equal(20);
     });
   });
 });

--- a/packages/shell-api/src/shard.spec.ts
+++ b/packages/shell-api/src/shard.spec.ts
@@ -2084,7 +2084,7 @@ describe('Shard', function () {
     });
     describe('chunks', function () {
       it('shows a full chunk list when there are 20 or less chunks', async function () {
-        for (let i = 0; i < 19; i++) {
+        for (let i = 1000; i < 1019; i++) {
           await sh.splitAt(ns, { key: i + 1 });
         }
         const chunks = (await sh.status()).value.databases.find(
@@ -2094,7 +2094,7 @@ describe('Shard', function () {
       });
 
       it('cuts a chunk list when there are more than 20 chunks', async function () {
-        await sh.splitAt(ns, { key: 20 });
+        await sh.splitAt(ns, { key: 1020 });
         const chunks = (await sh.status()).value.databases.find(
           (d) => d.database._id === 'test'
         ).collections[ns].chunks;


### PR DESCRIPTION
Show a full tag/chunk list when there are 20 or fewer items and cut a tag/chunk list when there are more than 20 items.