### PR TITLE
fix(i18n): fix help text for `oidcDumpTokens`

### DIFF
--- a/packages/i18n/src/locales/en_US.ts
+++ b/packages/i18n/src/locales/en_US.ts
@@ -91,7 +91,7 @@ const translations: Catalog = {
       oidcIdTokenAsAccessToken:
         'Use ID tokens in place of access tokens for auth',
       oidcDumpTokens:
-        "Debug OIDC by printing tokens to mongosh's output [full|include-secrets]",
+        "Debug OIDC by printing tokens to mongosh's output [redacted|include-secrets]",
       oidcNoNonce: "Don't send a nonce argument in the OIDC auth request",
     },
     'arg-parser': {


### PR DESCRIPTION
`full` is not an available value for this option.