### PR TITLE
chore(e2e-tests): account for race condition in driver version log file test MONGOSH-1934

### DIFF
--- a/packages/e2e-tests/test/e2e.spec.ts
+++ b/packages/e2e-tests/test/e2e.spec.ts
@@ -1494,12 +1494,14 @@ describe('e2e', function () {
               `connect(${JSON.stringify(connectionString)})`
             )
           ).to.include('test');
-          const log = await readLogfile();
-          expect(
-            log.filter(
-              (logEntry) => typeof logEntry.attr?.driver?.version === 'string'
-            )
-          ).to.have.lengthOf(1);
+          await eventually(async () => {
+            const log = await readLogfile();
+            expect(
+              log.filter(
+                (logEntry) => typeof logEntry.attr?.driver?.version === 'string'
+              )
+            ).to.have.lengthOf(1);
+          });
         });
       });
 


### PR DESCRIPTION
This test has been particularly flaky on macOS, so let's do the same thing that the preceding test does and account for the fact that the log file might not be flushed immediately before the output of the command is printed.