### PR TITLE
chore(ci): don't download chrome for cron tasks

### DIFF
--- a/.github/workflows/cron-tasks.yml
+++ b/.github/workflows/cron-tasks.yml
@@ -12,6 +12,10 @@ jobs:
   update_generated_files:
     name: Update automatically generated files
     runs-on: ubuntu-latest
+    env:
+      npm_config_loglevel: verbose
+      npm_config_foreground_scripts: "true"
+      PUPPETEER_SKIP_DOWNLOAD: "true"
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/update-node-js.yaml
+++ b/.github/workflows/update-node-js.yaml
@@ -11,7 +11,7 @@ jobs:
     name: Update Node.js versions
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           # don't checkout a detatched HEAD
           ref: ${{ github.head_ref }}
@@ -22,17 +22,17 @@ jobs:
 
       - name: Setup git
         run: |
-          git config --local user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git config --local user.name "github-actions[bot]"
+          git config --local user.email "devtoolsbot@users.noreply.github.com"
+          git config --local user.name "devtoolsbot"
 
-      - uses: actions/setup-node@v2
+      - uses: actions/setup-node@v4
         with:
-          node-version: 16.x
+          node-version: 20.x
           cache: "npm"
 
-      - name: Install npm@8.19.4
+      - name: Install npm@10
         run: |
-          npm install -g npm@8.19.4
+          npm install -g npm@10
 
       - name: Bump packages
         run: |
@@ -40,7 +40,6 @@ jobs:
           npm run update-evergreen-config
 
       - name: Create Pull Request
-        id: cpr
         uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # 7.0.5
         with:
           token: ${{ secrets.SVC_DEVTOOLSBOT_TOKEN }}

--- a/package-lock.json
+++ b/package-lock.json
@@ -13384,8 +13384,9 @@
       }
     },
     "node_modules/data-uri-to-buffer": {
-      "version": "5.0.1",
-      "license": "MIT",
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-6.0.2.tgz",
+      "integrity": "sha512-7hvf7/GW8e86rW0ptuwS3OcBGDjIi6SZva7hCyWC0yYry2cOPmLIjXAUHI6DK2HsnwJd9ifmt57i8eV2n4YNpw==",
       "engines": {
         "node": ">= 14"
       }
@@ -16147,7 +16148,6 @@
     "node_modules/fs-extra": {
       "version": "11.2.0",
       "license": "MIT",
-      "optional": true,
       "dependencies": {
         "graceful-fs": "^4.2.0",
         "jsonfile": "^6.0.1",
@@ -16354,42 +16354,17 @@
       }
     },
     "node_modules/get-uri": {
-      "version": "6.0.1",
-      "license": "MIT",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/get-uri/-/get-uri-6.0.3.tgz",
+      "integrity": "sha512-BzUrJBS9EcUb4cFol8r4W3v1cPsSyajLSthNkz5BxbpDcHN5tIrM10E2eNvfnvBn3DaT3DUgx0OpsBKkaOpanw==",
       "dependencies": {
         "basic-ftp": "^5.0.2",
-        "data-uri-to-buffer": "^5.0.1",
+        "data-uri-to-buffer": "^6.0.2",
         "debug": "^4.3.4",
-        "fs-extra": "^8.1.0"
+        "fs-extra": "^11.2.0"
       },
       "engines": {
         "node": ">= 14"
-      }
-    },
-    "node_modules/get-uri/node_modules/fs-extra": {
-      "version": "8.1.0",
-      "license": "MIT",
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^4.0.0",
-        "universalify": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=6 <7 || >=8"
-      }
-    },
-    "node_modules/get-uri/node_modules/jsonfile": {
-      "version": "4.0.0",
-      "license": "MIT",
-      "optionalDependencies": {
-        "graceful-fs": "^4.1.6"
-      }
-    },
-    "node_modules/get-uri/node_modules/universalify": {
-      "version": "0.1.2",
-      "license": "MIT",
-      "engines": {
-        "node": ">= 4.0.0"
       }
     },
     "node_modules/getpass": {
@@ -18657,7 +18632,6 @@
     },
     "node_modules/jsonfile": {
       "version": "6.1.0",
-      "devOptional": true,
       "license": "MIT",
       "dependencies": {
         "universalify": "^2.0.0"
@@ -27607,7 +27581,6 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/universalify/-/universalify-2.0.1.tgz",
       "integrity": "sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==",
-      "devOptional": true,
       "license": "MIT",
       "engines": {
         "node": ">= 10.0.0"


### PR DESCRIPTION
Realized the `npm ci` step was taking too long, so added the magic env variable. Additionally, does some minor clean up of the `update-node-js` workflow and bumps get-uri to 6.0.3 to remove some duplicated dependencies.