### PR TITLE
fix(ci): use rpm instead of zypper to install mongosh in suse docker images

### DIFF
--- a/scripts/docker/suse12-rpm.Dockerfile
+++ b/scripts/docker/suse12-rpm.Dockerfile
@@ -4,7 +4,10 @@ ARG artifact_url=""
 ADD ${artifact_url} /tmp
 ADD node_modules /usr/share/mongodb-crypt-library-version/node_modules
 RUN zypper --no-gpg-checks --non-interactive refresh
-RUN zypper --no-gpg-checks --non-interactive install /tmp/*mongosh*.rpm
+# For some reason zypper ignores half of the files listed for installation in
+# the rpm package (in particular the man files are not copied over as expected),
+# using rpm directly seems to fix the issue
+RUN rpm -i /tmp/*mongosh*.rpm
 RUN /usr/bin/mongosh --build-info
 RUN env MONGOSH_RUN_NODE_SCRIPT=1 mongosh /usr/share/mongodb-crypt-library-version/node_modules/.bin/mongodb-crypt-library-version /usr/lib64/mongosh_crypt_v1.so | grep -Eq '^mongo_(crypt|csfle)_v1-'
 ENTRYPOINT [ "mongosh" ]

--- a/scripts/docker/suse15-rpm.Dockerfile
+++ b/scripts/docker/suse15-rpm.Dockerfile
@@ -6,7 +6,10 @@ ADD node_modules /usr/share/mongodb-crypt-library-version/node_modules
 RUN zypper --no-gpg-checks --non-interactive addrepo https://download.opensuse.org/repositories/openSUSE:Leap:15.1:Update/standard/openSUSE:Leap:15.1:Update.repo
 RUN zypper --no-gpg-checks --non-interactive refresh
 RUN zypper --no-gpg-checks --non-interactive install man
-RUN zypper --no-gpg-checks --non-interactive install /tmp/*mongosh*.rpm
+# For some reason zypper ignores half of the files listed for installation in
+# the rpm package (in particular the man files are not copied over as expected),
+# using rpm directly seems to fix the issue
+RUN rpm -i /tmp/*mongosh*.rpm
 RUN /usr/bin/mongosh --build-info
 RUN env MONGOSH_RUN_NODE_SCRIPT=1 mongosh /usr/share/mongodb-crypt-library-version/node_modules/.bin/mongodb-crypt-library-version /usr/lib64/mongosh_crypt_v1.so | grep -Eq '^mongo_(crypt|csfle)_v1-'
 RUN man mongosh | grep -q tlsAllowInvalidCertificates


### PR DESCRIPTION
For some reason [somewhere around June 26th](https://spruce.mongodb.com/version/667c5725d78eb3000750f0c0/tasks?sorts=STATUS%3AASC%3BBASE_STATUS%3ADESC) suse tests started to fail because man page for `mongosh` was missing. I couldn't track it to the root cause or some issue I can link to, but seems like after a certain update `zypper` just stopped extracting all the files from the rpm package, like they are 100% there in the rpm, rpm can list them, but they are just not installed in those directories that are listed in rpm.

Switching to use `rpm` directy to install `mongosh` seems to work around this (at least locally, hopefully CI will confirm this too). I am not sure whether or not we specifically want to test that `zypper` installs `mongosh` correctly, but maybe even if that's the case we can apply the workaround for now to unblock the CI.