### PR TITLE
chore(ci): add an always failing test to check Foliage integration

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -8183,6 +8183,17 @@ tasks:
           mongosh_test_id: "types"
           mongosh_run_only_in_package: "types"
           task_name: ${task_name}
+  # TODO: This is an always failing test to check Foliage. Should be removed afterwards.
+  - name: test_always_failing
+    tags: ["assigned_to_jira_team_mongosh_mongosh", "unit-test"]
+    commands: 
+      - command: shell.exec
+        type: setup
+        params:
+          working_dir: src
+          shell: bash
+          script: |
+            node -e "throw new Error()"
 
   ###
   # INTEGRATION TESTS
@@ -15908,6 +15919,7 @@ buildvariants:
       - name: test_vscode
       - name: test_connectivity
       - name: test_apistrict
+      - name: test_always_failing
   - name: linux_coverage
     display_name: "Ubuntu 20.04 x64 (Coverage and Static Analysis Check)"
     run_on: ubuntu2004-small

--- a/.evergreen/evergreen.yml.in
+++ b/.evergreen/evergreen.yml.in
@@ -1147,7 +1147,7 @@ tasks:
   ###
   <% for (const { id, packageName } of ALL_UNIT_TESTS) { %>
   - name: test_<% out(id) %>
-    tags: <% out(["assigned_to_jira_team_mongosh_mongosh", "unit-test"]) %>
+    tags: ["assigned_to_jira_team_mongosh_mongosh","unit-test"]
     depends_on:
       - name: compile_ts
         variant: linux_compile
@@ -1165,6 +1165,17 @@ tasks:
           mongosh_run_only_in_package: "<% out(packageName) %>"
           task_name: ${task_name}
   <% } %>
+  # TODO: This is an always failing test to check Foliage. Should be removed afterwards.
+  - name: test_always_failing
+    tags: ["assigned_to_jira_team_mongosh_mongosh", "unit-test"]
+    commands: 
+      - command: shell.exec
+        type: setup
+        params:
+          working_dir: src
+          shell: bash
+          script: |
+            node -e "throw new Error()"
 
   ###
   # INTEGRATION TESTS
@@ -1597,6 +1608,7 @@ buildvariants:
       - name: test_vscode
       - name: test_connectivity
       - name: test_apistrict
+      - name: test_always_failing
   - name: linux_coverage
     display_name: "Ubuntu 20.04 x64 (Coverage and Static Analysis Check)"
     run_on: ubuntu2004-small


### PR DESCRIPTION
Introduces a test which always fails so we can be sure a Foliage ticket opens with this.