### PR TITLE
feat: create mechanism to expose log path within the repl MONGOSH-1090

### DIFF
--- a/packages/cli-repl/src/cli-repl.spec.ts
+++ b/packages/cli-repl/src/cli-repl.spec.ts
@@ -1340,6 +1340,7 @@ describe('CliRepl', function () {
       hasCollectionNames: true,
       hasDatabaseNames: true,
     });
+
     context('analytics integration', function () {
       context('with network connectivity', function () {
         let srv: http.Server;
@@ -1431,6 +1432,16 @@ describe('CliRepl', function () {
             ).to.have.lengthOf(1);
           });
 
+          it('can get a log path', async function () {
+            await cliRepl.start(await testServer.connectionString(), {});
+            expect(cliRepl.getLogPath()).equals(
+              path.join(
+                tmpdir.path,
+                (cliRepl.logWriter?.logId as string) + '_log'
+              )
+            );
+          });
+
           const customLogLocation = useTmpdir();
           it('can set the log location', async function () {
             cliRepl.config.logLocation = customLogLocation.path;
@@ -1440,6 +1451,12 @@ describe('CliRepl', function () {
               customLogLocation.path
             );
             expect(cliRepl.logWriter?.logFilePath).equals(
+              path.join(
+                customLogLocation.path,
+                (cliRepl.logWriter?.logId as string) + '_log'
+              )
+            );
+            expect(cliRepl.getLogPath()).equals(
               path.join(
                 customLogLocation.path,
                 (cliRepl.logWriter?.logId as string) + '_log'

--- a/packages/cli-repl/src/cli-repl.spec.ts
+++ b/packages/cli-repl/src/cli-repl.spec.ts
@@ -1470,18 +1470,12 @@ describe('CliRepl', function () {
             expect(await cliRepl.getConfig('logLocation')).equals(
               customLogHomePath
             );
-            expect(cliRepl.logWriter?.logFilePath).equals(
-              path.join(
-                customLogHomePath,
-                'mongosh_' + (cliRepl.logWriter?.logId as string) + '_log'
-              )
+            const logName = path.join(
+              customLogHomePath,
+              'mongosh_' + (cliRepl.logWriter?.logId as string) + '_log'
             );
-            expect(cliRepl.getLogPath()).equals(
-              path.join(
-                customLogLocation.path,
-                (cliRepl.logWriter?.logId as string) + '_log'
-              )
-            );
+            expect(cliRepl.logWriter?.logFilePath).equals(logName);
+            expect(cliRepl.getLogPath()).equals(path.join(logName));
           });
 
           it('can set log retention days', async function () {

--- a/packages/cli-repl/src/cli-repl.ts
+++ b/packages/cli-repl/src/cli-repl.ts
@@ -225,6 +225,13 @@ export class CliRepl implements MongoshIOProvider {
     this.setupOIDCTokenDumpListener();
   }
 
+  /**
+   * Implements getLogPath from the {@link ConfigProvider} interface.
+   */
+  getLogPath(): string | undefined {
+    return this.logWriter?.logFilePath ?? undefined;
+  }
+
   async getIsContainerizedEnvironment() {
     // Check for dockerenv file first
     try {

--- a/packages/cli-repl/src/mongosh-repl.ts
+++ b/packages/cli-repl/src/mongosh-repl.ts
@@ -78,6 +78,7 @@ export type MongoshIOProvider = Omit<
   ): Promise<{ contents: string; absolutePath: string }>;
   getCryptLibraryOptions(): Promise<AutoEncryptionOptions['extraOptions']>;
   bugReportErrorMessageInfo?(): string | undefined;
+  getLogPath(): string | undefined;
 };
 
 export type JSContext = 'repl' | 'plain-vm';

--- a/packages/cli-repl/src/mongosh-repl.ts
+++ b/packages/cli-repl/src/mongosh-repl.ts
@@ -1124,6 +1124,13 @@ class MongoshNodeRepl implements EvaluationListener {
   }
 
   /**
+   * Implements getLogPath from the {@link ConfigProvider} interface.
+   */
+  getLogPath(): string | undefined {
+    return this.ioProvider.getLogPath();
+  }
+
+  /**
    * Implements setConfig from the {@link ConfigProvider} interface.
    */
   async setConfig<K extends keyof CliUserConfig>(

--- a/packages/e2e-tests/test/e2e.spec.ts
+++ b/packages/e2e-tests/test/e2e.spec.ts
@@ -1984,6 +1984,13 @@ describe('e2e', function () {
           });
         });
 
+        it('gets a path to the current log file', async function () {
+          await shell.executeLine('log.getPath()');
+          expect(shell.assertNoErrors());
+          const logPath = path.join(logBasePath, `${shell.logId}_log`);
+          expect(shell.output).to.include(logPath);
+        });
+
         it('writes custom log directly', async function () {
           await shell.executeLine("log.info('This is a custom entry')");
           expect(shell.assertNoErrors());

--- a/packages/i18n/src/locales/en_US.ts
+++ b/packages/i18n/src/locales/en_US.ts
@@ -137,6 +137,10 @@ const translations: Catalog = {
           description: 'Shell log methods',
           link: '#',
           attributes: {
+            getPath: {
+              description: 'Gets a path to the current log file',
+              example: 'log.getPath()',
+            },
             info: {
               description: 'Writes a custom info message to the log file',
               example: 'log.info("Custom info message")',
@@ -167,7 +171,8 @@ const translations: Catalog = {
           attributes: {
             log: {
               description:
-                "'log.info(<msg>)': Write a custom info/warn/error/fatal/debug message to the log file",
+                "'log.info(<msg>)': Write a custom info/warn/error/fatal/debug message to the log file\n" +
+                "'log.getPath()': Gets a path to the current log file\n",
             },
             use: {
               description: 'Set current database',

--- a/packages/node-runtime-worker-thread/src/worker-runtime.spec.ts
+++ b/packages/node-runtime-worker-thread/src/worker-runtime.spec.ts
@@ -498,6 +498,7 @@ describe('worker-runtime', function () {
           return ['displayBatchSize'];
         },
         onRunInterruptible() {},
+        getLogPath() {},
       };
 
       spySandbox.spy(evalListener, 'onPrint');
@@ -508,6 +509,7 @@ describe('worker-runtime', function () {
       spySandbox.spy(evalListener, 'validateConfig');
       spySandbox.spy(evalListener, 'listConfigOptions');
       spySandbox.spy(evalListener, 'onRunInterruptible');
+      spySandbox.spy(evalListener, 'getLogPath');
 
       return evalListener;
     };
@@ -620,6 +622,20 @@ describe('worker-runtime', function () {
         expect(evalListener.resetConfig).to.have.been.calledWith(
           'displayBatchSize'
         );
+      });
+    });
+
+    describe('getLogPath', function () {
+      it('should be called when shell evaluates `getLogPath()`', async function () {
+        const { init, evaluate } = caller;
+        const evalListener = createSpiedEvaluationListener();
+
+        exposed = exposeAll(evalListener, worker);
+
+        await init('mongodb://nodb/', dummyOptions, { nodb: true });
+
+        await evaluate('getLogPath()');
+        expect(evalListener.getLogPath).to.have.been.called;
       });
     });
 

--- a/packages/node-runtime-worker-thread/src/worker-runtime.spec.ts
+++ b/packages/node-runtime-worker-thread/src/worker-runtime.spec.ts
@@ -626,7 +626,7 @@ describe('worker-runtime', function () {
     });
 
     describe('getLogPath', function () {
-      it('should be called when shell evaluates `getLogPath()`', async function () {
+      it('should be called when shell evaluates `log.getPath()`', async function () {
         const { init, evaluate } = caller;
         const evalListener = createSpiedEvaluationListener();
 
@@ -634,7 +634,7 @@ describe('worker-runtime', function () {
 
         await init('mongodb://nodb/', dummyOptions, { nodb: true });
 
-        await evaluate('getLogPath()');
+        await evaluate('log.getPath()');
         expect(evalListener.getLogPath).to.have.been.called;
       });
     });

--- a/packages/node-runtime-worker-thread/src/worker-runtime.ts
+++ b/packages/node-runtime-worker-thread/src/worker-runtime.ts
@@ -62,6 +62,7 @@ const evaluationListener = createCaller<WorkerRuntimeEvaluationListener>(
     'onClearCommand',
     'onExit',
     'onRunInterruptible',
+    'getLogPath',
   ],
   mainMessageBus,
   {

--- a/packages/node-runtime-worker-thread/src/worker-thread-evaluation-listener.ts
+++ b/packages/node-runtime-worker-thread/src/worker-thread-evaluation-listener.ts
@@ -56,6 +56,9 @@ export class WorkerThreadEvaluationListener {
             (Promise.resolve() as Promise<never>)
           );
         },
+        getLogPath() {
+          return workerRuntime.evaluationListener?.getLogPath?.();
+        },
       },
       worker
     );

--- a/packages/shell-api/src/shell-api.ts
+++ b/packages/shell-api/src/shell-api.ts
@@ -366,6 +366,15 @@ export default class ShellApi extends ShellApiClass {
     }
   }
 
+  @platforms(['CLI'])
+  getLogPath(): string | undefined {
+    try {
+      return this._instanceState.evaluationListener.getLogPath?.();
+    } catch (err: unknown) {
+      return String(err);
+    }
+  }
+
   @returnsPromise
   @platforms(['CLI'])
   async passwordPrompt(): Promise<string> {

--- a/packages/shell-api/src/shell-api.ts
+++ b/packages/shell-api/src/shell-api.ts
@@ -366,15 +366,6 @@ export default class ShellApi extends ShellApiClass {
     }
   }
 
-  @platforms(['CLI'])
-  getLogPath(): string | undefined {
-    try {
-      return this._instanceState.evaluationListener.getLogPath?.();
-    } catch (err: unknown) {
-      return String(err);
-    }
-  }
-
   @returnsPromise
   @platforms(['CLI'])
   async passwordPrompt(): Promise<string> {

--- a/packages/shell-api/src/shell-instance-state.ts
+++ b/packages/shell-api/src/shell-instance-state.ts
@@ -117,6 +117,11 @@ export interface EvaluationListener
    * options used to access it.
    */
   getCryptLibraryOptions?: () => Promise<AutoEncryptionOptions['extraOptions']>;
+
+  /**
+   * Called when log.getPath() is used in the shell.
+   */
+  getLogPath?: () => string | undefined;
 }
 
 /**

--- a/packages/shell-api/src/shell-log.ts
+++ b/packages/shell-api/src/shell-log.ts
@@ -21,6 +21,10 @@ export class ShellLog extends ShellApiClass {
     this[instanceStateSymbol] = instanceState;
   }
 
+  getPath(): string | undefined {
+    return this._instanceState.evaluationListener.getLogPath?.();
+  }
+
   info(message: string, attr?: unknown) {
     this[instanceStateSymbol].messageBus.emit('mongosh:write-custom-log', {
       method: 'info',
@@ -28,6 +32,7 @@ export class ShellLog extends ShellApiClass {
       attr,
     });
   }
+
   warn(message: string, attr?: unknown) {
     this[instanceStateSymbol].messageBus.emit('mongosh:write-custom-log', {
       method: 'warn',
@@ -35,6 +40,7 @@ export class ShellLog extends ShellApiClass {
       attr,
     });
   }
+
   error(message: string, attr?: unknown) {
     this[instanceStateSymbol].messageBus.emit('mongosh:write-custom-log', {
       method: 'error',
@@ -42,6 +48,7 @@ export class ShellLog extends ShellApiClass {
       attr,
     });
   }
+
   fatal(message: string, attr?: unknown) {
     this[instanceStateSymbol].messageBus.emit('mongosh:write-custom-log', {
       method: 'fatal',
@@ -49,6 +56,7 @@ export class ShellLog extends ShellApiClass {
       attr,
     });
   }
+
   debug(message: string, attr?: unknown, level?: 1 | 2 | 3 | 4 | 5) {
     this[instanceStateSymbol].messageBus.emit('mongosh:write-custom-log', {
       method: 'debug',

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -630,7 +630,6 @@ export interface ConfigProvider<T> {
     value: T[K]
   ): Promise<string | null>;
   listConfigOptions(): string[] | undefined | Promise<string[]>;
-  getLogPath(): string | undefined;
 }
 
 function isValidUrl(url: string): boolean {

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -424,6 +424,7 @@ export class ShellUserConfig {
   maxTimeMS: number | null = null;
   enableTelemetry = false;
   editor: string | null = null;
+  logLocation: string | undefined;
 }
 
 export class ShellUserConfigValidator {
@@ -623,6 +624,7 @@ export interface ConfigProvider<T> {
     value: T[K]
   ): Promise<string | null>;
   listConfigOptions(): string[] | undefined | Promise<string[]>;
+  getLogPath(): string | undefined;
 }
 
 function isValidUrl(url: string): boolean {


### PR DESCRIPTION
Implement the `log.getPath()` repl function that returns the log name that includes the current log location and log id. 