### PR TITLE
fix(ci): add publishing tags step when publishing auxiliary packages MONGOSH-1871

### DIFF
--- a/.github/workflows/bump-auxiliary-packages.yml
+++ b/.github/workflows/bump-auxiliary-packages.yml
@@ -17,7 +17,7 @@ jobs:
           private-key: ${{ secrets.DEVTOOLS_BOT_PRIVATE_KEY }}
       - uses: actions/checkout@v4
         with:
-          # don't checkout a detatched HEAD
+          # don't checkout a detached HEAD
           ref: ${{ github.head_ref }}
 
           # this is important so git log can pick up on

--- a/.github/workflows/cron-tasks.yml
+++ b/.github/workflows/cron-tasks.yml
@@ -28,7 +28,7 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          # don't checkout a detatched HEAD
+          # don't checkout a detached HEAD
           ref: ${{ github.head_ref }}
 
           # this is important so git log can pick up on

--- a/.github/workflows/publish-auxiliary-packages.yml
+++ b/.github/workflows/publish-auxiliary-packages.yml
@@ -58,10 +58,3 @@ jobs:
           npm config list
           echo "Publishing packages as $(npm whoami)"
           npm run publish-auxiliary
-
-      - name: "Publish tags"
-        run: |
-          npx lerna list -a --json | \
-            jq -r '.[] |  select(.name != "mongosh") | .name + "@" + .version' | \
-            xargs -i sh -c "git tag -a {} -m {} || true"
-          git push --follow-tags

--- a/.github/workflows/publish-auxiliary-packages.yml
+++ b/.github/workflows/publish-auxiliary-packages.yml
@@ -58,3 +58,10 @@ jobs:
           npm config list
           echo "Publishing packages as $(npm whoami)"
           npm run publish-auxiliary
+
+      - name: "Publish tags"
+        run: |
+          npx lerna list -a --json | \
+            jq -r '.[] |  select(.name != "mongosh") | .name + "@" + .version' | \
+            xargs -i sh -c "git tag -a {} -m {} || true"
+          git push --follow-tags

--- a/.github/workflows/temp-push-auxiliary-tags.yml
+++ b/.github/workflows/temp-push-auxiliary-tags.yml
@@ -12,7 +12,7 @@ jobs:
     environment: Production
 
     steps:
-      - uses: mongodb-js/devtools-shared/actions/setup-bot-token@main
+      - uses: mongodb-js/devtools-shared/actions/setup-bot-token@d638357cabd624ae626d9abb62cbac2760aea932
         id: app-token
         with:
           app-id: ${{ vars.DEVTOOLS_BOT_APP_ID }}

--- a/.github/workflows/temp-push-auxiliary-tags.yml
+++ b/.github/workflows/temp-push-auxiliary-tags.yml
@@ -1,0 +1,49 @@
+# Temporary workflow just to fix currently not pushed tags for our release, will be removed.
+name: Push Tags for Auxiliary Packages
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: none # We use the github app to checkout and push tags
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    environment: Production
+
+    steps:
+      - uses: mongodb-js/devtools-shared/actions/setup-bot-token@main
+        id: app-token
+        with:
+          app-id: ${{ vars.DEVTOOLS_BOT_APP_ID }}
+          private-key: ${{ secrets.DEVTOOLS_BOT_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v4
+        with:
+          # don't checkout a detatched HEAD
+          ref: ${{ github.head_ref }}
+
+          # this is important so git log can pick up on
+          # the whole history to generate the list of AUTHORS
+          fetch-depth: "0"
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: "Use Node.js 20"
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.16.0
+
+      - name: Install npm@10.2.4
+        run: npm install -g npm@10.2.4
+
+      - name: Install Dependencies
+        run: |
+          npm ci
+
+      - name: "Pushing tags..."
+        env:
+          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: |
+          echo "//registry.npmjs.org/:_authToken=${NPM_TOKEN}" >> ~/.npmrc
+          npm config list
+          npm run tags-auxiliary

--- a/.github/workflows/update-node-js.yaml
+++ b/.github/workflows/update-node-js.yaml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          # don't checkout a detatched HEAD
+          # don't checkout a detached HEAD
           ref: ${{ github.head_ref }}
           token: ${{ steps.app-token.outputs.token }}
 

--- a/package.json
+++ b/package.json
@@ -72,7 +72,8 @@
     "precommit": "precommit",
     "preinstall": "node scripts/sort-workspaces.js",
     "bump-auxiliary": "npm run bump-auxiliary --workspace @mongosh/build",
-    "publish-auxiliary": "npm run publish-auxiliary --workspace @mongosh/build"
+    "publish-auxiliary": "npm run publish-auxiliary --workspace @mongosh/build",
+    "tags-auxiliary": "npm run tags-auxiliary --workspace @mongosh/build"
   },
   "config": {
     "unsafe-perm": true

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -30,6 +30,7 @@
     "publish": "ts-node src/index.ts publish",
     "bump-auxiliary": "ts-node src/index.ts bump --auxiliary",
     "publish-auxiliary": "ts-node src/index.ts publish --auxiliary",
+    "tags-auxiliary": "ts-node src/index.ts temp-push-auxiliary-tags --auxiliary",
     "reformat": "npm run prettier -- --write . && npm run eslint --fix"
   },
   "license": "Apache-2.0",

--- a/packages/build/src/index.ts
+++ b/packages/build/src/index.ts
@@ -20,6 +20,7 @@ const validCommands: (ReleaseCommand | 'trigger-release')[] = [
   'download-crypt-shared-library',
   'download-and-list-artifacts',
   'trigger-release',
+  'temp-push-auxiliary-tags',
 ] as const;
 
 const isValidCommand = (

--- a/packages/build/src/npm-packages/index.ts
+++ b/packages/build/src/npm-packages/index.ts
@@ -1,2 +1,3 @@
 export { bumpAuxiliaryPackages } from './bump';
 export { publishToNpm } from './publish';
+export { pushTags } from './push-tags';

--- a/packages/build/src/npm-packages/publish.spec.ts
+++ b/packages/build/src/npm-packages/publish.spec.ts
@@ -25,62 +25,6 @@ describe('npm-packages publishToNpm', function () {
     spawnSync = sinon.stub();
   });
 
-  it('throws if mongosh is not existent when publishing all', function () {
-    const packages = [{ name: 'packageA', version: '0.7.0' }];
-    listNpmPackages.returns(packages);
-
-    expect(() =>
-      publishToNpm(
-        { isDryRun: false, useAuxiliaryPackagesOnly: false },
-        listNpmPackages,
-        markBumpedFilesAsAssumeUnchanged,
-        spawnSync
-      )
-    ).throws('mongosh package not found');
-  });
-
-  it('takes mongosh version and pushes tags', function () {
-    const packages = [
-      { name: 'packageA', version: '0.7.0' },
-      { name: 'mongosh', version: '1.2.0' },
-    ];
-    listNpmPackages.returns(packages);
-
-    publishToNpm(
-      { isDryRun: false, useAuxiliaryPackagesOnly: false },
-      listNpmPackages,
-      markBumpedFilesAsAssumeUnchanged,
-      spawnSync
-    );
-
-    expect(spawnSync).calledWith('git', ['tag', '-a', '1.2.0', '-m', '1.2.0']);
-    expect(spawnSync).calledWith('git', ['push', '--follow-tags']);
-  });
-
-  it('does not manually push tags with auxiliary packages', function () {
-    const packages = [
-      { name: 'packageA', version: '0.7.0' },
-      { name: 'mongosh', version: '1.2.0' },
-    ];
-    listNpmPackages.returns(packages);
-
-    publishToNpm(
-      { isDryRun: false, useAuxiliaryPackagesOnly: true },
-      listNpmPackages,
-      markBumpedFilesAsAssumeUnchanged,
-      spawnSync
-    );
-
-    expect(spawnSync).not.calledWith('git', [
-      'tag',
-      '-a',
-      '1.2.0',
-      '-m',
-      '1.2.0',
-    ]);
-    expect(spawnSync).not.calledWith('git', ['push', '--follow-tags']);
-  });
-
   it('calls lerna to publish packages for a real version', function () {
     const packages = [
       { name: 'packageA', version: '0.7.0' },

--- a/packages/build/src/npm-packages/push-tags.spec.ts
+++ b/packages/build/src/npm-packages/push-tags.spec.ts
@@ -1,0 +1,213 @@
+import { expect } from 'chai';
+import { existsTag, pushTags } from './push-tags';
+import sinon from 'sinon';
+import { MONGOSH_RELEASE_PACKAGES } from './constants';
+
+describe('pushing tags', function () {
+  let spawnSync: sinon.SinonStub;
+  let listNpmPackages: sinon.SinonStub;
+
+  describe('existsTag', function () {
+    it('returns true with existing tags', function () {
+      expect(existsTag('v1.0.0')).equals(true);
+    });
+
+    it('return false with tags that do not exist', function () {
+      expect(existsTag('this-tag-will-never-exist-12345')).equals(false);
+    });
+  });
+
+  describe('pushTags', function () {
+    const mongoshVersion = '1.2.0';
+    const allReleasablePackages = [
+      { name: 'packageA', version: '0.7.0' },
+      { name: 'packageB', version: '1.7.0' },
+      { name: 'packageC', version: '1.3.0' },
+      { name: 'mongosh', version: mongoshVersion },
+      { name: '@mongosh/cli-repl', version: mongoshVersion },
+    ];
+    const auxiliaryPackages = allReleasablePackages.filter(
+      (p) => !MONGOSH_RELEASE_PACKAGES.includes(p.name)
+    );
+    const mongoshReleasePackages = allReleasablePackages.filter((p) =>
+      MONGOSH_RELEASE_PACKAGES.includes(p.name)
+    );
+    let existsVersionTag: sinon.SinonStub;
+
+    beforeEach(function () {
+      spawnSync = sinon.stub();
+      spawnSync.returns(undefined);
+
+      listNpmPackages = sinon.stub();
+      listNpmPackages.returns(allReleasablePackages);
+      existsVersionTag = sinon.stub();
+      existsVersionTag.returns(false);
+    });
+
+    afterEach(function () {
+      sinon.restore();
+    });
+
+    it('throws if mongosh is not existent when publishing all', function () {
+      const packages = [{ name: 'packageA', version: '0.7.0' }];
+      listNpmPackages.returns(packages);
+
+      expect(() =>
+        pushTags(
+          { useAuxiliaryPackagesOnly: false },
+          listNpmPackages,
+          existsVersionTag,
+          spawnSync
+        )
+      ).throws('mongosh package not found');
+    });
+
+    it('takes mongosh version and pushes tags when releasing', function () {
+      pushTags(
+        {
+          useAuxiliaryPackagesOnly: false,
+        },
+        listNpmPackages,
+        existsVersionTag,
+        spawnSync
+      );
+
+      for (const packageInfo of allReleasablePackages) {
+        expect(spawnSync).calledWith('git', [
+          'tag',
+          '-a',
+          `${packageInfo.name}@${packageInfo.version}`,
+          '-m',
+          `${packageInfo.name}@${packageInfo.version}`,
+        ]);
+      }
+
+      expect(spawnSync).calledWith('git', [
+        'tag',
+        '-a',
+        `v${mongoshVersion}`,
+        '-m',
+        `v${mongoshVersion}`,
+      ]);
+      expect(spawnSync).calledWith('git', ['push', '--follow-tags']);
+    });
+
+    it('pushes only package tags when using auxiliary packages', function () {
+      pushTags(
+        {
+          useAuxiliaryPackagesOnly: true,
+        },
+        listNpmPackages,
+        existsVersionTag,
+        spawnSync
+      );
+
+      for (const packageInfo of auxiliaryPackages) {
+        expect(spawnSync).calledWith('git', [
+          'tag',
+          '-a',
+          `${packageInfo.name}@${packageInfo.version}`,
+          '-m',
+          `${packageInfo.name}@${packageInfo.version}`,
+        ]);
+      }
+
+      for (const packageInfo of mongoshReleasePackages) {
+        expect(spawnSync).not.calledWith('git', [
+          'tag',
+          '-a',
+          `${packageInfo.name}@${packageInfo.version}`,
+          '-m',
+          `${packageInfo.name}@${packageInfo.version}`,
+        ]);
+      }
+
+      expect(spawnSync).not.calledWith('git', [
+        'tag',
+        '-a',
+        `v${mongoshVersion}`,
+        '-m',
+        `v${mongoshVersion}`,
+      ]);
+      expect(spawnSync).calledWith('git', ['push', '--follow-tags']);
+    });
+
+    it('skips pushing version tags which already exist', function () {
+      const packagesToSkip = [
+        allReleasablePackages[0],
+        allReleasablePackages[1],
+      ];
+
+      for (const packageInfo of packagesToSkip) {
+        existsVersionTag
+          .withArgs(`${packageInfo.name}@${packageInfo.version}`)
+          .returns(true);
+      }
+
+      pushTags(
+        {
+          useAuxiliaryPackagesOnly: true,
+        },
+        listNpmPackages,
+        existsVersionTag,
+        spawnSync
+      );
+
+      for (const packageInfo of auxiliaryPackages.filter(
+        (p) => !packagesToSkip.includes(p)
+      )) {
+        expect(spawnSync).calledWith('git', [
+          'tag',
+          '-a',
+          `${packageInfo.name}@${packageInfo.version}`,
+          '-m',
+          `${packageInfo.name}@${packageInfo.version}`,
+        ]);
+      }
+
+      for (const packageInfo of [
+        ...mongoshReleasePackages,
+        ...packagesToSkip,
+      ]) {
+        expect(spawnSync).not.calledWith('git', [
+          'tag',
+          '-a',
+          `${packageInfo.name}@${packageInfo.version}`,
+          '-m',
+          `${packageInfo.name}@${packageInfo.version}`,
+        ]);
+      }
+
+      expect(spawnSync).not.calledWith('git', [
+        'tag',
+        '-a',
+        `v${mongoshVersion}`,
+        '-m',
+        `v${mongoshVersion}`,
+      ]);
+      expect(spawnSync).calledWith('git', ['push', '--follow-tags']);
+    });
+
+    it('skips mongosh release tag push if it exists', function () {
+      existsVersionTag.withArgs(`v${mongoshVersion}`).returns(true);
+
+      pushTags(
+        {
+          useAuxiliaryPackagesOnly: false,
+        },
+        listNpmPackages,
+        existsVersionTag,
+        spawnSync
+      );
+
+      expect(spawnSync).not.calledWith('git', [
+        'tag',
+        '-a',
+        `v${mongoshVersion}`,
+        '-m',
+        `v${mongoshVersion}`,
+      ]);
+      expect(spawnSync).calledWith('git', ['push', '--follow-tags']);
+    });
+  });
+});

--- a/packages/build/src/npm-packages/push-tags.ts
+++ b/packages/build/src/npm-packages/push-tags.ts
@@ -1,0 +1,92 @@
+import type { SpawnSyncOptionsWithStringEncoding } from 'child_process';
+import {
+  EXCLUDE_RELEASE_PACKAGES,
+  MONGOSH_RELEASE_PACKAGES,
+  PROJECT_ROOT,
+} from './constants';
+import type { LernaPackageDescription } from './list';
+import { listNpmPackages as listNpmPackagesFn } from './list';
+import { spawnSync as spawnSyncFn } from '../helpers/spawn-sync';
+
+export function pushTags(
+  { useAuxiliaryPackagesOnly }: { useAuxiliaryPackagesOnly: boolean },
+  listNpmPackages: typeof listNpmPackagesFn = listNpmPackagesFn,
+  existsVersionTag: typeof existsTag = existsTag,
+  spawnSync: typeof spawnSyncFn = spawnSyncFn
+) {
+  const allReleasablePackages = listNpmPackages().filter(
+    (packageConfig) => !EXCLUDE_RELEASE_PACKAGES.includes(packageConfig.name)
+  );
+
+  const packages: LernaPackageDescription[] = useAuxiliaryPackagesOnly
+    ? allReleasablePackages.filter(
+        (packageConfig) =>
+          !MONGOSH_RELEASE_PACKAGES.includes(packageConfig.name)
+      )
+    : allReleasablePackages;
+
+  const commandOptions: SpawnSyncOptionsWithStringEncoding = {
+    stdio: 'inherit',
+    cwd: PROJECT_ROOT,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+    },
+  };
+
+  for (const packageInfo of packages) {
+    const { name, version } = packageInfo;
+    const newTag = `${name}@${version}`;
+
+    if (existsVersionTag(newTag)) {
+      console.warn(`${newTag} tag already exists. Skipping...`);
+      continue;
+    }
+    spawnSync('git', ['tag', '-a', newTag, '-m', newTag], commandOptions);
+  }
+
+  if (!useAuxiliaryPackagesOnly) {
+    const mongoshVersion = packages.find(
+      (packageConfig) => packageConfig.name === 'mongosh'
+    )?.version;
+
+    if (!mongoshVersion) {
+      throw new Error('mongosh package not found');
+    }
+
+    const newVersionTag = `v${mongoshVersion}`;
+
+    if (!existsVersionTag(newVersionTag)) {
+      console.info(`Creating v${mongoshVersion} tag...`);
+      spawnSync(
+        'git',
+        ['tag', '-a', newVersionTag, '-m', newVersionTag],
+        commandOptions
+      );
+    } else {
+      console.warn(`${newVersionTag} tag already exists. Skipping...`);
+    }
+  }
+
+  spawnSync('git', ['push', '--follow-tags'], commandOptions);
+}
+
+/** Returns true if the tag exists in the remote repository. */
+export function existsTag(tag: string): boolean {
+  // rev-parse will return the hash of tagged commit
+  // if it exists or throw otherwise.
+  try {
+    const revParseResult = spawnSyncFn(
+      'git',
+      ['rev-parse', '--quiet', '--verify', `refs/tags/${tag}`],
+      {
+        cwd: PROJECT_ROOT,
+        encoding: 'utf8',
+        stdio: 'pipe',
+      }
+    );
+    return revParseResult.status === 0;
+  } catch (error) {
+    return false;
+  }
+}

--- a/packages/build/src/publish-auxiliary.ts
+++ b/packages/build/src/publish-auxiliary.ts
@@ -1,5 +1,5 @@
 import type { Config } from './config';
-import { publishToNpm } from './npm-packages';
+import { publishToNpm, pushTags } from './npm-packages';
 
 export function publishAuxiliaryPackages(config: Config) {
   if (!config.useAuxiliaryPackagesOnly) {
@@ -8,4 +8,5 @@ export function publishAuxiliaryPackages(config: Config) {
     );
   }
   publishToNpm(config);
+  pushTags({ useAuxiliaryPackagesOnly: true });
 }

--- a/packages/build/src/publish-mongosh.spec.ts
+++ b/packages/build/src/publish-mongosh.spec.ts
@@ -9,7 +9,10 @@ import type {
 import type { createAndPublishDownloadCenterConfig as createAndPublishDownloadCenterConfigFn } from './download-center';
 import { GithubRepo } from '@mongodb-js/devtools-github-repo';
 import type { publishToHomebrew as publishToHomebrewType } from './homebrew';
-import type { publishToNpm as publishToNpmType } from './npm-packages';
+import type {
+  publishToNpm as publishToNpmType,
+  pushTags as pushTagsType,
+} from './npm-packages';
 import { publishMongosh } from './publish-mongosh';
 import { dummyConfig } from '../test/helpers';
 
@@ -37,6 +40,7 @@ describe('publishMongosh', function () {
   let mongoHomebrewCoreForkRepo: GithubRepo;
   let homebrewCoreRepo: GithubRepo;
   let barque: Barque;
+  let pushTags: typeof pushTagsType;
 
   beforeEach(function () {
     config = { ...dummyConfig };
@@ -46,6 +50,8 @@ describe('publishMongosh', function () {
     writeBuildInfo = sinon.spy();
     publishToHomebrew = sinon.spy();
     shouldDoPublicRelease = sinon.spy();
+    pushTags = sinon.spy();
+
     githubRepo = createStubRepo();
     mongoHomebrewCoreForkRepo = createStubRepo();
     homebrewCoreRepo = createStubRepo();
@@ -86,6 +92,7 @@ describe('publishMongosh', function () {
             barque,
             createAndPublishDownloadCenterConfig,
             publishToNpm,
+            pushTags,
             writeBuildInfo,
             publishToHomebrew,
             shouldDoPublicRelease
@@ -111,6 +118,7 @@ describe('publishMongosh', function () {
             barque,
             createAndPublishDownloadCenterConfig,
             publishToNpm,
+            pushTags,
             writeBuildInfo,
             publishToHomebrew,
             shouldDoPublicRelease
@@ -131,6 +139,7 @@ describe('publishMongosh', function () {
         barque,
         createAndPublishDownloadCenterConfig,
         publishToNpm,
+        pushTags,
         writeBuildInfo,
         publishToHomebrew,
         shouldDoPublicRelease
@@ -161,6 +170,7 @@ describe('publishMongosh', function () {
         barque,
         createAndPublishDownloadCenterConfig,
         publishToNpm,
+        pushTags,
         writeBuildInfo,
         publishToHomebrew,
         shouldDoPublicRelease
@@ -183,6 +193,7 @@ describe('publishMongosh', function () {
         barque,
         createAndPublishDownloadCenterConfig,
         publishToNpm,
+        pushTags,
         writeBuildInfo,
         publishToHomebrew,
         shouldDoPublicRelease
@@ -200,6 +211,7 @@ describe('publishMongosh', function () {
         barque,
         createAndPublishDownloadCenterConfig,
         publishToNpm,
+        pushTags,
         writeBuildInfo,
         publishToHomebrew,
         shouldDoPublicRelease
@@ -218,6 +230,7 @@ describe('publishMongosh', function () {
         barque,
         createAndPublishDownloadCenterConfig,
         publishToNpm,
+        pushTags,
         writeBuildInfo,
         publishToHomebrew,
         shouldDoPublicRelease
@@ -248,6 +261,7 @@ describe('publishMongosh', function () {
         barque,
         createAndPublishDownloadCenterConfig,
         publishToNpm,
+        pushTags,
         writeBuildInfo,
         publishToHomebrew,
         shouldDoPublicRelease
@@ -265,6 +279,7 @@ describe('publishMongosh', function () {
         barque,
         createAndPublishDownloadCenterConfig,
         publishToNpm,
+        pushTags,
         writeBuildInfo,
         publishToHomebrew,
         shouldDoPublicRelease
@@ -282,6 +297,7 @@ describe('publishMongosh', function () {
         barque,
         createAndPublishDownloadCenterConfig,
         publishToNpm,
+        pushTags,
         writeBuildInfo,
         publishToHomebrew,
         shouldDoPublicRelease
@@ -299,6 +315,7 @@ describe('publishMongosh', function () {
         barque,
         createAndPublishDownloadCenterConfig,
         publishToNpm,
+        pushTags,
         writeBuildInfo,
         publishToHomebrew,
         shouldDoPublicRelease
@@ -316,6 +333,7 @@ describe('publishMongosh', function () {
         barque,
         createAndPublishDownloadCenterConfig,
         publishToNpm,
+        pushTags,
         writeBuildInfo,
         publishToHomebrew,
         shouldDoPublicRelease

--- a/packages/build/src/publish-mongosh.ts
+++ b/packages/build/src/publish-mongosh.ts
@@ -10,7 +10,8 @@ import type { createAndPublishDownloadCenterConfig as createAndPublishDownloadCe
 import { getArtifactUrl as getArtifactUrlFn } from './evergreen';
 import type { GithubRepo } from '@mongodb-js/devtools-github-repo';
 import type { publishToHomebrew as publishToHomebrewType } from './homebrew';
-import type { publishToNpm as publishToNpmType } from './npm-packages';
+import type { pushTags as pushTagsType } from './npm-packages';
+import { type publishToNpm as publishToNpmType } from './npm-packages';
 import type { PackageInformationProvider } from './packaging';
 import { getPackageFile } from './packaging';
 
@@ -22,6 +23,7 @@ export async function publishMongosh(
   barque: Barque,
   createAndPublishDownloadCenterConfig: typeof createAndPublishDownloadCenterConfigFn,
   publishToNpm: typeof publishToNpmType,
+  pushTags: typeof pushTagsType,
   writeBuildInfo: typeof writeBuildInfoType,
   publishToHomebrew: typeof publishToHomebrewType,
   shouldDoPublicRelease: typeof shouldDoPublicReleaseFn = shouldDoPublicReleaseFn,
@@ -93,6 +95,8 @@ export async function publishMongosh(
     `https://github.com/${mongoshGithubRepo.repo.owner}/${mongoshGithubRepo.repo.repo}/releases/tag/v${config.version}`,
     !!config.isDryRun
   );
+
+  pushTags({ useAuxiliaryPackagesOnly: true });
 
   console.info('mongosh: finished release process.');
 }

--- a/packages/build/src/release.ts
+++ b/packages/build/src/release.ts
@@ -34,6 +34,7 @@ export type ReleaseCommand =
   | 'download-crypt-shared-library'
   | 'download-and-list-artifacts'
   | 'draft'
+  | 'temp-push-auxiliary-tags'
   | 'publish';
 
 /**
@@ -55,6 +56,11 @@ export async function release(
     `mongosh: running command '${command}' with config:`,
     redactConfig(config)
   );
+
+  if (command === 'temp-push-auxiliary-tags') {
+    pushTags({ useAuxiliaryPackagesOnly: true });
+    return;
+  }
 
   if (command === 'bump') {
     bumpAuxiliaryPackages();

--- a/packages/build/src/release.ts
+++ b/packages/build/src/release.ts
@@ -14,7 +14,7 @@ import {
 } from './evergreen';
 import { GithubRepo } from '@mongodb-js/devtools-github-repo';
 import { publishToHomebrew } from './homebrew';
-import { bumpAuxiliaryPackages, publishToNpm } from './npm-packages';
+import { bumpAuxiliaryPackages, publishToNpm, pushTags } from './npm-packages';
 import { runPackage } from './packaging';
 import { runDraft } from './run-draft';
 import { publishMongosh } from './publish-mongosh';
@@ -125,6 +125,7 @@ export async function release(
         new Barque(config),
         createAndPublishDownloadCenterConfig,
         publishToNpm,
+        pushTags,
         writeBuildInfo,
         publishToHomebrew
       );


### PR DESCRIPTION
lerna publish [doesn't automatically push tags](https://github.com/lerna/lerna/issues/2085) when using from-package so we have to create and push the tags manually.

This is different from releasing mongosh as it does its own tag push already (without `mongosh@` prefix): https://github.com/mongodb-js/mongosh/blob/e0a051c30f3198fccd6257c77d4bf243a0cd173f/packages/build/src/npm-packages/publish.ts#L59-L73