### PR TITLE
chore: add optional for manual CodeQL dispatch

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -16,6 +16,7 @@ on:
       - completed
     branches:
       - main
+  workflow_dispatch:
 
 jobs:
   analyze:


### PR DESCRIPTION
This is needed for a bandaid fix for https://github.com/mongodb-js/mongosh/commit/eb9376b475937a7e7b16683a1028299aab75ff7e not having the CodeQL runs.