### PR TITLE
chore(ci): move macos signature verification to arm64 MONGOSH-1915

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -11618,7 +11618,7 @@ buildvariants:
       - name: verify_artifact_win32msi_x64
   - name: verify_mac_artifact
     display_name: "MacOS (Signature Verification)"
-    run_on: macos-11
+    run_on: macos-14-arm64
     tasks:
       - name: verify_artifact_darwin_arm64
       - name: verify_artifact_darwin_x64

--- a/.evergreen/evergreen.yml.in
+++ b/.evergreen/evergreen.yml.in
@@ -1567,7 +1567,7 @@ buildvariants:
       - name: verify_artifact_win32msi_x64
   - name: verify_mac_artifact
     display_name: "MacOS (Signature Verification)"
-    run_on: macos-11
+    run_on: macos-14-arm64
     tasks:
       - name: verify_artifact_darwin_arm64
       - name: verify_artifact_darwin_x64


### PR DESCRIPTION
I just missed this in MONGOSH-1915 / 7c26c7a516bd3a4448.