### PR TITLE
fix(cli-repl): use tls allowPartialTrustChain flag MONGOSH-1878

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -59,7 +59,7 @@
         "husky": "^9.0.11",
         "mocha": "^10.2.0",
         "mongodb": "^6.9.0",
-        "mongodb-runner": "^5.6.1",
+        "mongodb-runner": "^5.7.0",
         "node-gyp": "^9.0.0",
         "nyc": "^15.1.0",
         "pkg-up": "^3.1.0",
@@ -6014,11 +6014,12 @@
       }
     },
     "node_modules/@mongodb-js/devtools-connect": {
-      "version": "3.2.11",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-connect/-/devtools-connect-3.2.11.tgz",
-      "integrity": "sha512-Pl8XyHHvhN8rXOqt/pMokFGu0Ia38oB9KIvkeK/8UCThTlw1ZRGl1ZpLCFyhAU+6czPAd8nCoj1d5UxlNvRK/Q==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-connect/-/devtools-connect-3.3.0.tgz",
+      "integrity": "sha512-stjduqOZwN51E+Rl8WmZamIM/1UT1ZLt3LxnPazJXnBzycMXEge6kvQQCeYrHk8fokYggLhRxL5xL7IgXaBdbw==",
+      "license": "Apache-2.0",
       "dependencies": {
-        "@mongodb-js/devtools-proxy-support": "^0.3.10",
+        "@mongodb-js/devtools-proxy-support": "^0.4.0",
         "@mongodb-js/oidc-http-server-pages": "1.1.3",
         "lodash.merge": "^4.6.2",
         "mongodb-connection-string-url": "^3.0.0",
@@ -6032,7 +6033,7 @@
       },
       "peerDependencies": {
         "@mongodb-js/oidc-plugin": "^1.1.0",
-        "mongodb": "^6.8.0",
+        "mongodb": "^6.9.0",
         "mongodb-log-writer": "^1.4.2"
       }
     },
@@ -6045,9 +6046,10 @@
       }
     },
     "node_modules/@mongodb-js/devtools-proxy-support": {
-      "version": "0.3.10",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-proxy-support/-/devtools-proxy-support-0.3.10.tgz",
-      "integrity": "sha512-HComoStLokruxsPLR5m3mC+A167n9THKj3jCj6lQSh7szXotJI5zm500BFEI5IpcY/lVovbK4QlRYQP6WWS+5w==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-proxy-support/-/devtools-proxy-support-0.4.0.tgz",
+      "integrity": "sha512-NSHo+jE1tjH0XOFoDfOrCW7IAt+5l3TOpzgvWSbmNfVO4FqT/lE/mpQKIwsFOlMeGVI6ku2GOV7Obg6664OfTw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@mongodb-js/socksv5": "^0.0.10",
         "agent-base": "^7.1.1",
@@ -6059,13 +6061,14 @@
         "pac-proxy-agent": "^7.0.2",
         "socks-proxy-agent": "^8.0.4",
         "ssh2": "^1.15.0",
-        "system-ca": "^2.0.0"
+        "system-ca": "^2.0.1"
       }
     },
     "node_modules/@mongodb-js/devtools-proxy-support/node_modules/data-uri-to-buffer": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-4.0.1.tgz",
       "integrity": "sha512-0R9ikRb668HB7QDxT1vkpuUBtqc53YyAwMwGeUFKRojY/NWKvdZ+9UYtRfGmhqNbRkTSVpMbmyhXipFFv2cb/A==",
+      "license": "MIT",
       "engines": {
         "node": ">= 12"
       }
@@ -6074,6 +6077,7 @@
       "version": "4.3.7",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
       "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
       },
@@ -6090,6 +6094,7 @@
       "version": "11.0.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-11.0.1.tgz",
       "integrity": "sha512-CgeuL5uom6j/ZVrg7G/+1IXqRY8JXX4Hghfy5YE0EhoYQWvndP1kufu58cmZLNIDKnRhZrXfdS9urVWx98AipQ==",
+      "license": "ISC",
       "engines": {
         "node": "20 || >=22"
       }
@@ -6097,12 +6102,14 @@
     "node_modules/@mongodb-js/devtools-proxy-support/node_modules/ms": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "node_modules/@mongodb-js/devtools-proxy-support/node_modules/node-fetch": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-3.3.2.tgz",
       "integrity": "sha512-dRB78srN/l6gqWulah9SrxeYnxeddIG30+GOqK/9OlLVyLg3HPnr6SqOWTWOXKRwC2eGYCkZ59NNuSgvSrpgOA==",
+      "license": "MIT",
       "dependencies": {
         "data-uri-to-buffer": "^4.0.0",
         "fetch-blob": "^3.1.4",
@@ -6198,9 +6205,9 @@
       }
     },
     "node_modules/@mongodb-js/mongodb-downloader": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/mongodb-downloader/-/mongodb-downloader-0.3.5.tgz",
-      "integrity": "sha512-0tNik3E/eQxx8EkJpsa9+IIK5LtMle3N7M/1wtKQKMixJjZ1vsgAjJGguYbLfCyJqfnrw9KMyD1cwgaS37tvRA==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/mongodb-downloader/-/mongodb-downloader-0.3.6.tgz",
+      "integrity": "sha512-Cu82TRmAP/OIRizx9o+fReQf8FfovI28rjY0pu8wHyCoUlG7q3Zkxb/lppB7a9/kzQfONeHAoXIOQkvSasKYrw==",
       "license": "Apache-2.0",
       "dependencies": {
         "debug": "^4.3.4",
@@ -6397,9 +6404,10 @@
       }
     },
     "node_modules/@mongodb-js/saslprep": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.6.tgz",
-      "integrity": "sha512-jqTTXQ46H8cAxmXBu8wm1HTSIMBMrIcoVrsjdQkKdMBj3il/fSCgWyya4P2I1xjPBl69mw+nRphrPlcIqBd20Q==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.9.tgz",
+      "integrity": "sha512-tVkljjeEaAhCqTzajSdgbQ6gE6f3oneVwa3iXR6csiEwXXOFsiC6Uh9iAjAhXPtqa/XMDHWjjeNH/77m/Yq2dw==",
+      "license": "MIT",
       "dependencies": {
         "sparse-bitfield": "^3.0.3"
       }
@@ -6572,6 +6580,7 @@
       "version": "0.0.10",
       "resolved": "https://registry.npmjs.org/@mongodb-js/socksv5/-/socksv5-0.0.10.tgz",
       "integrity": "sha512-JDz2fLKsjMiSNUxKrCpGptsgu7DzsXfu4gnUQ3RhUaBS1d4YbLrt6HejpckAiHIAa+niBpZAeiUsoop0IihWsw==",
+      "license": "MIT",
       "dependencies": {
         "ip-address": "^9.0.5"
       },
@@ -20203,16 +20212,16 @@
       }
     },
     "node_modules/kerberos": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/kerberos/-/kerberos-2.2.0.tgz",
-      "integrity": "sha512-yz6iP+34Qp8XjwfmJ56SD9coeSfLIoH0JBrLi6Iw76FdwsRJoNw3nCgfpzENkfGyb/dgRqzYn3IMXLj7A43Vlg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/kerberos/-/kerberos-2.1.0.tgz",
+      "integrity": "sha512-HvOl6O6cyEN/8Z4CAocHe/sekJtvt5UrxUdCuu7bXDZ2Hnsy6OpsQbISW+lpm03vrbO2ir+1QQ5Sx/vMEhHnog==",
       "hasInstallScript": true,
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
         "bindings": "^1.5.0",
         "node-addon-api": "^6.1.0",
-        "prebuild-install": "^7.1.2"
+        "prebuild-install": "7.1.1"
       },
       "engines": {
         "node": ">=12.9.0"
@@ -20223,6 +20232,33 @@
       "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
       "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==",
       "optional": true
+    },
+    "node_modules/kerberos/node_modules/prebuild-install": {
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
+      "integrity": "sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "detect-libc": "^2.0.0",
+        "expand-template": "^2.0.3",
+        "github-from-package": "0.0.0",
+        "minimist": "^1.2.3",
+        "mkdirp-classic": "^0.5.3",
+        "napi-build-utils": "^1.0.1",
+        "node-abi": "^3.3.0",
+        "pump": "^3.0.0",
+        "rc": "^1.2.7",
+        "simple-get": "^4.0.0",
+        "tar-fs": "^2.0.0",
+        "tunnel-agent": "^0.6.0"
+      },
+      "bin": {
+        "prebuild-install": "bin.js"
+      },
+      "engines": {
+        "node": ">=10"
+      }
     },
     "node_modules/keyv": {
       "version": "3.0.0",
@@ -22740,15 +22776,16 @@
       }
     },
     "node_modules/mongodb-runner": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/mongodb-runner/-/mongodb-runner-5.6.1.tgz",
-      "integrity": "sha512-avPly0y9g4CNCnmwRY0VH+gQqnn95NcjTeucTPV/OgGJJAilOqJVHRTyeSVke44tIbvJ65k8AHxYpirKN80QgQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/mongodb-runner/-/mongodb-runner-5.7.0.tgz",
+      "integrity": "sha512-G7GmVj5SzoSL/GY7lMnhNSSrPUZLkWuV1/CtSwdadsrA7aGuxB0KDviTmyecfI2/OWsT39t8X3ISE5R30EV5Xg==",
       "dev": true,
+      "license": "Apache-2.0",
       "dependencies": {
-        "@mongodb-js/mongodb-downloader": "^0.3.1",
-        "@mongodb-js/saslprep": "^1.1.6",
+        "@mongodb-js/mongodb-downloader": "^0.3.6",
+        "@mongodb-js/saslprep": "^1.1.9",
         "debug": "^4.3.4",
-        "mongodb": "^6.3.0",
+        "mongodb": "^6.9.0",
         "mongodb-connection-string-url": "^3.0.0",
         "yargs": "^17.7.2"
       },
@@ -30912,7 +30949,7 @@
         "mongodb-connection-string-url": "^3.0.1"
       },
       "devDependencies": {
-        "@mongodb-js/devtools-connect": "^3.2.11",
+        "@mongodb-js/devtools-connect": "^3.3.0",
         "@mongodb-js/eslint-config-mongosh": "^1.0.0",
         "@mongodb-js/prettier-config-devtools": "^1.0.1",
         "@mongodb-js/tsconfig-mongosh": "^1.0.0",
@@ -31244,7 +31281,7 @@
       "version": "0.0.0-dev.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@mongodb-js/devtools-proxy-support": "^0.3.10",
+        "@mongodb-js/devtools-proxy-support": "^0.4.0",
         "@mongosh/arg-parser": "0.0.0-dev.0",
         "@mongosh/autocomplete": "0.0.0-dev.0",
         "@mongosh/editor": "0.0.0-dev.0",
@@ -31635,7 +31672,7 @@
       "version": "0.0.0-dev.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@mongodb-js/devtools-connect": "^3.2.11",
+        "@mongodb-js/devtools-connect": "^3.3.0",
         "@mongosh/errors": "0.0.0-dev.0",
         "@mongosh/history": "0.0.0-dev.0",
         "@mongosh/types": "0.0.0-dev.0",
@@ -31729,7 +31766,7 @@
       "version": "0.0.0-dev.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@mongodb-js/devtools-connect": "^3.2.11",
+        "@mongodb-js/devtools-connect": "^3.3.0",
         "@mongodb-js/oidc-plugin": "^1.1.1",
         "@mongosh/errors": "0.0.0-dev.0",
         "@mongosh/service-provider-core": "0.0.0-dev.0",
@@ -31752,7 +31789,7 @@
         "node": ">=14.15.1"
       },
       "optionalDependencies": {
-        "kerberos": "^2.2.0",
+        "kerberos": "2.1.0",
         "mongodb-client-encryption": "^6.1.0"
       }
     },
@@ -31812,7 +31849,7 @@
       "version": "0.0.0-dev.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@mongodb-js/devtools-proxy-support": "^0.3.10",
+        "@mongodb-js/devtools-proxy-support": "^0.4.0",
         "@mongosh/errors": "0.0.0-dev.0",
         "@mongosh/shell-api": "0.0.0-dev.0",
         "@mongosh/types": "0.0.0-dev.0",
@@ -31842,7 +31879,7 @@
       "version": "0.0.0-dev.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@mongodb-js/devtools-connect": "^3.2.11"
+        "@mongodb-js/devtools-connect": "^3.3.0"
       },
       "devDependencies": {
         "@mongodb-js/eslint-config-mongosh": "^1.0.0",
@@ -36620,11 +36657,11 @@
       }
     },
     "@mongodb-js/devtools-connect": {
-      "version": "3.2.11",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-connect/-/devtools-connect-3.2.11.tgz",
-      "integrity": "sha512-Pl8XyHHvhN8rXOqt/pMokFGu0Ia38oB9KIvkeK/8UCThTlw1ZRGl1ZpLCFyhAU+6czPAd8nCoj1d5UxlNvRK/Q==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-connect/-/devtools-connect-3.3.0.tgz",
+      "integrity": "sha512-stjduqOZwN51E+Rl8WmZamIM/1UT1ZLt3LxnPazJXnBzycMXEge6kvQQCeYrHk8fokYggLhRxL5xL7IgXaBdbw==",
       "requires": {
-        "@mongodb-js/devtools-proxy-support": "^0.3.10",
+        "@mongodb-js/devtools-proxy-support": "^0.4.0",
         "@mongodb-js/oidc-http-server-pages": "1.1.3",
         "kerberos": "^2.1.0",
         "lodash.merge": "^4.6.2",
@@ -36641,9 +36678,9 @@
       "integrity": "sha512-rBwJHZ0g3Ma6zluNUWfeFXvuxsz9ZtFX2YZ1qR/aQEwk64ZhOqjrVbcROSdtfGUs4qg1JGXFIU+ZQ+oLYqPEvQ=="
     },
     "@mongodb-js/devtools-proxy-support": {
-      "version": "0.3.10",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-proxy-support/-/devtools-proxy-support-0.3.10.tgz",
-      "integrity": "sha512-HComoStLokruxsPLR5m3mC+A167n9THKj3jCj6lQSh7szXotJI5zm500BFEI5IpcY/lVovbK4QlRYQP6WWS+5w==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-proxy-support/-/devtools-proxy-support-0.4.0.tgz",
+      "integrity": "sha512-NSHo+jE1tjH0XOFoDfOrCW7IAt+5l3TOpzgvWSbmNfVO4FqT/lE/mpQKIwsFOlMeGVI6ku2GOV7Obg6664OfTw==",
       "requires": {
         "@mongodb-js/socksv5": "^0.0.10",
         "agent-base": "^7.1.1",
@@ -36655,7 +36692,7 @@
         "pac-proxy-agent": "^7.0.2",
         "socks-proxy-agent": "^8.0.4",
         "ssh2": "^1.15.0",
-        "system-ca": "^2.0.0"
+        "system-ca": "^2.0.1"
       },
       "dependencies": {
         "data-uri-to-buffer": {
@@ -36772,9 +36809,9 @@
       }
     },
     "@mongodb-js/mongodb-downloader": {
-      "version": "0.3.5",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/mongodb-downloader/-/mongodb-downloader-0.3.5.tgz",
-      "integrity": "sha512-0tNik3E/eQxx8EkJpsa9+IIK5LtMle3N7M/1wtKQKMixJjZ1vsgAjJGguYbLfCyJqfnrw9KMyD1cwgaS37tvRA==",
+      "version": "0.3.6",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/mongodb-downloader/-/mongodb-downloader-0.3.6.tgz",
+      "integrity": "sha512-Cu82TRmAP/OIRizx9o+fReQf8FfovI28rjY0pu8wHyCoUlG7q3Zkxb/lppB7a9/kzQfONeHAoXIOQkvSasKYrw==",
       "requires": {
         "debug": "^4.3.4",
         "decompress": "^4.2.1",
@@ -36924,9 +36961,9 @@
       "requires": {}
     },
     "@mongodb-js/saslprep": {
-      "version": "1.1.6",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.6.tgz",
-      "integrity": "sha512-jqTTXQ46H8cAxmXBu8wm1HTSIMBMrIcoVrsjdQkKdMBj3il/fSCgWyya4P2I1xjPBl69mw+nRphrPlcIqBd20Q==",
+      "version": "1.1.9",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/saslprep/-/saslprep-1.1.9.tgz",
+      "integrity": "sha512-tVkljjeEaAhCqTzajSdgbQ6gE6f3oneVwa3iXR6csiEwXXOFsiC6Uh9iAjAhXPtqa/XMDHWjjeNH/77m/Yq2dw==",
       "requires": {
         "sparse-bitfield": "^3.0.3"
       }
@@ -37074,7 +37111,7 @@
     "@mongosh/arg-parser": {
       "version": "file:packages/arg-parser",
       "requires": {
-        "@mongodb-js/devtools-connect": "^3.2.11",
+        "@mongodb-js/devtools-connect": "^3.3.0",
         "@mongodb-js/eslint-config-mongosh": "^1.0.0",
         "@mongodb-js/prettier-config-devtools": "^1.0.1",
         "@mongodb-js/tsconfig-mongosh": "^1.0.0",
@@ -37324,7 +37361,7 @@
     "@mongosh/cli-repl": {
       "version": "file:packages/cli-repl",
       "requires": {
-        "@mongodb-js/devtools-proxy-support": "^0.3.10",
+        "@mongodb-js/devtools-proxy-support": "^0.4.0",
         "@mongodb-js/eslint-config-mongosh": "^1.0.0",
         "@mongodb-js/prettier-config-devtools": "^1.0.1",
         "@mongodb-js/sbom-tools": "^0.7.0",
@@ -37585,7 +37622,7 @@
     "@mongosh/logging": {
       "version": "file:packages/logging",
       "requires": {
-        "@mongodb-js/devtools-connect": "^3.2.11",
+        "@mongodb-js/devtools-connect": "^3.3.0",
         "@mongodb-js/eslint-config-mongosh": "^1.0.0",
         "@mongodb-js/prettier-config-devtools": "^1.0.1",
         "@mongodb-js/tsconfig-mongosh": "^1.0.0",
@@ -37643,7 +37680,7 @@
     "@mongosh/service-provider-server": {
       "version": "file:packages/service-provider-server",
       "requires": {
-        "@mongodb-js/devtools-connect": "^3.2.11",
+        "@mongodb-js/devtools-connect": "^3.3.0",
         "@mongodb-js/eslint-config-mongosh": "^1.0.0",
         "@mongodb-js/oidc-plugin": "^1.1.1",
         "@mongodb-js/prettier-config-devtools": "^1.0.1",
@@ -37655,7 +37692,7 @@
         "aws4": "^1.12.0",
         "depcheck": "^1.4.3",
         "eslint": "^7.25.0",
-        "kerberos": "^2.2.0",
+        "kerberos": "2.1.0",
         "mongodb": "^6.9.0",
         "mongodb-client-encryption": "^6.1.0",
         "mongodb-connection-string-url": "^3.0.1",
@@ -37703,7 +37740,7 @@
     "@mongosh/snippet-manager": {
       "version": "file:packages/snippet-manager",
       "requires": {
-        "@mongodb-js/devtools-proxy-support": "^0.3.10",
+        "@mongodb-js/devtools-proxy-support": "^0.4.0",
         "@mongodb-js/eslint-config-mongosh": "^1.0.0",
         "@mongodb-js/prettier-config-devtools": "^1.0.1",
         "@mongodb-js/tsconfig-mongosh": "^1.0.0",
@@ -37726,7 +37763,7 @@
     "@mongosh/types": {
       "version": "file:packages/types",
       "requires": {
-        "@mongodb-js/devtools-connect": "^3.2.11",
+        "@mongodb-js/devtools-connect": "^3.3.0",
         "@mongodb-js/eslint-config-mongosh": "^1.0.0",
         "@mongodb-js/prettier-config-devtools": "^1.0.1",
         "@mongodb-js/tsconfig-mongosh": "^1.0.0",
@@ -48331,14 +48368,14 @@
       }
     },
     "kerberos": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/kerberos/-/kerberos-2.2.0.tgz",
-      "integrity": "sha512-yz6iP+34Qp8XjwfmJ56SD9coeSfLIoH0JBrLi6Iw76FdwsRJoNw3nCgfpzENkfGyb/dgRqzYn3IMXLj7A43Vlg==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/kerberos/-/kerberos-2.1.0.tgz",
+      "integrity": "sha512-HvOl6O6cyEN/8Z4CAocHe/sekJtvt5UrxUdCuu7bXDZ2Hnsy6OpsQbISW+lpm03vrbO2ir+1QQ5Sx/vMEhHnog==",
       "optional": true,
       "requires": {
         "bindings": "^1.5.0",
         "node-addon-api": "^6.1.0",
-        "prebuild-install": "^7.1.2"
+        "prebuild-install": "7.1.1"
       },
       "dependencies": {
         "node-addon-api": {
@@ -48346,6 +48383,26 @@
           "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-6.1.0.tgz",
           "integrity": "sha512-+eawOlIgy680F0kBzPUNFhMZGtJ1YmqM6l4+Crf4IkImjYrO/mqPwRMh352g23uIaQKFItcQ64I7KMaJxHgAVA==",
           "optional": true
+        },
+        "prebuild-install": {
+          "version": "7.1.1",
+          "resolved": "https://registry.npmjs.org/prebuild-install/-/prebuild-install-7.1.1.tgz",
+          "integrity": "sha512-jAXscXWMcCK8GgCoHOfIr0ODh5ai8mj63L2nWrjuAgXE6tDyYGnx4/8o/rCgU+B4JSyZBKbeZqzhtwtC3ovxjw==",
+          "optional": true,
+          "requires": {
+            "detect-libc": "^2.0.0",
+            "expand-template": "^2.0.3",
+            "github-from-package": "0.0.0",
+            "minimist": "^1.2.3",
+            "mkdirp-classic": "^0.5.3",
+            "napi-build-utils": "^1.0.1",
+            "node-abi": "^3.3.0",
+            "pump": "^3.0.0",
+            "rc": "^1.2.7",
+            "simple-get": "^4.0.0",
+            "tar-fs": "^2.0.0",
+            "tunnel-agent": "^0.6.0"
+          }
         }
       }
     },
@@ -50287,15 +50344,15 @@
       }
     },
     "mongodb-runner": {
-      "version": "5.6.1",
-      "resolved": "https://registry.npmjs.org/mongodb-runner/-/mongodb-runner-5.6.1.tgz",
-      "integrity": "sha512-avPly0y9g4CNCnmwRY0VH+gQqnn95NcjTeucTPV/OgGJJAilOqJVHRTyeSVke44tIbvJ65k8AHxYpirKN80QgQ==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/mongodb-runner/-/mongodb-runner-5.7.0.tgz",
+      "integrity": "sha512-G7GmVj5SzoSL/GY7lMnhNSSrPUZLkWuV1/CtSwdadsrA7aGuxB0KDviTmyecfI2/OWsT39t8X3ISE5R30EV5Xg==",
       "dev": true,
       "requires": {
-        "@mongodb-js/mongodb-downloader": "^0.3.1",
-        "@mongodb-js/saslprep": "^1.1.6",
+        "@mongodb-js/mongodb-downloader": "^0.3.6",
+        "@mongodb-js/saslprep": "^1.1.9",
         "debug": "^4.3.4",
-        "mongodb": "^6.3.0",
+        "mongodb": "^6.9.0",
         "mongodb-connection-string-url": "^3.0.0",
         "yargs": "^17.7.2"
       },

--- a/package.json
+++ b/package.json
@@ -111,7 +111,7 @@
     "husky": "^9.0.11",
     "mocha": "^10.2.0",
     "mongodb": "^6.9.0",
-    "mongodb-runner": "^5.6.1",
+    "mongodb-runner": "^5.7.0",
     "node-gyp": "^9.0.0",
     "nyc": "^15.1.0",
     "pkg-up": "^3.1.0",

--- a/packages/arg-parser/package.json
+++ b/packages/arg-parser/package.json
@@ -40,7 +40,7 @@
     "mongodb-connection-string-url": "^3.0.1"
   },
   "devDependencies": {
-    "@mongodb-js/devtools-connect": "^3.2.11",
+    "@mongodb-js/devtools-connect": "^3.3.0",
     "@mongodb-js/eslint-config-mongosh": "^1.0.0",
     "@mongodb-js/prettier-config-devtools": "^1.0.1",
     "@mongodb-js/tsconfig-mongosh": "^1.0.0",

--- a/packages/cli-repl/package.json
+++ b/packages/cli-repl/package.json
@@ -61,7 +61,7 @@
     }
   },
   "dependencies": {
-    "@mongodb-js/devtools-proxy-support": "^0.3.10",
+    "@mongodb-js/devtools-proxy-support": "^0.4.0",
     "@mongosh/arg-parser": "0.0.0-dev.0",
     "@mongosh/autocomplete": "0.0.0-dev.0",
     "@mongosh/editor": "0.0.0-dev.0",

--- a/packages/cli-repl/src/run.ts
+++ b/packages/cli-repl/src/run.ts
@@ -34,6 +34,12 @@ import { TimingCategories } from '@mongosh/types';
 import './webpack-self-inspection';
 import { systemCA } from '@mongodb-js/devtools-proxy-support';
 
+if ('boxednode' in process) {
+  // compiled executable
+  // https://github.com/mongodb-js/devtools-shared/pull/476
+  (process as any).__tlsSupportsAllowPartialTrustChainFlag = true;
+}
+
 // TS does not yet have type definitions for v8.startupSnapshot
 if ((v8 as any)?.startupSnapshot?.isBuildingSnapshot?.()) {
   // Import a few nested deps of dependencies that cannot be included in the

--- a/packages/e2e-tests/test/e2e-tls.spec.ts
+++ b/packages/e2e-tests/test/e2e-tls.spec.ts
@@ -168,7 +168,7 @@ describe('e2e TLS', function () {
         const result = await shell.waitForPromptOrExit();
         expect(result.state).to.equal('exit');
         shell.assertContainsOutput(
-          /unable to verify the first certificate|self[- ]signed certificate in certificate chain/
+          /unable to verify the first certificate|self[- ]signed certificate in certificate chain|unable to get (local )?issuer certificate/
         );
       });
 
@@ -185,7 +185,7 @@ describe('e2e TLS', function () {
         const result = await shell.waitForPromptOrExit();
         expect(result.state).to.equal('exit');
         shell.assertContainsOutput(
-          /unable to verify the first certificate|self[- ]signed certificate in certificate chain/
+          /unable to verify the first certificate|self[- ]signed certificate in certificate chain|unable to get (local )?issuer certificate/
         );
       });
 

--- a/packages/logging/package.json
+++ b/packages/logging/package.json
@@ -17,7 +17,7 @@
     "node": ">=14.15.1"
   },
   "dependencies": {
-    "@mongodb-js/devtools-connect": "^3.2.11",
+    "@mongodb-js/devtools-connect": "^3.3.0",
     "@mongosh/errors": "0.0.0-dev.0",
     "@mongosh/history": "0.0.0-dev.0",
     "@mongosh/types": "0.0.0-dev.0",

--- a/packages/service-provider-server/package.json
+++ b/packages/service-provider-server/package.json
@@ -47,7 +47,7 @@
     }
   },
   "dependencies": {
-    "@mongodb-js/devtools-connect": "^3.2.11",
+    "@mongodb-js/devtools-connect": "^3.3.0",
     "@mongodb-js/oidc-plugin": "^1.1.1",
     "@mongosh/errors": "0.0.0-dev.0",
     "@mongosh/service-provider-core": "0.0.0-dev.0",
@@ -58,7 +58,7 @@
     "socks": "^2.8.3"
   },
   "optionalDependencies": {
-    "kerberos": "^2.2.0",
+    "kerberos": "2.1.0",
     "mongodb-client-encryption": "^6.1.0"
   },
   "devDependencies": {

--- a/packages/snippet-manager/package.json
+++ b/packages/snippet-manager/package.json
@@ -35,7 +35,7 @@
     "unitTestsOnly": true
   },
   "dependencies": {
-    "@mongodb-js/devtools-proxy-support": "^0.3.10",
+    "@mongodb-js/devtools-proxy-support": "^0.4.0",
     "@mongosh/errors": "0.0.0-dev.0",
     "@mongosh/shell-api": "0.0.0-dev.0",
     "@mongosh/types": "0.0.0-dev.0",

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -38,7 +38,7 @@
     "unitTestsOnly": true
   },
   "dependencies": {
-    "@mongodb-js/devtools-connect": "^3.2.11"
+    "@mongodb-js/devtools-connect": "^3.3.0"
   },
   "devDependencies": {
     "@mongodb-js/eslint-config-mongosh": "^1.0.0",

--- a/scripts/nodejs-patches/005-node-tls-allowpartialtrustchain-commit-1b3420274ea.patch
+++ b/scripts/nodejs-patches/005-node-tls-allowpartialtrustchain-commit-1b3420274ea.patch
@@ -1,0 +1,157 @@
+diff --git a/lib/internal/tls/secure-context.js b/lib/internal/tls/secure-context.js
+index b0f971e4eef273..84e74105fdbba9 100644
+--- a/lib/internal/tls/secure-context.js
++++ b/lib/internal/tls/secure-context.js
+@@ -130,6 +130,7 @@ function configSecureContext(context, options = kEmptyObject, name = 'options')
+   validateObject(options, name);
+
+   const {
++    allowPartialTrustChain,
+     ca,
+     cert,
+     ciphers = getDefaultCiphers(),
+@@ -182,6 +183,10 @@ function configSecureContext(context, options = kEmptyObject, name = 'options')
+     context.addRootCerts();
+   }
+
++  if (allowPartialTrustChain) {
++    context.setAllowPartialTrustChain();
++  }
++
+   if (cert) {
+     setCerts(context, ArrayIsArray(cert) ? cert : [cert], `${name}.cert`);
+   }
+diff --git a/src/crypto/crypto_context.cc b/src/crypto/crypto_context.cc
+index 1d60f7e856075a..cef0c877c67643 100644
+--- a/src/crypto/crypto_context.cc
++++ b/src/crypto/crypto_context.cc
+@@ -273,6 +273,8 @@ Local<FunctionTemplate> SecureContext::GetConstructorTemplate(
+     SetProtoMethod(isolate, tmpl, "setKey", SetKey);
+     SetProtoMethod(isolate, tmpl, "setCert", SetCert);
+     SetProtoMethod(isolate, tmpl, "addCACert", AddCACert);
++    SetProtoMethod(
++        isolate, tmpl, "setAllowPartialTrustChain", SetAllowPartialTrustChain);
+     SetProtoMethod(isolate, tmpl, "addCRL", AddCRL);
+     SetProtoMethod(isolate, tmpl, "addRootCerts", AddRootCerts);
+     SetProtoMethod(isolate, tmpl, "setCipherSuites", SetCipherSuites);
+@@ -354,6 +356,7 @@ void SecureContext::RegisterExternalReferences(
+   registry->Register(AddCACert);
+   registry->Register(AddCRL);
+   registry->Register(AddRootCerts);
++  registry->Register(SetAllowPartialTrustChain);
+   registry->Register(SetCipherSuites);
+   registry->Register(SetCiphers);
+   registry->Register(SetSigalgs);
+@@ -715,17 +718,39 @@ void SecureContext::SetCert(const FunctionCallbackInfo<Value>& args) {
+   USE(sc->AddCert(env, std::move(bio)));
+ }
+
++// NOLINTNEXTLINE(runtime/int)
++void SecureContext::SetX509StoreFlag(unsigned long flags) {
++  X509_STORE* cert_store = GetCertStoreOwnedByThisSecureContext();
++  CHECK_EQ(1, X509_STORE_set_flags(cert_store, flags));
++}
++
++X509_STORE* SecureContext::GetCertStoreOwnedByThisSecureContext() {
++  if (own_cert_store_cache_ != nullptr) return own_cert_store_cache_;
++
++  X509_STORE* cert_store = SSL_CTX_get_cert_store(ctx_.get());
++  if (cert_store == GetOrCreateRootCertStore()) {
++    cert_store = NewRootCertStore();
++    SSL_CTX_set_cert_store(ctx_.get(), cert_store);
++  }
++
++  return own_cert_store_cache_ = cert_store;
++}
++
++void SecureContext::SetAllowPartialTrustChain(
++    const FunctionCallbackInfo<Value>& args) {
++  SecureContext* sc;
++  ASSIGN_OR_RETURN_UNWRAP(&sc, args.This());
++  sc->SetX509StoreFlag(X509_V_FLAG_PARTIAL_CHAIN);
++}
++
+ void SecureContext::SetCACert(const BIOPointer& bio) {
+   ClearErrorOnReturn clear_error_on_return;
+   if (!bio) return;
+-  X509_STORE* cert_store = SSL_CTX_get_cert_store(ctx_.get());
+   while (X509Pointer x509 = X509Pointer(PEM_read_bio_X509_AUX(
+              bio.get(), nullptr, NoPasswordCallback, nullptr))) {
+-    if (cert_store == GetOrCreateRootCertStore()) {
+-      cert_store = NewRootCertStore();
+-      SSL_CTX_set_cert_store(ctx_.get(), cert_store);
+-    }
+-    CHECK_EQ(1, X509_STORE_add_cert(cert_store, x509.get()));
++    CHECK_EQ(1,
++             X509_STORE_add_cert(GetCertStoreOwnedByThisSecureContext(),
++                                 x509.get()));
+     CHECK_EQ(1, SSL_CTX_add_client_CA(ctx_.get(), x509.get()));
+   }
+ }
+@@ -754,11 +779,7 @@ Maybe<bool> SecureContext::SetCRL(Environment* env, const BIOPointer& bio) {
+     return Nothing<bool>();
+   }
+
+-  X509_STORE* cert_store = SSL_CTX_get_cert_store(ctx_.get());
+-  if (cert_store == GetOrCreateRootCertStore()) {
+-    cert_store = NewRootCertStore();
+-    SSL_CTX_set_cert_store(ctx_.get(), cert_store);
+-  }
++  X509_STORE* cert_store = GetCertStoreOwnedByThisSecureContext();
+
+   CHECK_EQ(1, X509_STORE_add_crl(cert_store, crl.get()));
+   CHECK_EQ(1,
+@@ -1042,8 +1063,6 @@ void SecureContext::LoadPKCS12(const FunctionCallbackInfo<Value>& args) {
+   sc->issuer_.reset();
+   sc->cert_.reset();
+
+-  X509_STORE* cert_store = SSL_CTX_get_cert_store(sc->ctx_.get());
+-
+   DeleteFnPtr<PKCS12, PKCS12_free> p12;
+   EVPKeyPointer pkey;
+   X509Pointer cert;
+@@ -1097,11 +1116,7 @@ void SecureContext::LoadPKCS12(const FunctionCallbackInfo<Value>& args) {
+   for (int i = 0; i < sk_X509_num(extra_certs.get()); i++) {
+     X509* ca = sk_X509_value(extra_certs.get(), i);
+
+-    if (cert_store == GetOrCreateRootCertStore()) {
+-      cert_store = NewRootCertStore();
+-      SSL_CTX_set_cert_store(sc->ctx_.get(), cert_store);
+-    }
+-    X509_STORE_add_cert(cert_store, ca);
++    X509_STORE_add_cert(sc->GetCertStoreOwnedByThisSecureContext(), ca);
+     SSL_CTX_add_client_CA(sc->ctx_.get(), ca);
+   }
+   ret = true;
+diff --git a/src/crypto/crypto_context.h b/src/crypto/crypto_context.h
+index 607b0984ba647a..4c76bdc5ec1a7c 100644
+--- a/src/crypto/crypto_context.h
++++ b/src/crypto/crypto_context.h
+@@ -65,6 +65,9 @@ class SecureContext final : public BaseObject {
+   void SetCACert(const BIOPointer& bio);
+   void SetRootCerts();
+
++  void SetX509StoreFlag(unsigned long flags);  // NOLINT(runtime/int)
++  X509_STORE* GetCertStoreOwnedByThisSecureContext();
++
+   // TODO(joyeecheung): track the memory used by OpenSSL types
+   SET_NO_MEMORY_INFO()
+   SET_MEMORY_INFO_NAME(SecureContext)
+@@ -91,6 +94,8 @@ class SecureContext final : public BaseObject {
+ #endif  // !OPENSSL_NO_ENGINE
+   static void SetCert(const v8::FunctionCallbackInfo<v8::Value>& args);
+   static void AddCACert(const v8::FunctionCallbackInfo<v8::Value>& args);
++  static void SetAllowPartialTrustChain(
++      const v8::FunctionCallbackInfo<v8::Value>& args);
+   static void AddCRL(const v8::FunctionCallbackInfo<v8::Value>& args);
+   static void AddRootCerts(const v8::FunctionCallbackInfo<v8::Value>& args);
+   static void SetCipherSuites(const v8::FunctionCallbackInfo<v8::Value>& args);
+@@ -143,6 +148,8 @@ class SecureContext final : public BaseObject {
+   SSLCtxPointer ctx_;
+   X509Pointer cert_;
+   X509Pointer issuer_;
++  // Non-owning cache for SSL_CTX_get_cert_store(ctx_.get())
++  X509_STORE* own_cert_store_cache_ = nullptr;
+ #ifndef OPENSSL_NO_ENGINE
+   bool client_cert_engine_provided_ = false;
+   EnginePointer private_key_engine_;


### PR DESCRIPTION
This should bring back startup performance to pre-2.3.1 levels.

Also pins kerberos to 2.1.0, since bumping it actually broke our Windows build.