### PR TITLE
fix(ci): make bumping mongosh apply only to mongosh packages

### DIFF
--- a/packages/build/src/npm-packages/bump.spec.ts
+++ b/packages/build/src/npm-packages/bump.spec.ts
@@ -10,12 +10,16 @@ import path from 'path';
 import { PROJECT_ROOT } from './constants';
 
 describe('npm-packages bump', function () {
-  let fsReadFile: SinonStub;
   let fsWriteFile: SinonStub;
+  const shellApiSrc = path.join(
+    PROJECT_ROOT,
+    'packages',
+    'shell-api',
+    'src',
+    'mongosh-version.ts'
+  );
 
   beforeEach(function () {
-    fsReadFile = sinon.stub(fs, 'readFile');
-
     fsWriteFile = sinon.stub(fs, 'writeFile');
     fsWriteFile.resolves();
   });
@@ -25,6 +29,13 @@ describe('npm-packages bump', function () {
   });
 
   describe('bumpMongoshReleasePackages', function () {
+    let fsReadFile: SinonStub;
+    let getPackagesInTopologicalOrder: sinon.SinonStub;
+    beforeEach(function () {
+      fsReadFile = sinon.stub(fs, 'readFile');
+      getPackagesInTopologicalOrder = sinon.stub();
+    });
+
     it('warns and does not run if version is not set', async function () {
       const consoleWarnSpy = sinon.spy(console, 'warn');
       await bumpMongoshReleasePackages('');
@@ -35,9 +46,112 @@ describe('npm-packages bump', function () {
       expect(fsWriteFile).not.called;
       consoleWarnSpy.restore();
     });
+
+    it('bumps only mongosh packages', async function () {
+      getPackagesInTopologicalOrder.resolves([
+        { name: 'mongosh', location: 'packages/mongosh' },
+        { name: '@mongosh/autocomplete', location: 'packages/autocomplete' },
+      ]);
+
+      const rootProjectJson = `${PROJECT_ROOT}/package.json`;
+      const mockPackageJson = [
+        [
+          rootProjectJson,
+          {
+            name: 'mongosh',
+            devDependencies: {
+              mongosh: '0.1.2',
+              '@mongosh/cli-repl': '0.1.2',
+              '@mongosh/autocomplete': '1.2.3',
+            },
+          },
+        ],
+        [
+          'packages/mongosh/package.json',
+          {
+            name: 'mongosh',
+            version: '0.1.2',
+            devDependencies: {
+              '@mongosh/cli-repl': '9.9.9',
+              '@mongosh/autocomplete': '1.2.3',
+            },
+          },
+        ],
+        [
+          'packages/autocomplete/package.json',
+          {
+            name: '@mongosh/autocomplete',
+            version: '1.2.3',
+            devDependencies: {
+              '@mongosh/cli-repl': '0.1.2',
+              '@mongosh/config': '3.3.3',
+            },
+          },
+        ],
+      ];
+
+      fsReadFile.throws('Unknown file');
+      for (const [file, json] of mockPackageJson) {
+        fsReadFile.withArgs(file, 'utf8').resolves(JSON.stringify(json));
+      }
+
+      const updateShellApiMongoshVersion = sinon.stub();
+      await bumpMongoshReleasePackages(
+        '9.9.9',
+        getPackagesInTopologicalOrder,
+        updateShellApiMongoshVersion
+      );
+      expect(fsWriteFile).callCount(3);
+
+      expect(
+        JSON.parse(
+          fsWriteFile.withArgs(rootProjectJson).firstCall.args[1] as string
+        )
+      ).deep.equals({
+        name: 'mongosh',
+        devDependencies: {
+          mongosh: '9.9.9',
+          '@mongosh/cli-repl': '9.9.9',
+          '@mongosh/autocomplete': '1.2.3',
+        },
+      });
+
+      expect(
+        JSON.parse(
+          fsWriteFile.withArgs('packages/mongosh/package.json').firstCall
+            .args[1] as string
+        )
+      ).deep.equals({
+        name: 'mongosh',
+        version: '9.9.9',
+        devDependencies: {
+          '@mongosh/cli-repl': '9.9.9',
+          '@mongosh/autocomplete': '1.2.3',
+        },
+      });
+
+      expect(
+        JSON.parse(
+          fsWriteFile.withArgs('packages/autocomplete/package.json').firstCall
+            .args[1] as string
+        )
+      ).deep.equals({
+        name: '@mongosh/autocomplete',
+        version: '1.2.3',
+        devDependencies: {
+          '@mongosh/cli-repl': '9.9.9',
+          '@mongosh/config': '3.3.3',
+        },
+      });
+    });
   });
 
   describe('updateShellApiMongoshVersion', function () {
+    let fsReadFile: SinonStub;
+    beforeEach(function () {
+      fsReadFile = sinon.stub(fs, 'readFile');
+    });
+
     it('updates the file to the set version', async function () {
       fsReadFile.resolves(`
     /** Current mongosh cli-repl version. */
@@ -47,13 +161,7 @@ describe('npm-packages bump', function () {
       await updateShellApiMongoshVersion(newVersion);
 
       expect(fsWriteFile).calledWith(
-        path.join(
-          PROJECT_ROOT,
-          'packages',
-          'shell-api',
-          'src',
-          'mongosh-version.ts'
-        ),
+        shellApiSrc,
         `
     /** Current mongosh cli-repl version. */
     export const MONGOSH_VERSION = '${newVersion}';`,

--- a/packages/build/src/npm-packages/bump.ts
+++ b/packages/build/src/npm-packages/bump.ts
@@ -8,11 +8,13 @@ import {
 import { promises as fs } from 'fs';
 import path from 'path';
 import { spawnSync as spawnSyncFn } from '../helpers';
-import { getPackagesInTopologicalOrder } from '@mongodb-js/monorepo-tools';
+import { getPackagesInTopologicalOrder as getPackagesInTopologicalOrderFn } from '@mongodb-js/monorepo-tools';
 
 /** Bumps only the main mongosh release packages to the set version. */
 export async function bumpMongoshReleasePackages(
-  version: string
+  version: string,
+  getPackagesInTopologicalOrder: typeof getPackagesInTopologicalOrderFn = getPackagesInTopologicalOrderFn,
+  updateShellApiMongoshVersionFn: typeof updateShellApiMongoshVersion = updateShellApiMongoshVersion
 ): Promise<void> {
   if (!version) {
     console.warn(
@@ -22,12 +24,10 @@ export async function bumpMongoshReleasePackages(
   }
 
   console.info(`mongosh: Bumping mongosh release packages to ${version}`);
-  const monorepoRootPath = path.resolve(__dirname, '..', '..', '..', '..');
+  const monorepoRootPath = PROJECT_ROOT;
   const packages = await getPackagesInTopologicalOrder(monorepoRootPath);
 
-  const workspaceNames = packages
-    .map((p) => p.name)
-    .filter((name) => MONGOSH_RELEASE_PACKAGES.includes(name));
+  const bumpedPackages = MONGOSH_RELEASE_PACKAGES;
 
   const locations = [monorepoRootPath, ...packages.map((p) => p.location)];
 
@@ -35,7 +35,12 @@ export async function bumpMongoshReleasePackages(
     const packageJsonPath = path.join(location, 'package.json');
     const packageJson = JSON.parse(await fs.readFile(packageJsonPath, 'utf8'));
 
-    packageJson.version = version;
+    if (
+      bumpedPackages.includes(packageJson.name as string) &&
+      location !== monorepoRootPath
+    ) {
+      packageJson.version = version;
+    }
     for (const grouping of [
       'dependencies',
       'devDependencies',
@@ -47,7 +52,7 @@ export async function bumpMongoshReleasePackages(
       }
 
       for (const name of Object.keys(packageJson[grouping])) {
-        if (!workspaceNames.includes(name)) {
+        if (!bumpedPackages.includes(name)) {
           continue;
         }
         packageJson[grouping][name] = version;
@@ -60,7 +65,7 @@ export async function bumpMongoshReleasePackages(
     );
   }
 
-  await updateShellApiMongoshVersion(version);
+  await updateShellApiMongoshVersionFn(version);
 }
 
 /** Updates the shell-api constant to match the mongosh version. */


### PR DESCRIPTION
mongosh bump would actually end up overriding most auxiliary packages. This was likely not noticable before as the versions were already aligned and the ordering of the auxiliary bump was after the mongosh bump in tests