### PR TITLE
feat: add sh.moveRange helper MONGOSH-1926

### DIFF
--- a/packages/i18n/src/locales/en_US.ts
+++ b/packages/i18n/src/locales/en_US.ts
@@ -2028,6 +2028,12 @@ const translations: Catalog = {
                 'Moves the chunk that contains the document specified by the query to the destination shard. Uses the moveChunk command',
               example: 'sh.moveChunk(ns, query, destination)',
             },
+            moveRange: {
+              link: 'https://docs.mongodb.com/manual/reference/method/sh.moveRange',
+              description:
+                'Moves a range of documents specified by the min and max keys to the destination shard. Uses the moveRange command',
+              example: 'sh.moveRange(ns, toShard, min?, max?)',
+            },
             balancerCollectionStatus: {
               link: 'https://docs.mongodb.com/manual/reference/method/sh.balancerCollectionStatus',
               description:

--- a/packages/shell-api/src/shard.spec.ts
+++ b/packages/shell-api/src/shard.spec.ts
@@ -35,6 +35,7 @@ import { dummyOptions } from './helpers.spec';
 
 describe('Shard', function () {
   skipIfApiStrict();
+
   describe('help', function () {
     const apiClass: any = new Shard({} as any);
     it('calls help function', async function () {
@@ -50,6 +51,7 @@ describe('Shard', function () {
       );
     });
   });
+
   describe('signatures', function () {
     it('type', function () {
       expect(signatures.Shard.type).to.equal('Shard');
@@ -70,6 +72,7 @@ describe('Shard', function () {
       });
     });
   });
+
   describe('Metadata', function () {
     describe('toShellResult', function () {
       const mongo = { _uri: 'test_uri' } as Mongo;
@@ -85,6 +88,7 @@ describe('Shard', function () {
       });
     });
   });
+
   describe('unit', function () {
     let mongo: Mongo;
     let serviceProvider: StubbedInstance<ServiceProvider>;
@@ -2054,6 +2058,50 @@ describe('Shard', function () {
         serviceProvider.runCommandWithCheck.rejects(expectedError);
         const caughtError = await shard
           .abortUnshardCollection('db.coll')
+          .catch((e) => e);
+        expect(caughtError).to.equal(expectedError);
+      });
+    });
+
+    describe('moveRange', function () {
+      it('calls serviceProvider.runCommandWithCheck with arg', async function () {
+        serviceProvider.runCommandWithCheck.resolves({
+          ok: 1,
+          msg: 'isdbgrid',
+        });
+        await shard.moveRange('ns', 'destination', { key: 0 }, { key: 10 });
+
+        expect(serviceProvider.runCommandWithCheck).to.have.been.calledWith(
+          ADMIN_DB,
+          {
+            moveRange: 'ns',
+            min: { key: 0 },
+            max: { key: 10 },
+            toShard: 'destination',
+          }
+        );
+      });
+
+      it('returns whatever serviceProvider.runCommandWithCheck returns', async function () {
+        const expectedResult = {
+          ok: 1,
+          operationTime: { $timestamp: { t: 1741189797, i: 1 } },
+        };
+        serviceProvider.runCommandWithCheck.resolves(expectedResult);
+        const result = await shard.moveRange(
+          'ns',
+          'destination',
+          { key: 0 },
+          { key: 10 }
+        );
+        expect(result).to.deep.equal(expectedResult);
+      });
+
+      it('throws if serviceProvider.runCommandWithCheck rejects', async function () {
+        const expectedError = new Error();
+        serviceProvider.runCommandWithCheck.rejects(expectedError);
+        const caughtError = await shard
+          .moveRange('ns', 'destination', { key: 0 }, { key: 10 })
           .catch((e) => e);
         expect(caughtError).to.equal(expectedError);
       });

--- a/packages/shell-api/src/shard.spec.ts
+++ b/packages/shell-api/src/shard.spec.ts
@@ -2098,10 +2098,12 @@ describe('Shard', function () {
       });
 
       it('throws if serviceProvider.runCommandWithCheck rejects', async function () {
-        const expectedError = new Error();
+        const expectedError = new Error(
+          "Missing required parameter 'min' or 'max'"
+        );
         serviceProvider.runCommandWithCheck.rejects(expectedError);
         const caughtError = await shard
-          .moveRange('ns', 'destination', { key: 0 }, { key: 10 })
+          .moveRange('ns', 'destination')
           .catch((e) => e);
         expect(caughtError).to.equal(expectedError);
       });

--- a/packages/shell-api/src/shard.ts
+++ b/packages/shell-api/src/shard.ts
@@ -466,7 +466,7 @@ export default class Shard extends ShellApiWithMongoClass {
   async moveChunk(
     ns: string,
     query: Document,
-    destination: string | undefined
+    destination: string
   ): Promise<Document> {
     assertArgsDefinedType(
       [ns, query, destination],
@@ -478,6 +478,31 @@ export default class Shard extends ShellApiWithMongoClass {
       moveChunk: ns,
       find: query,
       to: destination,
+    });
+  }
+
+  @returnsPromise
+  @serverVersions(['6.0.0', ServerVersions.latest])
+  async moveRange(
+    ns: string,
+    toShard: string,
+    min?: Document,
+    max?: Document
+  ): Promise<Document> {
+    assertArgsDefinedType(
+      [ns, toShard, min, max],
+      ['string', 'string', ['object', undefined], ['object', undefined]],
+      'Shard.moveRange'
+    );
+
+    this._emitShardApiCall('moveRange', { ns, toShard, min, max });
+    await getConfigDB(this._database); // will error if not connected to mongos
+
+    return this._database._runAdminCommand({
+      moveRange: ns,
+      toShard,
+      min,
+      max,
     });
   }
 


### PR DESCRIPTION
Adds a `sh.moveRange` helper modeled after `sh.moveChunk`.