### PR TITLE
chore(deps): bump mongodb-client-encryption COMPASS-8816

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -29955,7 +29955,7 @@
       },
       "optionalDependencies": {
         "kerberos": "2.1.0",
-        "mongodb-client-encryption": "^6.1.1"
+        "mongodb-client-encryption": "^6.3.0"
       }
     },
     "packages/service-provider-node-driver/node_modules/@mongodb-js/oidc-plugin": {

--- a/packages/service-provider-node-driver/package.json
+++ b/packages/service-provider-node-driver/package.json
@@ -56,12 +56,12 @@
     "mongodb": "^6.14.2",
     "mongodb-connection-string-url": "^3.0.1",
     "socks": "^2.8.3",
-    "mongodb-client-encryption": "^6.1.1",
+    "mongodb-client-encryption": "^6.3.0",
     "kerberos": "2.1.0"
   },
   "optionalDependencies": {
     "kerberos": "2.1.0",
-    "mongodb-client-encryption": "^6.1.1"
+    "mongodb-client-encryption": "^6.3.0"
   },
   "devDependencies": {
     "@mongodb-js/eslint-config-mongosh": "^1.0.0",


### PR DESCRIPTION
Bumping the missed dependency with latest `mongodb-client-encryption`.