### PR TITLE
fix(browser-repl): make sure we are actually using initial value of initialEvaluate

### DIFF
--- a/packages/browser-repl/src/components/shell.tsx
+++ b/packages/browser-repl/src/components/shell.tsx
@@ -162,15 +162,18 @@ export class Shell extends Component<ShellProps, ShellState> {
   };
 
   componentDidMount(): void {
+    // Store the intial prop value on mount so that we're not using potentially
+    // updated one when actually running the lines
+    let evalLines: string[] = [];
+    if (this.props.initialEvaluate) {
+      evalLines = Array.isArray(this.props.initialEvaluate)
+        ? this.props.initialEvaluate
+        : [this.props.initialEvaluate];
+    }
     this.scrollToBottom();
     void this.updateShellPrompt().then(async () => {
-      if (this.props.initialEvaluate) {
-        const evalLines = Array.isArray(this.props.initialEvaluate)
-          ? this.props.initialEvaluate
-          : [this.props.initialEvaluate];
-        for (const input of evalLines) {
-          await this.onInput(input);
-        }
+      for (const input of evalLines) {
+        await this.onInput(input);
       }
     });
   }


### PR DESCRIPTION
Stumbled on this when adding new "Open shell" buttons in Compas. Because we are evaling these initial values async, we need to store the initial value syncronously when component is first mounted, otherwise it can already update at the moment when we're reading it from the props object