### PR TITLE
chore(ci): set `MACOSX_DEPLOYMENT_TARGET`

### DIFF
--- a/.evergreen/compile-artifact.sh
+++ b/.evergreen/compile-artifact.sh
@@ -26,6 +26,7 @@ if [ `uname` = Darwin ]; then
   # match what Node.js 20 does on their own builder machines
   export CFLAGS='-mmacosx-version-min=10.15'
   export CXXFLAGS='-mmacosx-version-min=10.15'
+  export MACOSX_DEPLOYMENT_TARGET=10.15
 fi
 
 # The CI machines we have for Windows and x64 macOS are not


### PR DESCRIPTION
No change in semantics, but the environment variable is generally replacing the `-mmacosx-version-min` compiler flag, so let's specify both.

(We could raise the minimum as well at some point, but unless there's an actual reason to do so other than "we can" I'd just leave it as-is.)