### PR TITLE
chore(ci): skip chromium download for most tasks

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -121,6 +121,7 @@ functions:
           NODE_JS_VERSION: ${node_js_version}
           DISTRO_ID: ${distro_id}
           MONOGDB_DRIVER_VERSION_OVERRIDE: ${mongodb_driver_version_override}
+          PUPPETEER_SKIP_DOWNLOAD: "true"
         script: |
           set -e
           set -x
@@ -161,7 +162,7 @@ functions:
           NODE_JS_VERSION: ${node_js_version}
           DISTRO_ID: ${distro_id}
           MONOGDB_DRIVER_VERSION_OVERRIDE: ${mongodb_driver_version_override}
-          PUPPETEER_SKIP_DOWNLOAD: ${puppeteer_skip_download}
+          PUPPETEER_SKIP_DOWNLOAD: ${puppeteer_skip_download|true}
         script: |
           set -e
           set -x
@@ -9677,7 +9678,6 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          PUPPETEER_SKIP_DOWNLOAD: "true" 
           node_js_version: "20.19.0"
       - func: create_static_analysis_report
         vars:
@@ -9705,7 +9705,6 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          PUPPETEER_SKIP_DOWNLOAD: "true" 
           node_js_version: "20.19.0"
       - func: release_draft
         vars:

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -4310,7 +4310,6 @@ functions:
           {
           export NODE_JS_VERSION=${node_js_version}
           source .evergreen/setup-env.sh
-          export PUPPETEER_SKIP_DOWNLOAD="true"
           npm run evergreen-release draft
           git add .
           git commit --no-allow-empty -m "chore(release): bump to prepare for mongosh release"
@@ -4330,7 +4329,6 @@ functions:
           node_js_version: ${node_js_version}
         script: |
           set -e
-          export PUPPETEER_SKIP_DOWNLOAD="true"
           .evergreen/run-evergreen-release.sh download-and-list-artifacts
     - command: shell.exec
       params:
@@ -4359,7 +4357,6 @@ functions:
           node_js_version: ${node_js_version}
         script: |
           set -e
-          export PUPPETEER_SKIP_DOWNLOAD="true"
           .evergreen/run-evergreen-release.sh publish -- --dry-run
 
   release_publish:
@@ -4378,7 +4375,6 @@ functions:
           node_js_version: ${node_js_version}
         script: |
           set -e
-          export PUPPETEER_SKIP_DOWNLOAD="true"
           .evergreen/run-evergreen-release.sh publish
 
   run_perf_tests:

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -161,6 +161,7 @@ functions:
           NODE_JS_VERSION: ${node_js_version}
           DISTRO_ID: ${distro_id}
           MONOGDB_DRIVER_VERSION_OVERRIDE: ${mongodb_driver_version_override}
+          PUPPETEER_SKIP_DOWNLOAD: ${puppeteer_skip_download}
         script: |
           set -e
           set -x
@@ -4943,6 +4944,7 @@ tasks:
           mongosh_test_id: "arg_parser"
           mongosh_run_only_in_package: "arg-parser"
           task_name: ${task_name}
+          puppeteer_skip_download: "true"
   - name: test_async_rewriter2
     tags: ["assigned_to_jira_team_mongosh_mongosh","unit-test"]
     depends_on:
@@ -4961,6 +4963,7 @@ tasks:
           mongosh_test_id: "async_rewriter2"
           mongosh_run_only_in_package: "async-rewriter2"
           task_name: ${task_name}
+          puppeteer_skip_download: "true"
   - name: test_autocomplete
     tags: ["assigned_to_jira_team_mongosh_mongosh","unit-test"]
     depends_on:
@@ -4979,6 +4982,7 @@ tasks:
           mongosh_test_id: "autocomplete"
           mongosh_run_only_in_package: "autocomplete"
           task_name: ${task_name}
+          puppeteer_skip_download: "true"
   - name: test_browser_repl
     tags: ["assigned_to_jira_team_mongosh_mongosh","unit-test"]
     depends_on:
@@ -4997,6 +5001,7 @@ tasks:
           mongosh_test_id: "browser_repl"
           mongosh_run_only_in_package: "browser-repl"
           task_name: ${task_name}
+          puppeteer_skip_download: "false"
   - name: test_browser_runtime_core
     tags: ["assigned_to_jira_team_mongosh_mongosh","unit-test"]
     depends_on:
@@ -5015,6 +5020,7 @@ tasks:
           mongosh_test_id: "browser_runtime_core"
           mongosh_run_only_in_package: "browser-runtime-core"
           task_name: ${task_name}
+          puppeteer_skip_download: "true"
   - name: test_browser_runtime_electron
     tags: ["assigned_to_jira_team_mongosh_mongosh","unit-test"]
     depends_on:
@@ -5033,6 +5039,7 @@ tasks:
           mongosh_test_id: "browser_runtime_electron"
           mongosh_run_only_in_package: "browser-runtime-electron"
           task_name: ${task_name}
+          puppeteer_skip_download: "true"
   - name: test_build
     tags: ["assigned_to_jira_team_mongosh_mongosh","unit-test"]
     depends_on:
@@ -5051,6 +5058,7 @@ tasks:
           mongosh_test_id: "build"
           mongosh_run_only_in_package: "build"
           task_name: ${task_name}
+          puppeteer_skip_download: "true"
   - name: test_cli_repl
     tags: ["assigned_to_jira_team_mongosh_mongosh","unit-test"]
     depends_on:
@@ -5069,6 +5077,7 @@ tasks:
           mongosh_test_id: "cli_repl"
           mongosh_run_only_in_package: "cli-repl"
           task_name: ${task_name}
+          puppeteer_skip_download: "true"
   - name: test_connectivity_tests
     tags: ["assigned_to_jira_team_mongosh_mongosh","unit-test"]
     depends_on:
@@ -5087,6 +5096,7 @@ tasks:
           mongosh_test_id: "connectivity_tests"
           mongosh_run_only_in_package: "connectivity-tests"
           task_name: ${task_name}
+          puppeteer_skip_download: "true"
   - name: test_e2e_tests
     tags: ["assigned_to_jira_team_mongosh_mongosh","unit-test"]
     depends_on:
@@ -5105,6 +5115,7 @@ tasks:
           mongosh_test_id: "e2e_tests"
           mongosh_run_only_in_package: "e2e-tests"
           task_name: ${task_name}
+          puppeteer_skip_download: "true"
   - name: test_editor
     tags: ["assigned_to_jira_team_mongosh_mongosh","unit-test"]
     depends_on:
@@ -5123,6 +5134,7 @@ tasks:
           mongosh_test_id: "editor"
           mongosh_run_only_in_package: "editor"
           task_name: ${task_name}
+          puppeteer_skip_download: "true"
   - name: test_errors
     tags: ["assigned_to_jira_team_mongosh_mongosh","unit-test"]
     depends_on:
@@ -5141,6 +5153,7 @@ tasks:
           mongosh_test_id: "errors"
           mongosh_run_only_in_package: "errors"
           task_name: ${task_name}
+          puppeteer_skip_download: "true"
   - name: test_history
     tags: ["assigned_to_jira_team_mongosh_mongosh","unit-test"]
     depends_on:
@@ -5159,6 +5172,7 @@ tasks:
           mongosh_test_id: "history"
           mongosh_run_only_in_package: "history"
           task_name: ${task_name}
+          puppeteer_skip_download: "true"
   - name: test_i18n
     tags: ["assigned_to_jira_team_mongosh_mongosh","unit-test"]
     depends_on:
@@ -5177,6 +5191,7 @@ tasks:
           mongosh_test_id: "i18n"
           mongosh_run_only_in_package: "i18n"
           task_name: ${task_name}
+          puppeteer_skip_download: "true"
   - name: test_java_shell
     tags: ["assigned_to_jira_team_mongosh_mongosh","unit-test"]
     depends_on:
@@ -5195,6 +5210,7 @@ tasks:
           mongosh_test_id: "java_shell"
           mongosh_run_only_in_package: "java-shell"
           task_name: ${task_name}
+          puppeteer_skip_download: "true"
   - name: test_js_multiline_to_singleline
     tags: ["assigned_to_jira_team_mongosh_mongosh","unit-test"]
     depends_on:
@@ -5213,6 +5229,7 @@ tasks:
           mongosh_test_id: "js_multiline_to_singleline"
           mongosh_run_only_in_package: "js-multiline-to-singleline"
           task_name: ${task_name}
+          puppeteer_skip_download: "true"
   - name: test_logging
     tags: ["assigned_to_jira_team_mongosh_mongosh","unit-test"]
     depends_on:
@@ -5231,6 +5248,7 @@ tasks:
           mongosh_test_id: "logging"
           mongosh_run_only_in_package: "logging"
           task_name: ${task_name}
+          puppeteer_skip_download: "true"
   - name: test_mongosh
     tags: ["assigned_to_jira_team_mongosh_mongosh","unit-test"]
     depends_on:
@@ -5249,6 +5267,7 @@ tasks:
           mongosh_test_id: "mongosh"
           mongosh_run_only_in_package: "mongosh"
           task_name: ${task_name}
+          puppeteer_skip_download: "true"
   - name: test_node_runtime_worker_thread
     tags: ["assigned_to_jira_team_mongosh_mongosh","unit-test"]
     depends_on:
@@ -5267,6 +5286,7 @@ tasks:
           mongosh_test_id: "node_runtime_worker_thread"
           mongosh_run_only_in_package: "node-runtime-worker-thread"
           task_name: ${task_name}
+          puppeteer_skip_download: "true"
   - name: test_service_provider_core
     tags: ["assigned_to_jira_team_mongosh_mongosh","unit-test"]
     depends_on:
@@ -5285,6 +5305,7 @@ tasks:
           mongosh_test_id: "service_provider_core"
           mongosh_run_only_in_package: "service-provider-core"
           task_name: ${task_name}
+          puppeteer_skip_download: "true"
   - name: test_service_provider_node_driver
     tags: ["assigned_to_jira_team_mongosh_mongosh","unit-test"]
     depends_on:
@@ -5303,6 +5324,7 @@ tasks:
           mongosh_test_id: "service_provider_node_driver"
           mongosh_run_only_in_package: "service-provider-node-driver"
           task_name: ${task_name}
+          puppeteer_skip_download: "true"
   - name: test_shell_api
     tags: ["assigned_to_jira_team_mongosh_mongosh","unit-test"]
     depends_on:
@@ -5321,6 +5343,7 @@ tasks:
           mongosh_test_id: "shell_api"
           mongosh_run_only_in_package: "shell-api"
           task_name: ${task_name}
+          puppeteer_skip_download: "true"
   - name: test_shell_evaluator
     tags: ["assigned_to_jira_team_mongosh_mongosh","unit-test"]
     depends_on:
@@ -5339,6 +5362,7 @@ tasks:
           mongosh_test_id: "shell_evaluator"
           mongosh_run_only_in_package: "shell-evaluator"
           task_name: ${task_name}
+          puppeteer_skip_download: "true"
   - name: test_snippet_manager
     tags: ["assigned_to_jira_team_mongosh_mongosh","unit-test"]
     depends_on:
@@ -5357,6 +5381,7 @@ tasks:
           mongosh_test_id: "snippet_manager"
           mongosh_run_only_in_package: "snippet-manager"
           task_name: ${task_name}
+          puppeteer_skip_download: "true"
   - name: test_types
     tags: ["assigned_to_jira_team_mongosh_mongosh","unit-test"]
     depends_on:
@@ -5375,6 +5400,7 @@ tasks:
           mongosh_test_id: "types"
           mongosh_run_only_in_package: "types"
           task_name: ${task_name}
+          puppeteer_skip_download: "true"
 
   ###
   # INTEGRATION TESTS
@@ -9651,6 +9677,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
+          PUPPETEER_SKIP_DOWNLOAD: "true" 
           node_js_version: "20.19.0"
       - func: create_static_analysis_report
         vars:
@@ -9678,6 +9705,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
+          PUPPETEER_SKIP_DOWNLOAD: "true" 
           node_js_version: "20.19.0"
       - func: release_draft
         vars:

--- a/.evergreen/compile-artifact.sh
+++ b/.evergreen/compile-artifact.sh
@@ -22,7 +22,7 @@ trap "rm -rf /tmp/m" EXIT
 export TMP=/tmp/m
 export TMPDIR=/tmp/m
 
-if [ `uname` = Darwin ]; then
+if [ $(uname) = Darwin ]; then
   # match what Node.js 20 does on their own builder machines
   export CFLAGS='-mmacosx-version-min=10.15'
   export CXXFLAGS='-mmacosx-version-min=10.15'
@@ -76,7 +76,6 @@ elif [ -n "$MONGOSH_SHARED_OPENSSL" ]; then
   export LD_LIBRARY_PATH=/opt/devtools/lib:/tmp/m/opt/lib
 fi
 
-export PUPPETEER_SKIP_DOWNLOAD="true"
 npm run evergreen-release compile
 dist/mongosh --version
 dist/mongosh --build-info

--- a/.evergreen/evergreen.yml.in
+++ b/.evergreen/evergreen.yml.in
@@ -170,6 +170,7 @@ functions:
           NODE_JS_VERSION: ${node_js_version}
           DISTRO_ID: ${distro_id}
           MONOGDB_DRIVER_VERSION_OVERRIDE: ${mongodb_driver_version_override}
+          PUPPETEER_SKIP_DOWNLOAD: ${puppeteer_skip_download|true}
         script: |
           set -e
           set -x
@@ -1101,7 +1102,7 @@ tasks:
   # UNIT TESTS
   # E.g. test_m60xc_n20 stands for mongod 6.0.x, community edition, Node.js 20
   ###
-  <% for (const { id, packageName } of UNIT_TESTS) { %>
+  <% for (const { id, packageName, usePuppeteer } of UNIT_TESTS) { %>
   - name: test_<% out(id) %>
     tags: ["assigned_to_jira_team_mongosh_mongosh","unit-test"]
     depends_on:
@@ -1120,6 +1121,7 @@ tasks:
           mongosh_test_id: "<% out(id) %>"
           mongosh_run_only_in_package: "<% out(packageName) %>"
           task_name: ${task_name}
+          puppeteer_skip_download: "<% out(usePuppeteer ? "false" : "true") %>"
   <% } %>
 
   ###
@@ -1428,6 +1430,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
+          PUPPETEER_SKIP_DOWNLOAD: "true" 
           node_js_version: "<% out(NODE_JS_VERSION_20) %>"
       - func: create_static_analysis_report
         vars:
@@ -1455,6 +1458,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
+          PUPPETEER_SKIP_DOWNLOAD: "true" 
           node_js_version: "<% out(NODE_JS_VERSION_20) %>"
       - func: release_draft
         vars:

--- a/.evergreen/evergreen.yml.in
+++ b/.evergreen/evergreen.yml.in
@@ -130,6 +130,7 @@ functions:
           NODE_JS_VERSION: ${node_js_version}
           DISTRO_ID: ${distro_id}
           MONOGDB_DRIVER_VERSION_OVERRIDE: ${mongodb_driver_version_override}
+          PUPPETEER_SKIP_DOWNLOAD: "true"
         script: |
           set -e
           set -x
@@ -1430,7 +1431,6 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          PUPPETEER_SKIP_DOWNLOAD: "true" 
           node_js_version: "<% out(NODE_JS_VERSION_20) %>"
       - func: create_static_analysis_report
         vars:
@@ -1458,7 +1458,6 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          PUPPETEER_SKIP_DOWNLOAD: "true" 
           node_js_version: "<% out(NODE_JS_VERSION_20) %>"
       - func: release_draft
         vars:

--- a/.evergreen/evergreen.yml.in
+++ b/.evergreen/evergreen.yml.in
@@ -955,7 +955,6 @@ functions:
           {
           export NODE_JS_VERSION=${node_js_version}
           source .evergreen/setup-env.sh
-          export PUPPETEER_SKIP_DOWNLOAD="true"
           npm run evergreen-release draft
           git add .
           git commit --no-allow-empty -m "chore(release): bump to prepare for mongosh release"
@@ -975,7 +974,6 @@ functions:
           node_js_version: ${node_js_version}
         script: |
           set -e
-          export PUPPETEER_SKIP_DOWNLOAD="true"
           .evergreen/run-evergreen-release.sh download-and-list-artifacts
     - command: shell.exec
       params:
@@ -1004,7 +1002,6 @@ functions:
           node_js_version: ${node_js_version}
         script: |
           set -e
-          export PUPPETEER_SKIP_DOWNLOAD="true"
           .evergreen/run-evergreen-release.sh publish -- --dry-run
 
   release_publish:
@@ -1023,7 +1020,6 @@ functions:
           node_js_version: ${node_js_version}
         script: |
           set -e
-          export PUPPETEER_SKIP_DOWNLOAD="true"
           .evergreen/run-evergreen-release.sh publish
 
   run_perf_tests:

--- a/.evergreen/package-and-upload-artifact.sh
+++ b/.evergreen/package-and-upload-artifact.sh
@@ -13,7 +13,7 @@ if [ "$(uname)" == Linux ]; then
   cp "$(pwd)/../tmp/expansions.yaml" tmp/expansions.yaml
   (cd scripts/docker && bash "$BASEDIR/retry-with-backoff.sh" docker build -t rocky8-package -f rocky8-package.Dockerfile .)
   echo Starting Docker container packaging
-  docker run -e PUPPETEER_SKIP_DOWNLOAD \
+  docker run \
     -e EVERGREEN_EXPANSIONS_PATH=/tmp/build/tmp/expansions.yaml \
     -e NODE_JS_VERSION \
     -e PACKAGE_VARIANT \

--- a/.evergreen/run-evergreen-release.sh
+++ b/.evergreen/run-evergreen-release.sh
@@ -1,9 +1,8 @@
 #! /usr/bin/env bash
 set -e
 
-echo "//registry.npmjs.org/:_authToken=${devtoolsbot_npm_token}" > .npmrc
+echo "//registry.npmjs.org/:_authToken=${devtoolsbot_npm_token}" >.npmrc
 set -x
 export NODE_JS_VERSION=${node_js_version}
 source .evergreen/setup-env.sh
-export PUPPETEER_SKIP_DOWNLOAD="true"
 npm run evergreen-release $@

--- a/.evergreen/tasks/unit-tests.js
+++ b/.evergreen/tasks/unit-tests.js
@@ -33,7 +33,8 @@ for (const packageInfo of MONGOSH_PACKAGES) {
   UNIT_TESTS.push({
     id,
     packageName: packageInfo.name,
-    unitTestsOnly: packageInfo.unitTestsOnly,
+    unitTestsOnly: packageInfo.unitTestsOnly || false,
+    usePuppeteer: packageInfo.usePuppeteer || false,
     variants,
   });
 }

--- a/packages/browser-repl/package.json
+++ b/packages/browser-repl/package.json
@@ -51,6 +51,7 @@
   },
   "mongosh": {
     "unitTestsOnly": true,
+    "usePuppeteer": true,
     "variants": [
       "darwin"
     ]

--- a/packages/build/src/npm-packages/bump.ts
+++ b/packages/build/src/npm-packages/bump.ts
@@ -81,6 +81,10 @@ export class PackageBumper {
       stdio: 'inherit',
       cwd: monorepoRootPath,
       encoding: 'utf8',
+      env: {
+        ...process.env,
+        PUPPETEER_SKIP_DOWNLOAD: 'true',
+      },
     });
   }
 


### PR DESCRIPTION
Out of experiencing the pain of seeing what seemed to be potentially a 10 minute download and install of puppeteer each time during release, I became curious whether we're actually skipping things correctly. 

`PUPPETEER_SKIP_DOWNLOAD` only applies at a post-install script but in many places we set it after all dependencies have already been installed. This sets it at the install stage instead. Not sure whatever the issues were with https://github.com/mongodb-js/mongosh/pull/2311/ would come up here, seems all good so far.

Not super scientific but this leads to quicker execution on hosts which tend to not have the Chromium in their cache like RHEL:

### Before
![billede](https://github.com/user-attachments/assets/cb4b8538-054f-4c53-ad8b-029bc6dffd7b)

### After
![billede](https://github.com/user-attachments/assets/58970661-5ad1-4b56-9eea-d1186b07327a)
