### PR TITLE
chore(deps): update signing-utils to latest DEVPROD-13200

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6127,15 +6127,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/@mongodb-js/signing-utils": {
-      "version": "0.3.3",
-      "license": "SSPL",
-      "dependencies": {
-        "@types/ssh2": "^1.11.19",
-        "debug": "^4.3.4",
-        "ssh2": "^1.15.0"
-      }
-    },
     "node_modules/@mongodb-js/socksv5": {
       "version": "0.0.10",
       "license": "MIT",
@@ -29088,7 +29079,7 @@
         "@mongodb-js/devtools-github-repo": "^1.0.1",
         "@mongodb-js/dl-center": "^1.1.1",
         "@mongodb-js/mongodb-downloader": "^0.3.7",
-        "@mongodb-js/signing-utils": "^0.3.3",
+        "@mongodb-js/signing-utils": "^0.3.7",
         "@octokit/rest": "^17.9.0",
         "aws-sdk": "^2.674.0",
         "boxednode": "^2.4.3",
@@ -29127,6 +29118,17 @@
       },
       "engines": {
         "node": ">=14.15.1"
+      }
+    },
+    "packages/build/node_modules/@mongodb-js/signing-utils": {
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/signing-utils/-/signing-utils-0.3.7.tgz",
+      "integrity": "sha512-f3ZKCxVDkosfOETarmhuTYdOLQxKCinBtcoX5FjcKsYSNRhE+tth7Wy223lyn/hiA3S2MQ4mKTznliEAUj+Siw==",
+      "license": "SSPL",
+      "dependencies": {
+        "@types/ssh2": "^1.11.19",
+        "debug": "^4.3.4",
+        "ssh2": "^1.15.0"
       }
     },
     "packages/build/node_modules/@types/cross-spawn": {

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -63,7 +63,7 @@
     "@mongodb-js/devtools-github-repo": "^1.0.1",
     "@mongodb-js/dl-center": "^1.1.1",
     "@mongodb-js/mongodb-downloader": "^0.3.7",
-    "@mongodb-js/signing-utils": "^0.3.3",
+    "@mongodb-js/signing-utils": "^0.3.7",
     "@octokit/rest": "^17.9.0",
     "aws-sdk": "^2.674.0",
     "boxednode": "^2.4.3",


### PR DESCRIPTION
This commit updates the signing-utils package to the latest version because our Authenticode certificate has nearly expired and we need the latest package version in order to use the new one.