### PR TITLE
chore(ci): remove redundant version tag push

### DIFF
--- a/packages/build/src/npm-packages/publish.spec.ts
+++ b/packages/build/src/npm-packages/publish.spec.ts
@@ -140,13 +140,6 @@ describe('PackagePublisher', function () {
         ]);
       }
 
-      expect(spawnSync).calledWith('git', [
-        'tag',
-        '-a',
-        `v${mongoshVersion}`,
-        '-m',
-        `v${mongoshVersion}`,
-      ]);
       expect(spawnSync).calledWith('git', ['push', '--tags']);
     });
 

--- a/packages/build/src/npm-packages/publish.ts
+++ b/packages/build/src/npm-packages/publish.ts
@@ -111,19 +111,6 @@ export class PackagePublisher {
       if (!mongoshVersion) {
         throw new Error('mongosh package not found');
       }
-
-      const newVersionTag = `v${mongoshVersion}`;
-
-      if (!this.existsTag(newVersionTag)) {
-        console.info(`Creating v${mongoshVersion} tag...`);
-        this.spawnSync(
-          'git',
-          ['tag', '-a', newVersionTag, '-m', newVersionTag],
-          commandOptions
-        );
-      } else {
-        console.warn(`${newVersionTag} tag already exists. Skipping...`);
-      }
     }
 
     if (!this.config.isDryRun) {


### PR DESCRIPTION
When releasing we try to push a tag to `vx.x.x`. This does not fit in our current flow where this is actually the tag which triggered the release job in the first place, so this tag will always already exist and always gets skipped. This removes this step completely as we instead rely on `mongosh@x.x.x` as the tag reference for the published update.