### PR TITLE
fix(ci): use more resilient approach for installing docker test dependencies

### DIFF
--- a/scripts/docker/build.sh
+++ b/scripts/docker/build.sh
@@ -4,7 +4,8 @@ set -e
 cd "$(dirname "$0")"
 
 # Used for verifying that we actually have a working csfle shared library
-[ -x node_modules/mongodb-crypt-library-version ] || ((cd ../.. && npm ci) && cp -r ../../node_modules node_modules)
+# --prefix=$PWD prevents npm from detecing the monorepo root and installing anything there
+[ -x node_modules/mongodb-crypt-library-version ] || (npm install --prefix="$PWD")
 
 # we don't have credentials for registry.suse.com and docker now requires them due to our config
 if [[ "$1" == suse* ]]; then


### PR DESCRIPTION
Our docker tests partially require `mongodb-crypt-library-version` to be present in `scripts/docker/node_modules`, installing it there directly and explicitly is more reliable than running `npm ci` in the monorepo root and copying `node_modules` over from there (esp. since `npm ci` may not work after packages have been bumped as part of a relase).