### PR TITLE
chore(ci): correctly pass args to mongodb-runner MONGOSH-2011

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -20,7 +20,7 @@ jobs:
         run: brew install mongosh
 
       - name: Run smoke tests
-        run: npx --yes mongodb-runner exec -- sh -c 'env MONGOSH_SMOKE_TEST_SERVER=$MONGODB_URI mongosh --smokeTests'
+        run: npx --yes mongodb-runner -- exec -- sh -c 'env MONGOSH_SMOKE_TEST_SERVER=$MONGODB_URI mongosh --smokeTests'
 
       - name: Report failure
         if: ${{ failure() }}

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -36,4 +36,4 @@ jobs:
         run: npm ci
 
       - name: Run smoke tests
-        run: npx mongodb-runner exec -- sh -c 'env MONGOSH_SMOKE_TEST_SERVER=$MONGODB_URI npm run test-smoke'
+        run: npx mongodb-runner -- exec -- sh -c 'env MONGOSH_SMOKE_TEST_SERVER=$MONGODB_URI npm run test-smoke'


### PR DESCRIPTION
On windows with node 22/23, when running mongodb-runner with npx, the `--` will be applied to npx command rather than the exec, so we need another set of dashes to make yargs happy.