### PR TITLE
fix(cli-repl): improve debuggability of `mongosh not initialized yet`errors MONGOSH-1943

### DIFF
--- a/packages/cli-repl/src/mongosh-repl.spec.ts
+++ b/packages/cli-repl/src/mongosh-repl.spec.ts
@@ -121,7 +121,7 @@ describe('MongoshNodeRepl', function () {
 
   it('throws an error if internal methods are used too early', function () {
     expect(() => mongoshRepl.runtimeState()).to.throw(
-      'Mongosh not initialized yet'
+      /mongosh not initialized yet\nCurrent trace/
     );
   });
 

--- a/packages/cli-repl/src/mongosh-repl.ts
+++ b/packages/cli-repl/src/mongosh-repl.ts
@@ -1032,7 +1032,7 @@ class MongoshNodeRepl implements EvaluationListener {
       // This error can be really hard to debug, so we always attach stack traces
       // from both when .close() was called and when
       throw new MongoshInternalError(
-        `mongosh not initialized yet\nCurrentTrace: ${
+        `mongosh not initialized yet\nCurrent trace: ${
           new Error().stack
         }\nClose trace: ${this.closeTrace}\n`
       );

--- a/packages/cli-repl/src/mongosh-repl.ts
+++ b/packages/cli-repl/src/mongosh-repl.ts
@@ -126,6 +126,7 @@ type Mutable<T> = {
  */
 class MongoshNodeRepl implements EvaluationListener {
   _runtimeState: MongoshRuntimeState | null;
+  closeTrace?: string;
   input: Readable;
   lineByLineInput: LineByLineInput;
   output: Writable;
@@ -1028,7 +1029,13 @@ class MongoshNodeRepl implements EvaluationListener {
    */
   runtimeState(): MongoshRuntimeState {
     if (this._runtimeState === null) {
-      throw new MongoshInternalError('Mongosh not initialized yet');
+      // This error can be really hard to debug, so we always attach stack traces
+      // from both when .close() was called and when
+      throw new MongoshInternalError(
+        `mongosh not initialized yet\nCurrentTrace: ${
+          new Error().stack
+        }\nClose trace: ${this.closeTrace}\n`
+      );
     }
     return this._runtimeState;
   }
@@ -1043,6 +1050,7 @@ class MongoshNodeRepl implements EvaluationListener {
     const rs = this._runtimeState;
     if (rs) {
       this._runtimeState = null;
+      this.closeTrace = new Error().stack;
       rs.repl?.close();
       await rs.instanceState.close(true);
       await new Promise((resolve) => this.output.write('', resolve));


### PR DESCRIPTION
These errors have historically been very hard to debug, so adding stack traces unconditionally will hopefully improve this situation in the long term.