### PR TITLE
fix(proxy-support): update proxy-support to latest version that works around erraneous expired certs in system CA

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6014,12 +6014,11 @@
       }
     },
     "node_modules/@mongodb-js/devtools-connect": {
-      "version": "3.2.10",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-connect/-/devtools-connect-3.2.10.tgz",
-      "integrity": "sha512-x+MhIwJzCKjc5NhGHbns5IGa6yBwj/Nm6uVh0TwmhdKGxBbIP4o0xa4YVRwRajxHHGrxhiKQRNRJsHD6IzVVOw==",
-      "license": "Apache-2.0",
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-connect/-/devtools-connect-3.2.11.tgz",
+      "integrity": "sha512-Pl8XyHHvhN8rXOqt/pMokFGu0Ia38oB9KIvkeK/8UCThTlw1ZRGl1ZpLCFyhAU+6czPAd8nCoj1d5UxlNvRK/Q==",
       "dependencies": {
-        "@mongodb-js/devtools-proxy-support": "^0.3.9",
+        "@mongodb-js/devtools-proxy-support": "^0.3.10",
         "@mongodb-js/oidc-http-server-pages": "1.1.3",
         "lodash.merge": "^4.6.2",
         "mongodb-connection-string-url": "^3.0.0",
@@ -6046,10 +6045,9 @@
       }
     },
     "node_modules/@mongodb-js/devtools-proxy-support": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-proxy-support/-/devtools-proxy-support-0.3.9.tgz",
-      "integrity": "sha512-y6EpBQuOYMSbnc3y7lWG3ThFWC7iv6HHZn8+7tRsr9diSMwHRoxM/GNrz2yeldT7xstFdGL4zmmSK/3JcSz+8g==",
-      "license": "Apache-2.0",
+      "version": "0.3.10",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-proxy-support/-/devtools-proxy-support-0.3.10.tgz",
+      "integrity": "sha512-HComoStLokruxsPLR5m3mC+A167n9THKj3jCj6lQSh7szXotJI5zm500BFEI5IpcY/lVovbK4QlRYQP6WWS+5w==",
       "dependencies": {
         "@mongodb-js/socksv5": "^0.0.10",
         "agent-base": "^7.1.1",
@@ -6068,18 +6066,16 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
       "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
-      "license": "MIT",
       "engines": {
         "node": ">= 12"
       }
     },
     "node_modules/@mongodb-js/devtools-proxy-support/node_modules/debug": {
-      "version": "4.3.6",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
-      "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
-      "license": "MIT",
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
       "dependencies": {
-        "ms": "2.1.2"
+        "ms": "^2.1.3"
       },
       "engines": {
         "node": ">=6.0"
@@ -6091,19 +6087,22 @@
       }
     },
     "node_modules/@mongodb-js/devtools-proxy-support/node_modules/lru-cache": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.0.tgz",
-      "integrity": "sha512-Qv32eSV1RSCfhY3fpPE2GNZ8jgM9X7rdAfemLWqTUxwiyIC4jJ6Sy0fZ8H+oLWevO6i4/bizg7c8d8i6bxrzbA==",
-      "license": "ISC",
+      "version": "11.0.1",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.1.tgz",
+      "integrity": "sha512-CgeuL5uom6j/ZVrg7G/+1IXqRY8JXX4Hghfy5YE0EhoYQWvndP1kufu58cmZLNIDKnRhZrXfdS9urVWx98AipQ==",
       "engines": {
         "node": "20 || >=22"
       }
+    },
+    "node_modules/@mongodb-js/devtools-proxy-support/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
     },
     "node_modules/@mongodb-js/devtools-proxy-support/node_modules/node-fetch": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
       "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
-      "license": "MIT",
       "dependencies": {
         "data-uri-to-buffer": "^4.0.0",
         "fetch-blob": "^3.1.4",
@@ -6573,7 +6572,6 @@
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/@mongodb-js/socksv5/-/socksv5-0.0.10.tgz",
       "integrity": "sha512-JDz2fLKsjMiSNUxKrCpGptsgu7DzsXfu4gnUQ3RhUaBS1d4YbLrt6HejpckAiHIAa+niBpZAeiUsoop0IihWsw==",
-      "license": "MIT",
       "dependencies": {
         "ip-address": "^9.0.5"
       },
@@ -30704,7 +30702,7 @@
         "mongodb-connection-string-url": "^3.0.1"
       },
       "devDependencies": {
-        "@mongodb-js/devtools-connect": "^3.2.10",
+        "@mongodb-js/devtools-connect": "^3.2.11",
         "@mongodb-js/eslint-config-mongosh": "^1.0.0",
         "@mongodb-js/prettier-config-devtools": "^1.0.1",
         "@mongodb-js/tsconfig-mongosh": "^1.0.0",
@@ -31036,7 +31034,7 @@
       "version": "0.0.0-dev.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@mongodb-js/devtools-proxy-support": "^0.3.9",
+        "@mongodb-js/devtools-proxy-support": "^0.3.10",
         "@mongosh/arg-parser": "0.0.0-dev.0",
         "@mongosh/autocomplete": "0.0.0-dev.0",
         "@mongosh/editor": "0.0.0-dev.0",
@@ -31427,7 +31425,7 @@
       "version": "0.0.0-dev.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@mongodb-js/devtools-connect": "^3.2.10",
+        "@mongodb-js/devtools-connect": "^3.2.11",
         "@mongosh/errors": "0.0.0-dev.0",
         "@mongosh/history": "0.0.0-dev.0",
         "@mongosh/types": "0.0.0-dev.0",
@@ -31521,7 +31519,7 @@
       "version": "0.0.0-dev.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@mongodb-js/devtools-connect": "^3.2.10",
+        "@mongodb-js/devtools-connect": "^3.2.11",
         "@mongodb-js/oidc-plugin": "^1.1.1",
         "@mongosh/errors": "0.0.0-dev.0",
         "@mongosh/service-provider-core": "0.0.0-dev.0",
@@ -31604,7 +31602,7 @@
       "version": "0.0.0-dev.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@mongodb-js/devtools-proxy-support": "^0.3.9",
+        "@mongodb-js/devtools-proxy-support": "^0.3.10",
         "@mongosh/errors": "0.0.0-dev.0",
         "@mongosh/shell-api": "0.0.0-dev.0",
         "@mongosh/types": "0.0.0-dev.0",
@@ -31634,7 +31632,7 @@
       "version": "0.0.0-dev.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@mongodb-js/devtools-connect": "^3.2.10"
+        "@mongodb-js/devtools-connect": "^3.2.11"
       },
       "devDependencies": {
         "@mongodb-js/eslint-config-mongosh": "^1.0.0",
@@ -36412,11 +36410,11 @@
       }
     },
     "@mongodb-js/devtools-connect": {
-      "version": "3.2.10",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-connect/-/devtools-connect-3.2.10.tgz",
-      "integrity": "sha512-x+MhIwJzCKjc5NhGHbns5IGa6yBwj/Nm6uVh0TwmhdKGxBbIP4o0xa4YVRwRajxHHGrxhiKQRNRJsHD6IzVVOw==",
+      "version": "3.2.11",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-connect/-/devtools-connect-3.2.11.tgz",
+      "integrity": "sha512-Pl8XyHHvhN8rXOqt/pMokFGu0Ia38oB9KIvkeK/8UCThTlw1ZRGl1ZpLCFyhAU+6czPAd8nCoj1d5UxlNvRK/Q==",
       "requires": {
-        "@mongodb-js/devtools-proxy-support": "^0.3.9",
+        "@mongodb-js/devtools-proxy-support": "^0.3.10",
         "@mongodb-js/oidc-http-server-pages": "1.1.3",
         "kerberos": "^2.1.0",
         "lodash.merge": "^4.6.2",
@@ -36433,9 +36431,9 @@
       "integrity": "sha512-rBwJHZ0g3Ma6zluNUWfeFXvuxsz9ZtFX2YZ1qR/aQEwk64ZhOqjrVbcROSdtfGUs4qg1JGXFIU+ZQ+oLYqPEvQ=="
     },
     "@mongodb-js/devtools-proxy-support": {
-      "version": "0.3.9",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-proxy-support/-/devtools-proxy-support-0.3.9.tgz",
-      "integrity": "sha512-y6EpBQuOYMSbnc3y7lWG3ThFWC7iv6HHZn8+7tRsr9diSMwHRoxM/GNrz2yeldT7xstFdGL4zmmSK/3JcSz+8g==",
+      "version": "0.3.10",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-proxy-support/-/devtools-proxy-support-0.3.10.tgz",
+      "integrity": "sha512-HComoStLokruxsPLR5m3mC+A167n9THKj3jCj6lQSh7szXotJI5zm500BFEI5IpcY/lVovbK4QlRYQP6WWS+5w==",
       "requires": {
         "@mongodb-js/socksv5": "^0.0.10",
         "agent-base": "^7.1.1",
@@ -36456,17 +36454,22 @@
           "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A=="
         },
         "debug": {
-          "version": "4.3.6",
-          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.6.tgz",
-          "integrity": "sha512-O/09Bd4Z1fBrU4VzkhFqVgpPzaGbw6Sm9FEkBT1A/YBXQFGuuSxa1dN2nxgxS34JmKXqYx8CZAwEVoJFImUXIg==",
+          "version": "4.3.7",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+          "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
           "requires": {
-            "ms": "2.1.2"
+            "ms": "^2.1.3"
           }
         },
         "lru-cache": {
-          "version": "11.0.0",
-          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.0.tgz",
-          "integrity": "sha512-Qv32eSV1RSCfhY3fpPE2GNZ8jgM9X7rdAfemLWqTUxwiyIC4jJ6Sy0fZ8H+oLWevO6i4/bizg7c8d8i6bxrzbA=="
+          "version": "11.0.1",
+          "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.1.tgz",
+          "integrity": "sha512-CgeuL5uom6j/ZVrg7G/+1IXqRY8JXX4Hghfy5YE0EhoYQWvndP1kufu58cmZLNIDKnRhZrXfdS9urVWx98AipQ=="
+        },
+        "ms": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+          "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
         },
         "node-fetch": {
           "version": "3.3.2",
@@ -36861,7 +36864,7 @@
     "@mongosh/arg-parser": {
       "version": "file:packages/arg-parser",
       "requires": {
-        "@mongodb-js/devtools-connect": "^3.2.10",
+        "@mongodb-js/devtools-connect": "^3.2.11",
         "@mongodb-js/eslint-config-mongosh": "^1.0.0",
         "@mongodb-js/prettier-config-devtools": "^1.0.1",
         "@mongodb-js/tsconfig-mongosh": "^1.0.0",
@@ -37111,7 +37114,7 @@
     "@mongosh/cli-repl": {
       "version": "file:packages/cli-repl",
       "requires": {
-        "@mongodb-js/devtools-proxy-support": "^0.3.9",
+        "@mongodb-js/devtools-proxy-support": "^0.3.10",
         "@mongodb-js/eslint-config-mongosh": "^1.0.0",
         "@mongodb-js/prettier-config-devtools": "^1.0.1",
         "@mongodb-js/sbom-tools": "^0.7.0",
@@ -37372,7 +37375,7 @@
     "@mongosh/logging": {
       "version": "file:packages/logging",
       "requires": {
-        "@mongodb-js/devtools-connect": "^3.2.10",
+        "@mongodb-js/devtools-connect": "^3.2.11",
         "@mongodb-js/eslint-config-mongosh": "^1.0.0",
         "@mongodb-js/prettier-config-devtools": "^1.0.1",
         "@mongodb-js/tsconfig-mongosh": "^1.0.0",
@@ -37430,7 +37433,7 @@
     "@mongosh/service-provider-server": {
       "version": "file:packages/service-provider-server",
       "requires": {
-        "@mongodb-js/devtools-connect": "^3.2.10",
+        "@mongodb-js/devtools-connect": "^3.2.11",
         "@mongodb-js/eslint-config-mongosh": "^1.0.0",
         "@mongodb-js/oidc-plugin": "^1.1.1",
         "@mongodb-js/prettier-config-devtools": "^1.0.1",
@@ -37490,7 +37493,7 @@
     "@mongosh/snippet-manager": {
       "version": "file:packages/snippet-manager",
       "requires": {
-        "@mongodb-js/devtools-proxy-support": "^0.3.9",
+        "@mongodb-js/devtools-proxy-support": "^0.3.10",
         "@mongodb-js/eslint-config-mongosh": "^1.0.0",
         "@mongodb-js/prettier-config-devtools": "^1.0.1",
         "@mongodb-js/tsconfig-mongosh": "^1.0.0",
@@ -37513,7 +37516,7 @@
     "@mongosh/types": {
       "version": "file:packages/types",
       "requires": {
-        "@mongodb-js/devtools-connect": "^3.2.10",
+        "@mongodb-js/devtools-connect": "^3.2.11",
         "@mongodb-js/eslint-config-mongosh": "^1.0.0",
         "@mongodb-js/prettier-config-devtools": "^1.0.1",
         "@mongodb-js/tsconfig-mongosh": "^1.0.0",

--- a/packages/arg-parser/package.json
+++ b/packages/arg-parser/package.json
@@ -40,7 +40,7 @@
     "mongodb-connection-string-url": "^3.0.1"
   },
   "devDependencies": {
-    "@mongodb-js/devtools-connect": "^3.2.10",
+    "@mongodb-js/devtools-connect": "^3.2.11",
     "@mongodb-js/eslint-config-mongosh": "^1.0.0",
     "@mongodb-js/prettier-config-devtools": "^1.0.1",
     "@mongodb-js/tsconfig-mongosh": "^1.0.0",

--- a/packages/cli-repl/package.json
+++ b/packages/cli-repl/package.json
@@ -61,7 +61,7 @@
     }
   },
   "dependencies": {
-    "@mongodb-js/devtools-proxy-support": "^0.3.9",
+    "@mongodb-js/devtools-proxy-support": "^0.3.10",
     "@mongosh/arg-parser": "0.0.0-dev.0",
     "@mongosh/autocomplete": "0.0.0-dev.0",
     "@mongosh/editor": "0.0.0-dev.0",

--- a/packages/logging/package.json
+++ b/packages/logging/package.json
@@ -17,7 +17,7 @@
     "node": ">=14.15.1"
   },
   "dependencies": {
-    "@mongodb-js/devtools-connect": "^3.2.10",
+    "@mongodb-js/devtools-connect": "^3.2.11",
     "@mongosh/errors": "0.0.0-dev.0",
     "@mongosh/history": "0.0.0-dev.0",
     "@mongosh/types": "0.0.0-dev.0",

--- a/packages/service-provider-server/package.json
+++ b/packages/service-provider-server/package.json
@@ -47,7 +47,7 @@
     }
   },
   "dependencies": {
-    "@mongodb-js/devtools-connect": "^3.2.10",
+    "@mongodb-js/devtools-connect": "^3.2.11",
     "@mongodb-js/oidc-plugin": "^1.1.1",
     "@mongosh/errors": "0.0.0-dev.0",
     "@mongosh/service-provider-core": "0.0.0-dev.0",

--- a/packages/snippet-manager/package.json
+++ b/packages/snippet-manager/package.json
@@ -35,7 +35,7 @@
     "unitTestsOnly": true
   },
   "dependencies": {
-    "@mongodb-js/devtools-proxy-support": "^0.3.9",
+    "@mongodb-js/devtools-proxy-support": "^0.3.10",
     "@mongosh/errors": "0.0.0-dev.0",
     "@mongosh/shell-api": "0.0.0-dev.0",
     "@mongosh/types": "0.0.0-dev.0",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -38,7 +38,7 @@
     "unitTestsOnly": true
   },
   "dependencies": {
-    "@mongodb-js/devtools-connect": "^3.2.10"
+    "@mongodb-js/devtools-connect": "^3.2.11"
   },
   "devDependencies": {
     "@mongodb-js/eslint-config-mongosh": "^1.0.0",


### PR DESCRIPTION
See https://jira.mongodb.org/browse/COMPASS-8322 and https://github.com/mongodb-js/devtools-shared/pull/474