### PR TITLE
chore(ci): align package bump commits

### DIFF
--- a/.github/workflows/bump-auxiliary-packages.yml
+++ b/.github/workflows/bump-auxiliary-packages.yml
@@ -42,15 +42,15 @@ jobs:
         run: |
           npm run bump-auxiliary
           git add .
-          git commit --no-allow-empty -m "chore(release): bump auxiliary packages" || true
+          git commit --no-allow-empty -m "chore(release): bump packages for auxiliary release" || true
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # 7.0.5
         with:
           token: ${{ steps.app-token.outputs.token }}
-          commit-message: "chore(release): bump auxiliary packages"
+          commit-message: "chore(release): bump packages for auxiliary release"
           branch: ci/bump-auxiliary-packages
-          title: "chore(release): bump auxiliary packages"
+          title: "chore(release): bump packages for auxiliary release"
           labels: no-title-validation
           body: |
             - Bumps auxiliary package versions. Merging will trigger a release of these packages.

--- a/.github/workflows/publish-auxiliary-packages.yml
+++ b/.github/workflows/publish-auxiliary-packages.yml
@@ -16,7 +16,7 @@ jobs:
   publish:
     if: |
       github.event_name == 'workflow_dispatch' ||
-        startsWith(github.event.head_commit.message, 'chore(release): bump auxiliary packages')
+        startsWith(github.event.head_commit.message, 'chore(release): bump packages for auxiliary release')
 
     runs-on: ubuntu-latest
     environment: Production

--- a/packages/build/src/npm-packages/bump.ts
+++ b/packages/build/src/npm-packages/bump.ts
@@ -110,7 +110,7 @@ export function bumpAuxiliaryPackages() {
     encoding: 'utf8',
     env: {
       ...process.env,
-      LAST_BUMP_COMMIT_MESSAGE: 'chore(release): bump auxiliary packages',
+      LAST_BUMP_COMMIT_MESSAGE: 'chore(release): bump packages',
       SKIP_BUMP_PACKAGES: [
         ...EXCLUDE_RELEASE_PACKAGES,
         ...MONGOSH_RELEASE_PACKAGES,
@@ -120,6 +120,7 @@ export function bumpAuxiliaryPackages() {
 }
 
 export function commitBumpedPackages(
+  { useAuxiliaryPackagesOnly }: { useAuxiliaryPackagesOnly: boolean },
   spawnSync: typeof spawnSyncFn = spawnSyncFn
 ) {
   spawnSync('git', ['add', '.'], {
@@ -128,9 +129,19 @@ export function commitBumpedPackages(
     encoding: 'utf8',
   });
 
-  spawnSync('git', ['commit', '-m', 'chore(release): bump packages'], {
-    stdio: 'inherit',
-    cwd: PROJECT_ROOT,
-    encoding: 'utf8',
-  });
+  spawnSync(
+    'git',
+    [
+      'commit',
+      '-m',
+      `chore(release): bump packages for ${
+        useAuxiliaryPackagesOnly ? 'auxiliary' : 'mongosh'
+      } release`,
+    ],
+    {
+      stdio: 'inherit',
+      cwd: PROJECT_ROOT,
+      encoding: 'utf8',
+    }
+  );
 }

--- a/packages/build/src/publish-mongosh.ts
+++ b/packages/build/src/publish-mongosh.ts
@@ -70,7 +70,7 @@ export async function publishMongosh(
 
   bumpAuxiliaryPackages();
   await bumpMongoshReleasePackages(releaseVersion);
-  commitBumpedPackages(spawnSync);
+  commitBumpedPackages({ useAuxiliaryPackagesOnly: false }, spawnSync);
   pushTags({
     useAuxiliaryPackagesOnly: false,
     isDryRun: config.isDryRun || false,


### PR DESCRIPTION
Currently we bump packages with 2 different commit messages: 
`"chore(release): bump auxiliary packages"` during an auxiliary and
`"chore(release): bump packages"` during a mongosh release. 

The problem is the mono repo tools' bump looks for commits messages starting with `"..bump auxiliary packages"` and thus ignores already released changes if they were made during a mongosh release. 

To align this while also differentiating them for the purpose of the auxiliary publishing workflow, these commits will now both starts with `"chore(release): bump packages"` and instead have different ending "for mongosh release" or "for auxiliary release"