### PR TITLE
chore(connectivity-tests): use HTTPS clone instead of SSH clone MONGOSH-1900

### DIFF
--- a/packages/connectivity-tests/test/all.sh
+++ b/packages/connectivity-tests/test/all.sh
@@ -17,7 +17,7 @@ else
   export MONGOSH="${MONGOSH_ROOT_DIR}/${TEST_MONGOSH_EXECUTABLE}"
 fi
 
-git clone git@github.com:mongodb-js/devtools-docker-test-envs.git test-envs
+git clone https://github.com/mongodb-js/devtools-docker-test-envs.git test-envs
 cd test-envs
 
 git checkout ca4bacd23e6f7ea07618c303b20556e3e4c9c2e6


### PR DESCRIPTION

Usage of SSH cloning is being removed from Evergreen, so we should update this call site to use HTTPS instead.