### PR TITLE
chore(cli-repl): add a smoke test for require in non-repl mode MONGOSH-1741

### DIFF
--- a/packages/cli-repl/src/smoke-tests.ts
+++ b/packages/cli-repl/src/smoke-tests.ts
@@ -151,6 +151,15 @@ export async function runSmokeTests({
       tags: ['startup'],
     },
     {
+      name: 'eval_nodb_require',
+      input: '',
+      output: /foobar/,
+      includeStderr: false,
+      testArgs: ['--nodb', '--eval', 'require("util").format("%sbar", "foo")'],
+      exitCode: 0,
+      perfTestIterations: 0,
+    },
+    {
       name: 'mongosh_version',
       input: '',
       output: new RegExp(escapeRegexp(baseBuildInfo().version)),


### PR DESCRIPTION
I just did what Maurizio suggested in a comment on the ticket.