### PR TITLE
feat(shell-api): add stream processor modify MONGOSH-1864

### DIFF
--- a/packages/i18n/src/locales/en_US.ts
+++ b/packages/i18n/src/locales/en_US.ts
@@ -2771,6 +2771,9 @@ const translations: Catalog = {
               description:
                 'Return stats captured from a named stream processor.',
             },
+            modify: {
+              description: 'Modify a stream processor definition.',
+            },
           },
         },
       },

--- a/packages/shell-api/src/stream-processor.ts
+++ b/packages/shell-api/src/stream-processor.ts
@@ -75,7 +75,7 @@ export default class StreamProcessor extends ShellApiWithMongoClass {
     if (Array.isArray(pipelineOrOptions)) {
       options['pipeline'] = pipelineOrOptions;
     } else if (typeof pipelineOrOptions === 'object') {
-      if (Object.keys(options).length != 0) {
+      if (Object.keys(options).length !== 0) {
         throw new MongoshInvalidInputError(
           'If the first argument to modify is an object, the second argument should not be specified.',
           CommonErrors.InvalidArgument

--- a/packages/shell-api/src/stream-processor.ts
+++ b/packages/shell-api/src/stream-processor.ts
@@ -62,6 +62,7 @@ export default class StreamProcessor extends ShellApiWithMongoClass {
    * modify can be used like so:
    *  Change the pipeline:
    *    sp.name.modify(pipeline)
+   *  Change the pipeline with additional options:
    *    sp.name.modify(pipeline, {resumeFromCheckpoint: false})
    *  For modify requests that don't change the pipeline:
    *    sp.name.modify({resumeFromCheckpoint: false})

--- a/packages/shell-api/src/stream-processor.ts
+++ b/packages/shell-api/src/stream-processor.ts
@@ -64,24 +64,21 @@ export default class StreamProcessor extends ShellApiWithMongoClass {
    *    sp.name.modify(newPipeline)
    *  Keep the same pipeline, change other options:
    *   sp.name.modify({resumeFromCheckpoint: false})
+   *  Change the pipeline and set additional options:
+   *    sp.name.modify(newPipeline, {resumeFromCheckpoint: false})
    */
   async modify(options: Document): Promise<Document>;
   async modify(pipeline: Document[], options?: Document): Promise<Document>;
 
-  /**
-   * modify is used to modify a stream processor definition, like below:
-   *  Change the pipeline and set additional options:
-   *    sp.name.modify(newPipeline, {resumeFromCheckpoint: false})
-   */
   @returnsPromise
   async modify(
     pipelineOrOptions: Document[] | Document,
-    options: Document = {}
+    options?: Document
   ): Promise<Document> {
     if (Array.isArray(pipelineOrOptions)) {
       options = { ...options, pipeline: pipelineOrOptions };
     } else if (typeof pipelineOrOptions === 'object') {
-      if (Object.keys(options).length !== 0) {
+      if (options) {
         throw new MongoshInvalidInputError(
           'If the first argument to modify is an object, the second argument should not be specified.',
           CommonErrors.InvalidArgument

--- a/packages/shell-api/src/stream-processor.ts
+++ b/packages/shell-api/src/stream-processor.ts
@@ -1,4 +1,5 @@
 import type { Document } from '@mongosh/service-provider-core';
+import { CommonErrors, MongoshInvalidInputError } from '@mongosh/errors';
 
 import type Mongo from './mongo';
 import { asPrintable } from './enums';
@@ -54,6 +55,31 @@ export default class StreamProcessor extends ShellApiWithMongoClass {
     return this._streams._runStreamCommand({
       getStreamProcessorStats: this.name,
       ...options,
+    });
+  }
+
+  /**
+   * modify can be used like so:
+   *  sp.name.modify(pipeline)
+   *  sp.name.modify(pipeline, {resumeFromCheckpoint: false})
+   *  sp.name.modify({resumeFromCheckpoint: false})
+   */
+  @returnsPromise
+  async modify(pipelineOrOptions: Document[] | Document, options: Document = {}) {
+    if (Array.isArray(pipelineOrOptions)) {
+      options["pipeline"] = pipelineOrOptions;
+    } else if (typeof pipelineOrOptions == "object") {
+      options = {...options, ...pipelineOrOptions};
+    } else {
+        throw new MongoshInvalidInputError(
+          "The first argument to modify must be an array or object.",
+          CommonErrors.InvalidArgument
+        );
+    }
+
+    return this._streams._runStreamCommand({
+      modifyStreamProcessor: this.name,
+      ...options
     });
   }
 

--- a/packages/shell-api/src/stream-processor.ts
+++ b/packages/shell-api/src/stream-processor.ts
@@ -60,26 +60,31 @@ export default class StreamProcessor extends ShellApiWithMongoClass {
 
   /**
    * modify can be used like so:
-   *  sp.name.modify(pipeline)
-   *  sp.name.modify(pipeline, {resumeFromCheckpoint: false})
-   *  sp.name.modify({resumeFromCheckpoint: false})
+   *  Change the pipeline:
+   *    sp.name.modify(pipeline)
+   *    sp.name.modify(pipeline, {resumeFromCheckpoint: false})
+   *  For modify requests that don't change the pipeline:
+   *    sp.name.modify({resumeFromCheckpoint: false})
    */
   @returnsPromise
-  async modify(pipelineOrOptions: Document[] | Document, options: Document = {}) {
+  async modify(
+    pipelineOrOptions: Document[] | Document,
+    options: Document = {}
+  ) {
     if (Array.isArray(pipelineOrOptions)) {
-      options["pipeline"] = pipelineOrOptions;
-    } else if (typeof pipelineOrOptions == "object") {
-      options = {...options, ...pipelineOrOptions};
+      options['pipeline'] = pipelineOrOptions;
+    } else if (typeof pipelineOrOptions == 'object') {
+      options = { ...options, ...pipelineOrOptions };
     } else {
-        throw new MongoshInvalidInputError(
-          "The first argument to modify must be an array or object.",
-          CommonErrors.InvalidArgument
-        );
+      throw new MongoshInvalidInputError(
+        'The first argument to modify must be an array or object.',
+        CommonErrors.InvalidArgument
+      );
     }
 
     return this._streams._runStreamCommand({
       modifyStreamProcessor: this.name,
-      ...options
+      ...options,
     });
   }
 

--- a/packages/shell-api/src/stream-processor.ts
+++ b/packages/shell-api/src/stream-processor.ts
@@ -65,7 +65,8 @@ export default class StreamProcessor extends ShellApiWithMongoClass {
    *  Keep the same pipeline, change other options:
    *   sp.name.modify({resumeFromCheckpoint: false})
    */
-  async modify(pipelineOrOptions: Document[] | Document): Promise<Document>;
+  async modify(options: Document): Promise<Document>;
+  async modify(pipeline: Document[], options?: Document): Promise<Document>;
 
   /**
    * modify is used to modify a stream processor definition, like below:

--- a/packages/shell-api/src/stream-processor.ts
+++ b/packages/shell-api/src/stream-processor.ts
@@ -59,21 +59,26 @@ export default class StreamProcessor extends ShellApiWithMongoClass {
   }
 
   /**
-   * modify can be used like so:
+   * modify is used to modify a stream processor definition, like below:
    *  Change the pipeline:
-   *    sp.name.modify(pipeline)
-   *  Change the pipeline with additional options:
-   *    sp.name.modify(pipeline, {resumeFromCheckpoint: false})
-   *  For modify requests that don't change the pipeline:
-   *    sp.name.modify({resumeFromCheckpoint: false})
+   *    sp.name.modify(newPipeline)
+   *  Keep the same pipeline, change other options:
+   *   sp.name.modify({resumeFromCheckpoint: false})
+   */
+  async modify(pipelineOrOptions: Document[] | Document): Promise<Document>;
+
+  /**
+   * modify is used to modify a stream processor definition, like below:
+   *  Change the pipeline and set additional options:
+   *    sp.name.modify(newPipeline, {resumeFromCheckpoint: false})
    */
   @returnsPromise
   async modify(
     pipelineOrOptions: Document[] | Document,
     options: Document = {}
-  ) {
+  ): Promise<Document> {
     if (Array.isArray(pipelineOrOptions)) {
-      options['pipeline'] = pipelineOrOptions;
+      options = { ...options, pipeline: pipelineOrOptions };
     } else if (typeof pipelineOrOptions === 'object') {
       if (Object.keys(options).length !== 0) {
         throw new MongoshInvalidInputError(

--- a/packages/shell-api/src/stream-processor.ts
+++ b/packages/shell-api/src/stream-processor.ts
@@ -73,7 +73,7 @@ export default class StreamProcessor extends ShellApiWithMongoClass {
   ) {
     if (Array.isArray(pipelineOrOptions)) {
       options['pipeline'] = pipelineOrOptions;
-    } else if (typeof pipelineOrOptions == 'object') {
+    } else if (typeof pipelineOrOptions === 'object') {
       options = { ...options, ...pipelineOrOptions };
     } else {
       throw new MongoshInvalidInputError(

--- a/packages/shell-api/src/stream-processor.ts
+++ b/packages/shell-api/src/stream-processor.ts
@@ -75,7 +75,13 @@ export default class StreamProcessor extends ShellApiWithMongoClass {
     if (Array.isArray(pipelineOrOptions)) {
       options['pipeline'] = pipelineOrOptions;
     } else if (typeof pipelineOrOptions === 'object') {
-      options = { ...options, ...pipelineOrOptions };
+      if (Object.keys(options).length != 0) {
+        throw new MongoshInvalidInputError(
+          'If the first argument to modify is an object, the second argument should not be specified.',
+          CommonErrors.InvalidArgument
+        );
+      }
+      options = { ...pipelineOrOptions };
     } else {
       throw new MongoshInvalidInputError(
         'The first argument to modify must be an array or object.',

--- a/packages/shell-api/src/streams.spec.ts
+++ b/packages/shell-api/src/streams.spec.ts
@@ -162,4 +162,97 @@ describe('Streams', function () {
       ).to.be.true;
     });
   });
+
+  describe('modify', function () {
+    it('throws with invalid parameters', async function () {
+      // Create the stream processor.
+      const runCmdStub = sinon
+        .stub(mongo._serviceProvider, 'runCommand')
+        .resolves({ ok: 1 });
+      const name = 'p1';
+      const pipeline = [{ $match: { foo: 'bar' } }];
+      const processor = await streams.createStreamProcessor(name, pipeline);
+      expect(processor).to.eql(streams.getProcessor(name));
+      const cmd = { createStreamProcessor: name, pipeline };
+      expect(runCmdStub.calledOnceWithExactly('admin', cmd, {})).to.be.true;
+
+      // No arguments to modify.
+      const caught = await processor.modify().catch((e: any) => e);
+      expect(caught.message).to.contain(
+        '[COMMON-10001] The first argument to modify must be an array or object.'
+      );
+
+      // A single numeric argument to modify.
+      const caught2 = await processor.modify(1).catch((e: any) => e);
+      expect(caught2.message).to.contain(
+        '[COMMON-10001] The first argument to modify must be an array or object.'
+      );
+    });
+
+    it('works with pipeline and options arguments', async function () {
+      const runCmdStub = sinon
+        .stub(mongo._serviceProvider, 'runCommand')
+        .resolves({ ok: 1 });
+
+      // Create the stream processor.
+      const name = 'p1';
+      const pipeline = [{ $match: { foo: 'bar' } }];
+      const processor = await streams.createStreamProcessor(name, pipeline);
+      expect(processor).to.eql(streams.getProcessor(name));
+      const cmd = { createStreamProcessor: name, pipeline };
+      expect(runCmdStub.calledOnceWithExactly('admin', cmd, {})).to.be.true;
+
+      // Start the stream processor.
+      await processor.start();
+      expect(
+        runCmdStub.calledWithExactly(
+          'admin',
+          { startStreamProcessor: name },
+          {}
+        )
+      ).to.be.true;
+
+      // Stop the stream processor.
+      await processor.stop();
+      expect(
+        runCmdStub.calledWithExactly('admin', { stopStreamProcessor: name }, {})
+      ).to.be.true;
+
+      // Modify the stream processor.
+      const pipeline2 = [{ $match: { foo: 'baz' } }];
+      processor.modify(pipeline2);
+      expect(
+        runCmdStub.calledWithExactly(
+          'admin',
+          { modifyStreamProcessor: name, pipeline: pipeline2 },
+          {}
+        )
+      ).to.be.true;
+
+      // Modify the stream processor with extra options.
+      const pipeline3 = [{ $match: { foo: 'bat' } }];
+      processor.modify(pipeline3, { resumeFromCheckpoint: false });
+      expect(
+        runCmdStub.calledWithExactly(
+          'admin',
+          {
+            modifyStreamProcessor: name,
+            pipeline: pipeline3,
+            resumeFromCheckpoint: false,
+          },
+          {}
+        )
+      ).to.be.true;
+
+      // Modify the stream processor without changing pipeline.
+      processor.modify({ resumeFromCheckpoint: false });
+      expect(
+        runCmdStub.calledWithExactly(
+          'admin',
+          { modifyStreamProcessor: name, resumeFromCheckpoint: false },
+          {}
+        )
+      ).to.be.true;
+    });
+  });
 });

--- a/packages/shell-api/src/streams.spec.ts
+++ b/packages/shell-api/src/streams.spec.ts
@@ -192,6 +192,17 @@ describe('Streams', function () {
       expect(caught2.message).to.contain(
         '[COMMON-10001] The first argument to modify must be an array or object.'
       );
+
+      // Two object arguments to modify.
+      const caught3 = await processor
+        .modify(
+          { resumeFromCheckpoint: false },
+          { dlq: { connectionName: 'foo' } }
+        )
+        .catch((e: MongoshInvalidInputError) => e);
+      expect(caught3.message).to.contain(
+        '[COMMON-10001] If the first argument to modify is an object, the second argument should not be specified.'
+      );
     });
 
     it('works with pipeline and options arguments', async function () {

--- a/packages/shell-api/src/streams.spec.ts
+++ b/packages/shell-api/src/streams.spec.ts
@@ -5,6 +5,7 @@ import type Mongo from './mongo';
 import Database from './database';
 import { Streams } from './streams';
 import { InterruptFlag, MongoshInterruptedError } from './interruptor';
+import { MongoshInvalidInputError } from '@mongosh/errors';
 
 describe('Streams', function () {
   let mongo: Mongo;
@@ -177,13 +178,17 @@ describe('Streams', function () {
       expect(runCmdStub.calledOnceWithExactly('admin', cmd, {})).to.be.true;
 
       // No arguments to modify.
-      const caught = await processor.modify().catch((e) => e);
+      const caught = await processor
+        .modify()
+        .catch((e: MongoshInvalidInputError) => e);
       expect(caught.message).to.contain(
         '[COMMON-10001] The first argument to modify must be an array or object.'
       );
 
       // A single numeric argument to modify.
-      const caught2 = await processor.modify(1).catch((e) => e);
+      const caught2 = await processor
+        .modify(1)
+        .catch((e: MongoshInvalidInputError) => e);
       expect(caught2.message).to.contain(
         '[COMMON-10001] The first argument to modify must be an array or object.'
       );

--- a/packages/shell-api/src/streams.spec.ts
+++ b/packages/shell-api/src/streams.spec.ts
@@ -5,7 +5,7 @@ import type Mongo from './mongo';
 import Database from './database';
 import { Streams } from './streams';
 import { InterruptFlag, MongoshInterruptedError } from './interruptor';
-import { MongoshInvalidInputError } from '@mongosh/errors';
+import type { MongoshInvalidInputError } from '@mongosh/errors';
 
 describe('Streams', function () {
   let mongo: Mongo;

--- a/packages/shell-api/src/streams.spec.ts
+++ b/packages/shell-api/src/streams.spec.ts
@@ -177,13 +177,13 @@ describe('Streams', function () {
       expect(runCmdStub.calledOnceWithExactly('admin', cmd, {})).to.be.true;
 
       // No arguments to modify.
-      const caught = await processor.modify().catch((e: any) => e);
+      const caught = await processor.modify().catch((e) => e);
       expect(caught.message).to.contain(
         '[COMMON-10001] The first argument to modify must be an array or object.'
       );
 
       // A single numeric argument to modify.
-      const caught2 = await processor.modify(1).catch((e: any) => e);
+      const caught2 = await processor.modify(1).catch((e) => e);
       expect(caught2.message).to.contain(
         '[COMMON-10001] The first argument to modify must be an array or object.'
       );


### PR DESCRIPTION
This PR adds a stream processor `modify` method. It can be used to modify the definition of a stream processor.