### PR TITLE
feat(logging): print help for the global log property MONGOSH-1995

### DIFF
--- a/packages/i18n/src/locales/en_US.ts
+++ b/packages/i18n/src/locales/en_US.ts
@@ -137,7 +137,6 @@ const translations: Catalog = {
           description: 'Shell log methods',
           link: '#',
           attributes: {
-            // TODO(MONGOSH-1995): Print help for the global log property.
             info: {
               description: 'Writes a custom info message to the log file',
               example: 'log.info("Custom info message")',
@@ -166,6 +165,10 @@ const translations: Catalog = {
           description: 'Shell Help',
           link: 'https://docs.mongodb.com/manual/reference/method',
           attributes: {
+            log: {
+              description:
+                "'log.info(<msg>)': Writes a custom info/warn/error/fatal/debug message to the log file",
+            },
             use: {
               description: 'Set current database',
             },
@@ -181,13 +184,13 @@ const translations: Catalog = {
             },
             show: {
               description:
-                "'show databases'/'show dbs': Print a list of all available databases.\n" +
-                "'show collections'/'show tables': Print a list of all collections for current database.\n" +
-                "'show profile': Prints system.profile information.\n" +
-                "'show users': Print a list of all users for current database.\n" +
-                "'show roles': Print a list of all roles for current database.\n" +
+                "'show databases'/'show dbs': Print a list of all available databases\n" +
+                "'show collections'/'show tables': Print a list of all collections for current database\n" +
+                "'show profile': Prints system.profile information\n" +
+                "'show users': Print a list of all users for current database\n" +
+                "'show roles': Print a list of all roles for current database\n" +
                 "'show log <type>': log for current connection, if type is not set uses 'global'\n" +
-                "'show logs': Print all logs.\n",
+                "'show logs': Print all logs",
             },
             connect: {
               description:

--- a/packages/i18n/src/locales/en_US.ts
+++ b/packages/i18n/src/locales/en_US.ts
@@ -167,7 +167,7 @@ const translations: Catalog = {
           attributes: {
             log: {
               description:
-                "'log.info(<msg>)': Writes a custom info/warn/error/fatal/debug message to the log file",
+                "'log.info(<msg>)': Write a custom info/warn/error/fatal/debug message to the log file",
             },
             use: {
               description: 'Set current database',

--- a/packages/shell-api/src/decorators.ts
+++ b/packages/shell-api/src/decorators.ts
@@ -473,14 +473,22 @@ function shellApiClassGeneric<T extends { prototype: any }>(
       constructor.prototype,
       propertyName
     );
+
+    if (toIgnore.includes(propertyName) || propertyName.startsWith('_')) {
+      continue;
+    }
+
     const isMethod =
       descriptor?.value && typeof descriptor.value === 'function';
-    if (
-      !isMethod ||
-      toIgnore.includes(propertyName) ||
-      propertyName.startsWith('_')
-    )
+    if (!isMethod) {
+      const attributeHelpKeyPrefix = `${classHelpKeyPrefix}.attributes.${propertyName}`;
+      classHelp.attr.push({
+        name: propertyName,
+        description: `${attributeHelpKeyPrefix}.description`,
+      });
       continue;
+    }
+
     let method: any = (descriptor as any).value;
 
     if ((constructor as any)[addSourceToResultsSymbol]) {

--- a/packages/shell-api/src/shell-api.ts
+++ b/packages/shell-api/src/shell-api.ts
@@ -36,6 +36,7 @@ import { dirname } from 'path';
 import { ShellUserConfig } from '@mongosh/types';
 import i18n from '@mongosh/i18n';
 import { MONGOSH_VERSION } from './mongosh-version';
+import type { ShellLog } from './shell-log';
 
 const instanceStateSymbol = Symbol.for('@@mongosh.instanceState');
 const loadCallNestingLevelSymbol = Symbol.for('@@mongosh.loadCallNestingLevel');
@@ -186,6 +187,10 @@ export default class ShellApi extends ShellApiClass {
     this[loadCallNestingLevelSymbol] = 0;
     this.DBQuery = new DBQuery(instanceState);
     this.config = new ShellConfig(instanceState);
+  }
+
+  get log(): ShellLog {
+    return this[instanceStateSymbol].shellLog;
   }
 
   get _instanceState(): ShellInstanceState {

--- a/packages/shell-api/src/shell-instance-state.ts
+++ b/packages/shell-api/src/shell-instance-state.ts
@@ -316,6 +316,7 @@ export default class ShellInstanceState {
   setCtx(contextObject: any): void {
     this.context = contextObject;
     Object.assign(contextObject, this.shellApi);
+    contextObject.log = this.shellLog;
     for (const name of Object.getOwnPropertyNames(ShellApi.prototype)) {
       const { shellApi } = this;
       if (
@@ -364,8 +365,6 @@ export default class ShellInstanceState {
         get: () => this.currentDb,
       });
     }
-
-    contextObject.log = this.shellLog;
 
     this.messageBus.emit('mongosh:setCtx', { method: 'setCtx', arguments: {} });
   }


### PR DESCRIPTION
When running the ShellApi `help` command, print the description for the ShellLog methods.