### PR TITLE
chore(deps): update win-export-cert-and-key to latest

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30379,9 +30379,9 @@
       "dev": true
     },
     "node_modules/win-export-certificate-and-key": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/win-export-certificate-and-key/-/win-export-certificate-and-key-2.0.0.tgz",
-      "integrity": "sha512-bJBsQxyN+Chp4AqXIGSc2FkyTIQcv4npVIr74JvOE0dFjYkudAbulKz+ylia8dsNHwBA1nSxif0Xl8LrcRl9mg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/win-export-certificate-and-key/-/win-export-certificate-and-key-2.0.1.tgz",
+      "integrity": "sha512-GsPUuIn95CepWgfiaqyIBWlj1uzr0LMfWIHBESSa+f84Zll9SjIX7Jj0+xNs/FlhH5zEkPO6k+SRQX1dfv3zPg==",
       "hasInstallScript": true,
       "optional": true,
       "os": [
@@ -31213,7 +31213,7 @@
         "glibc-version": "^1.0.0",
         "macos-export-certificate-and-key": "^1.1.2",
         "mongodb-crypt-library-version": "^1.0.5",
-        "win-export-certificate-and-key": "^2.0.0"
+        "win-export-certificate-and-key": "^2.0.1"
       }
     },
     "packages/cli-repl/node_modules/argparse": {
@@ -37582,7 +37582,7 @@
         "strip-ansi": "^6.0.0",
         "text-table": "^0.2.0",
         "webpack-merge": "^5.8.0",
-        "win-export-certificate-and-key": "^2.0.0",
+        "win-export-certificate-and-key": "^2.0.1",
         "yargs-parser": "^20.2.4"
       },
       "dependencies": {
@@ -56120,9 +56120,9 @@
       "dev": true
     },
     "win-export-certificate-and-key": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/win-export-certificate-and-key/-/win-export-certificate-and-key-2.0.0.tgz",
-      "integrity": "sha512-bJBsQxyN+Chp4AqXIGSc2FkyTIQcv4npVIr74JvOE0dFjYkudAbulKz+ylia8dsNHwBA1nSxif0Xl8LrcRl9mg==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/win-export-certificate-and-key/-/win-export-certificate-and-key-2.0.1.tgz",
+      "integrity": "sha512-GsPUuIn95CepWgfiaqyIBWlj1uzr0LMfWIHBESSa+f84Zll9SjIX7Jj0+xNs/FlhH5zEkPO6k+SRQX1dfv3zPg==",
       "optional": true,
       "requires": {
         "bindings": "^1.5.0",

--- a/packages/cli-repl/package.json
+++ b/packages/cli-repl/package.json
@@ -118,6 +118,6 @@
     "glibc-version": "^1.0.0",
     "macos-export-certificate-and-key": "^1.1.2",
     "mongodb-crypt-library-version": "^1.0.5",
-    "win-export-certificate-and-key": "^2.0.0"
+    "win-export-certificate-and-key": "^2.0.1"
   }
 }


### PR DESCRIPTION
Not necessarily required, but this is the min required version for electron / Compass, so we want mongosh to be on the same one