### PR TITLE
fix(ci): apply Kondukto changes to evergreen template file

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -3780,6 +3780,23 @@ functions:
   # - signature_tag (either 'signed' or 'unsigned')
   ###
   add_crypt_shared_and_sbom:
+    - command: ec2.assume_role
+      display_name: Assume IAM role with permissions to pull Kondukto API token
+      params:
+        role_arn: ${kondukto_role_arn}
+    - command: shell.exec
+      display_name: Pull Kondukto API token from AWS Secrets Manager and write it to file
+      params:
+        silent: true
+        shell: bash
+        working_dir: src
+        include_expansions_in_env: [AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN]
+        script: |
+          set -e
+          # use AWS CLI to get the Kondukto API token from AWS Secrets Manager
+          kondukto_token=$(aws secretsmanager get-secret-value --secret-id "kondukto-token" --region "us-east-1" --query 'SecretString' --output text)
+          # set the KONDUKTO_TOKEN environment variable
+          echo "KONDUKTO_TOKEN=$kondukto_token" > /tmp/kondukto_credentials.env
     - command: subprocess.exec
       params:
         working_dir: src
@@ -3790,10 +3807,8 @@ functions:
           PACKAGE_VARIANT: ${package_variant}
           ARTIFACTORY_USERNAME: ${artifactory_username}
           ARTIFACTORY_PASSWORD: ${artifactory_password}
-          # for Silk SBOM integration
-          SILK_ASSET_GROUP: mongosh-${executable_os_id}
-          SILK_CLIENT_ID: ${silk_client_id}
-          SILK_CLIENT_SECRET: ${silk_client_secret}
+          # for Kondukto SBOM integration
+          KONDUKTO_BRANCH: ${branch_name}_${executable_os_id}
   create_static_analysis_report:
     - command: s3.get
       params:

--- a/.evergreen/evergreen.yml.in
+++ b/.evergreen/evergreen.yml.in
@@ -489,6 +489,23 @@ functions:
   # - signature_tag (either 'signed' or 'unsigned')
   ###
   add_crypt_shared_and_sbom:
+    - command: ec2.assume_role
+      display_name: Assume IAM role with permissions to pull Kondukto API token
+      params:
+        role_arn: ${kondukto_role_arn}
+    - command: shell.exec
+      display_name: Pull Kondukto API token from AWS Secrets Manager and write it to file
+      params:
+        silent: true
+        shell: bash
+        working_dir: src
+        include_expansions_in_env: [AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_SESSION_TOKEN]
+        script: |
+          set -e
+          # use AWS CLI to get the Kondukto API token from AWS Secrets Manager
+          kondukto_token=$(aws secretsmanager get-secret-value --secret-id "kondukto-token" --region "us-east-1" --query 'SecretString' --output text)
+          # set the KONDUKTO_TOKEN environment variable
+          echo "KONDUKTO_TOKEN=$kondukto_token" > /tmp/kondukto_credentials.env
     - command: subprocess.exec
       params:
         working_dir: src
@@ -499,10 +516,8 @@ functions:
           PACKAGE_VARIANT: ${package_variant}
           ARTIFACTORY_USERNAME: ${artifactory_username}
           ARTIFACTORY_PASSWORD: ${artifactory_password}
-          # for Silk SBOM integration
-          SILK_ASSET_GROUP: mongosh-${executable_os_id}
-          SILK_CLIENT_ID: ${silk_client_id}
-          SILK_CLIENT_SECRET: ${silk_client_secret}
+          # for Kondukto SBOM integration
+          KONDUKTO_BRANCH: ${branch_name}_${executable_os_id}
   create_static_analysis_report:
   <%
   let firstPartyDepsFilenames = [];


### PR DESCRIPTION
aba4ba16ae83b84 included the correct changes but in the wrong file (evergreen.yml instead of the template file), so 89762a550e9eb30f8cb1 undid those changes partially and our CI has been failing since then.

Applying these changes to the correct file should fix that.