### PR TITLE
chore(deps): bump oidc-plugin package MONGOSH-2027

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5913,6 +5913,7 @@
       "resolved": "https://registry.npmjs.org/@mongodb-js/oidc-plugin/-/oidc-plugin-1.1.5.tgz",
       "integrity": "sha512-K76ADgrDpL+lg6L/QsEBIGbSjTEUljYDGDX75Tq4+zIkx3JQgeQhS5J3qZNzKwJa4nj+EwhihaADLRgsMpAtrA==",
       "license": "Apache-2.0",
+      "peer": true,
       "dependencies": {
         "express": "^4.18.2",
         "open": "^9.1.0",
@@ -5925,6 +5926,7 @@
     "node_modules/@mongodb-js/oidc-plugin/node_modules/define-lazy-prop": {
       "version": "3.0.0",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -5935,6 +5937,7 @@
     "node_modules/@mongodb-js/oidc-plugin/node_modules/open": {
       "version": "9.1.0",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "default-browser": "^4.0.0",
         "define-lazy-prop": "^3.0.0",
@@ -29364,7 +29367,7 @@
       "version": "3.5.0",
       "license": "Apache-2.0",
       "dependencies": {
-        "@mongodb-js/oidc-plugin": "^1.1.5",
+        "@mongodb-js/oidc-plugin": "^1.1.6",
         "@mongosh/cli-repl": "2.4.0",
         "@mongosh/service-provider-core": "3.0.5",
         "strip-ansi": "^6.0.0"
@@ -29406,6 +29409,20 @@
         "oidc-mock-provider": "bin/oidc-mock-provider.js"
       }
     },
+    "packages/e2e-tests/node_modules/@mongodb-js/oidc-plugin": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/oidc-plugin/-/oidc-plugin-1.1.6.tgz",
+      "integrity": "sha512-fuL4B9x1njcqdJqV+V3pt8s/9PX4uy9ojhcsP12BavDcg61ju6WEqCkDmUZCykDIvsDbb8tIhO97aCKDxcXROw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "express": "^4.18.2",
+        "open": "^9.1.0",
+        "openid-client": "^5.6.4"
+      },
+      "engines": {
+        "node": ">= 16.20.1"
+      }
+    },
     "packages/e2e-tests/node_modules/cliui": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -29429,6 +29446,18 @@
       "license": "MIT",
       "engines": {
         "node": ">= 12"
+      }
+    },
+    "packages/e2e-tests/node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "packages/e2e-tests/node_modules/mongodb-log-writer": {
@@ -29461,6 +29490,24 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/node-fetch"
+      }
+    },
+    "packages/e2e-tests/node_modules/open": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-9.1.0.tgz",
+      "integrity": "sha512-OS+QTnw1/4vrf+9hh1jc1jnYjzSG4ttTBB8UxOwAnInG3Uo4ssetzC1ihqaIHjLJnA5GGlRl6QlZXOTQhRBUvg==",
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^4.0.0",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "packages/e2e-tests/node_modules/yargs": {
@@ -29784,7 +29831,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@mongodb-js/devtools-connect": "^3.4.1",
-        "@mongodb-js/oidc-plugin": "^1.1.5",
+        "@mongodb-js/oidc-plugin": "^1.1.6",
         "@mongosh/errors": "2.4.0",
         "@mongosh/service-provider-core": "3.0.5",
         "@mongosh/types": "3.5.0",
@@ -29808,6 +29855,50 @@
       "optionalDependencies": {
         "kerberos": "2.1.0",
         "mongodb-client-encryption": "^6.1.1"
+      }
+    },
+    "packages/service-provider-node-driver/node_modules/@mongodb-js/oidc-plugin": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/oidc-plugin/-/oidc-plugin-1.1.6.tgz",
+      "integrity": "sha512-fuL4B9x1njcqdJqV+V3pt8s/9PX4uy9ojhcsP12BavDcg61ju6WEqCkDmUZCykDIvsDbb8tIhO97aCKDxcXROw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "express": "^4.18.2",
+        "open": "^9.1.0",
+        "openid-client": "^5.6.4"
+      },
+      "engines": {
+        "node": ">= 16.20.1"
+      }
+    },
+    "packages/service-provider-node-driver/node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "packages/service-provider-node-driver/node_modules/open": {
+      "version": "9.1.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-9.1.0.tgz",
+      "integrity": "sha512-OS+QTnw1/4vrf+9hh1jc1jnYjzSG4ttTBB8UxOwAnInG3Uo4ssetzC1ihqaIHjLJnA5GGlRl6QlZXOTQhRBUvg==",
+      "license": "MIT",
+      "dependencies": {
+        "default-browser": "^4.0.0",
+        "define-lazy-prop": "^3.0.0",
+        "is-inside-container": "^1.0.0",
+        "is-wsl": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "packages/shell-api": {

--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -29,7 +29,7 @@
   "dependencies": {
     "@mongosh/cli-repl": "2.4.0",
     "@mongosh/service-provider-core": "3.0.5",
-    "@mongodb-js/oidc-plugin": "^1.1.5",
+    "@mongodb-js/oidc-plugin": "^1.1.6",
     "strip-ansi": "^6.0.0"
   },
   "devDependencies": {

--- a/packages/service-provider-node-driver/package.json
+++ b/packages/service-provider-node-driver/package.json
@@ -48,7 +48,7 @@
   },
   "dependencies": {
     "@mongodb-js/devtools-connect": "^3.4.1",
-    "@mongodb-js/oidc-plugin": "^1.1.5",
+    "@mongodb-js/oidc-plugin": "^1.1.6",
     "@mongosh/errors": "2.4.0",
     "@mongosh/service-provider-core": "3.0.5",
     "@mongosh/types": "3.5.0",


### PR DESCRIPTION
Pulls in the duplicate address fix, which we'll need to then release as part of the `service-provider-node-driver` package that vscode uses.