### PR TITLE
chore: push auto-generated files directly instead of using PRs

### DIFF
--- a/.github/workflows/cron-tasks.yml
+++ b/.github/workflows/cron-tasks.yml
@@ -21,6 +21,7 @@ jobs:
           # this is important so git log can pick up on
           # the whole history to generate the list of AUTHORS
           fetch-depth: "0"
+          token: ${{ secrets.SVC_DEVTOOLSBOT_TOKEN }}
 
       - name: Set up Git
         run: |

--- a/.github/workflows/cron-tasks.yml
+++ b/.github/workflows/cron-tasks.yml
@@ -24,8 +24,8 @@ jobs:
 
       - name: Set up Git
         run: |
-          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
+          git config --local user.email "devtoolsbot@users.noreply.github.com"
+          git config --local user.name "devtoolsbot"
 
       - uses: actions/setup-node@v4
         with:
@@ -44,7 +44,7 @@ jobs:
       - name: Update THIRD_PARTY_NOTICES.md
         run: |
           npm run update-third-party-notices
-          git commit --no-allow-empty -m "chore: update THIRD_PARTY_NOTICES" THIRD_PARTY_NOTICES.md || true
+          git add THIRD_PARTY_NOTICES.md
 
       - name: Update AUTHORS
         run: |
@@ -73,20 +73,7 @@ jobs:
           npm run update-cli-usage-text packages/*/*.md *.md
           git add packages/*/*.md *.md
 
-      - name: Create pull request
-        id: cpr
-        uses: peter-evans/create-pull-request@v6
-        with:
-          commit-message: Update auto-generated files
-          branch: ci/cron-tasks-update-files
-          title: "chore: update auto-generated files"
-          body: |
-            - Update auto-generated files
-
-      - name: Merge PR
-        env:
-          PULL_REQUEST_NUMBER: ${{steps.cpr.outputs.pull-request-number}}
-          # NOTE: we don't use a PAT so to not trigger further automation
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - name: Commit and push
         run: |
-          gh pr merge $PULL_REQUEST_NUMBER --squash --delete-branch
+          git commit -m "chore: update auto-generated files"
+          git push

--- a/.github/workflows/cron-tasks.yml
+++ b/.github/workflows/cron-tasks.yml
@@ -75,5 +75,5 @@ jobs:
 
       - name: Commit and push
         run: |
-          git commit -m "chore: update auto-generated files"
+          git commit --no-allow-empty -m "chore: update auto-generated files" || true
           git push

--- a/.github/workflows/update-node-js.yaml
+++ b/.github/workflows/update-node-js.yaml
@@ -19,7 +19,6 @@ jobs:
           # this is important so git log can pick up on
           # the whole history to generate the list of AUTHORS
           fetch-depth: "0"
-          token: ${{ secrets.SVC_DEVTOOLSBOT_TOKEN }}
 
       - name: Setup git
         run: |
@@ -39,15 +38,13 @@ jobs:
         run: |
           npm run update-node-js-versions
           npm run update-evergreen-config
-          git add .
-          git commit --no-allow-empty -m "chore: update node.js version" || true
 
       - name: Create Pull Request
         id: cpr
-        uses: peter-evans/create-pull-request@v6
+        uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # 7.0.5
         with:
-          token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: "chore: update node.js"
+          token: ${{ secrets.SVC_DEVTOOLSBOT_TOKEN }}
+          commit-message: "chore: update node.js version"
           branch: ci/update-node-js-versions
           title: "chore: update node.js"
           body: |

--- a/.github/workflows/update-node-js.yaml
+++ b/.github/workflows/update-node-js.yaml
@@ -18,7 +18,8 @@ jobs:
 
           # this is important so git log can pick up on
           # the whole history to generate the list of AUTHORS
-          fetch-depth: '0'
+          fetch-depth: "0"
+          token: ${{ secrets.SVC_DEVTOOLSBOT_TOKEN }}
 
       - name: Setup git
         run: |
@@ -28,7 +29,7 @@ jobs:
       - uses: actions/setup-node@v2
         with:
           node-version: 16.x
-          cache: 'npm'
+          cache: "npm"
 
       - name: Install npm@8.19.4
         run: |
@@ -46,8 +47,8 @@ jobs:
         uses: peter-evans/create-pull-request@v6
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          commit-message: 'chore: update node.js'
+          commit-message: "chore: update node.js"
           branch: ci/update-node-js-versions
-          title: 'chore: update node.js'
+          title: "chore: update node.js"
           body: |
             - Update node.js


### PR DESCRIPTION
Changes the workflow to update auto-generated files to directly push to main. This should eliminate the extra PR we open after every merge. The devtoolsbot user has been exempted from the PR requirement, so should be able to push directly to main. While this is not ideal, it's not less secure than what we previously had where the github actions bot would open a PR and then immediately merge it with no checks/approvals required.

If this works well, I'll copy it over to the other repos we manage.