### PR TITLE
Revert "chore(ci): never download chromium in CI MONGOSH-1942 (#2295)"

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -4272,6 +4272,7 @@ functions:
           {
           export NODE_JS_VERSION=${node_js_version}
           source .evergreen/setup-env.sh
+          export PUPPETEER_SKIP_DOWNLOAD="true"
           npm run evergreen-release draft
           }
 
@@ -4289,6 +4290,7 @@ functions:
           node_js_version: ${node_js_version}
         script: |
           set -e
+          export PUPPETEER_SKIP_DOWNLOAD="true"
           .evergreen/run-evergreen-release.sh download-and-list-artifacts
     - command: shell.exec
       params:
@@ -4317,6 +4319,7 @@ functions:
           node_js_version: ${node_js_version}
         script: |
           set -e
+          export PUPPETEER_SKIP_DOWNLOAD="true"
           .evergreen/run-evergreen-release.sh publish -- --dry-run
 
   release_publish:
@@ -4335,6 +4338,7 @@ functions:
           node_js_version: ${node_js_version}
         script: |
           set -e
+          export PUPPETEER_SKIP_DOWNLOAD="true"
           .evergreen/run-evergreen-release.sh publish
 
   run_perf_tests:

--- a/.evergreen/compile-artifact.sh
+++ b/.evergreen/compile-artifact.sh
@@ -74,6 +74,7 @@ elif [ -n "$MONGOSH_SHARED_OPENSSL" ]; then
   export LD_LIBRARY_PATH=/tmp/m/opt/lib
 fi
 
+export PUPPETEER_SKIP_DOWNLOAD="true"
 npm run evergreen-release compile
 dist/mongosh --version
 dist/mongosh --build-info

--- a/.evergreen/evergreen.yml.in
+++ b/.evergreen/evergreen.yml.in
@@ -917,6 +917,7 @@ functions:
           {
           export NODE_JS_VERSION=${node_js_version}
           source .evergreen/setup-env.sh
+          export PUPPETEER_SKIP_DOWNLOAD="true"
           npm run evergreen-release draft
           }
 
@@ -934,6 +935,7 @@ functions:
           node_js_version: ${node_js_version}
         script: |
           set -e
+          export PUPPETEER_SKIP_DOWNLOAD="true"
           .evergreen/run-evergreen-release.sh download-and-list-artifacts
     - command: shell.exec
       params:
@@ -962,6 +964,7 @@ functions:
           node_js_version: ${node_js_version}
         script: |
           set -e
+          export PUPPETEER_SKIP_DOWNLOAD="true"
           .evergreen/run-evergreen-release.sh publish -- --dry-run
 
   release_publish:
@@ -980,6 +983,7 @@ functions:
           node_js_version: ${node_js_version}
         script: |
           set -e
+          export PUPPETEER_SKIP_DOWNLOAD="true"
           .evergreen/run-evergreen-release.sh publish
 
   run_perf_tests:

--- a/.evergreen/package-and-upload-artifact.sh
+++ b/.evergreen/package-and-upload-artifact.sh
@@ -13,7 +13,7 @@ if [ "$(uname)" == Linux ]; then
   cp "$(pwd)/../tmp/expansions.yaml" tmp/expansions.yaml
   (cd scripts/docker && bash "$BASEDIR/retry-with-backoff.sh" docker build -t rocky8-package -f rocky8-package.Dockerfile .)
   echo Starting Docker container packaging
-  docker run -e PUPPETEER_SKIP_DOWNLOAD=1 \
+  docker run -e PUPPETEER_SKIP_DOWNLOAD \
     -e EVERGREEN_EXPANSIONS_PATH=/tmp/build/tmp/expansions.yaml \
     -e NODE_JS_VERSION \
     -e PACKAGE_VARIANT \

--- a/.evergreen/run-evergreen-release.sh
+++ b/.evergreen/run-evergreen-release.sh
@@ -5,4 +5,5 @@ echo "//registry.npmjs.org/:_authToken=${devtoolsbot_npm_token}" > .npmrc
 set -x
 export NODE_JS_VERSION=${node_js_version}
 source .evergreen/setup-env.sh
+export PUPPETEER_SKIP_DOWNLOAD="true"
 npm run evergreen-release $@

--- a/.evergreen/setup-env.sh
+++ b/.evergreen/setup-env.sh
@@ -16,7 +16,6 @@ export PATH="/cygdrive/c/python/Python311/Scripts:/cygdrive/c/python/Python311:/
 export MONGOSH_TEST_ONLY_MAX_LOG_FILE_COUNT=100000
 export IS_MONGOSH_EVERGREEN_CI=1
 export DEBUG="mongodb*,$DEBUG"
-export PUPPETEER_SKIP_DOWNLOAD="true"
 
 if [ "$OS" != "Windows_NT" ]; then
   if which realpath; then # No realpath on macOS, but also not needed there


### PR DESCRIPTION
This reverts commit 5f5ea259b5d1dd086aaf6f0383e46bd3ee8def3f. (Clean revert without conflicts)

We do actually need this in macOS CI, this just happened to work a lot of the time because macOS hosts are static hosts and apparently an already-installed chromium persists on those.

In order to keep things simple and keep CI green, let's just revert this for now.