### PR TITLE
fix(scripts): drop `--no-since` from `lerna ls`

### DIFF
--- a/scripts/sort-workspaces.js
+++ b/scripts/sort-workspaces.js
@@ -22,7 +22,7 @@ async function main() {
   ));
 
   // should use the scopes in lerna.json
-  const { stdout } = await exec('npx -y lerna ls --all --no-since --toposort --json');
+  const { stdout } = await exec('npx -y lerna ls --all --toposort --json');
   packageJSON.workspaces = JSON.parse(stdout).map(({ location }) => path.relative(monorepoRoot, location));
 
   await fs.writeFile(


### PR DESCRIPTION
Packages that are otherwise missing are now included, since lerna treats `--no-since` differently from not specifying `--since` at all.