### PR TITLE
chore(ci): don't download chrome in bump-auxiliary-packages

### DIFF
--- a/.github/workflows/bump-auxiliary-packages.yml
+++ b/.github/workflows/bump-auxiliary-packages.yml
@@ -5,6 +5,14 @@ on:
 permissions:
   contents: none # We use the github app to checkout and create PR
 
+env:
+  PUPPETEER_SKIP_DOWNLOAD: "true"
+
+description: |
+  This workflow increases the versions of the auxiliary (i.e. non-mongosh) packages and creates a PR
+  as a first step for a release. Use this workflow when you don't want to do a full mongosh release,
+  but do need to pick up unreleased changes in one of the @mongosh/* packages.
+
 jobs:
   update_generated_files:
     name: Bump packages
@@ -41,8 +49,6 @@ jobs:
       - name: Bump packages
         run: |
           npm run bump-auxiliary
-          git add .
-          git commit --no-allow-empty -m "chore(release): bump packages for auxiliary release" || true
 
       - name: Create Pull Request
         uses: peter-evans/create-pull-request@5e914681df9dc83aa4e4905692ca88beb2f9e91f # 7.0.5

--- a/.github/workflows/publish-auxiliary-packages.yml
+++ b/.github/workflows/publish-auxiliary-packages.yml
@@ -8,9 +8,15 @@ on:
   push:
     branches:
       - main
+env:
+  PUPPETEER_SKIP_DOWNLOAD: "true"
 
 permissions:
   contents: none # We use the github app to checkout and push tags
+
+description: |
+  This is a workflow that publishes any unpublished auxiliary packages to NPM. It is triggered
+  when we merge the PR created by the bump-auxiliary-packages workflow.
 
 jobs:
   publish:


### PR DESCRIPTION
This is a minor change that sets the `PUPPETEER_SKIP_DOWNLOAD` environment variable in `bump-auxiliary-packages.yml` as we don't really need chrome there. Additionally, it adds a description for the workflow and removes some redundant committing. 