### PR TITLE
chore(release): use a different release process when publishing auxiliary packages

### DIFF
--- a/packages/build/src/npm-packages/index.ts
+++ b/packages/build/src/npm-packages/index.ts
@@ -1,2 +1,2 @@
 export { bumpAuxiliaryPackages } from './bump';
-export { publishNpmPackages } from './publish';
+export { publishToNpm } from './publish';

--- a/packages/build/src/npm-packages/publish.spec.ts
+++ b/packages/build/src/npm-packages/publish.spec.ts
@@ -2,9 +2,9 @@ import { expect } from 'chai';
 import path from 'path';
 import type { SinonStub } from 'sinon';
 import sinon from 'sinon';
-import { publishNpmPackages } from './publish';
+import { publishToNpm } from './publish';
 
-describe('npm-packages publishNpmPackages', function () {
+describe('npm-packages publishToNpm', function () {
   let listNpmPackages: SinonStub;
   let markBumpedFilesAsAssumeUnchanged: SinonStub;
   let spawnSync: SinonStub;
@@ -30,7 +30,7 @@ describe('npm-packages publishNpmPackages', function () {
     listNpmPackages.returns(packages);
 
     expect(() =>
-      publishNpmPackages(
+      publishToNpm(
         { isDryRun: false, useAuxiliaryPackagesOnly: false },
         listNpmPackages,
         markBumpedFilesAsAssumeUnchanged,
@@ -46,7 +46,7 @@ describe('npm-packages publishNpmPackages', function () {
     ];
     listNpmPackages.returns(packages);
 
-    publishNpmPackages(
+    publishToNpm(
       { isDryRun: false, useAuxiliaryPackagesOnly: false },
       listNpmPackages,
       markBumpedFilesAsAssumeUnchanged,
@@ -64,7 +64,7 @@ describe('npm-packages publishNpmPackages', function () {
     ];
     listNpmPackages.returns(packages);
 
-    publishNpmPackages(
+    publishToNpm(
       { isDryRun: false, useAuxiliaryPackagesOnly: true },
       listNpmPackages,
       markBumpedFilesAsAssumeUnchanged,
@@ -88,7 +88,7 @@ describe('npm-packages publishNpmPackages', function () {
     ];
     listNpmPackages.returns(packages);
 
-    publishNpmPackages(
+    publishToNpm(
       { isDryRun: false, useAuxiliaryPackagesOnly: false },
       listNpmPackages,
       markBumpedFilesAsAssumeUnchanged,
@@ -124,7 +124,7 @@ describe('npm-packages publishNpmPackages', function () {
     spawnSync.throws(new Error('meeep'));
 
     try {
-      publishNpmPackages(
+      publishToNpm(
         { isDryRun: false, useAuxiliaryPackagesOnly: false },
         listNpmPackages,
         markBumpedFilesAsAssumeUnchanged,

--- a/packages/build/src/npm-packages/publish.ts
+++ b/packages/build/src/npm-packages/publish.ts
@@ -10,7 +10,7 @@ import { listNpmPackages as listNpmPackagesFn } from './list';
 import { spawnSync as spawnSyncFn } from '../helpers/spawn-sync';
 import type { SpawnSyncOptionsWithStringEncoding } from 'child_process';
 
-export function publishNpmPackages(
+export function publishToNpm(
   { isDryRun = false, useAuxiliaryPackagesOnly = false },
   listNpmPackages: typeof listNpmPackagesFn = listNpmPackagesFn,
   markBumpedFilesAsAssumeUnchangedFn: typeof markBumpedFilesAsAssumeUnchanged = markBumpedFilesAsAssumeUnchanged,

--- a/packages/build/src/publish-auxiliary.ts
+++ b/packages/build/src/publish-auxiliary.ts
@@ -1,0 +1,11 @@
+import type { Config } from './config';
+import { publishToNpm } from './npm-packages';
+
+export function publishAuxiliaryPackages(config: Config) {
+  if (!config.useAuxiliaryPackagesOnly) {
+    throw new Error(
+      'This should only be used when publishing auxiliary packages'
+    );
+  }
+  publishToNpm(config);
+}

--- a/packages/build/src/publish-mongosh.spec.ts
+++ b/packages/build/src/publish-mongosh.spec.ts
@@ -9,8 +9,8 @@ import type {
 import type { createAndPublishDownloadCenterConfig as createAndPublishDownloadCenterConfigFn } from './download-center';
 import { GithubRepo } from '@mongodb-js/devtools-github-repo';
 import type { publishToHomebrew as publishToHomebrewType } from './homebrew';
-import type { publishNpmPackages as publishNpmPackagesType } from './npm-packages';
-import { runPublish } from './run-publish';
+import type { publishToNpm as publishToNpmType } from './npm-packages';
+import { publishMongosh } from './publish-mongosh';
 import { dummyConfig } from '../test/helpers';
 
 chai.use(require('sinon-chai'));
@@ -26,10 +26,10 @@ function createStubBarque(overrides?: any): Barque {
   return sinon.createStubInstance(Barque, overrides) as unknown as Barque;
 }
 
-describe('publish', function () {
+describe('publishMongosh', function () {
   let config: Config;
   let createAndPublishDownloadCenterConfig: typeof createAndPublishDownloadCenterConfigFn;
-  let publishNpmPackages: typeof publishNpmPackagesType;
+  let publishToNpm: typeof publishToNpmType;
   let writeBuildInfo: typeof writeBuildInfoType;
   let publishToHomebrew: typeof publishToHomebrewType;
   let shouldDoPublicRelease: typeof shouldDoPublicReleaseFn;
@@ -42,7 +42,7 @@ describe('publish', function () {
     config = { ...dummyConfig };
 
     createAndPublishDownloadCenterConfig = sinon.spy();
-    publishNpmPackages = sinon.spy();
+    publishToNpm = sinon.spy();
     writeBuildInfo = sinon.spy();
     publishToHomebrew = sinon.spy();
     shouldDoPublicRelease = sinon.spy();
@@ -78,14 +78,14 @@ describe('publish', function () {
           getMostRecentDraftTagForRelease: sinon.stub().resolves(undefined),
         });
         try {
-          await runPublish(
+          await publishMongosh(
             config,
             githubRepo,
             mongoHomebrewCoreForkRepo,
             homebrewCoreRepo,
             barque,
             createAndPublishDownloadCenterConfig,
-            publishNpmPackages,
+            publishToNpm,
             writeBuildInfo,
             publishToHomebrew,
             shouldDoPublicRelease
@@ -103,14 +103,14 @@ describe('publish', function () {
             .resolves({ name: 'v0.7.0-draft.42', sha: 'wrong' }),
         });
         try {
-          await runPublish(
+          await publishMongosh(
             config,
             githubRepo,
             mongoHomebrewCoreForkRepo,
             homebrewCoreRepo,
             barque,
             createAndPublishDownloadCenterConfig,
-            publishNpmPackages,
+            publishToNpm,
             writeBuildInfo,
             publishToHomebrew,
             shouldDoPublicRelease
@@ -123,14 +123,14 @@ describe('publish', function () {
     });
 
     it('publishes artifacts to barque', async function () {
-      await runPublish(
+      await publishMongosh(
         config,
         githubRepo,
         mongoHomebrewCoreForkRepo,
         homebrewCoreRepo,
         barque,
         createAndPublishDownloadCenterConfig,
-        publishNpmPackages,
+        publishToNpm,
         writeBuildInfo,
         publishToHomebrew,
         shouldDoPublicRelease
@@ -153,14 +153,14 @@ describe('publish', function () {
     });
 
     it('updates the download center config', async function () {
-      await runPublish(
+      await publishMongosh(
         config,
         githubRepo,
         mongoHomebrewCoreForkRepo,
         homebrewCoreRepo,
         barque,
         createAndPublishDownloadCenterConfig,
-        publishNpmPackages,
+        publishToNpm,
         writeBuildInfo,
         publishToHomebrew,
         shouldDoPublicRelease
@@ -175,14 +175,14 @@ describe('publish', function () {
     });
 
     it('promotes the release in github', async function () {
-      await runPublish(
+      await publishMongosh(
         config,
         githubRepo,
         mongoHomebrewCoreForkRepo,
         homebrewCoreRepo,
         barque,
         createAndPublishDownloadCenterConfig,
-        publishNpmPackages,
+        publishToNpm,
         writeBuildInfo,
         publishToHomebrew,
         shouldDoPublicRelease
@@ -192,34 +192,32 @@ describe('publish', function () {
     });
 
     it('writes analytics config and then publishes NPM packages', async function () {
-      await runPublish(
+      await publishMongosh(
         config,
         githubRepo,
         mongoHomebrewCoreForkRepo,
         homebrewCoreRepo,
         barque,
         createAndPublishDownloadCenterConfig,
-        publishNpmPackages,
+        publishToNpm,
         writeBuildInfo,
         publishToHomebrew,
         shouldDoPublicRelease
       );
 
       expect(writeBuildInfo).to.have.been.calledOnceWith(config);
-      expect(publishNpmPackages).to.have.been.calledWith();
-      expect(publishNpmPackages).to.have.been.calledAfter(
-        writeBuildInfo as any
-      );
+      expect(publishToNpm).to.have.been.calledWith();
+      expect(publishToNpm).to.have.been.calledAfter(writeBuildInfo as any);
     });
     it('publishes to homebrew', async function () {
-      await runPublish(
+      await publishMongosh(
         config,
         githubRepo,
         mongoHomebrewCoreForkRepo,
         homebrewCoreRepo,
         barque,
         createAndPublishDownloadCenterConfig,
-        publishNpmPackages,
+        publishToNpm,
         writeBuildInfo,
         publishToHomebrew,
         shouldDoPublicRelease
@@ -242,14 +240,14 @@ describe('publish', function () {
     });
 
     it('does not update the download center config', async function () {
-      await runPublish(
+      await publishMongosh(
         config,
         githubRepo,
         mongoHomebrewCoreForkRepo,
         homebrewCoreRepo,
         barque,
         createAndPublishDownloadCenterConfig,
-        publishNpmPackages,
+        publishToNpm,
         writeBuildInfo,
         publishToHomebrew,
         shouldDoPublicRelease
@@ -259,14 +257,14 @@ describe('publish', function () {
     });
 
     it('does not promote the release in github', async function () {
-      await runPublish(
+      await publishMongosh(
         config,
         githubRepo,
         mongoHomebrewCoreForkRepo,
         homebrewCoreRepo,
         barque,
         createAndPublishDownloadCenterConfig,
-        publishNpmPackages,
+        publishToNpm,
         writeBuildInfo,
         publishToHomebrew,
         shouldDoPublicRelease
@@ -276,31 +274,31 @@ describe('publish', function () {
     });
 
     it('does not publish npm packages', async function () {
-      await runPublish(
+      await publishMongosh(
         config,
         githubRepo,
         mongoHomebrewCoreForkRepo,
         homebrewCoreRepo,
         barque,
         createAndPublishDownloadCenterConfig,
-        publishNpmPackages,
+        publishToNpm,
         writeBuildInfo,
         publishToHomebrew,
         shouldDoPublicRelease
       );
 
-      expect(publishNpmPackages).not.to.have.been.called;
+      expect(publishToNpm).not.to.have.been.called;
     });
 
     it('does not publish to homebrew', async function () {
-      await runPublish(
+      await publishMongosh(
         config,
         githubRepo,
         mongoHomebrewCoreForkRepo,
         homebrewCoreRepo,
         barque,
         createAndPublishDownloadCenterConfig,
-        publishNpmPackages,
+        publishToNpm,
         writeBuildInfo,
         publishToHomebrew,
         shouldDoPublicRelease
@@ -310,14 +308,14 @@ describe('publish', function () {
     });
 
     it('does not release to barque', async function () {
-      await runPublish(
+      await publishMongosh(
         config,
         githubRepo,
         mongoHomebrewCoreForkRepo,
         homebrewCoreRepo,
         barque,
         createAndPublishDownloadCenterConfig,
-        publishNpmPackages,
+        publishToNpm,
         writeBuildInfo,
         publishToHomebrew,
         shouldDoPublicRelease

--- a/packages/build/src/publish-mongosh.ts
+++ b/packages/build/src/publish-mongosh.ts
@@ -10,18 +10,18 @@ import type { createAndPublishDownloadCenterConfig as createAndPublishDownloadCe
 import { getArtifactUrl as getArtifactUrlFn } from './evergreen';
 import type { GithubRepo } from '@mongodb-js/devtools-github-repo';
 import type { publishToHomebrew as publishToHomebrewType } from './homebrew';
-import type { publishNpmPackages as publishNpmPackagesType } from './npm-packages';
+import type { publishToNpm as publishToNpmType } from './npm-packages';
 import type { PackageInformationProvider } from './packaging';
 import { getPackageFile } from './packaging';
 
-export async function runPublish(
+export async function publishMongosh(
   config: Config,
   mongoshGithubRepo: GithubRepo,
   mongodbHomebrewForkGithubRepo: GithubRepo,
   homebrewCoreGithubRepo: GithubRepo,
   barque: Barque,
   createAndPublishDownloadCenterConfig: typeof createAndPublishDownloadCenterConfigFn,
-  publishNpmPackages: typeof publishNpmPackagesType,
+  publishToNpm: typeof publishToNpmType,
   writeBuildInfo: typeof writeBuildInfoType,
   publishToHomebrew: typeof publishToHomebrewType,
   shouldDoPublicRelease: typeof shouldDoPublicReleaseFn = shouldDoPublicReleaseFn,
@@ -81,7 +81,7 @@ export async function runPublish(
   // ensures the segment api key to be present in the published packages
   await writeBuildInfo(config, 'packaged');
 
-  publishNpmPackages({
+  publishToNpm({
     isDryRun: config.isDryRun,
     useAuxiliaryPackagesOnly: config.useAuxiliaryPackagesOnly,
   });

--- a/packages/build/src/release.ts
+++ b/packages/build/src/release.ts
@@ -14,15 +14,16 @@ import {
 } from './evergreen';
 import { GithubRepo } from '@mongodb-js/devtools-github-repo';
 import { publishToHomebrew } from './homebrew';
-import { bumpAuxiliaryPackages, publishNpmPackages } from './npm-packages';
+import { bumpAuxiliaryPackages, publishToNpm } from './npm-packages';
 import { runPackage } from './packaging';
 import { runDraft } from './run-draft';
-import { runPublish } from './run-publish';
+import { publishMongosh } from './publish-mongosh';
 import { runUpload } from './run-upload';
 import { runSign } from './packaging/run-sign';
 import { runDownloadAndListArtifacts } from './run-download-and-list-artifacts';
 import { runDownloadCryptLibrary } from './packaging/run-download-crypt-library';
 import { bumpMongoshReleasePackages } from './npm-packages/bump';
+import { publishAuxiliaryPackages } from './publish-auxiliary';
 
 export type ReleaseCommand =
   | 'bump'
@@ -113,18 +114,21 @@ export async function release(
   } else if (command === 'download-and-list-artifacts') {
     await runDownloadAndListArtifacts(config);
   } else if (command === 'publish') {
-    const barque = new Barque(config);
-    await runPublish(
-      config,
-      githubRepo,
-      mongoHomebrewForkRepo,
-      homebrewCoreRepo,
-      barque,
-      createAndPublishDownloadCenterConfig,
-      publishNpmPackages,
-      writeBuildInfo,
-      publishToHomebrew
-    );
+    if (config.useAuxiliaryPackagesOnly) {
+      publishAuxiliaryPackages(config);
+    } else {
+      await publishMongosh(
+        config,
+        githubRepo,
+        mongoHomebrewForkRepo,
+        homebrewCoreRepo,
+        new Barque(config),
+        createAndPublishDownloadCenterConfig,
+        publishToNpm,
+        writeBuildInfo,
+        publishToHomebrew
+      );
+    }
   } else {
     throw new Error(`Unknown command: ${command}`);
   }


### PR DESCRIPTION
Some refactoring to make it different scenarios clearer and use a different function when just publishing auxiliary packages.
We should just be publishing to npm in this case (and let lerna push tags).