### PR TITLE
chore(release): use root npm install

### DIFF
--- a/.github/workflows/bump-auxiliary-packages.yml
+++ b/.github/workflows/bump-auxiliary-packages.yml
@@ -33,7 +33,7 @@ jobs:
 
       - name: Install Dependencies
         run: |
-          npm ci --workspace @mongosh/build
+          npm ci
 
       - name: Bump packages
         run: |

--- a/.github/workflows/publish-auxiliary-packages.yml
+++ b/.github/workflows/publish-auxiliary-packages.yml
@@ -44,7 +44,7 @@ jobs:
 
     - name: Install Dependencies
       run: |
-        npm ci --workspace @mongosh/build
+        npm ci
 
     - name: "Publish what is not already in NPM"
       env:


### PR DESCRIPTION
The attempt to do workspace-based installs already seemed to have led to some trickier than expected issues... So let's stick with the usual for now.