### PR TITLE
feat(browser-repl): allow to set initial input

### DIFF
--- a/packages/browser-repl/package.json
+++ b/packages/browser-repl/package.json
@@ -10,14 +10,14 @@
   "exports": {
     ".": {
       "types": "./lib/index.d.ts",
-      "require": "./lib/index.js"
+      "default": "./lib/index.js"
     },
     "./shell": {
       "types": "./lib/components/shell.d.ts",
-      "require": "./lib/components/shell.js"
+      "default": "./lib/components/shell.js"
     },
     "./package.json": {
-      "require": "./package.json"
+      "default": "./package.json"
     }
   },
   "scripts": {

--- a/packages/browser-repl/src/components/shell-input.tsx
+++ b/packages/browser-repl/src/components/shell-input.tsx
@@ -20,6 +20,8 @@ interface ShellInputProps {
   prompt?: string;
   onSigInt?(): Promise<boolean>;
   editorRef?: (editor: EditorRef | null) => void;
+  initialText?: string;
+  onTextChange?: (text: string) => void;
 }
 
 interface ShellInputState {
@@ -29,7 +31,7 @@ interface ShellInputState {
 
 export class ShellInput extends Component<ShellInputProps, ShellInputState> {
   readonly state: ShellInputState = {
-    currentValue: '',
+    currentValue: this.props.initialText ?? '',
     readOnly: false,
   };
 
@@ -61,6 +63,7 @@ export class ShellInput extends Component<ShellInputProps, ShellInputState> {
   }
 
   private onChange = (value: string): void => {
+    this.props.onTextChange?.(value);
     this.setState({ currentValue: value });
   };
 

--- a/packages/browser-repl/src/components/shell.spec.tsx
+++ b/packages/browser-repl/src/components/shell.spec.tsx
@@ -516,4 +516,11 @@ describe('<Shell />', function () {
       expect(wrapper.find('ShellInput').prop('prompt')).to.equal('abc>');
     });
   });
+
+  it('sets initial text for the shell input', function () {
+    wrapper = mount(
+      <Shell runtime={fakeRuntime} initialInput="db.coll.find({})" />
+    );
+    expect(wrapper.find('Editor').prop('value')).to.eq('db.coll.find({})');
+  });
 });

--- a/packages/browser-repl/src/sandbox.tsx
+++ b/packages/browser-repl/src/sandbox.tsx
@@ -154,6 +154,8 @@ const IframeRuntimeExample: React.FunctionComponent = () => {
   const [redactInfo, setRedactInfo] = useState(false);
   const [maxOutputLength, setMaxOutputLength] = useState(1000);
   const [maxHistoryLength, setMaxHistoryLength] = useState(1000);
+  const [initialInput, setInitialInput] = useState('');
+  const [initialEvaluate, setInitialEvaluate] = useState<string[]>([]);
   const [initialOutput] = useState<ShellOutputEntry[]>([
     { format: 'output', value: { foo: 1, bar: true, buz: function () {} } },
   ]);
@@ -171,8 +173,8 @@ const IframeRuntimeExample: React.FunctionComponent = () => {
   }, []);
 
   const key = useMemo(() => {
-    return initialHistory.join('');
-  }, [initialHistory]);
+    return initialHistory.concat(initialInput, initialEvaluate).join('');
+  }, [initialHistory, initialInput, initialEvaluate]);
 
   return (
     <div className={sandboxContainer}>
@@ -183,6 +185,8 @@ const IframeRuntimeExample: React.FunctionComponent = () => {
           redactInfo={redactInfo}
           maxOutputLength={maxOutputLength}
           maxHistoryLength={maxHistoryLength}
+          initialInput={initialInput}
+          initialEvaluate={initialEvaluate.filter(Boolean)}
           initialOutput={initialOutput}
           initialHistory={initialHistory.filter(Boolean)}
         />
@@ -259,6 +263,38 @@ const IframeRuntimeExample: React.FunctionComponent = () => {
             value={initialHistory.join('\n')}
             onChange={(evt) => {
               setInitialHistory(evt.currentTarget.value.split('\n'));
+            }}
+            className={cx(textarea, textInput)}
+          />
+        </FormFieldContainer>
+
+        <FormFieldContainer className={formField}>
+          <Label id="initialInputLabel" htmlFor="initialInput">
+            initialInput
+          </Label>
+          <Description>Initial value in the shell input field</Description>
+          <TextInput
+            className={textInput}
+            aria-labelledby="initialInputLabel"
+            value={initialInput}
+            onChange={(evt) => {
+              setInitialInput(evt.currentTarget.value);
+            }}
+          />
+        </FormFieldContainer>
+
+        <FormFieldContainer className={formField}>
+          <Label id="initialEvaluateLabel" htmlFor="initialEvaluate">
+            initialEvaluate
+          </Label>
+          <Description>
+            A set of input strings to evaluate right after shell is mounted
+          </Description>
+          <TextArea
+            aria-labelledby="initialEvaluate"
+            value={initialEvaluate.join('\n')}
+            onChange={(evt) => {
+              setInitialEvaluate(evt.currentTarget.value.split('\n'));
             }}
             className={cx(textarea, textInput)}
           />


### PR DESCRIPTION
So that we can preserve the input in shell when it's in tab mode in multiple connections