### PR TITLE
fix(ci): skip pushing tags on a dry run and push all tags on release

### DIFF
--- a/packages/build/src/npm-packages/push-tags.spec.ts
+++ b/packages/build/src/npm-packages/push-tags.spec.ts
@@ -54,7 +54,10 @@ describe('pushing tags', function () {
 
       expect(() =>
         pushTags(
-          { useAuxiliaryPackagesOnly: false },
+          {
+            isDryRun: false,
+            useAuxiliaryPackagesOnly: false,
+          },
           listNpmPackages,
           existsVersionTag,
           spawnSync
@@ -65,6 +68,7 @@ describe('pushing tags', function () {
     it('takes mongosh version and pushes tags when releasing', function () {
       pushTags(
         {
+          isDryRun: false,
           useAuxiliaryPackagesOnly: false,
         },
         listNpmPackages,
@@ -95,6 +99,7 @@ describe('pushing tags', function () {
     it('pushes only package tags when using auxiliary packages', function () {
       pushTags(
         {
+          isDryRun: false,
           useAuxiliaryPackagesOnly: true,
         },
         listNpmPackages,
@@ -146,6 +151,7 @@ describe('pushing tags', function () {
 
       pushTags(
         {
+          isDryRun: false,
           useAuxiliaryPackagesOnly: true,
         },
         listNpmPackages,
@@ -194,6 +200,7 @@ describe('pushing tags', function () {
       pushTags(
         {
           useAuxiliaryPackagesOnly: false,
+          isDryRun: false,
         },
         listNpmPackages,
         existsVersionTag,
@@ -208,6 +215,30 @@ describe('pushing tags', function () {
         `v${mongoshVersion}`,
       ]);
       expect(spawnSync).calledWith('git', ['push', '--follow-tags']);
+    });
+
+    it('skips tag push if it is a dry run', function () {
+      existsVersionTag.withArgs(`v${mongoshVersion}`).returns(true);
+
+      pushTags(
+        {
+          useAuxiliaryPackagesOnly: false,
+          isDryRun: true,
+        },
+        listNpmPackages,
+        existsVersionTag,
+        spawnSync
+      );
+
+      expect(spawnSync).not.calledWith('git', [
+        'tag',
+        '-a',
+        `v${mongoshVersion}`,
+        '-m',
+        `v${mongoshVersion}`,
+      ]);
+
+      expect(spawnSync).not.calledWith('git', ['push', '--follow-tags']);
     });
   });
 });

--- a/packages/build/src/npm-packages/push-tags.ts
+++ b/packages/build/src/npm-packages/push-tags.ts
@@ -9,7 +9,10 @@ import { listNpmPackages as listNpmPackagesFn } from './list';
 import { spawnSync as spawnSyncFn } from '../helpers/spawn-sync';
 
 export function pushTags(
-  { useAuxiliaryPackagesOnly }: { useAuxiliaryPackagesOnly: boolean },
+  {
+    useAuxiliaryPackagesOnly,
+    isDryRun,
+  }: { useAuxiliaryPackagesOnly: boolean; isDryRun: boolean },
   listNpmPackages: typeof listNpmPackagesFn = listNpmPackagesFn,
   existsVersionTag: typeof existsTag = existsTag,
   spawnSync: typeof spawnSyncFn = spawnSyncFn
@@ -68,7 +71,9 @@ export function pushTags(
     }
   }
 
-  spawnSync('git', ['push', '--follow-tags'], commandOptions);
+  if (!isDryRun) {
+    spawnSync('git', ['push', '--follow-tags'], commandOptions);
+  }
 }
 
 /** Returns true if the tag exists in the remote repository. */

--- a/packages/build/src/publish-auxiliary.ts
+++ b/packages/build/src/publish-auxiliary.ts
@@ -8,5 +8,8 @@ export function publishAuxiliaryPackages(config: Config) {
     );
   }
   publishToNpm(config);
-  pushTags({ useAuxiliaryPackagesOnly: true });
+  pushTags({
+    useAuxiliaryPackagesOnly: true,
+    isDryRun: config.isDryRun || false,
+  });
 }

--- a/packages/build/src/publish-mongosh.ts
+++ b/packages/build/src/publish-mongosh.ts
@@ -105,7 +105,10 @@ export async function publishMongosh(
     !!config.isDryRun
   );
 
-  pushTags({ useAuxiliaryPackagesOnly: true });
+  pushTags({
+    useAuxiliaryPackagesOnly: true,
+    isDryRun: config.isDryRun || false,
+  });
 
   console.info('mongosh: finished release process.');
 }

--- a/packages/build/src/publish-mongosh.ts
+++ b/packages/build/src/publish-mongosh.ts
@@ -106,7 +106,7 @@ export async function publishMongosh(
   );
 
   pushTags({
-    useAuxiliaryPackagesOnly: true,
+    useAuxiliaryPackagesOnly: false,
     isDryRun: config.isDryRun || false,
   });
 


### PR DESCRIPTION
Noticed this will happen in dry mode and another bug with tags that will happen and should be prevented.