### PR TITLE
feat(cli-repl): do not wait for log clean-up MONGOSH-1990

### DIFF
--- a/packages/cli-repl/src/cli-repl.spec.ts
+++ b/packages/cli-repl/src/cli-repl.spec.ts
@@ -38,7 +38,7 @@ const { EJSON } = bson;
 
 const delay = promisify(setTimeout);
 
-describe.only('CliRepl', function () {
+describe('CliRepl', function () {
   let cliReplOptions: CliReplOptions;
   let cliRepl: CliRepl & {
     start(

--- a/packages/cli-repl/src/cli-repl.spec.ts
+++ b/packages/cli-repl/src/cli-repl.spec.ts
@@ -33,12 +33,12 @@ import type { DevtoolsConnectOptions } from '@mongosh/service-provider-node-driv
 import type { AddressInfo } from 'net';
 import sinon from 'sinon';
 import type { CliUserConfig } from '@mongosh/types';
-import { MongoLogWriter } from 'mongodb-log-writer';
+import { MongoLogWriter, MongoLogManager } from 'mongodb-log-writer';
 const { EJSON } = bson;
 
 const delay = promisify(setTimeout);
 
-describe('CliRepl', function () {
+describe.only('CliRepl', function () {
   let cliReplOptions: CliReplOptions;
   let cliRepl: CliRepl & {
     start(
@@ -478,12 +478,14 @@ describe('CliRepl', function () {
         cliRepl = new CliRepl(cliReplOptions);
         await cliRepl.start('', {});
         await fs.stat(newerlogfile);
-        try {
-          await fs.stat(oldlogfile);
-          expect.fail('missed exception');
-        } catch (err: any) {
-          expect(err.code).to.equal('ENOENT');
-        }
+        await eventually(async () => {
+          try {
+            await fs.stat(oldlogfile);
+            expect.fail('missed exception');
+          } catch (err: any) {
+            expect(err.code).to.equal('ENOENT');
+          }
+        });
       });
 
       it('verifies the Node.js version', async function () {
@@ -1382,6 +1384,7 @@ describe('CliRepl', function () {
           srv.close();
           await once(srv, 'close');
           setTelemetryDelay(0);
+          sinon.restore();
         });
 
         context('logging configuration', function () {
@@ -1408,6 +1411,20 @@ describe('CliRepl', function () {
             expect(onLogInitialized).not.called;
 
             expect(cliRepl.logWriter).is.undefined;
+          });
+
+          it('logs cleanup errors', async function () {
+            sinon
+              .stub(MongoLogManager.prototype, 'cleanupOldLogFiles')
+              .rejects(new Error('Method not implemented'));
+            await cliRepl.start(await testServer.connectionString(), {});
+            expect(
+              (await log()).filter(
+                (entry) =>
+                  entry.ctx === 'log' &&
+                  entry.msg === 'Error: Method not implemented'
+              )
+            ).to.have.lengthOf(1);
           });
         });
 

--- a/packages/cli-repl/src/cli-repl.ts
+++ b/packages/cli-repl/src/cli-repl.ts
@@ -267,11 +267,14 @@ export class CliRepl implements MongoshIOProvider {
     });
 
     // Do not wait for log cleanup and log errors if MongoLogManager throws any.
-    void this.logManager.cleanupOldLogFiles().catch((err) => {
-      this.bus.emit('mongosh:error', err, 'log');
-    });
-
-    markTime(TimingCategories.Logging, 'cleaned up log files');
+    void this.logManager
+      .cleanupOldLogFiles()
+      .catch((err) => {
+        this.bus.emit('mongosh:error', err, 'log');
+      })
+      .finally(() => {
+        markTime(TimingCategories.Logging, 'cleaned up log files');
+      });
 
     if (!this.logWriter) {
       this.logWriter ??= await this.logManager.createLogWriter();

--- a/packages/cli-repl/src/cli-repl.ts
+++ b/packages/cli-repl/src/cli-repl.ts
@@ -266,7 +266,11 @@ export class CliRepl implements MongoshIOProvider {
         this.warnAboutInaccessibleFile(err, path),
     });
 
-    await this.logManager.cleanupOldLogFiles();
+    // Do not wait for log cleanup and log errors if MongoLogManager throws any.
+    void this.logManager.cleanupOldLogFiles().catch((err) => {
+      this.bus.emit('mongosh:error', err, 'log');
+    });
+
     markTime(TimingCategories.Logging, 'cleaned up log files');
 
     if (!this.logWriter) {


### PR DESCRIPTION
When cleaning up the old log files, we won’t wait for those processes to finish to unblock the main process. We will log errors if MongoLogManager throws any.