### PR TITLE
fix(shell-api): Add support for running aggregate database with a single stage MONGOSH-1868

### DIFF
--- a/packages/shell-api/src/collection.ts
+++ b/packages/shell-api/src/collection.ts
@@ -164,7 +164,7 @@ export default class Collection extends ShellApiWithMongoClass {
   async aggregate(
     pipeline: Document[],
     options: Document & { explain: ExplainVerbosityLike }
-  ): Promise<Document>;
+  ): Promise<AggregationCursor>;
   async aggregate(...stages: Document[]): Promise<AggregationCursor>;
   @returnsPromise
   @returnType('AggregationCursor')
@@ -191,7 +191,10 @@ export default class Collection extends ShellApiWithMongoClass {
       this._database._name,
       this._name,
       pipeline,
-      { ...(await this._database._baseOptions()), ...aggOptions },
+      {
+        ...(await this._database._baseOptions()),
+        ...aggOptions,
+      },
       dbOptions
     );
     const cursor = new AggregationCursor(this._mongo, providerCursor);

--- a/packages/shell-api/src/collection.ts
+++ b/packages/shell-api/src/collection.ts
@@ -164,7 +164,7 @@ export default class Collection extends ShellApiWithMongoClass {
   async aggregate(
     pipeline: Document[],
     options: Document & { explain: ExplainVerbosityLike }
-  ): Promise<AggregationCursor>;
+  ): Promise<Document>;
   async aggregate(...stages: Document[]): Promise<AggregationCursor>;
   @returnsPromise
   @returnType('AggregationCursor')
@@ -191,10 +191,7 @@ export default class Collection extends ShellApiWithMongoClass {
       this._database._name,
       this._name,
       pipeline,
-      {
-        ...(await this._database._baseOptions()),
-        ...aggOptions,
-      },
+      { ...(await this._database._baseOptions()), ...aggOptions },
       dbOptions
     );
     const cursor = new AggregationCursor(this._mongo, providerCursor);

--- a/packages/shell-api/src/database.spec.ts
+++ b/packages/shell-api/src/database.spec.ts
@@ -390,6 +390,17 @@ describe('Database', function () {
         serviceProviderCursor = stubInterface<ServiceProviderAggCursor>();
       });
 
+      it('throws if the given argument is not an array', async function () {
+        let caughtError: MongoshInvalidInputError | undefined;
+        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
+        await database.aggregate({} as any).catch((err) => {
+          caughtError = err;
+        });
+        expect(caughtError?.message).contains(
+          'Aggregate pipeline argument must be an array'
+        );
+      });
+
       it('calls serviceProvider.aggregateDb with pipleline and options', async function () {
         await database.aggregate([{ $piplelineStage: {} }], { options: true });
 

--- a/packages/shell-api/src/database.spec.ts
+++ b/packages/shell-api/src/database.spec.ts
@@ -390,19 +390,18 @@ describe('Database', function () {
         serviceProviderCursor = stubInterface<ServiceProviderAggCursor>();
       });
 
-      it('throws if the given argument is not an array', async function () {
-        let caughtError: MongoshInvalidInputError | undefined;
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-argument
-        await database.aggregate({} as any).catch((err) => {
-          caughtError = err;
-        });
-        expect(caughtError?.message).contains(
-          'Aggregate pipeline argument must be an array'
+      it('calls serviceProvider.aggregateDb with pipleline and options', async function () {
+        await database.aggregate([{ $piplelineStage: {} }], { options: true });
+
+        expect(serviceProvider.aggregateDb).to.have.been.calledWith(
+          database._name,
+          [{ $piplelineStage: {} }],
+          { options: true }
         );
       });
 
-      it('calls serviceProvider.aggregateDb with pipleline and options', async function () {
-        await database.aggregate([{ $piplelineStage: {} }], { options: true });
+      it('supports a single aggregation stage', async function () {
+        await database.aggregate({ $piplelineStage: {} }, { options: true });
 
         expect(serviceProvider.aggregateDb).to.have.been.calledWith(
           database._name,

--- a/packages/shell-api/src/database.ts
+++ b/packages/shell-api/src/database.ts
@@ -412,6 +412,14 @@ export default class Database extends ShellApiWithMongoClass {
     return await this._runAdminCommand(cmd, {});
   }
 
+  async aggregate(
+    singleStage: Document,
+    options?: Document
+  ): Promise<AggregationCursor>;
+  async aggregate(
+    pipeline: Document[],
+    options?: Document
+  ): Promise<AggregationCursor>;
   /**
    * Run an aggregation against the db.
    *
@@ -423,7 +431,7 @@ export default class Database extends ShellApiWithMongoClass {
   @returnType('AggregationCursor')
   @apiVersions([1])
   async aggregate(
-    pipeline: Document[],
+    pipelineOrSingleStage: Document | Document[],
     options?: Document
   ): Promise<AggregationCursor> {
     if ('background' in (options ?? {})) {
@@ -431,6 +439,10 @@ export default class Database extends ShellApiWithMongoClass {
         aggregateBackgroundOptionNotSupportedHelp
       );
     }
+    const pipeline: Document[] = Array.isArray(pipelineOrSingleStage)
+      ? pipelineOrSingleStage
+      : [pipelineOrSingleStage];
+
     assertArgsDefinedType([pipeline], [true], 'Database.aggregate');
 
     if (!Array.isArray(pipeline)) {

--- a/packages/shell-api/src/database.ts
+++ b/packages/shell-api/src/database.ts
@@ -412,14 +412,6 @@ export default class Database extends ShellApiWithMongoClass {
     return await this._runAdminCommand(cmd, {});
   }
 
-  async aggregate(
-    singleStage: Document,
-    options?: Document
-  ): Promise<AggregationCursor>;
-  async aggregate(
-    pipeline: Document[],
-    options?: Document
-  ): Promise<AggregationCursor>;
   /**
    * Run an aggregation against the db.
    *

--- a/packages/shell-api/src/database.ts
+++ b/packages/shell-api/src/database.ts
@@ -445,13 +445,6 @@ export default class Database extends ShellApiWithMongoClass {
 
     assertArgsDefinedType([pipeline], [true], 'Database.aggregate');
 
-    if (!Array.isArray(pipeline)) {
-      throw new MongoshInvalidInputError(
-        'Aggregate pipeline argument must be an array',
-        CommonErrors.InvalidArgument
-      );
-    }
-
     this._emitDatabaseApiCall('aggregate', { options, pipeline });
 
     const { aggOptions, dbOptions, explain } = adaptAggregateOptions(options);

--- a/packages/shell-api/src/database.ts
+++ b/packages/shell-api/src/database.ts
@@ -432,6 +432,14 @@ export default class Database extends ShellApiWithMongoClass {
       );
     }
     assertArgsDefinedType([pipeline], [true], 'Database.aggregate');
+
+    if (!Array.isArray(pipeline)) {
+      throw new MongoshInvalidInputError(
+        'Aggregate pipeline argument must be an array',
+        CommonErrors.InvalidArgument
+      );
+    }
+
     this._emitDatabaseApiCall('aggregate', { options, pipeline });
 
     const { aggOptions, dbOptions, explain } = adaptAggregateOptions(options);
@@ -1429,6 +1437,7 @@ export default class Database extends ShellApiWithMongoClass {
         CommonErrors.CommandFailed
       );
     }
+    // eslint-disable-next-line @typescript-eslint/no-unnecessary-type-assertion
     for (const cmdDescription of Object.values(result.commands) as Document[]) {
       if ('slaveOk' in cmdDescription) {
         cmdDescription.secondaryOk = cmdDescription.slaveOk;


### PR DESCRIPTION
Running aggregate() on a database with a non-array pipeline will now run a single stage aggregation. This will make it consistent with `db.{collection}aggregate`  behavior so
```
db.aggregate({$listLocalSessions: {}}
```
is same as 
```
db.aggregate([{$listLocalSessions: {}}])
```