### PR TITLE
chore(ci): add e2e and smoke tests for MacOS 14 MONGOSH-1834

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -17988,10 +17988,7 @@ buildvariants:
   - name: pkg_smoke_tests_macos_1400_x64
     display_name: "package smoke tests (macos 14.00 x64)"
     run_on: macos-14
-    expansions:
-      executable_os_id: darwin-x64
     tasks:
-      - name: e2e_tests_darwin_x64
       - name: pkg_test_macos_darwin_x64
   - name: pkg_smoke_tests_macos_1400_arm64
     display_name: "package smoke tests (macos 14.00 arm64)"

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -17640,6 +17640,20 @@ buildvariants:
     run_on: rhel83-zseries-small
     tasks:
       - name: e2e_tests_linux_s390x
+  - name: e2e_macos14_x64
+    display_name: "MacOS 14 x64 (E2E Tests)"
+    run_on: macos-14
+    expansions:
+      executable_os_id: darwin-x64
+    tasks:
+      - name: e2e_tests_darwin_x64
+  - name: e2e_macos14_arm64
+    display_name: "MacOS 14 arm64 (E2E Tests)"
+    run_on: macos-14-arm64
+    expansions:
+      executable_os_id: darwin-arm64
+    tasks:
+      - name: e2e_tests_darwin_arm64
 
   - name: win32_unit
     display_name: "Windows (Unit tests)"
@@ -17969,6 +17983,19 @@ buildvariants:
   - name: pkg_smoke_tests_macos_1300_arm64
     display_name: "package smoke tests (macos 13.00 arm64)"
     run_on: macos-1300-arm64
+    tasks:
+      - name: pkg_test_macos_darwin_arm64
+  - name: pkg_smoke_tests_macos_1400_x64
+    display_name: "package smoke tests (macos 14.00 x64)"
+    run_on: macos-14
+    expansions:
+      executable_os_id: darwin-x64
+    tasks:
+      - name: e2e_tests_darwin_x64
+      - name: pkg_test_macos_darwin_x64
+  - name: pkg_smoke_tests_macos_1400_arm64
+    display_name: "package smoke tests (macos 14.00 arm64)"
+    run_on: macos-14-arm64
     tasks:
       - name: pkg_test_macos_darwin_arm64
   - name: pkg_smoke_tests_rhel72_s390x

--- a/.evergreen/evergreen.yml.in
+++ b/.evergreen/evergreen.yml.in
@@ -1942,10 +1942,7 @@ buildvariants:
   - name: pkg_smoke_tests_macos_1400_x64
     display_name: "package smoke tests (macos 14.00 x64)"
     run_on: macos-14
-    expansions:
-      executable_os_id: darwin-x64
     tasks:
-      - name: e2e_tests_darwin_x64
       - name: pkg_test_macos_darwin_x64
   - name: pkg_smoke_tests_macos_1400_arm64
     display_name: "package smoke tests (macos 14.00 arm64)"

--- a/.evergreen/evergreen.yml.in
+++ b/.evergreen/evergreen.yml.in
@@ -1824,6 +1824,20 @@ buildvariants:
     run_on: rhel83-zseries-small
     tasks:
       - name: e2e_tests_linux_s390x
+  - name: e2e_macos14_x64
+    display_name: "MacOS 14 x64 (E2E Tests)"
+    run_on: macos-14
+    expansions:
+      executable_os_id: darwin-x64
+    tasks:
+      - name: e2e_tests_darwin_x64
+  - name: e2e_macos14_arm64
+    display_name: "MacOS 14 arm64 (E2E Tests)"
+    run_on: macos-14-arm64
+    expansions:
+      executable_os_id: darwin-arm64
+    tasks:
+      - name: e2e_tests_darwin_arm64
 
   - name: win32_unit
     display_name: "Windows (Unit tests)"
@@ -1923,6 +1937,19 @@ buildvariants:
   - name: pkg_smoke_tests_macos_1300_arm64
     display_name: "package smoke tests (macos 13.00 arm64)"
     run_on: macos-1300-arm64
+    tasks:
+      - name: pkg_test_macos_darwin_arm64
+  - name: pkg_smoke_tests_macos_1400_x64
+    display_name: "package smoke tests (macos 14.00 x64)"
+    run_on: macos-14
+    expansions:
+      executable_os_id: darwin-x64
+    tasks:
+      - name: e2e_tests_darwin_x64
+      - name: pkg_test_macos_darwin_x64
+  - name: pkg_smoke_tests_macos_1400_arm64
+    display_name: "package smoke tests (macos 14.00 arm64)"
+    run_on: macos-14-arm64
     tasks:
       - name: pkg_test_macos_darwin_arm64
   - name: pkg_smoke_tests_rhel72_s390x


### PR DESCRIPTION
No particular urgency attached to this, just got reminded that the server was looking into MacOS 14 support and figured there's no real reason for us not to test that platform, assuming that everything works out of the box. (If not, we'll see what to do about it, but it's probably a good time to learn about issues we might be running into)