### PR TITLE
feat(shell-api): add options in stream processor start, stop, and drop MONGOSH-1920

### DIFF
--- a/packages/shell-api/src/stream-processor.ts
+++ b/packages/shell-api/src/stream-processor.ts
@@ -26,27 +26,30 @@ export default class StreamProcessor extends ShellApiWithMongoClass {
   }
 
   @returnsPromise
-  async start() {
+  async start(options: Document = {}) {
     return await this._streams._runStreamCommand({
       startStreamProcessor: this.name,
+      ...options,
     });
   }
 
   @returnsPromise
-  async stop() {
+  async stop(options: Document = {}) {
     return await this._streams._runStreamCommand({
       stopStreamProcessor: this.name,
+      ...options,
     });
   }
 
   @returnsPromise
-  async drop() {
-    return this._drop();
+  async drop(options: Document = {}) {
+    return this._drop(options);
   }
 
-  async _drop() {
+  async _drop(options: Document = {}) {
     return await this._streams._runStreamCommand({
       dropStreamProcessor: this.name,
+      ...options,
     });
   }
 

--- a/packages/shell-api/src/streams.spec.ts
+++ b/packages/shell-api/src/streams.spec.ts
@@ -7,7 +7,7 @@ import { Streams } from './streams';
 import { InterruptFlag, MongoshInterruptedError } from './interruptor';
 import type { MongoshInvalidInputError } from '@mongosh/errors';
 
-describe.only('Streams', function () {
+describe('Streams', function () {
   let mongo: Mongo;
   let streams: Streams;
   const identity = (a: unknown) => a;


### PR DESCRIPTION
* Add an options parameter to the stream processor start, stop, and drop methods. We already do this for sample and stats methods.
* This allows Atlas Stream Processing to support features like STREAMS-872.