### PR TITLE
fix(ci): use vault repos for yum on centos7

### DIFF
--- a/scripts/docker/centos7-epel-rpm.Dockerfile
+++ b/scripts/docker/centos7-epel-rpm.Dockerfile
@@ -3,6 +3,9 @@ FROM centos:7
 ARG artifact_url=""
 ADD ${artifact_url} /tmp
 ADD node_modules /usr/share/mongodb-crypt-library-version/node_modules
+# centos7 is eol, switch to vault repos
+RUN yum-config-manager --disable base extras updates
+RUN yum-config-manager --enable C7.8.2003-base C7.8.2003-extras C7.8.2003-updates
 RUN yum repolist
 # epel-release so that openssl11 is installable
 RUN yum install -y epel-release

--- a/scripts/docker/centos7-rpm.Dockerfile
+++ b/scripts/docker/centos7-rpm.Dockerfile
@@ -3,6 +3,9 @@ FROM centos:7
 ARG artifact_url=""
 ADD ${artifact_url} /tmp
 ADD node_modules /usr/share/mongodb-crypt-library-version/node_modules
+# centos7 is eol, switch to vault repos
+RUN yum-config-manager --disable base extras updates
+RUN yum-config-manager --enable C7.8.2003-base C7.8.2003-extras C7.8.2003-updates
 RUN yum repolist
 RUN yum install -y /tmp/*mongosh*.rpm
 RUN /usr/bin/mongosh --build-info


### PR DESCRIPTION
Currently fails in CI with yum error because CentOS 7 is EoL since June 30th and seems like they completely removed original repos used by this version

```
[2024/07/04 13:20:12.395] #9 0.823 Could not retrieve mirrorlist http://mirrorlist.centos.org/?release=7&arch=x86_64&repo=os&infra=container error was
[2024/07/04 13:20:12.395] #9 0.823 14: curl#6 - "Could not resolve host: mirrorlist.centos.org; Unknown error"
```

This patch fixes the issue by switching yum to use vault repos instead of base ones