### PR TITLE
fix: include nonce in oidc request by default MONGOSH-1905

### DIFF
--- a/.github/workflows/cron-tasks.yml
+++ b/.github/workflows/cron-tasks.yml
@@ -13,24 +13,24 @@ jobs:
     name: Update automatically generated files
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           # don't checkout a detatched HEAD
           ref: ${{ github.head_ref }}
 
           # this is important so git log can pick up on
           # the whole history to generate the list of AUTHORS
-          fetch-depth: '0'
+          fetch-depth: "0"
 
       - name: Set up Git
         run: |
           git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git config --local user.name "github-actions[bot]"
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
           node-version: ^16.x
-          cache: 'npm'
+          cache: "npm"
 
       - name: Install npm@8
         run: |
@@ -50,7 +50,6 @@ jobs:
         run: |
           npm run update-authors
           git add AUTHORS \*/AUTHORS
-          git commit --no-allow-empty -m "chore: update AUTHORS" || true
 
       - name: Generate Error Documentation
         run: |
@@ -58,25 +57,21 @@ jobs:
           mv error-overview.md error-overview.rst packages/errors/generated/
           npm run reformat
           git add packages/errors/generated
-          git commit --no-allow-empty -m "chore: update error documentation" || true
 
       - name: Regenerate Evergreen Config
         run: |
           npm run update-evergreen-config
           git add .evergreen.yml
-          git commit --no-allow-empty -m "chore: update evergreen config" || true
 
       - name: Update Security Test Summary
         run: |
           npm run update-security-test-summary
           git add docs/security-test-summary.md
-          git commit --no-allow-empty -m "chore: update security test summary" || true
 
       - name: Regenerate CLI usage text in README files
         run: |
           npm run update-cli-usage-text packages/*/*.md *.md
           git add packages/*/*.md *.md
-          git commit --no-allow-empty -m "chore: update CLI usage text" || true
 
       - name: Create pull request
         id: cpr
@@ -84,7 +79,7 @@ jobs:
         with:
           commit-message: Update auto-generated files
           branch: ci/cron-tasks-update-files
-          title: 'chore: update auto-generated files'
+          title: "chore: update auto-generated files"
           body: |
             - Update auto-generated files
 

--- a/README.md
+++ b/README.md
@@ -90,6 +90,7 @@ variable. For detailed instructions for each of our supported platforms, please 
         --oidcTrustedEndpoint                  Treat the cluster/database mongosh as a trusted endpoint
         --oidcIdTokenAsAccessToken             Use ID tokens in place of access tokens for auth
         --oidcDumpTokens[=mode]                Debug OIDC by printing tokens to mongosh's output [full|include-secrets]
+        --oidcNoNonce                          Don't send a nonce argument in the OIDC auth request
 
   DB Address Examples:
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5978,7 +5978,9 @@
       }
     },
     "node_modules/@mongodb-js/oidc-plugin": {
-      "version": "1.1.1",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/oidc-plugin/-/oidc-plugin-1.1.2.tgz",
+      "integrity": "sha512-lMSOUX28ranfDt/a9WKZJcGEmUgSZ6F8KvSyGSKkzWPLRucb05slQmFN4lA5RR2fQIPrTLNPCdV39qAU2RLUSQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "express": "^4.18.2",
@@ -29685,7 +29687,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@mongodb-js/devtools-connect": "^3.3.3",
-        "@mongodb-js/oidc-plugin": "^1.1.1",
+        "@mongodb-js/oidc-plugin": "^1.1.2",
         "@mongosh/errors": "0.0.0-dev.0",
         "@mongosh/service-provider-core": "0.0.0-dev.0",
         "@mongosh/types": "0.0.0-dev.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5928,55 +5928,6 @@
       "version": "1.1.3",
       "license": "Apache-2.0"
     },
-    "node_modules/@mongodb-js/oidc-mock-provider": {
-      "version": "0.10.0",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "yargs": "17.7.2"
-      },
-      "bin": {
-        "oidc-mock-provider": "bin/oidc-mock-provider.js"
-      }
-    },
-    "node_modules/@mongodb-js/oidc-mock-provider/node_modules/cliui": {
-      "version": "8.0.1",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@mongodb-js/oidc-mock-provider/node_modules/yargs": {
-      "version": "17.7.2",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/@mongodb-js/oidc-mock-provider/node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "dev": true,
-      "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
     "node_modules/@mongodb-js/oidc-plugin": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/@mongodb-js/oidc-plugin/-/oidc-plugin-1.1.2.tgz",
@@ -29373,7 +29324,7 @@
       },
       "devDependencies": {
         "@mongodb-js/eslint-config-mongosh": "^1.0.0",
-        "@mongodb-js/oidc-mock-provider": "^0.10.0",
+        "@mongodb-js/oidc-mock-provider": "^0.10.2",
         "@mongodb-js/prettier-config-devtools": "^1.0.1",
         "@mongodb-js/tsconfig-mongosh": "^1.0.0",
         "@types/chai-as-promised": "^7.1.3",
@@ -29392,6 +29343,34 @@
       },
       "engines": {
         "node": ">=16.15.0"
+      }
+    },
+    "packages/e2e-tests/node_modules/@mongodb-js/oidc-mock-provider": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/oidc-mock-provider/-/oidc-mock-provider-0.10.2.tgz",
+      "integrity": "sha512-mH9tpgqYvF2ZRBbFKta+ziN48V+t/+NPLQoe7nZ8bYbWsGfXY79QKMIElaXlU8HnemnqUbOqBSYuizgs62OxfQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "yargs": "17.7.2"
+      },
+      "bin": {
+        "oidc-mock-provider": "bin/oidc-mock-provider.js"
+      }
+    },
+    "packages/e2e-tests/node_modules/cliui": {
+      "version": "8.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "string-width": "^4.2.0",
+        "strip-ansi": "^6.0.1",
+        "wrap-ansi": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=12"
       }
     },
     "packages/e2e-tests/node_modules/data-uri-to-buffer": {
@@ -29417,6 +29396,35 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "packages/e2e-tests/node_modules/yargs": {
+      "version": "17.7.2",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
+      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cliui": "^8.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "require-directory": "^2.1.1",
+        "string-width": "^4.2.3",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^21.1.1"
+      },
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "packages/e2e-tests/node_modules/yargs-parser": {
+      "version": "21.1.1",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+      "dev": true,
+      "license": "ISC",
+      "engines": {
+        "node": ">=12"
       }
     },
     "packages/editor": {

--- a/packages/arg-parser/src/arg-mapper.spec.ts
+++ b/packages/arg-parser/src/arg-mapper.spec.ts
@@ -450,6 +450,22 @@ describe('arg-mapper.mapCliToDriver', function () {
     });
   });
 
+  context('when cli args have oidcNoNonce', function () {
+    const cliOptions: CliOptions = {
+      oidcNoNonce: true,
+    };
+
+    it('maps to oidc skipNonceInAuthCodeRequest', function () {
+      expect(optionsTest(cliOptions)).to.deep.equal({
+        driver: {
+          oidc: {
+            skipNonceInAuthCodeRequest: true,
+          },
+        },
+      });
+    });
+  });
+
   context('when cli args have browser', function () {
     it('maps to oidc command', function () {
       expect(optionsTest({ browser: '/usr/bin/browser' })).to.deep.equal({

--- a/packages/arg-parser/src/arg-mapper.ts
+++ b/packages/arg-parser/src/arg-mapper.ts
@@ -29,7 +29,7 @@ function setServerApi<Key extends keyof ServerApi>(
   const serverApi =
     typeof previousServerApi === 'string'
       ? { version: previousServerApi }
-      : { ...previousServerApi } ?? {};
+      : { ...previousServerApi };
   serverApi[key] = value;
   return setDriver(i, 'serverApi', serverApi as Required<ServerApi>);
 }
@@ -237,6 +237,7 @@ const MAPPINGS: {
       v.split(',').filter(Boolean) as OIDCOptions['allowedFlows']
     ),
   oidcIdTokenAsAccessToken: (i, v) => setOIDC(i, 'passIdTokenAsAccessToken', v),
+  oidcNoNonce: (i, v) => setOIDC(i, 'skipNonceInAuthCodeRequest', v),
   browser: (i, v) =>
     setOIDC(i, 'openBrowser', typeof v === 'string' ? { command: v } : v),
 };

--- a/packages/arg-parser/src/cli-options.ts
+++ b/packages/arg-parser/src/cli-options.ts
@@ -56,5 +56,6 @@ export interface CliOptions {
   oidcTrustedEndpoint?: boolean;
   oidcIdTokenAsAccessToken?: boolean;
   oidcDumpTokens?: boolean | 'redacted' | 'include-secrets';
+  oidcNoNonce?: boolean;
   browser?: string | false;
 }

--- a/packages/cli-repl/README.md
+++ b/packages/cli-repl/README.md
@@ -75,6 +75,7 @@ of mongosh, visit https://www.mongodb.com/try/download/shell.
         --oidcTrustedEndpoint                  Treat the cluster/database mongosh as a trusted endpoint
         --oidcIdTokenAsAccessToken             Use ID tokens in place of access tokens for auth
         --oidcDumpTokens[=mode]                Debug OIDC by printing tokens to mongosh's output [full|include-secrets]
+        --oidcNoNonce                          Don't send a nonce argument in the OIDC auth request
 
   DB Address Examples:
 

--- a/packages/cli-repl/src/arg-parser.ts
+++ b/packages/cli-repl/src/arg-parser.ts
@@ -65,6 +65,7 @@ const OPTIONS = {
     'norc',
     'oidcTrustedEndpoint',
     'oidcIdTokenAsAccessToken',
+    'oidcNoNonce',
     'perfTests',
     'quiet',
     'retryWrites',

--- a/packages/cli-repl/src/constants.ts
+++ b/packages/cli-repl/src/constants.ts
@@ -152,6 +152,9 @@ export const USAGE = `
         --oidcDumpTokens[=mode]                ${i18n.__(
           'cli-repl.args.oidcDumpTokens'
         )}
+        --oidcNoNonce                          ${i18n.__(
+          'cli-repl.args.oidcNoNonce'
+        )}
 
   ${clr(i18n.__('cli-repl.args.dbAddressOptions'), 'mongosh:section-header')}
 

--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -33,7 +33,7 @@
   },
   "devDependencies": {
     "@mongodb-js/eslint-config-mongosh": "^1.0.0",
-    "@mongodb-js/oidc-mock-provider": "^0.10.0",
+    "@mongodb-js/oidc-mock-provider": "^0.10.2",
     "@mongodb-js/prettier-config-devtools": "^1.0.1",
     "@mongodb-js/tsconfig-mongosh": "^1.0.0",
     "@types/chai-as-promised": "^7.1.3",

--- a/packages/e2e-tests/test/e2e-oidc.spec.ts
+++ b/packages/e2e-tests/test/e2e-oidc.spec.ts
@@ -180,20 +180,30 @@ describe('OIDC auth e2e', function () {
     );
   }
 
-  it('can successfully authenticate using OIDC Auth Code Flow', async function () {
-    shell = this.startTestShell({
-      args: [
-        await testServer.connectionString(),
-        '--authenticationMechanism=MONGODB-OIDC',
-        '--oidcRedirectUri=http://localhost:0/',
-        `--browser=${fetchBrowserFixture}`,
-      ],
-    });
-    await shell.waitForPrompt();
+  for (const useNonce of [true, false]) {
+    describe(`with nonce=${useNonce}`, function () {
+      it('can successfully authenticate using OIDC Auth Code Flow', async function () {
+        const args = [
+          await testServer.connectionString(),
+          '--authenticationMechanism=MONGODB-OIDC',
+          '--oidcRedirectUri=http://localhost:0/',
+          `--browser=${fetchBrowserFixture}`,
+        ];
 
-    await verifyUser(shell, 'testuser', 'testServer-group');
-    shell.assertNoErrors();
-  });
+        if (!useNonce) {
+          args.push('--oidcNoNonce');
+        }
+
+        shell = this.startTestShell({
+          args,
+        });
+        await shell.waitForPrompt();
+
+        await verifyUser(shell, 'testuser', 'testServer-group');
+        shell.assertNoErrors();
+      });
+    });
+  }
 
   it('can successfully authenticate using OIDC Auth Code Flow when a username is specified', async function () {
     shell = this.startTestShell({

--- a/packages/i18n/src/locales/en_US.ts
+++ b/packages/i18n/src/locales/en_US.ts
@@ -92,6 +92,7 @@ const translations: Catalog = {
         'Use ID tokens in place of access tokens for auth',
       oidcDumpTokens:
         "Debug OIDC by printing tokens to mongosh's output [full|include-secrets]",
+      oidcNoNonce: "Don't send a nonce argument in the OIDC auth request",
     },
     'arg-parser': {
       'unknown-option': 'Error parsing command line: unrecognized option:',

--- a/packages/mongosh/README.md
+++ b/packages/mongosh/README.md
@@ -79,6 +79,7 @@ of mongosh, visit https://www.mongodb.com/try/download/shell.
         --oidcTrustedEndpoint                  Treat the cluster/database mongosh as a trusted endpoint
         --oidcIdTokenAsAccessToken             Use ID tokens in place of access tokens for auth
         --oidcDumpTokens[=mode]                Debug OIDC by printing tokens to mongosh's output [full|include-secrets]
+        --oidcNoNonce                          Don't send a nonce argument in the OIDC auth request
 
   DB Address Examples:
 

--- a/packages/service-provider-node-driver/package.json
+++ b/packages/service-provider-node-driver/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@mongodb-js/devtools-connect": "^3.3.3",
-    "@mongodb-js/oidc-plugin": "^1.1.1",
+    "@mongodb-js/oidc-plugin": "^1.1.2",
     "@mongosh/errors": "0.0.0-dev.0",
     "@mongosh/service-provider-core": "0.0.0-dev.0",
     "@mongosh/types": "0.0.0-dev.0",


### PR DESCRIPTION
Pulls in latest `oidc-plugin` and adds an `--oidcNoNonce` argument to the cli that allows users to return to the old behavior in case their auth provider doesn't handle requests with a nonce.