### PR TITLE
fix(shell-api): mongosh should throw an error when trying to drop a non-primary index MONGOSH-1608

### DIFF
--- a/packages/cli-repl/AUTHORS
+++ b/packages/cli-repl/AUTHORS
@@ -22,3 +22,4 @@ Paula Stachova <paula.stachova@tutanota.com>
 Basit <1305718+mabaasit@users.noreply.github.com>
 Alena Khineika <alena.khineika@mongodb.com>
 Kræn Hansen <mail@kraenhansen.dk>
+Gagik Amaryan <me@gagik.co>

--- a/packages/shell-api/src/collection.spec.ts
+++ b/packages/shell-api/src/collection.spec.ts
@@ -1165,26 +1165,29 @@ describe('Collection', function () {
       context(
         'when serviceProvider.dropIndexes rejects IndexNotFound',
         function () {
+          let expectedError: Error;
           beforeEach(function () {
-            const error = new Error('index not found with name [index_1]');
-            Object.assign(error, {
+            expectedError = new Error('index not found with name [index_1]');
+            Object.assign(expectedError, {
               ok: 0,
               errmsg: 'index not found with name [index_1]',
               code: 27,
               codeName: 'IndexNotFound',
-              name: 'MongoError',
+              name: 'MongoServerError',
             });
 
-            serviceProvider.runCommandWithCheck.rejects(error);
+            serviceProvider.runCommandWithCheck.rejects(expectedError);
           });
 
           it('returns the error as object', async function () {
-            expect(await collection.dropIndexes('index_1')).to.deep.equal({
-              ok: 0,
-              errmsg: 'index not found with name [index_1]',
-              code: 27,
-              codeName: 'IndexNotFound',
-            });
+            let caughtError: Error | undefined;
+            expect(
+              await collection
+                .dropIndexes('index_1')
+                .catch((err) => (caughtError = err))
+            );
+
+            expect(caughtError).to.deep.equal(expectedError);
           });
         }
       );

--- a/packages/shell-api/src/collection.spec.ts
+++ b/packages/shell-api/src/collection.spec.ts
@@ -1181,11 +1181,9 @@ describe('Collection', function () {
 
           it('returns the error as object', async function () {
             let caughtError: Error | undefined;
-            expect(
-              await collection
-                .dropIndexes('index_1')
-                .catch((err) => (caughtError = err))
-            );
+            await collection
+              .dropIndexes('index_1')
+              .catch((err) => (caughtError = err));
 
             expect(caughtError).to.deep.equal(expectedError);
           });

--- a/packages/shell-api/src/collection.ts
+++ b/packages/shell-api/src/collection.ts
@@ -1335,15 +1335,6 @@ export default class Collection extends ShellApiWithMongoClass {
         return all.sort((a, b) => b.nIndexesWas - a.nIndexesWas)[0];
       }
 
-      if (error?.codeName === 'IndexNotFound') {
-        return {
-          ok: error.ok,
-          errmsg: error.errmsg,
-          code: error.code,
-          codeName: error.codeName,
-        };
-      }
-
       throw error;
     }
   }


### PR DESCRIPTION
```
test> response = db.test.dropIndex({"a": 1});
MongoshInternalError: can't find index with key: { a: 1 }

test> console.info(response);
{
  ok: 0,
  errmsg: "can't find index with key: { a: 1 }",
  code: 27,
  codeName: 'IndexNotFound'
}
```
mongosh seems to throw the error here instead of the dropIndex request going to the server. Hence `response` variable doesn't end up being set.