### PR TITLE
fix(cli-repl): Revert workaround for depcheck for searchParams type

### DIFF
--- a/packages/cli-repl/src/cli-repl.ts
+++ b/packages/cli-repl/src/cli-repl.ts
@@ -1017,11 +1017,12 @@ export class CliRepl implements MongoshIOProvider {
   }
 
   async isTlsKeyFilePasswordMissingURI(
-    searchParams: unknown
+    searchParams: ReturnType<
+      typeof ConnectionString.prototype.typedSearchParams<DevtoolsConnectOptions>
+    >
   ): Promise<boolean> {
-    const searchMap = searchParams as Map<keyof DevtoolsConnectOptions, string>;
-    const tlsCertificateKeyFile = searchMap.get('tlsCertificateKeyFile');
-    const tlsCertificateKeyFilePassword = searchMap.get(
+    const tlsCertificateKeyFile = searchParams.get('tlsCertificateKeyFile');
+    const tlsCertificateKeyFilePassword = searchParams.get(
       'tlsCertificateKeyFilePassword'
     );
 


### PR DESCRIPTION
After https://github.com/mongodb-js/mongosh/pull/2222, the https://github.com/mongodb-js/mongosh/pull/2219 workaround is no longer necessary.