### PR TITLE
chore(ci): pin to MongoDB 8.0.5 in homebrew smoke test

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -20,7 +20,8 @@ jobs:
         run: brew install mongosh
 
       - name: Run smoke tests
-        run: npx --yes mongodb-runner -- exec -- sh -c 'env MONGOSH_SMOKE_TEST_SERVER=$MONGODB_URI mongosh --smokeTests'
+        # 8.0.5 due to us having macos-13 in the platform support list, SERVER-101020
+        run: npx --yes mongodb-runner --version 8.0.5-enterprise -- exec -- sh -c 'env MONGOSH_SMOKE_TEST_SERVER=$MONGODB_URI mongosh --smokeTests'
 
       - name: Report failure
         if: ${{ failure() }}


### PR DESCRIPTION
Since it's a smoke test, we don't really need to worry about the specific server version and can just remove this again once we drop macOS 13.