### PR TITLE
feat(shell-api): throw for EJSON.serialize(cursor) MONGOSH-2002

### DIFF
--- a/packages/e2e-tests/test/e2e.spec.ts
+++ b/packages/e2e-tests/test/e2e.spec.ts
@@ -737,13 +737,10 @@ describe('e2e', function () {
 
     it('throws the .toArray() suggestion when a user attempts to serialize a cursor', async function () {
       await shell.executeLine('const b = db.test.find()');
-      await shell.executeLine('b.b = b');
       await shell.executeLine('console.log(JSON.stringify(b));');
-      await eventually(() => {
-        shell.assertContainsOutput(
-          'Error serializing a cursor. Did you mean to call .toArray() first?'
-        );
-      });
+      shell.assertContainsOutput(
+        'Cannot serialize a cursor to JSON. Did you mean to call .toArray() first?'
+      );
     });
 
     it('expands explain output from aggregation indefinitely', async function () {

--- a/packages/e2e-tests/test/e2e.spec.ts
+++ b/packages/e2e-tests/test/e2e.spec.ts
@@ -735,6 +735,17 @@ describe('e2e', function () {
       );
     });
 
+    it('throws the .toArray() suggestion when a user attempts to serialize a cursor', async function () {
+      await shell.executeLine('const b = db.test.find()');
+      await shell.executeLine('b.b = b');
+      await shell.executeLine('console.log(JSON.stringify(b));');
+      await eventually(() => {
+        shell.assertContainsOutput(
+          'Error serializing a cursor. Did you mean to call .toArray() first?'
+        );
+      });
+    });
+
     it('expands explain output from aggregation indefinitely', async function () {
       await shell.executeLine(
         'explainOutput = db.test.aggregate([{ $limit: 1 }], {explain: "queryPlanner"})'

--- a/packages/shell-api/src/cursor.spec.ts
+++ b/packages/shell-api/src/cursor.spec.ts
@@ -809,7 +809,7 @@ describe('Cursor', function () {
         } catch (e: any) {
           expect(e).to.be.instanceOf(MongoshInvalidInputError);
           expect(e.message).to.contain(
-            'Error serializing a cursor. Did you mean to call .toArray() first?'
+            'Cannot serialize a cursor to JSON. Did you mean to call .toArray() first?'
           );
           expect(e.code).to.equal(CommonErrors.InvalidArgument);
         }

--- a/packages/shell-api/src/cursor.spec.ts
+++ b/packages/shell-api/src/cursor.spec.ts
@@ -793,6 +793,29 @@ describe('Cursor', function () {
       });
     });
 
+    describe('#toJSON', function () {
+      let spCursor: StubbedInstance<ServiceProviderCursor>;
+      let shellApiCursor: Cursor;
+
+      beforeEach(function () {
+        spCursor = stubInterface<ServiceProviderCursor>();
+        shellApiCursor = new Cursor(mongo, spCursor);
+      });
+
+      it('throws with the .toArray() suggestion', function () {
+        try {
+          shellApiCursor.toJSON();
+          expect.fail('expected error');
+        } catch (e: any) {
+          expect(e).to.be.instanceOf(MongoshInvalidInputError);
+          expect(e.message).to.contain(
+            'Error serializing a cursor. Did you mean to call .toArray() first?'
+          );
+          expect(e.code).to.equal(CommonErrors.InvalidArgument);
+        }
+      });
+    });
+
     describe('#maxScan', function () {
       let spCursor: StubbedInstance<ServiceProviderCursor>;
       let shellApiCursor: Cursor;

--- a/packages/shell-api/src/cursor.spec.ts
+++ b/packages/shell-api/src/cursor.spec.ts
@@ -804,7 +804,7 @@ describe('Cursor', function () {
 
       it('throws with the .toArray() suggestion', function () {
         try {
-          shellApiCursor.toJSON();
+          JSON.stringify(shellApiCursor);
           expect.fail('expected error');
         } catch (e: any) {
           expect(e).to.be.instanceOf(MongoshInvalidInputError);

--- a/packages/shell-api/src/cursor.ts
+++ b/packages/shell-api/src/cursor.ts
@@ -44,7 +44,7 @@ export default class Cursor extends AggregateOrFindCursor<ServiceProviderFindCur
    */
   toJSON(): void {
     throw new MongoshInvalidInputError(
-      'Error serializing a cursor. Did you mean to call .toArray() first?',
+      'Cannot serialize a cursor to JSON. Did you mean to call .toArray() first?',
       CommonErrors.InvalidArgument
     );
   }

--- a/packages/shell-api/src/cursor.ts
+++ b/packages/shell-api/src/cursor.ts
@@ -35,6 +35,21 @@ export default class Cursor extends AggregateOrFindCursor<ServiceProviderFindCur
   }
 
   /**
+   * Throw a custom exception when a user attempts to serialize a cursor,
+   * pointing to the fact that .toArray() needs to be called first.
+   *
+   * @param {CursorFlag} flag - The cursor flag.
+   *
+   * @returns {void}
+   */
+  toJSON(): void {
+    throw new MongoshInvalidInputError(
+      'Error serializing a cursor. Did you mean to call .toArray() first?',
+      CommonErrors.InvalidArgument
+    );
+  }
+
+  /**
    * Add a flag and return the cursor.
    *
    * @param {CursorFlag} flag - The cursor flag.


### PR DESCRIPTION
Throw a custom exception when a user attempts to serialize a cursor, pointing them to the fact that they likely want to call `.toArray()` first.