### PR TITLE
feat(cli-repl): Ask for tlsCertificateKeyFilePassword when it is needed MONGOSH-1730

### DIFF
--- a/packages/cli-repl/src/cli-repl.ts
+++ b/packages/cli-repl/src/cli-repl.ts
@@ -288,6 +288,14 @@ export class CliRepl implements MongoshIOProvider {
       if (this.isPasswordMissingURI(cs)) {
         cs.password = encodeURIComponent(await this.requirePassword());
       }
+
+      if (await this.isTlsKeyFilePasswordMissingURI(searchParams)) {
+        const keyFilePassword = encodeURIComponent(
+          await this.requirePassword('Enter TLS key file password')
+        );
+        searchParams.set('tlsCertificateKeyFilePassword', keyFilePassword);
+      }
+
       this.ensurePasswordFieldIsPresentInAuth(driverOptions);
       driverUri = cs.toString();
     }
@@ -1008,6 +1016,28 @@ export class CliRepl implements MongoshIOProvider {
     );
   }
 
+  async isTlsKeyFilePasswordMissingURI(
+    searchParams: ReturnType<
+      typeof ConnectionString.prototype.typedSearchParams<DevtoolsConnectOptions>
+    >
+  ): Promise<boolean> {
+    const tlsCertificateKeyFile = searchParams.get('tlsCertificateKeyFile');
+    const tlsCertificateKeyFilePassword = searchParams.get(
+      'tlsCertificateKeyFilePassword'
+    );
+
+    if (tlsCertificateKeyFile && !tlsCertificateKeyFilePassword) {
+      const { contents } = await this.readFileUTF8(tlsCertificateKeyFile);
+
+      // Matches standard encrypted key formats for PKCS#12/PKCS#8 and PKCS#1
+      return (
+        contents.search(/(ENCRYPTED PRIVATE KEY|Proc-Type: 4,ENCRYPTED)/) !== -1
+      );
+    }
+
+    return false;
+  }
+
   /**
    * Sets the auth.password field to undefined in the driverOptions if the auth
    * object is present with a truthy username. This is required by the driver, e.g.
@@ -1028,13 +1058,13 @@ export class CliRepl implements MongoshIOProvider {
   /**
    * Require the user to enter a password.
    */
-  async requirePassword(): Promise<string> {
+  async requirePassword(passwordPrompt = 'Enter password'): Promise<string> {
     const passwordPromise = askpassword({
       input: this.input,
       output: this.promptOutput,
       replacementCharacter: '*',
     });
-    this.promptOutput.write('Enter password: ');
+    this.promptOutput.write(`${passwordPrompt}: `);
     try {
       try {
         return (await passwordPromise).toString();

--- a/packages/e2e-tests/test/test-shell.ts
+++ b/packages/e2e-tests/test/test-shell.ts
@@ -183,6 +183,22 @@ export class TestShell {
     return this._process;
   }
 
+  async waitForLine(pattern: RegExp, start = 0): Promise<void> {
+    await eventually(() => {
+      const output = this._output.slice(start);
+      const lines = output.split('\n');
+      const found = !!lines.filter((l) => pattern.exec(l));
+      if (!found) {
+        throw new assert.AssertionError({
+          message: 'expected line',
+          expected: pattern.toString(),
+          actual:
+            this._output.slice(0, start) + '[line search starts here]' + output,
+        });
+      }
+    });
+  }
+
   async waitForPrompt(start = 0): Promise<void> {
     await eventually(() => {
       const output = this._output.slice(start);


### PR DESCRIPTION
When using TLS enabled with a Certificate that requires a password, the mongosh does not prompt for a passphrase automatically, failing with an error. This adds a password prompt for that case.