### PR TITLE
fix(ci): use the correct commit message when bumping packages MONGOSH-1871

### DIFF
--- a/packages/build/src/npm-packages/bump.ts
+++ b/packages/build/src/npm-packages/bump.ts
@@ -95,6 +95,7 @@ export function bumpAuxiliaryPackages() {
     encoding: 'utf8',
     env: {
       ...process.env,
+      LAST_BUMP_COMMIT_MESSAGE: 'chore(release): bump auxiliary packages',
       SKIP_BUMP_PACKAGES: [
         ...EXCLUDE_RELEASE_PACKAGES,
         ...MONGOSH_RELEASE_PACKAGES,


### PR DESCRIPTION
bump-packages from monorepo-tools is looking for `chore(ci): bump packages` as the start of the commit to calculate the semver bump. The problem is that our commit message doesn't start with this - instead it's `chore(release): bump auxiliary packages`. This means that the next time we run it, we go back to the start of time and sure enough, we find some breaking: ... commit message and decide we need to bump major. Luckily there's a `LAST_BUMP_COMMIT_MESSAGE` we can use to set this, so this does that.