### PR TITLE
chore(ci): cleanup auto generated file workflow MONGOSH-1927

### DIFF
--- a/.github/workflows/cron-tasks.yml
+++ b/.github/workflows/cron-tasks.yml
@@ -39,7 +39,6 @@ jobs:
           # the whole history to generate the list of AUTHORS
           fetch-depth: "0"
           token: ${{ steps.app-token.outputs.token }}
-          persist-credentials: false
 
       - name: Set up Git
         run: |

--- a/.github/workflows/cron-tasks.yml
+++ b/.github/workflows/cron-tasks.yml
@@ -33,7 +33,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           # don't checkout a detatched HEAD
-          ref: ${{ github.head_ref }}
+          ref: main # TODO: change to {{ github.head_ref }}
 
           # this is important so git log can pick up on
           # the whole history to generate the list of AUTHORS

--- a/.github/workflows/cron-tasks.yml
+++ b/.github/workflows/cron-tasks.yml
@@ -7,7 +7,6 @@ on:
   push:
     branches:
       - main
-  workflow_dispatch: # This should be removed once the workflow is tested and working
 
 jobs:
   update_generated_files:
@@ -33,7 +32,7 @@ jobs:
       - uses: actions/checkout@v4
         with:
           # don't checkout a detatched HEAD
-          ref: main # TODO: change to {{ github.head_ref }}
+          ref: ${{ github.head_ref }}
 
           # this is important so git log can pick up on
           # the whole history to generate the list of AUTHORS
@@ -91,5 +90,5 @@ jobs:
 
       - name: Commit and push
         run: |
-          git commit --no-allow-empty -m "chore: update auto-generated files" || true
+          git commit --no-allow-empty -m "chore: update auto-generated files [skip actions]" || true
           git push


### PR DESCRIPTION
Follow up on https://github.com/mongodb-js/mongosh/pull/2280
- removes the `workflow_dispatch` trigger
- fixes the token persistence issue that would prevent the push from going through
- adds `[skip actions]` to the commit message to avoid running the workflow recursively