### PR TITLE
chore(ci): move macos packaging tasks to arm runners MONGOSH-1915

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -15876,10 +15876,6 @@ buildvariants:
     tasks:
       - name: compile_artifact
       - name: e2e_tests_darwin_x64
-      - name: package_artifact_darwin_x64
-      - name: sign_artifact_darwin_x64
-      - name: package_artifact_darwin_arm64
-      - name: sign_artifact_darwin_arm64
   - name: darwin_arm64
     display_name: "MacOS Big Sur (arm64)"
     run_on: macos-11-arm64
@@ -15888,6 +15884,10 @@ buildvariants:
     tasks:
       - name: compile_artifact
       - name: e2e_tests_darwin_arm64
+      - name: package_artifact_darwin_x64
+      - name: sign_artifact_darwin_x64
+      - name: package_artifact_darwin_arm64
+      - name: sign_artifact_darwin_arm64
 
   - name: linux_compile
     display_name: "Ubuntu 20.04 x64 (Compile and Check)"

--- a/.evergreen/evergreen.yml.in
+++ b/.evergreen/evergreen.yml.in
@@ -1565,10 +1565,6 @@ buildvariants:
     tasks:
       - name: compile_artifact
       - name: e2e_tests_darwin_x64
-      - name: package_artifact_darwin_x64
-      - name: sign_artifact_darwin_x64
-      - name: package_artifact_darwin_arm64
-      - name: sign_artifact_darwin_arm64
   - name: darwin_arm64
     display_name: "MacOS Big Sur (arm64)"
     run_on: macos-11-arm64
@@ -1577,6 +1573,10 @@ buildvariants:
     tasks:
       - name: compile_artifact
       - name: e2e_tests_darwin_arm64
+      - name: package_artifact_darwin_x64
+      - name: sign_artifact_darwin_x64
+      - name: package_artifact_darwin_arm64
+      - name: sign_artifact_darwin_arm64
 
   - name: linux_compile
     display_name: "Ubuntu 20.04 x64 (Compile and Check)"


### PR DESCRIPTION
This just reduces operating costs by a bit, and the change is fairly straightforward.