### PR TITLE
fix(ci): run prepublish topologically to fix auxiliary publishing

### DIFF
--- a/packages/build/src/npm-packages/publish.ts
+++ b/packages/build/src/npm-packages/publish.ts
@@ -18,6 +18,11 @@ export function publishToNpm(
     },
   };
 
+  // There seems to be a bug where lerna does not run prepublish topologically
+  // during the publish step, causing build errors. This ensures all packages are topologically
+  // compiled beforehand.
+  spawnSync(LERNA_BIN, ['run', 'prepublish', '--sort'], commandOptions);
+
   // Lerna requires a clean repository for a publish from-package
   // we use git update-index --assume-unchanged on files we know have been bumped
   spawnSync(


### PR DESCRIPTION
There seems to be a bug where lerna does not run prepublish topologically during the publish step, causing build errors. This ensures all packages are topologically compiled beforehand.

I tried different ways of forcing on `lerna`, including updating it, and could not come up with a better solution.

## Steps to Reproduce Locally:
1. Get a clean repository of `mongosh` or cleanup the builds of i.e. `rm -rf packages/errors/lib`
2. Run `npm_config_dry_run=true npx lerna publish from-package --no-private --no-changelog --exact --yes --sort`
3. Some packages which depend on `@mongosh/errors` i.e. `@mongosh/service-provider-core` fail as their prepublish gets called before the `errors`. The `--sort` tag doesn't help.