### PR TITLE
chore: bump tar-fs 2.1.1 to 2.1.2 MONGOSH-2126

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -26787,7 +26787,9 @@
       }
     },
     "node_modules/tar-fs": {
-      "version": "2.1.1",
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/tar-fs/-/tar-fs-2.1.2.tgz",
+      "integrity": "sha512-EsaAXwxmx8UB7FRKqeozqEPop69DXcmYwTQwXvyAPF352HJsPdkVhvTaDPYqfNgruveJIJy3TA2l+2zj8LJIJA==",
       "license": "MIT",
       "dependencies": {
         "chownr": "^1.1.1",


### PR DESCRIPTION
```
mongosh@ /Users/leroux.bodenstein/mongo/mongosh
├─┬ @mongosh/browser-repl@3.6.0 -> ./packages/browser-repl
│ └─┬ puppeteer@21.0.3
│   └─┬ @puppeteer/browsers@1.6.0
│     └── tar-fs@3.0.4
├─┬ @mongosh/build@3.3.1 -> ./packages/build
│ └── tar-fs@2.1.1
├─┬ @mongosh/service-provider-core@3.1.0 -> ./packages/service-provider-core
│ └─┬ mongodb-client-encryption@6.3.0
│   └─┬ prebuild-install@7.1.3
│     └── tar-fs@2.1.1 deduped
└─┬ @mongosh/service-provider-node-driver@3.6.0 -> ./packages/service-provider-node-driver
  └─┬ kerberos@2.1.0
    └─┬ prebuild-install@7.1.1
      └── tar-fs@2.1.1 deduped
```