### PR TITLE
feat(shell-api): add automerge information to sh.status() MONGOSH-1649

### DIFF
--- a/packages/shell-api/src/helpers.spec.ts
+++ b/packages/shell-api/src/helpers.spec.ts
@@ -224,6 +224,7 @@ describe('getPrintableShardStatus', function () {
     );
     expect(status['most recently active mongoses']).to.have.lengthOf(1);
     expect(status.autosplit['Currently enabled']).to.equal('yes');
+    expect(status.automerge['Currently enabled']).to.equal('yes');
     expect(status.balancer['Currently enabled']).to.equal('yes');
     expect(
       status.balancer['Failed balancer rounds in last 5 attempts']

--- a/packages/shell-api/src/helpers.ts
+++ b/packages/shell-api/src/helpers.ts
@@ -328,6 +328,14 @@ export async function getPrintableShardStatus(
       };
     })(),
     (async (): Promise<void> => {
+      // Is automerge currently enabled, available since >= 7.0
+      const automerge = await settingsColl.findOne({ _id: 'automerge' });
+      result.automerge = {
+        'Currently enabled':
+          automerge === null || automerge.enabled ? 'yes' : 'no',
+      };
+    })(),
+    (async (): Promise<void> => {
       // Is the balancer currently enabled
       const balancerEnabled = await settingsColl.findOne({ _id: 'balancer' });
       balancerRes['Currently enabled'] =
@@ -711,6 +719,10 @@ export type ShardingStatusResult = {
             };
       }[];
   autosplit: {
+    'Currently enabled': 'yes' | 'no';
+  };
+  /** Available from 7.0.0 */
+  automerge: {
     'Currently enabled': 'yes' | 'no';
   };
   balancer: {

--- a/packages/shell-api/src/shard.spec.ts
+++ b/packages/shell-api/src/shard.spec.ts
@@ -2419,6 +2419,7 @@ describe('Shard', function () {
           'shardingVersion',
           'shards',
           'autosplit',
+          'automerge',
           'balancer',
           'databases',
         ]);
@@ -2463,6 +2464,7 @@ describe('Shard', function () {
             'shardingVersion',
             'shards',
             'autosplit',
+            'automerge',
             'balancer',
             'databases',
           ]);


### PR DESCRIPTION
We expose a status for the automerge being enabled/disabled so we'd want it to be shown in `sh.status()`

This does that in form:
```
automerge: 
    Currently enabled: yes
```