### PR TITLE
fix(shell-api): the explainable cursor should reflect simple collation MONGOSH-1670

### DIFF
--- a/packages/shell-api/src/explainable.spec.ts
+++ b/packages/shell-api/src/explainable.spec.ts
@@ -110,46 +110,70 @@ describe('Explainable', function () {
     });
 
     describe('find', function () {
-      let cursorStub;
-      let explainResult;
-      beforeEach(async function () {
-        explainResult = { ok: 1 };
+      let explainResult: Document;
+      const expectedExplainResult = { ok: 1 };
 
-        const cursorSpy = {
-          explain: sinon.spy(() => explainResult),
-        } as unknown;
-        collection.find = sinon.spy(() => Promise.resolve(cursorSpy as Cursor));
+      context('without options', function () {
+        let cursorStub;
+        let explainResult;
 
-        cursorStub = await explainable.find({ query: 1 }, { projection: 1 });
-      });
+        beforeEach(async function () {
+          explainResult = { ok: 1 };
 
-      it('calls collection.find with arguments', function () {
-        expect(collection.find).to.have.been.calledOnceWithExactly(
-          { query: 1 },
-          { projection: 1 }
+          const cursorSpy = {
+            explain: sinon.spy(() => explainResult),
+          } as unknown;
+          collection.find = sinon.spy(() =>
+            Promise.resolve(cursorSpy as Cursor)
+          );
+
+          cursorStub = await explainable.find({ query: 1 }, { projection: 1 });
+        });
+
+        it('calls collection.find with arguments', function () {
+          expect(collection.find).to.have.been.calledOnceWithExactly(
+            { query: 1 },
+            { projection: 1 },
+            {}
+          );
+        });
+
+        it('returns an cursor that has toShellResult when evaluated', async function () {
+          expect((await toShellResult(cursorStub)).type).to.equal(
+            'ExplainableCursor'
+          );
+        });
+
+        context(
+          'when calling toShellResult().printable on the result',
+          function () {
+            it('calls explain with verbosity', function () {
+              expect(cursorStub._verbosity).to.equal('queryPlanner');
+            });
+
+            it('returns the explain result', async function () {
+              expect((await toShellResult(cursorStub)).printable).to.equal(
+                explainResult
+              );
+            });
+          }
         );
       });
 
-      it('returns an cursor that has toShellResult when evaluated', async function () {
-        expect((await toShellResult(cursorStub)).type).to.equal(
-          'ExplainableCursor'
-        );
+      context('with options', function () {
+        beforeEach(function () {
+          collection.aggregate = sinon.spy(() =>
+            Promise.resolve(expectedExplainResult)
+          ) as any;
+        });
+
+        it('returns the explain result', async function () {
+          explainResult = await explainable.aggregate([{ pipeline: 1 }], {
+            aggregate: 1,
+          });
+          expect(explainResult).to.equal(expectedExplainResult);
+        });
       });
-
-      context(
-        'when calling toShellResult().printable on the result',
-        function () {
-          it('calls explain with verbosity', function () {
-            expect(cursorStub._verbosity).to.equal('queryPlanner');
-          });
-
-          it('returns the explain result', async function () {
-            expect((await toShellResult(cursorStub)).printable).to.equal(
-              explainResult
-            );
-          });
-        }
-      );
     });
 
     describe('aggregate', function () {

--- a/packages/shell-api/src/explainable.ts
+++ b/packages/shell-api/src/explainable.ts
@@ -31,6 +31,7 @@ import type {
   FindOneAndDeleteOptions,
   FindOneAndReplaceOptions,
   FindOneAndUpdateOptions,
+  FindOptions,
 } from '@mongosh/service-provider-core';
 
 @shellApiClassDefault
@@ -97,11 +98,12 @@ export default class Explainable extends ShellApiWithMongoClass {
   @returnsPromise
   async find(
     query?: Document,
-    projection?: Document
+    projection?: Document,
+    options: FindOptions = {}
   ): Promise<ExplainableCursor> {
     this._emitExplainableApiCall('find', { query, projection });
 
-    const cursor = await this._collection.find(query, projection);
+    const cursor = await this._collection.find(query, projection, options);
     return new ExplainableCursor(this._mongo, cursor, this._verbosity);
   }
 

--- a/packages/shell-api/src/integration.spec.ts
+++ b/packages/shell-api/src/integration.spec.ts
@@ -1569,12 +1569,17 @@ describe('Shell API (integration)', function () {
         ]);
       });
 
-      it('the explainable cursor reflects collation', async function () {
-        const cursor = await explainable.find({}, undefined, {
-          collation: { locale: 'simple' },
+      describe('after server 4.4', function () {
+        skipIfServerVersion(testServer, '<= 4.4');
+        it('the explainable cursor reflects collation', async function () {
+          const cursor = await explainable.find({}, undefined, {
+            collation: { locale: 'simple' },
+          });
+          const result = await toShellResult(cursor);
+          expect(result.printable.command.collation.locale).to.be.equal(
+            'simple'
+          );
         });
-        const result = await toShellResult(cursor);
-        expect(result.printable.command.collation.locale).to.be.equal('simple');
       });
     });
 

--- a/packages/shell-api/src/integration.spec.ts
+++ b/packages/shell-api/src/integration.spec.ts
@@ -1568,6 +1568,14 @@ describe('Shell API (integration)', function () {
           'serverInfo',
         ]);
       });
+
+      it('the explainable cursor reflects collation', async function () {
+        const cursor = await explainable.find({}, undefined, {
+          collation: { locale: 'simple' },
+        });
+        const result = await toShellResult(cursor);
+        expect(result.printable.command.collation.locale).to.be.equal('simple');
+      });
     });
 
     describe('aggregate', function () {


### PR DESCRIPTION
The explain().find() should support options including collation. See [MONGOSH-1670](https://jira.mongodb.org/browse/MONGOSH-1670) for more details and examples.