### PR TITLE
fix: stick to 8.0.x crypt_shared library for now MONGOSH-2177 MONGOSH-2178 MONGOSH-2179 MONGOSH-2180

### DIFF
--- a/packages/build/src/packaging/download-crypt-library.ts
+++ b/packages/build/src/packaging/download-crypt-library.ts
@@ -34,12 +34,12 @@ export async function downloadCryptLibrary(
   );
   // Download mongodb for latest server version, including rapid releases
   // (for the platforms that they exist for, i.e. for ppc64le/s390x only pick stable releases).
-  let versionSpec = 'continuous';
+  let versionSpec = 'stable'; // TODO(MONGOSH-2192): Switch back to 'continuous' and deal with affected platform support.
   if (/ppc64|s390x/.test(opts.arch || process.arch)) {
     versionSpec = 'stable';
   }
   if ((opts.platform || process.platform) === 'darwin') {
-    versionSpec = '8.0.5'; // TBD(SERVER-101020): Figure out at what point we use a later version.
+    versionSpec = '8.0.5'; // TBD(MONGOSH-2192,SERVER-101020): Figure out at what point we use a later version.
   }
   const { downloadedBinDir: libdir, version } =
     await downloadMongoDbWithVersionInfo(cryptTmpTargetDir, versionSpec, opts);


### PR DESCRIPTION
Our Amazon Linux 2 package smoke tests have been failing because 8.1.x raised the effective minimum platform requirements, so we avoid breakage by sticking to 8.0.x for now, just like we do for macOS already. See MONGOSH-2192 for details.