### PR TITLE
chore(e2e-tests): add workload OIDC test MONGOSH-1832

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29291,6 +29291,7 @@
       "version": "0.0.0-dev.0",
       "license": "Apache-2.0",
       "dependencies": {
+        "@mongodb-js/oidc-plugin": "^1.1.5",
         "@mongosh/cli-repl": "0.0.0-dev.0",
         "@mongosh/service-provider-core": "0.0.0-dev.0",
         "strip-ansi": "^6.0.0"

--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -29,6 +29,7 @@
   "dependencies": {
     "@mongosh/cli-repl": "0.0.0-dev.0",
     "@mongosh/service-provider-core": "0.0.0-dev.0",
+    "@mongodb-js/oidc-plugin": "^1.1.5",
     "strip-ansi": "^6.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Now that the driver has support for the Kubernetes OIDC workload integration, it's quite easy to add a test for OIDC workload usage with mongosh.