### PR TITLE
feat(browser-repl): allow to render browser-repl in light mode

### DIFF
--- a/packages/browser-repl/src/components/password-prompt.tsx
+++ b/packages/browser-repl/src/components/password-prompt.tsx
@@ -1,18 +1,15 @@
 import React, { Component } from 'react';
-import { css, palette, fontFamilies } from '@mongodb-js/compass-components';
+import { css, fontFamilies, TextInput } from '@mongodb-js/compass-components';
 
 const passwordPrompt = css({
   paddingLeft: 23,
   '& input': {
-    fontSize: '13px',
-    lineHeight: '24px',
     fontFamily: fontFamilies.code,
-    backgroundColor: palette.gray.dark4,
-    color: palette.gray.light3,
-    padding: '0 3px',
-    border: `1px solid ${palette.gray.light3}`,
-    borderRadius: 3,
   },
+});
+
+const passwordPropmtInputStyles = css({
+  display: 'inline-block',
 });
 
 interface PasswordPromptProps {
@@ -42,9 +39,16 @@ export class PasswordPrompt extends Component<PasswordPromptProps> {
 
   render(): JSX.Element {
     return (
-      <label className={passwordPrompt}>
+      <label id="password-promt-label" className={passwordPrompt}>
         {this.props.prompt}:&nbsp;
-        <input type="password" onKeyDown={this.onKeyDown} autoFocus />
+        <TextInput
+          aria-labelledby="password-promt-label"
+          type="password"
+          onKeyDown={this.onKeyDown}
+          className={passwordPropmtInputStyles}
+          sizeVariant="xsmall"
+          autoFocus
+        ></TextInput>
       </label>
     );
   }

--- a/packages/browser-repl/src/components/shell-loader.tsx
+++ b/packages/browser-repl/src/components/shell-loader.tsx
@@ -1,10 +1,5 @@
 import React, { Component } from 'react';
-import { SpinLoader, css, palette } from '@mongodb-js/compass-components';
-
-// TODO: Add dark mode to compass components spinner
-const shellLoader = css({
-  '& div': { borderTopColor: palette.green.light2 },
-});
+import { SpinLoader } from '@mongodb-js/compass-components';
 
 interface ShellLoaderProps {
   size?: string;
@@ -18,7 +13,7 @@ export default class ShellLoader extends Component<ShellLoaderProps> {
   render() {
     const { size } = this.props;
     return (
-      <div className={shellLoader}>
+      <div>
         <SpinLoader size={size} />
       </div>
     );

--- a/packages/browser-repl/src/components/shell.spec.tsx
+++ b/packages/browser-repl/src/components/shell.spec.tsx
@@ -4,7 +4,7 @@ import { expect } from '../../testing/chai';
 import type { ReactWrapper, ShallowWrapper } from '../../testing/enzyme';
 import { mount, shallow } from '../../testing/enzyme';
 import { PasswordPrompt } from './password-prompt';
-import { Shell } from './shell';
+import { _Shell as Shell } from './shell';
 import { ShellInput } from './shell-input';
 import { ShellOutput } from './shell-output';
 import type { ShellOutputEntry } from './shell-output-line';

--- a/packages/browser-repl/src/sandbox.tsx
+++ b/packages/browser-repl/src/sandbox.tsx
@@ -2,6 +2,8 @@ import ReactDOM from 'react-dom';
 import React, { useEffect, useMemo, useState } from 'react';
 import {
   css,
+  ThemeProvider,
+  Theme,
   Description,
   FormFieldContainer,
   Label,
@@ -151,6 +153,7 @@ class DemoServiceProvider {
 const runtime = new IframeRuntime(new DemoServiceProvider() as any);
 
 const IframeRuntimeExample: React.FunctionComponent = () => {
+  const [darkMode, setDarkMode] = useState(true);
   const [redactInfo, setRedactInfo] = useState(false);
   const [maxOutputLength, setMaxOutputLength] = useState(1000);
   const [maxHistoryLength, setMaxHistoryLength] = useState(1000);
@@ -163,6 +166,8 @@ const IframeRuntimeExample: React.FunctionComponent = () => {
     'show dbs',
     'db.coll.stats()',
     '{x: 1, y: {z: 2}, k: [1, 2, 3]}',
+    'passwordPrompt()',
+    '(() => { throw new Error("Whoops!"); })()',
   ]);
 
   useEffect(() => {
@@ -179,19 +184,37 @@ const IframeRuntimeExample: React.FunctionComponent = () => {
   return (
     <div className={sandboxContainer}>
       <div className={shellContainer}>
-        <Shell
-          key={key}
-          runtime={runtime}
-          redactInfo={redactInfo}
-          maxOutputLength={maxOutputLength}
-          maxHistoryLength={maxHistoryLength}
-          initialInput={initialInput}
-          initialEvaluate={initialEvaluate.filter(Boolean)}
-          initialOutput={initialOutput}
-          initialHistory={initialHistory.filter(Boolean)}
-        />
+        <ThemeProvider
+          theme={{ theme: darkMode ? Theme.Dark : Theme.Light, enabled: true }}
+        >
+          <Shell
+            key={key}
+            runtime={runtime}
+            redactInfo={redactInfo}
+            maxOutputLength={maxOutputLength}
+            maxHistoryLength={maxHistoryLength}
+            initialInput={initialInput}
+            initialEvaluate={initialEvaluate.filter(Boolean)}
+            initialOutput={initialOutput}
+            initialHistory={initialHistory.filter(Boolean)}
+          />
+        </ThemeProvider>
       </div>
       <div className={controlsContainer}>
+        <FormFieldContainer className={formField}>
+          <Label id="darkModeLabel" htmlFor="darkMode">
+            darkMode
+          </Label>
+          <Description>Toggle shell dark mode</Description>
+          <Toggle
+            aria-labelledby="darkModeLabel"
+            id="darkMode"
+            size="small"
+            checked={darkMode}
+            onChange={setDarkMode}
+          />
+        </FormFieldContainer>
+
         <FormFieldContainer className={formField}>
           <Label id="redactInfoLabel" htmlFor="redactInfo">
             redactInfo


### PR DESCRIPTION
This patch removes the theme provider hardcoded to always show dark mode that we wrap around the shell so that we can render it in light mode if needed

|Dark|Light|
|---|---|
|<img width="374" alt="image" src="https://github.com/mongodb-js/mongosh/assets/5036933/57689f18-53cc-4b7e-971e-5d1334932cec"><img width="369" alt="image" src="https://github.com/mongodb-js/mongosh/assets/5036933/65ca74c3-5282-4065-8870-2621213303e3">|<img width="380" alt="image" src="https://github.com/mongodb-js/mongosh/assets/5036933/872a98d5-e071-4a7b-b52f-19a403a5c786"><img width="385" alt="image" src="https://github.com/mongodb-js/mongosh/assets/5036933/fc7c8901-d61d-4e21-9678-6d21b827b8b5">|