### PR TITLE
fix(browser-repl): use an error background color that makes syntax highlighting legible COMPASS-8308

### DIFF
--- a/packages/browser-repl/src/components/shell-output-line.tsx
+++ b/packages/browser-repl/src/components/shell-output-line.tsx
@@ -19,8 +19,8 @@ const shellOutputLine = css({
 });
 
 const shellOutputLineError = css({
-  backgroundColor: palette.red.light2,
-  color: palette.red.dark3,
+  backgroundColor: 'inherit',
+  color: palette.red.light1,
 });
 
 const shellOutputLineIcon = css({

--- a/packages/browser-repl/src/components/types/error-output.tsx
+++ b/packages/browser-repl/src/components/types/error-output.tsx
@@ -1,6 +1,7 @@
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import { isShouldReportAsBugError } from '@mongosh/errors';
+import { css, cx, palette } from '@mongodb-js/compass-components';
 
 import { SimpleTypeOutput } from './simple-type-output';
 import { Expandable } from '../utils/expandable';
@@ -9,6 +10,14 @@ import type { MongoServerError } from 'mongodb';
 interface ErrorOutputProps {
   value: any;
 }
+
+const errInfo = css({
+  pre: {
+    borderLeft: '3px solid',
+    paddingLeft: '0px',
+    borderColor: palette.red.light2,
+  },
+});
 
 export class ErrorOutput extends Component<ErrorOutputProps> {
   static propTypes = {
@@ -87,7 +96,7 @@ export class ErrorOutput extends Component<ErrorOutputProps> {
     return (
       <div>
         {this.renderCollapsed(toggle)}
-        <div>
+        <div className={cx(errInfo)}>
           {this.formatErrorBugReportInfo()}
           {this.formatErrorInfo()}
           {this.formatErrorResult()}

--- a/packages/browser-repl/src/components/types/error-output.tsx
+++ b/packages/browser-repl/src/components/types/error-output.tsx
@@ -11,12 +11,16 @@ interface ErrorOutputProps {
   value: any;
 }
 
-const errInfo = css({
-  pre: {
+const errInfoCss = css({
+  '&&': {
     borderLeft: '3px solid',
     paddingLeft: '0px',
-    borderColor: palette.red.light2,
+    borderColor: palette.red.light1,
   },
+});
+
+const messageCss = css({
+  color: palette.white,
 });
 
 export class ErrorOutput extends Component<ErrorOutputProps> {
@@ -39,7 +43,7 @@ export class ErrorOutput extends Component<ErrorOutputProps> {
           >
             {formattedName || 'Error'}:
           </a>{' '}
-          {message}
+          <span className={messageCss}>{message}</span>
         </pre>
       </div>
     );
@@ -96,11 +100,11 @@ export class ErrorOutput extends Component<ErrorOutputProps> {
     return (
       <div>
         {this.renderCollapsed(toggle)}
-        <div className={cx(errInfo)}>
+        <div className={messageCss}>
           {this.formatErrorBugReportInfo()}
           {this.formatErrorInfo()}
           {this.formatErrorResult()}
-          <pre>{this.formatStack()}</pre>
+          <pre className={errInfoCss}>{this.formatStack()}</pre>
         </div>
       </div>
     );


### PR DESCRIPTION
These changes are requested by design:

1. The light red background should remain the darker background.
2. The initial error declaration should be light red not dark red.
3. The first line of the error, and the initial text, should be white.
4. There should be a light red indent bar (in css, a left border) to the left of the stack.

## New, better:
![image](https://github.com/user-attachments/assets/f9b04887-a56e-4dd5-871d-472ef69b2516)

## Old, worse:

![image](https://github.com/user-attachments/assets/b12ead9f-c16d-40e2-8171-ced72eed857f)

