### PR TITLE
fix(browser-repl): ensure that input can't be modified or evaluated while operation is in progress COMPASS-8256

### DIFF
--- a/packages/browser-repl/src/components/editor.tsx
+++ b/packages/browser-repl/src/components/editor.tsx
@@ -168,7 +168,47 @@ export class Editor extends Component<EditorProps> {
         () => null
       );
     };
-    this.commands = createCommands(this.props);
+    this.commands = createCommands(this);
+  }
+
+  onEnter() {
+    // Do not allow commands that can modify / evaluate the input while
+    // operation is in progress
+    if (this.props.operationInProgress) {
+      return;
+    }
+    return this.props.onEnter();
+  }
+
+  onArrowDownOnLastLine() {
+    // Do not allow commands that can modify / evaluate the input while
+    // operation is in progress
+    if (this.props.operationInProgress) {
+      return Promise.resolve(false);
+    }
+    return this.props.onArrowDownOnLastLine();
+  }
+
+  onArrowUpOnFirstLine() {
+    // Do not allow commands that can modify / evaluate the input while
+    // operation is in progress
+    if (this.props.operationInProgress) {
+      return Promise.resolve(false);
+    }
+    return this.props.onArrowUpOnFirstLine();
+  }
+
+  onClearCommand() {
+    // Do not allow commands that can modify / evaluate the input while
+    // operation is in progress
+    if (this.props.operationInProgress) {
+      return;
+    }
+    return this.props.onClearCommand();
+  }
+
+  onSigInt() {
+    return this.props.onSigInt();
   }
 
   render(): JSX.Element {

--- a/packages/browser-repl/src/components/shell.tsx
+++ b/packages/browser-repl/src/components/shell.tsx
@@ -144,6 +144,23 @@ const noop = (): void => {
   /* */
 };
 
+const normalizeInitialEvaluate = (initialEvaluate: string | string[]) => {
+  return (
+    Array.isArray(initialEvaluate) ? initialEvaluate : [initialEvaluate]
+  ).filter((line) => {
+    // Filter out empty lines if passed by accident
+    return !!line;
+  });
+};
+
+const isInitialEvaluateEmpty = (
+  initialEvaluate?: string | string[] | undefined
+) => {
+  return (
+    !initialEvaluate || normalizeInitialEvaluate(initialEvaluate).length === 0
+  );
+};
+
 /**
  * The browser-repl Shell component
  */
@@ -166,7 +183,7 @@ export class _Shell extends Component<ShellProps, ShellState> {
   private onCancelPasswordPrompt: () => void = noop;
 
   readonly state: ShellState = {
-    operationInProgress: false,
+    operationInProgress: !isInitialEvaluateEmpty(this.props.initialEvaluate),
     output: this.props.initialOutput.slice(-this.props.maxOutputLength),
     history: this.props.initialHistory.slice(0, this.props.maxHistoryLength),
     passwordPrompt: '',
@@ -178,9 +195,7 @@ export class _Shell extends Component<ShellProps, ShellState> {
     // updated one when actually running the lines
     let evalLines: string[] = [];
     if (this.props.initialEvaluate) {
-      evalLines = Array.isArray(this.props.initialEvaluate)
-        ? this.props.initialEvaluate
-        : [this.props.initialEvaluate];
+      evalLines = normalizeInitialEvaluate(this.props.initialEvaluate);
     }
     this.scrollToBottom();
     void this.updateShellPrompt().then(async () => {


### PR DESCRIPTION
There is a slightly unexpected behavior in browser-repl right now where even though we don't allow user to type in shell input while operation is in progress, we don't disable the editor commands, and so it's still possible to run a command in parallel or choose a different input from history. Seems like this bug was there for awhile now, but we only noticed it now that we automatically run some commands in compass shell when opening a tab in certain contexts.