### PR TITLE
chore(ci): don't use gcc on macOS MONGOSH-2029

### DIFF
--- a/.evergreen/install-node-source.sh
+++ b/.evergreen/install-node-source.sh
@@ -18,7 +18,13 @@ fi
 export PATH="$TOOLCHAIN_PATH:${ORIGINAL_PATH}"
 
 
-if [ `uname` != Darwin ]; then
+if [ `uname` = Darwin ]; then
+    echo "Using clang version:"
+    (which clang && clang --version)
+
+    echo "Using clang++ version:"
+    (which clang++ && clang++ --version)
+else
     export CC=gcc
     export CXX=g++
 

--- a/.evergreen/install-node-source.sh
+++ b/.evergreen/install-node-source.sh
@@ -15,11 +15,19 @@ else
     echo "[INFO] Choosing v3 because OS_ARCH is $OS_ARCH"
     export TOOLCHAIN_PATH='/opt/mongodbtoolchain/v3/bin'
 fi
-export PATH="$TOOLCHAIN_PATH:/opt/mongodbtoolchain/v4/bin:/opt/mongodbtoolchain/v3/bin:${ORIGINAL_PATH}"
+export PATH="$TOOLCHAIN_PATH:${ORIGINAL_PATH}"
 
-export PATH="/opt/mongodbtoolchain/v4/bin:/opt/mongodbtoolchain/v3/bin:${ORIGINAL_PATH}"
-export CC=gcc
-export CXX=g++
+
+if [ `uname` != Darwin ]; then
+    export CC=gcc
+    export CXX=g++
+
+    echo "Using gcc version:"
+    (which gcc && gcc --version)
+
+    echo "Using g++ version:"
+    (which g++ && g++ --version)
+fi
 
 NODE_JS_TARBALL_FILE="node-v${NODE_JS_VERSION}.tar.gz"
 NODE_JS_TARBALL_PATH="${EVGDIR}/${NODE_JS_TARBALL_FILE}"
@@ -28,12 +36,6 @@ NODE_JS_SOURCE_PATH="${EVGDIR}/node-v${NODE_JS_VERSION}"
 # We install our custom built node in nvm dir so its easier for rest of the
 # scripts to simply do `nvm use`
 NODE_JS_INSTALL_DIR="${NVM_DIR}/versions/node/v${NODE_JS_VERSION}"
-
-echo "Using gcc version:"
-(which gcc && gcc --version)
-
-echo "Using g++ version:"
-(which g++ && g++ --version)
 
 echo "Using python3 version:"
 (which python3 && python3 --version) || true

--- a/.evergreen/setup-env.sh
+++ b/.evergreen/setup-env.sh
@@ -2,7 +2,7 @@ set -e
 set -x
 
 OS_ARCH="$(uname "-m")"
-if [ "$OS_ARCH" = "ppc64le" ] || [ "$OS_ARCH" = "ppc64" ] || [ "$OS_ARCH" = "arm64" ]; then
+if [ "$OS_ARCH" = "ppc64le" ] || [ "$OS_ARCH" = "ppc64" ]; then
     echo "[INFO] Choosing v4 because OS_ARCH is $OS_ARCH"
     export TOOLCHAIN_PATH='/opt/mongodbtoolchain/v4/bin'
 else
@@ -38,14 +38,16 @@ if [ "$OS" != "Windows_NT" ]; then
   set -x
   export PATH="$NVM_BIN:$PATH"
 
-  export CC=gcc
-  export CXX=g++
+  if [ `uname` != Darwin ]; then
+    export CC=gcc
+    export CXX=g++
 
-  echo "Using gcc version:"
-  (which gcc && gcc --version)
+    echo "Using gcc version:"
+    (which gcc && gcc --version)
 
-  echo "Using g++ version:"
-  (which g++ && g++ --version)
+    echo "Using g++ version:"
+    (which g++ && g++ --version)
+  fi
 
   if [ -x "$BASEDIR/git-2/git" ]; then
     export GIT_EXEC_PATH="$BASEDIR/git-2"

--- a/.evergreen/setup-env.sh
+++ b/.evergreen/setup-env.sh
@@ -38,7 +38,13 @@ if [ "$OS" != "Windows_NT" ]; then
   set -x
   export PATH="$NVM_BIN:$PATH"
 
-  if [ `uname` != Darwin ]; then
+  if [ `uname` = Darwin ]; then
+    echo "Using clang version:"
+    (which clang && clang --version)
+
+    echo "Using clang++ version:"
+    (which clang++ && clang++ --version)
+  else
     export CC=gcc
     export CXX=g++
 

--- a/.evergreen/setup-env.sh
+++ b/.evergreen/setup-env.sh
@@ -2,7 +2,7 @@ set -e
 set -x
 
 OS_ARCH="$(uname "-m")"
-if [ "$OS_ARCH" = "ppc64le" ] || [ "$OS_ARCH" = "ppc64" ] ; then
+if [ "$OS_ARCH" = "ppc64le" ] || [ "$OS_ARCH" = "ppc64" ] || [ "$OS_ARCH" = "arm64" ]; then
     echo "[INFO] Choosing v4 because OS_ARCH is $OS_ARCH"
     export TOOLCHAIN_PATH='/opt/mongodbtoolchain/v4/bin'
 else


### PR DESCRIPTION
gcc is not officially supported on macOS (per [Build Platform Support Tiers]( https://docs.google.com/document/d/1G7JioblpjLdi8WiJP2A7OaZfNBF7yZ6-yXSCEarU2Sg/edit?tab=t.0#heading=h.4itnffmo0xv8)) and would typically not be installed, which is why the scripts have worked previously. It appears that there was a rogue task that installed the linux toolchain on those macs and is currently being removed. Still, I think the changes in this PR make sense as a way to protect us against future incidents.