### PR TITLE
chore(ci): add automatic merging of the release tag MONGOSH-2018

### DIFF
--- a/.github/workflows/merge-release-tag.yml
+++ b/.github/workflows/merge-release-tag.yml
@@ -22,26 +22,11 @@ jobs:
 
       - uses: actions/checkout@v4
         with:
-          ref: ${{ github.ref }}
+          ref: main
           fetch-depth: "0"
           token: ${{ steps.app-token.outputs.token }}
 
-      - name: Extract version from tag
-        uses: actions-ecosystem/action-regex-match@d50fd2e7a37d0e617aea3d7ada663bd56862b9cc
-        id: version-match
-        with:
-          text: ${{ github.ref }}
-          regex: 'refs/tags/mongosh@([0-9]+\.[0-9]+\.[0-9]+.*)'
-
-      - uses: actions/github-script@v7
-        if: steps.version-match.outputs.group1 == ''
-        with:
-          script: |
-            core.setFailed('Could not extract version from tag: ${{ github.ref }}');
-
       - name: Merge release tag into main
         run: |
-          git checkout -b package-release/v${{ steps.version-match.outputs.group1 }} ${{ github.ref }}
-          git checkout main
-          git merge package-release/v${{ steps.version-match.outputs.group1 }}
+          git merge ${{ github.ref }} -m "chore(release): merge changes from ${{ github.ref_name }}"
           git push origin main

--- a/.github/workflows/merge-release-tag.yml
+++ b/.github/workflows/merge-release-tag.yml
@@ -3,7 +3,8 @@ name: Merge Release Tag
 on:
   push:
     tags:
-      - 'mongosh@[0-9]+.[0-9]+.[0-9]+*'
+      - 'mongosh@[0-9]+.[0-9]+.[0-9]+'
+      - 'mongosh@[0-9]+.[0-9]+.[0-9]-rc.[0-9]+'
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/merge-release-tag.yml
+++ b/.github/workflows/merge-release-tag.yml
@@ -1,0 +1,54 @@
+name: Merge Release Tag
+
+on:
+  push:
+    tags:
+      - 'mongosh@[0-9]+.[0-9]+.[0-9]+'
+  workflow_dispatch:
+
+jobs:
+  merge-release-tag:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: mongodb-js/devtools-shared/actions/setup-bot-token@main
+        id: app-token
+        with:
+          app-id: ${{ vars.DEVTOOLS_BOT_APP_ID }}
+          private-key: ${{ secrets.DEVTOOLS_BOT_PRIVATE_KEY }}
+
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.ref }}
+          fetch-depth: "0"
+          token: ${{ steps.app-token.outputs.token }}
+
+      - name: Extract version from tag
+        id: version
+        run: echo "RELEASE_VERSION=$(echo ${GITHUB_REF} | sed -n 's/refs\/tags\/mongosh@\([0-9]\+\.[0-9]\+\.[0-9]\+\)/\1/p')" >> $GITHUB_ENV
+
+      - name: Validate release version
+        shell: bash
+        run: |
+          if [ -z "${RELEASE_VERSION}" ]; then
+            echo "RELEASE_TAG is not set or is empty"
+            exit 1
+          fi
+
+          if git rev-parse "release/v$RELEASE_VERSION" >/dev/null 2>&1; then
+            echo "Error: Branch release/v$RELEASE_TAG already exists"
+            echo "If this version has already been released consider using a different one."
+            exit 1
+          fi
+
+      - name: Create and push branch from tag
+        run: |
+          git checkout -b release/v$RELEASE_VERSION ${{ github.ref }}
+          git push origin release/v$RELEASE_VERSION
+
+      - name: Merge branch into main
+        run: |
+          git checkout main
+          git merge release/v$RELEASE_VERSION
+          git push origin main
+          git push -d origin release/v$RELEASE_VERSION

--- a/.github/workflows/merge-release-tag.yml
+++ b/.github/workflows/merge-release-tag.yml
@@ -3,7 +3,7 @@ name: Merge Release Tag
 on:
   push:
     tags:
-      - 'mongosh@[0-9]+.[0-9]+.*'
+      - 'mongosh@[0-9]+.[0-9]+.[0-9]+*'
   workflow_dispatch:
 
 permissions:
@@ -31,27 +31,17 @@ jobs:
         id: version-match
         with:
           text: ${{ github.ref }}
-          regex: 'refs/tags/mongosh@([0-9]+\.[0-9]+\.*)'
+          regex: 'refs/tags/mongosh@([0-9]+\.[0-9]+\.[0-9]+.*)'
 
-      - name: Validate release version
-        shell: bash
-        id: validate
-        run: |
-          if [[ -z "${{ steps.version-match.outputs.group1 }}" ]]; then
-            echo "Error: Could not extract version from tag"
-            exit 1
-          fi
-
-          if git rev-parse "release/v${{ steps.version-match.outputs.group1 }}" >/dev/null 2>&1; then
-            echo "Error: Branch release/v$RELEASE_TAG already exists"
-            echo "If this version has already been released consider using a different one."
-            exit 1
-          fi
-          echo "::set-output name=version::${{ steps.version-match.outputs.group1 }}"
+      - uses: actions/github-script@v7
+        if: steps.version-match.outputs.group1 == ''
+        with:
+          script: |
+            core.setFailed('Could not extract version from tag: ${{ github.ref }}');
 
       - name: Merge release tag into main
         run: |
-          git checkout -b release/v${{ steps.validate.outputs.version }} ${{ github.ref }}
+          git checkout -b package-release/v${{ steps.version-match.outputs.group1 }} ${{ github.ref }}
           git checkout main
-          git merge release/v${{ steps.validate.outputs.version }}
+          git merge package-release/v${{ steps.version-match.outputs.group1 }}
           git push origin main

--- a/.github/workflows/merge-release-tag.yml
+++ b/.github/workflows/merge-release-tag.yml
@@ -3,8 +3,11 @@ name: Merge Release Tag
 on:
   push:
     tags:
-      - 'mongosh@[0-9]+.[0-9]+.[0-9]+'
+      - 'mongosh@[0-9]+.[0-9]+.*'
   workflow_dispatch:
+
+permissions:
+  contents: none # We use the github app to checkout and push tags
 
 jobs:
   merge-release-tag:
@@ -24,31 +27,31 @@ jobs:
           token: ${{ steps.app-token.outputs.token }}
 
       - name: Extract version from tag
-        id: version
-        run: echo "RELEASE_VERSION=$(echo ${GITHUB_REF} | sed -n 's/refs\/tags\/mongosh@\([0-9]\+\.[0-9]\+\.[0-9]\+\)/\1/p')" >> $GITHUB_ENV
+        uses: actions-ecosystem/action-regex-match@d50fd2e7a37d0e617aea3d7ada663bd56862b9cc
+        id: version-match
+        with:
+          text: ${{ github.ref }}
+          regex: 'refs/tags/mongosh@([0-9]+\.[0-9]+\.*)'
 
       - name: Validate release version
         shell: bash
+        id: validate
         run: |
-          if [ -z "${RELEASE_VERSION}" ]; then
-            echo "RELEASE_TAG is not set or is empty"
+          if [[ -z "${{ steps.version-match.outputs.group1 }}" ]]; then
+            echo "Error: Could not extract version from tag"
             exit 1
           fi
 
-          if git rev-parse "release/v$RELEASE_VERSION" >/dev/null 2>&1; then
+          if git rev-parse "release/v${{ steps.version-match.outputs.group1 }}" >/dev/null 2>&1; then
             echo "Error: Branch release/v$RELEASE_TAG already exists"
             echo "If this version has already been released consider using a different one."
             exit 1
           fi
+          echo "::set-output name=version::${{ steps.version-match.outputs.group1 }}"
 
-      - name: Create and push branch from tag
+      - name: Merge release tag into main
         run: |
-          git checkout -b release/v$RELEASE_VERSION ${{ github.ref }}
-          git push origin release/v$RELEASE_VERSION
-
-      - name: Merge branch into main
-        run: |
+          git checkout -b release/v${{ steps.validate.outputs.version }} ${{ github.ref }}
           git checkout main
-          git merge release/v$RELEASE_VERSION
+          git merge release/v${{ steps.validate.outputs.version }}
           git push origin main
-          git push -d origin release/v$RELEASE_VERSION

--- a/.github/workflows/merge-release-tag.yml
+++ b/.github/workflows/merge-release-tag.yml
@@ -7,7 +7,7 @@ on:
   workflow_dispatch:
 
 permissions:
-  contents: none # We use the github app to checkout and push tags
+  contents: none # We use the github app to checkout and push changes
 
 jobs:
   merge-release-tag:

--- a/packages/build/README.md
+++ b/packages/build/README.md
@@ -39,7 +39,7 @@ Execute the following steps to publish a new release:
    ```
    Follow the instructions and verify the inferred release version is correct.
 7. Wait for Evergreen to finish the publication stage.
-8. Ensure the release version bump has been automatically merged into the main branch from the `release/vx.x.x` branch.
+8. Ensure that the version bump was automatically merged into main and that it is synced up with the `mongosh@x.x.x` tag.
 9. Close the Jira ticket for the release, post an update in the `#mongosh` Slack channel and ping the docs team.
 
 ### Branches and Tags

--- a/packages/build/README.md
+++ b/packages/build/README.md
@@ -39,7 +39,7 @@ Execute the following steps to publish a new release:
    ```
    Follow the instructions and verify the inferred release version is correct.
 7. Wait for Evergreen to finish the publication stage.
-8. The previous step will have pushed tags for the npm publishes. Check out the tag for `mongosh@<version>` (not `v<version>`), create a branch for it, push that branch and open a PR with it. Then immediately merge that branch **using the `git merge` CLI command into main** and push to main. **NEVER** use the Github PR merge functionality, since that would squash the commit and give it a new commit hash that is different from the one in the tag.
+8. Ensure the release version bump has been automatically merged into the main branch from the `release/vx.x.x` branch.
 9. Close the Jira ticket for the release, post an update in the `#mongosh` Slack channel and ping the docs team.
 
 ### Branches and Tags


### PR DESCRIPTION
The new system requires us to manually merge into main. This automates it through a workflow.

It can also be triggered manually with a workflow dispatch.