### PR TITLE
chore(ci): do not expect CSFLE/QE support in homebrew

### DIFF
--- a/.github/workflows/homebrew.yml
+++ b/.github/workflows/homebrew.yml
@@ -22,6 +22,9 @@ jobs:
 
       - name: Run smoke tests
         # 8.0.5 due to us having macos-13 in the platform support list, SERVER-101020
+        env:
+          # MONGOSH-1216, MONGOSH-1120
+          MONGOSH_NO_AUTOMATIC_ENCRYPTION_SUPPORT=1
         run: npx --yes mongodb-runner --version 8.0.5-enterprise -- exec -- sh -c 'env MONGOSH_SMOKE_TEST_SERVER=$MONGODB_URI mongosh --smokeTests'
 
       - name: Report failure


### PR DESCRIPTION
These aren't supported yet. Because my previous commit (1e6cef4a9170e) pinned the version to an enterprise one, rather than a community server, we were now trying to run the CSFLE smoke test but can't.

(We could also go back to testing with a community server, but in general the idea of testing enterprise features in smoke tests is not a bad one.)