### PR TITLE
fix(shell-api): remove accidentally copied decorators on internal method

### DIFF
--- a/packages/shell-api/src/shell-api.ts
+++ b/packages/shell-api/src/shell-api.ts
@@ -213,9 +213,7 @@ export default class ShellApi extends ShellApiClass {
     return await this._instanceState.currentDb._mongo.show(cmd, arg);
   }
 
-  @directShellCommand
   @returnsPromise
-  @shellCommandCompleter(showCompleter)
   async _untrackedShow(cmd: string, arg?: string): Promise<CommandResult> {
     return await this._instanceState.currentDb._mongo.show(cmd, arg, false);
   }


### PR DESCRIPTION
These were almost certainly unintentionally copied over from `show`, but shouldn't apply here since this is just an internal method and not user-facing.