### PR TITLE
fix(e2e-tests): make version test independent of package.json files

### DIFF
--- a/packages/e2e-tests/test/e2e.spec.ts
+++ b/packages/e2e-tests/test/e2e.spec.ts
@@ -38,6 +38,7 @@ describe('e2e', function () {
       // --version from the cli-repl package.json and --build-info from the generated build-info.json
       // (if available), which should all match.
       const shell = this.startTestShell({ args: ['--nodb'] });
+      await shell.waitForPrompt();
       const versionFromShellApi = (await shell.executeLine('version()'))
         .replace(/>/g, '')
         .trim();
@@ -50,7 +51,7 @@ describe('e2e', function () {
       await buildInfoShell.waitForSuccessfulExit();
       const versionFromBuildInfo = JSON.parse(buildInfoShell.output).version;
 
-      expect(versionFromShellApi).to.contain(versionFromCliFlag);
+      expect(versionFromShellApi).to.equal(versionFromCliFlag);
       expect(versionFromCliFlag).to.equal(versionFromBuildInfo);
     });
   });

--- a/packages/e2e-tests/test/e2e.spec.ts
+++ b/packages/e2e-tests/test/e2e.spec.ts
@@ -50,7 +50,7 @@ describe('e2e', function () {
       await buildInfoShell.waitForSuccessfulExit();
       const versionFromBuildInfo = JSON.parse(buildInfoShell.output).version;
 
-      expect(versionFromShellApi).to.equal(versionFromCliFlag);
+      expect(versionFromShellApi).to.contain(versionFromCliFlag);
       expect(versionFromCliFlag).to.equal(versionFromBuildInfo);
     });
   });


### PR DESCRIPTION
`--version`, `version()` and `--build-info` all source their version information differently. It should be sufficient to include a test to verify that they all match, without having to rely on the specific dependency from the e2e-test package.json file (which is in line with the general idea that e2e tests should not actually depend on the specific shell implementation and only test externally visible behavior of that implementation).