### PR TITLE
fix(release): add a bump step to draft and publish stages

### DIFF
--- a/packages/build/src/npm-packages/bump.spec.ts
+++ b/packages/build/src/npm-packages/bump.spec.ts
@@ -25,16 +25,14 @@ describe('npm-packages bump', function () {
   });
 
   describe('bumpMongoshReleasePackages', function () {
-    it('throws if MONGOSH_RELEASE_VERSION is not set', async function () {
-      process.env.MONGOSH_RELEASE_VERSION = '';
-
+    it('throws if version is not set', async function () {
       try {
-        await bumpMongoshReleasePackages();
+        await bumpMongoshReleasePackages('');
         expect.fail('did not error');
       } catch (error) {
         expect(error).instanceOf(Error);
         expect((error as Error).message).equals(
-          'MONGOSH_RELEASE_VERSION version not specified during mongosh bump'
+          'version not specified during mongosh bump'
         );
       }
     });

--- a/packages/build/src/npm-packages/bump.spec.ts
+++ b/packages/build/src/npm-packages/bump.spec.ts
@@ -49,7 +49,6 @@ describe('npm-packages bump', function () {
 
       expect(fsWriteFile).calledWith(
         path.join(
-          __dirname,
           PROJECT_ROOT,
           'packages',
           'shell-api',

--- a/packages/build/src/npm-packages/bump.ts
+++ b/packages/build/src/npm-packages/bump.ts
@@ -62,7 +62,6 @@ export async function bumpMongoshReleasePackages(
 /** Updates the shell-api constant to match the mongosh version. */
 export async function updateShellApiMongoshVersion(version: string) {
   const shellApiVersionFilePath = path.join(
-    __dirname,
     PROJECT_ROOT,
     'packages',
     'shell-api',

--- a/packages/build/src/npm-packages/bump.ts
+++ b/packages/build/src/npm-packages/bump.ts
@@ -10,14 +10,14 @@ import path from 'path';
 import { getPackagesInTopologicalOrder } from '@mongodb-js/monorepo-tools';
 
 /** Bumps only the main mongosh release packages to the set version. */
-export async function bumpMongoshReleasePackages(): Promise<void> {
-  const version = process.env.MONGOSH_RELEASE_VERSION;
+export async function bumpMongoshReleasePackages(
+  version: string
+): Promise<void> {
   if (!version) {
-    throw new Error(
-      'MONGOSH_RELEASE_VERSION version not specified during mongosh bump'
-    );
+    throw new Error('version not specified during mongosh bump');
   }
-  console.info(`mongosh: Bumping package versions to ${version}`);
+
+  console.info(`mongosh: Bumping mongosh release packages to ${version}`);
   const monorepoRootPath = path.resolve(__dirname, '..', '..', '..', '..');
   const packages = await getPackagesInTopologicalOrder(monorepoRootPath);
 

--- a/packages/build/src/npm-packages/index.ts
+++ b/packages/build/src/npm-packages/index.ts
@@ -1,3 +1,3 @@
-export { bumpAuxiliaryPackages } from './bump';
+export { bumpAuxiliaryPackages, bumpMongoshReleasePackages } from './bump';
 export { publishToNpm } from './publish';
 export { pushTags } from './push-tags';

--- a/packages/build/src/publish-mongosh.spec.ts
+++ b/packages/build/src/publish-mongosh.spec.ts
@@ -9,12 +9,17 @@ import type {
 import type { createAndPublishDownloadCenterConfig as createAndPublishDownloadCenterConfigFn } from './download-center';
 import { GithubRepo } from '@mongodb-js/devtools-github-repo';
 import type { publishToHomebrew as publishToHomebrewType } from './homebrew';
+import {
+  type publishToNpm as publishToNpmType,
+  type pushTags as pushTagsType,
+} from './npm-packages';
 import type {
-  publishToNpm as publishToNpmType,
-  pushTags as pushTagsType,
+  bumpMongoshReleasePackages as bumpMongoshReleasePackagesFn,
+  bumpAuxiliaryPackages as bumpAuxiliaryPackagesFn,
 } from './npm-packages';
 import { publishMongosh } from './publish-mongosh';
 import { dummyConfig } from '../test/helpers';
+import { getArtifactUrl } from './evergreen';
 
 chai.use(require('sinon-chai'));
 
@@ -36,11 +41,14 @@ describe('publishMongosh', function () {
   let writeBuildInfo: typeof writeBuildInfoType;
   let publishToHomebrew: typeof publishToHomebrewType;
   let shouldDoPublicRelease: typeof shouldDoPublicReleaseFn;
+  let bumpMongoshReleasePackages: typeof bumpMongoshReleasePackagesFn;
+  let bumpAuxiliaryPackages: typeof bumpAuxiliaryPackagesFn;
   let githubRepo: GithubRepo;
   let mongoHomebrewCoreForkRepo: GithubRepo;
   let homebrewCoreRepo: GithubRepo;
   let barque: Barque;
   let pushTags: typeof pushTagsType;
+  const getEvergreenArtifactUrl = getArtifactUrl;
 
   beforeEach(function () {
     config = { ...dummyConfig };
@@ -51,6 +59,8 @@ describe('publishMongosh', function () {
     publishToHomebrew = sinon.spy();
     shouldDoPublicRelease = sinon.spy();
     pushTags = sinon.spy();
+    bumpMongoshReleasePackages = sinon.spy();
+    bumpAuxiliaryPackages = sinon.spy();
 
     githubRepo = createStubRepo();
     mongoHomebrewCoreForkRepo = createStubRepo();
@@ -95,7 +105,10 @@ describe('publishMongosh', function () {
             pushTags,
             writeBuildInfo,
             publishToHomebrew,
-            shouldDoPublicRelease
+            shouldDoPublicRelease,
+            getEvergreenArtifactUrl,
+            bumpMongoshReleasePackages,
+            bumpAuxiliaryPackages
           );
         } catch (e: any) {
           return expect(e.message).to.contain('Could not find prior draft tag');
@@ -121,7 +134,10 @@ describe('publishMongosh', function () {
             pushTags,
             writeBuildInfo,
             publishToHomebrew,
-            shouldDoPublicRelease
+            shouldDoPublicRelease,
+            getEvergreenArtifactUrl,
+            bumpMongoshReleasePackages,
+            bumpAuxiliaryPackages
           );
         } catch (e: any) {
           return expect(e.message).to.contain('Version mismatch');
@@ -142,7 +158,10 @@ describe('publishMongosh', function () {
         pushTags,
         writeBuildInfo,
         publishToHomebrew,
-        shouldDoPublicRelease
+        shouldDoPublicRelease,
+        getEvergreenArtifactUrl,
+        bumpMongoshReleasePackages,
+        bumpAuxiliaryPackages
       );
 
       expect(barque.releaseToBarque).to.have.been.callCount(26);
@@ -173,7 +192,10 @@ describe('publishMongosh', function () {
         pushTags,
         writeBuildInfo,
         publishToHomebrew,
-        shouldDoPublicRelease
+        shouldDoPublicRelease,
+        getEvergreenArtifactUrl,
+        bumpMongoshReleasePackages,
+        bumpAuxiliaryPackages
       );
 
       expect(createAndPublishDownloadCenterConfig).to.have.been.calledWith(
@@ -196,7 +218,10 @@ describe('publishMongosh', function () {
         pushTags,
         writeBuildInfo,
         publishToHomebrew,
-        shouldDoPublicRelease
+        shouldDoPublicRelease,
+        getEvergreenArtifactUrl,
+        bumpMongoshReleasePackages,
+        bumpAuxiliaryPackages
       );
 
       expect(githubRepo.promoteRelease).to.have.been.calledWith(config);
@@ -214,7 +239,10 @@ describe('publishMongosh', function () {
         pushTags,
         writeBuildInfo,
         publishToHomebrew,
-        shouldDoPublicRelease
+        shouldDoPublicRelease,
+        getEvergreenArtifactUrl,
+        bumpMongoshReleasePackages,
+        bumpAuxiliaryPackages
       );
 
       expect(writeBuildInfo).to.have.been.calledOnceWith(config);
@@ -233,7 +261,10 @@ describe('publishMongosh', function () {
         pushTags,
         writeBuildInfo,
         publishToHomebrew,
-        shouldDoPublicRelease
+        shouldDoPublicRelease,
+        getEvergreenArtifactUrl,
+        bumpMongoshReleasePackages,
+        bumpAuxiliaryPackages
       );
 
       expect(publishToHomebrew).to.have.been.calledWith(
@@ -264,7 +295,10 @@ describe('publishMongosh', function () {
         pushTags,
         writeBuildInfo,
         publishToHomebrew,
-        shouldDoPublicRelease
+        shouldDoPublicRelease,
+        getEvergreenArtifactUrl,
+        bumpMongoshReleasePackages,
+        bumpAuxiliaryPackages
       );
 
       expect(createAndPublishDownloadCenterConfig).not.to.have.been.called;
@@ -282,7 +316,10 @@ describe('publishMongosh', function () {
         pushTags,
         writeBuildInfo,
         publishToHomebrew,
-        shouldDoPublicRelease
+        shouldDoPublicRelease,
+        getEvergreenArtifactUrl,
+        bumpMongoshReleasePackages,
+        bumpAuxiliaryPackages
       );
 
       expect(githubRepo.promoteRelease).not.to.have.been.called;
@@ -300,7 +337,10 @@ describe('publishMongosh', function () {
         pushTags,
         writeBuildInfo,
         publishToHomebrew,
-        shouldDoPublicRelease
+        shouldDoPublicRelease,
+        getEvergreenArtifactUrl,
+        bumpMongoshReleasePackages,
+        bumpAuxiliaryPackages
       );
 
       expect(publishToNpm).not.to.have.been.called;
@@ -318,7 +358,10 @@ describe('publishMongosh', function () {
         pushTags,
         writeBuildInfo,
         publishToHomebrew,
-        shouldDoPublicRelease
+        shouldDoPublicRelease,
+        getEvergreenArtifactUrl,
+        bumpMongoshReleasePackages,
+        bumpAuxiliaryPackages
       );
 
       expect(publishToHomebrew).not.to.have.been.called;
@@ -336,7 +379,10 @@ describe('publishMongosh', function () {
         pushTags,
         writeBuildInfo,
         publishToHomebrew,
-        shouldDoPublicRelease
+        shouldDoPublicRelease,
+        getEvergreenArtifactUrl,
+        bumpMongoshReleasePackages,
+        bumpAuxiliaryPackages
       );
 
       expect(barque.releaseToBarque).not.to.have.been.called;

--- a/packages/build/src/publish-mongosh.ts
+++ b/packages/build/src/publish-mongosh.ts
@@ -15,9 +15,9 @@ import { type publishToNpm as publishToNpmType } from './npm-packages';
 import type { PackageInformationProvider } from './packaging';
 import { getPackageFile } from './packaging';
 import {
-  bumpAuxiliaryPackages,
-  bumpMongoshReleasePackages,
-} from './npm-packages/bump';
+  bumpMongoshReleasePackages as bumpMongoshReleasePackagesFn,
+  bumpAuxiliaryPackages as bumpAuxiliaryPackagesFn,
+} from './npm-packages';
 
 export async function publishMongosh(
   config: Config,
@@ -31,7 +31,9 @@ export async function publishMongosh(
   writeBuildInfo: typeof writeBuildInfoType,
   publishToHomebrew: typeof publishToHomebrewType,
   shouldDoPublicRelease: typeof shouldDoPublicReleaseFn = shouldDoPublicReleaseFn,
-  getEvergreenArtifactUrl: typeof getArtifactUrlFn = getArtifactUrlFn
+  getEvergreenArtifactUrl: typeof getArtifactUrlFn = getArtifactUrlFn,
+  bumpMongoshReleasePackages: typeof bumpMongoshReleasePackagesFn = bumpMongoshReleasePackagesFn,
+  bumpAuxiliaryPackages: typeof bumpAuxiliaryPackagesFn = bumpAuxiliaryPackagesFn
 ): Promise<void> {
   if (!shouldDoPublicRelease(config)) {
     console.warn(

--- a/packages/build/src/publish-mongosh.ts
+++ b/packages/build/src/publish-mongosh.ts
@@ -14,6 +14,10 @@ import type { pushTags as pushTagsType } from './npm-packages';
 import { type publishToNpm as publishToNpmType } from './npm-packages';
 import type { PackageInformationProvider } from './packaging';
 import { getPackageFile } from './packaging';
+import {
+  bumpAuxiliaryPackages,
+  bumpMongoshReleasePackages,
+} from './npm-packages/bump';
 
 export async function publishMongosh(
   config: Config,
@@ -58,6 +62,9 @@ export async function publishMongosh(
     'mongosh: Re-using artifacts from most recent draft tag',
     latestDraftTag.name
   );
+
+  bumpAuxiliaryPackages();
+  await bumpMongoshReleasePackages(releaseVersion);
 
   await publishArtifactsToBarque(
     barque,

--- a/packages/build/src/release.ts
+++ b/packages/build/src/release.ts
@@ -59,7 +59,7 @@ export async function release(
   if (command === 'bump') {
     bumpAuxiliaryPackages();
     if (!config.useAuxiliaryPackagesOnly) {
-      await bumpMongoshReleasePackages();
+      await bumpMongoshReleasePackages(config.version);
     }
     return;
   }

--- a/packages/build/src/run-draft.spec.ts
+++ b/packages/build/src/run-draft.spec.ts
@@ -37,6 +37,8 @@ describe('draft', function () {
   });
 
   describe('runDraft', function () {
+    const bumpMongoshReleasePackages = sinon.spy();
+    const bumpMongoshAuxiliaryPackages = sinon.spy();
     let ensureGithubReleaseExistsAndUpdateChangelog: typeof ensureGithubReleaseExistsAndUpdateChangelogFn;
 
     beforeEach(function () {
@@ -58,7 +60,9 @@ describe('draft', function () {
           githubRepo,
           uploadArtifactToDownloadCenter,
           downloadArtifactFromEvergreen,
-          ensureGithubReleaseExistsAndUpdateChangelog
+          ensureGithubReleaseExistsAndUpdateChangelog,
+          bumpMongoshReleasePackages,
+          bumpMongoshAuxiliaryPackages
         );
       });
 
@@ -102,7 +106,9 @@ describe('draft', function () {
         githubRepo,
         uploadArtifactToDownloadCenter,
         downloadArtifactFromEvergreen,
-        ensureGithubReleaseExistsAndUpdateChangelog
+        ensureGithubReleaseExistsAndUpdateChangelog,
+        bumpMongoshReleasePackages,
+        bumpMongoshAuxiliaryPackages
       );
       expect(ensureGithubReleaseExistsAndUpdateChangelog).to.not.have.been
         .called;
@@ -125,7 +131,9 @@ describe('draft', function () {
           githubRepo,
           uploadArtifactToDownloadCenter,
           downloadArtifactFromEvergreen,
-          ensureGithubReleaseExistsAndUpdateChangelog
+          ensureGithubReleaseExistsAndUpdateChangelog,
+          bumpMongoshReleasePackages,
+          bumpMongoshAuxiliaryPackages
         );
       } catch (e: any) {
         expect(e.message).to.contain('Missing package information from config');

--- a/packages/build/src/run-draft.ts
+++ b/packages/build/src/run-draft.ts
@@ -7,6 +7,10 @@ import { downloadArtifactFromEvergreen as downloadArtifactFromEvergreenFn } from
 import { generateChangelog as generateChangelogFn } from './git';
 import type { GithubRepo } from '@mongodb-js/devtools-github-repo';
 import { getPackageFile } from './packaging';
+import {
+  bumpAuxiliaryPackages,
+  bumpMongoshReleasePackages,
+} from './npm-packages/bump';
 
 export async function runDraft(
   config: Config,
@@ -16,7 +20,8 @@ export async function runDraft(
   ensureGithubReleaseExistsAndUpdateChangelog: typeof ensureGithubReleaseExistsAndUpdateChangelogFn = ensureGithubReleaseExistsAndUpdateChangelogFn
 ): Promise<void> {
   const { triggeringGitTag } = config;
-  if (!triggeringGitTag || !getReleaseVersionFromTag(triggeringGitTag)) {
+  const draftReleaseVersion = getReleaseVersionFromTag(triggeringGitTag);
+  if (!triggeringGitTag || !draftReleaseVersion) {
     console.error(
       'mongosh: skipping draft as not triggered by a git tag that matches a draft/release tag'
     );
@@ -43,6 +48,9 @@ export async function runDraft(
     `draft-${Date.now()}`
   );
   await fs.mkdir(tmpDir, { recursive: true });
+
+  bumpAuxiliaryPackages();
+  await bumpMongoshReleasePackages(draftReleaseVersion);
 
   for await (const variant of ALL_PACKAGE_VARIANTS) {
     const tarballFile = getPackageFile(variant, config.packageInformation);

--- a/packages/build/src/run-draft.ts
+++ b/packages/build/src/run-draft.ts
@@ -8,8 +8,8 @@ import { generateChangelog as generateChangelogFn } from './git';
 import type { GithubRepo } from '@mongodb-js/devtools-github-repo';
 import { getPackageFile } from './packaging';
 import {
-  bumpAuxiliaryPackages,
-  bumpMongoshReleasePackages,
+  bumpAuxiliaryPackages as bumpAuxiliaryPackagesFn,
+  bumpMongoshReleasePackages as bumpMongoshReleasePackagesFn,
 } from './npm-packages/bump';
 
 export async function runDraft(
@@ -17,7 +17,9 @@ export async function runDraft(
   githubRepo: GithubRepo,
   uploadToDownloadCenter: typeof uploadArtifactToDownloadCenterFn = uploadArtifactToDownloadCenterFn,
   downloadArtifactFromEvergreen: typeof downloadArtifactFromEvergreenFn = downloadArtifactFromEvergreenFn,
-  ensureGithubReleaseExistsAndUpdateChangelog: typeof ensureGithubReleaseExistsAndUpdateChangelogFn = ensureGithubReleaseExistsAndUpdateChangelogFn
+  ensureGithubReleaseExistsAndUpdateChangelog: typeof ensureGithubReleaseExistsAndUpdateChangelogFn = ensureGithubReleaseExistsAndUpdateChangelogFn,
+  bumpMongoshReleasePackages: typeof bumpMongoshReleasePackagesFn = bumpMongoshReleasePackagesFn,
+  bumpAuxiliaryPackages: typeof bumpAuxiliaryPackagesFn = bumpAuxiliaryPackagesFn
 ): Promise<void> {
   const { triggeringGitTag } = config;
   const draftReleaseVersion = getReleaseVersionFromTag(triggeringGitTag);


### PR DESCRIPTION
Draft release will bump mongosh + other packages and build a release but not persist
Publish release will also bump mongosh + other packages (there's an assumption that nothing happened between the draft => publish stage) and "persist" that in sense that it'll push a tag, and then we can make a PR to merge the tags' content into main.
