### PR TITLE
chore: add manual SHA setting to CodeQL action

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -17,6 +17,11 @@ on:
     branches:
       - main
   workflow_dispatch:
+    inputs:
+      sha:
+        description: 'Commit SHA to analyze'
+        required: false
+        type: string
 
 jobs:
   analyze:
@@ -37,6 +42,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.inputs.sha || github.sha }}
 
       # Initializes the CodeQL tools for scanning.
       - name: Initialize CodeQL


### PR DESCRIPTION
Follow up from #2441 since an old branch cannot run it otherwise.