### PR TITLE
fix(scripts): account for `unminimize` being gone from ubuntu24.04 docker img

### DIFF
--- a/scripts/docker/ubuntu24.04-deb.Dockerfile
+++ b/scripts/docker/ubuntu24.04-deb.Dockerfile
@@ -4,8 +4,8 @@ ARG artifact_url=""
 ADD ${artifact_url} /tmp
 ADD node_modules /usr/share/mongodb-crypt-library-version/node_modules
 RUN apt-get update
-RUN yes | unminimize
 RUN apt-get install -y man-db
+RUN rm -f /usr/bin/man /etc/dpkg/dpkg.cfg.d/excludes && ln -s /usr/bin/man.REAL /usr/bin/man # unminimize
 RUN apt-get install -y /tmp/*mongosh*.deb
 RUN /usr/bin/mongosh --build-info
 RUN env MONGOSH_RUN_NODE_SCRIPT=1 mongosh /usr/share/mongodb-crypt-library-version/node_modules/.bin/mongodb-crypt-library-version /usr/lib/mongosh_crypt_v1.so | grep -Eq '^mongo_(crypt|csfle)_v1-'


### PR DESCRIPTION
The `unminimize` script is no longer part of Ubuntu 24.04 docker images, so we need to manually emulate its effects in order to be able to test the man page installation.