### PR TITLE
chore: switch to `@mongodb-js/device-id`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6337,6 +6337,12 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/@mongodb-js/device-id": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/device-id/-/device-id-0.2.1.tgz",
+      "integrity": "sha512-kC/F1/ryJMNeIt+n7CATAf9AL/X5Nz1Tju8VseyViL2DF640dmF/JQwWmjakpsSTy5X9TVNOkG9ye4Mber8GHQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@mongodb-js/devtools-connect": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-connect/-/devtools-connect-3.4.1.tgz",
@@ -34598,54 +34604,6 @@
         "node": ">=14.15.1"
       }
     },
-    "packages/logging/node_modules/@mongodb-js/device-id": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/device-id/-/device-id-0.2.1.tgz",
-      "integrity": "sha512-kC/F1/ryJMNeIt+n7CATAf9AL/X5Nz1Tju8VseyViL2DF640dmF/JQwWmjakpsSTy5X9TVNOkG9ye4Mber8GHQ==",
-      "license": "Apache-2.0"
-    },
-    "packages/logging/node_modules/@segment/analytics-core": {
-      "version": "1.8.1",
-      "resolved": "https://registry.npmjs.org/@segment/analytics-core/-/analytics-core-1.8.1.tgz",
-      "integrity": "sha512-EYcdBdhfi1pOYRX+Sf5orpzzYYFmDHTEu6+w0hjXpW5bWkWct+Nv6UJg1hF4sGDKEQjpZIinLTpQ4eioFM4KeQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@lukeed/uuid": "^2.0.0",
-        "@segment/analytics-generic-utils": "1.2.0",
-        "dset": "^3.1.4",
-        "tslib": "^2.4.1"
-      }
-    },
-    "packages/logging/node_modules/@segment/analytics-generic-utils": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/@segment/analytics-generic-utils/-/analytics-generic-utils-1.2.0.tgz",
-      "integrity": "sha512-DfnW6mW3YQOLlDQQdR89k4EqfHb0g/3XvBXkovH1FstUN93eL1kfW9CsDcVQyH3bAC5ZsFyjA/o/1Q2j0QeoWw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "tslib": "^2.4.1"
-      }
-    },
-    "packages/logging/node_modules/@segment/analytics-node": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/@segment/analytics-node/-/analytics-node-2.2.1.tgz",
-      "integrity": "sha512-J+p5r2BewzowI6YsnSH6U+W9IAvRbEyheqDOSUEwh6QDbxjwcBXwzuPwtz5DtEjbEGMu2QwrwoJvZlZ/n5fugw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@lukeed/uuid": "^2.0.0",
-        "@segment/analytics-core": "1.8.1",
-        "@segment/analytics-generic-utils": "1.2.0",
-        "buffer": "^6.0.3",
-        "jose": "^5.1.0",
-        "node-fetch": "^2.6.7",
-        "tslib": "^2.4.1"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
     "packages/logging/node_modules/@sinonjs/commons": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/@sinonjs/commons/-/commons-3.0.1.tgz",
@@ -34695,31 +34653,6 @@
       "dev": true,
       "license": "(Unlicense OR Apache-2.0)"
     },
-    "packages/logging/node_modules/buffer": {
-      "version": "6.0.3",
-      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
-      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "MIT",
-      "dependencies": {
-        "base64-js": "^1.3.1",
-        "ieee754": "^1.2.1"
-      }
-    },
     "packages/logging/node_modules/diff": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
@@ -34728,37 +34661,6 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
-      }
-    },
-    "packages/logging/node_modules/ieee754": {
-      "version": "1.2.1",
-      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
-      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
-      "dev": true,
-      "funding": [
-        {
-          "type": "github",
-          "url": "https://github.com/sponsors/feross"
-        },
-        {
-          "type": "patreon",
-          "url": "https://www.patreon.com/feross"
-        },
-        {
-          "type": "consulting",
-          "url": "https://feross.org/support"
-        }
-      ],
-      "license": "BSD-3-Clause"
-    },
-    "packages/logging/node_modules/jose": {
-      "version": "5.10.0",
-      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
-      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
-      "dev": true,
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/panva"
       }
     },
     "packages/logging/node_modules/just-extend": {
@@ -34828,13 +34730,6 @@
         "type": "opencollective",
         "url": "https://opencollective.com/sinon"
       }
-    },
-    "packages/logging/node_modules/tslib": {
-      "version": "2.8.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
-      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
-      "license": "0BSD"
     },
     "packages/mongosh": {
       "version": "2.5.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6337,6 +6337,12 @@
       "dev": true,
       "license": "Apache-2.0"
     },
+    "node_modules/@mongodb-js/device-id": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/device-id/-/device-id-0.2.0.tgz",
+      "integrity": "sha512-auEMkQc6hpSQSQziK5AbeuJeVnI7OQvWmaoMIWcXrMm+RA6pF0ADXZPS6kBtBIrRhWElV6PVYiq+Gfzsss2RYQ==",
+      "license": "Apache-2.0"
+    },
     "node_modules/@mongodb-js/devtools-connect": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-connect/-/devtools-connect-3.4.1.tgz",
@@ -34575,6 +34581,7 @@
       "version": "3.7.2",
       "license": "Apache-2.0",
       "dependencies": {
+        "@mongodb-js/device-id": "^0.2.0",
         "@mongodb-js/devtools-connect": "^3.4.1",
         "@mongosh/errors": "2.4.0",
         "@mongosh/history": "2.4.6",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34588,7 +34588,7 @@
         "@mongodb-js/eslint-config-mongosh": "^1.0.0",
         "@mongodb-js/prettier-config-devtools": "^1.0.1",
         "@mongodb-js/tsconfig-mongosh": "^1.0.0",
-        "@segment/analytics-node": "^2.2.1",
+        "@segment/analytics-node": "^1.3.0",
         "depcheck": "^1.4.7",
         "eslint": "^7.25.0",
         "prettier": "^2.8.8",

--- a/package-lock.json
+++ b/package-lock.json
@@ -6337,12 +6337,6 @@
       "dev": true,
       "license": "Apache-2.0"
     },
-    "node_modules/@mongodb-js/device-id": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/device-id/-/device-id-0.2.0.tgz",
-      "integrity": "sha512-auEMkQc6hpSQSQziK5AbeuJeVnI7OQvWmaoMIWcXrMm+RA6pF0ADXZPS6kBtBIrRhWElV6PVYiq+Gfzsss2RYQ==",
-      "license": "Apache-2.0"
-    },
     "node_modules/@mongodb-js/devtools-connect": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/@mongodb-js/devtools-connect/-/devtools-connect-3.4.1.tgz",
@@ -34581,7 +34575,7 @@
       "version": "3.7.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@mongodb-js/device-id": "^0.2.0",
+        "@mongodb-js/device-id": "^0.2.1",
         "@mongodb-js/devtools-connect": "^3.4.1",
         "@mongosh/errors": "2.4.0",
         "@mongosh/history": "2.4.6",
@@ -34602,6 +34596,12 @@
       "engines": {
         "node": ">=14.15.1"
       }
+    },
+    "packages/logging/node_modules/@mongodb-js/device-id": {
+      "version": "0.2.1",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/device-id/-/device-id-0.2.1.tgz",
+      "integrity": "sha512-kC/F1/ryJMNeIt+n7CATAf9AL/X5Nz1Tju8VseyViL2DF640dmF/JQwWmjakpsSTy5X9TVNOkG9ye4Mber8GHQ==",
+      "license": "Apache-2.0"
     },
     "packages/logging/node_modules/@sinonjs/commons": {
       "version": "3.0.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -34588,6 +34588,7 @@
         "@mongodb-js/eslint-config-mongosh": "^1.0.0",
         "@mongodb-js/prettier-config-devtools": "^1.0.1",
         "@mongodb-js/tsconfig-mongosh": "^1.0.0",
+        "@segment/analytics-node": "^2.2.1",
         "depcheck": "^1.4.7",
         "eslint": "^7.25.0",
         "prettier": "^2.8.8",
@@ -34602,6 +34603,48 @@
       "resolved": "https://registry.npmjs.org/@mongodb-js/device-id/-/device-id-0.2.1.tgz",
       "integrity": "sha512-kC/F1/ryJMNeIt+n7CATAf9AL/X5Nz1Tju8VseyViL2DF640dmF/JQwWmjakpsSTy5X9TVNOkG9ye4Mber8GHQ==",
       "license": "Apache-2.0"
+    },
+    "packages/logging/node_modules/@segment/analytics-core": {
+      "version": "1.8.1",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-core/-/analytics-core-1.8.1.tgz",
+      "integrity": "sha512-EYcdBdhfi1pOYRX+Sf5orpzzYYFmDHTEu6+w0hjXpW5bWkWct+Nv6UJg1hF4sGDKEQjpZIinLTpQ4eioFM4KeQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@lukeed/uuid": "^2.0.0",
+        "@segment/analytics-generic-utils": "1.2.0",
+        "dset": "^3.1.4",
+        "tslib": "^2.4.1"
+      }
+    },
+    "packages/logging/node_modules/@segment/analytics-generic-utils": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-generic-utils/-/analytics-generic-utils-1.2.0.tgz",
+      "integrity": "sha512-DfnW6mW3YQOLlDQQdR89k4EqfHb0g/3XvBXkovH1FstUN93eL1kfW9CsDcVQyH3bAC5ZsFyjA/o/1Q2j0QeoWw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tslib": "^2.4.1"
+      }
+    },
+    "packages/logging/node_modules/@segment/analytics-node": {
+      "version": "2.2.1",
+      "resolved": "https://registry.npmjs.org/@segment/analytics-node/-/analytics-node-2.2.1.tgz",
+      "integrity": "sha512-J+p5r2BewzowI6YsnSH6U+W9IAvRbEyheqDOSUEwh6QDbxjwcBXwzuPwtz5DtEjbEGMu2QwrwoJvZlZ/n5fugw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@lukeed/uuid": "^2.0.0",
+        "@segment/analytics-core": "1.8.1",
+        "@segment/analytics-generic-utils": "1.2.0",
+        "buffer": "^6.0.3",
+        "jose": "^5.1.0",
+        "node-fetch": "^2.6.7",
+        "tslib": "^2.4.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "packages/logging/node_modules/@sinonjs/commons": {
       "version": "3.0.1",
@@ -34652,6 +34695,31 @@
       "dev": true,
       "license": "(Unlicense OR Apache-2.0)"
     },
+    "packages/logging/node_modules/buffer": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-6.0.3.tgz",
+      "integrity": "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.2.1"
+      }
+    },
     "packages/logging/node_modules/diff": {
       "version": "7.0.0",
       "resolved": "https://registry.npmjs.org/diff/-/diff-7.0.0.tgz",
@@ -34660,6 +34728,37 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.3.1"
+      }
+    },
+    "packages/logging/node_modules/ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/feross"
+        },
+        {
+          "type": "patreon",
+          "url": "https://www.patreon.com/feross"
+        },
+        {
+          "type": "consulting",
+          "url": "https://feross.org/support"
+        }
+      ],
+      "license": "BSD-3-Clause"
+    },
+    "packages/logging/node_modules/jose": {
+      "version": "5.10.0",
+      "resolved": "https://registry.npmjs.org/jose/-/jose-5.10.0.tgz",
+      "integrity": "sha512-s+3Al/p9g32Iq+oqXxkW//7jk2Vig6FF1CFqzVXoTUXt2qz89YWbL+OwS17NFYEvxC35n0FKeGO2LGYSxeM2Gg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/panva"
       }
     },
     "packages/logging/node_modules/just-extend": {
@@ -34729,6 +34828,13 @@
         "type": "opencollective",
         "url": "https://opencollective.com/sinon"
       }
+    },
+    "packages/logging/node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "dev": true,
+      "license": "0BSD"
     },
     "packages/mongosh": {
       "version": "2.5.1",

--- a/packages/logging/package.json
+++ b/packages/logging/package.json
@@ -17,6 +17,7 @@
     "node": ">=14.15.1"
   },
   "dependencies": {
+    "@mongodb-js/device-id": "^0.2.0",
     "@mongodb-js/devtools-connect": "^3.4.1",
     "@mongosh/errors": "2.4.0",
     "@mongosh/history": "2.4.6",

--- a/packages/logging/package.json
+++ b/packages/logging/package.json
@@ -30,7 +30,7 @@
     "@mongodb-js/eslint-config-mongosh": "^1.0.0",
     "@mongodb-js/prettier-config-devtools": "^1.0.1",
     "@mongodb-js/tsconfig-mongosh": "^1.0.0",
-    "@segment/analytics-node": "^2.2.1",
+    "@segment/analytics-node": "^1.3.0",
     "depcheck": "^1.4.7",
     "eslint": "^7.25.0",
     "prettier": "^2.8.8",

--- a/packages/logging/package.json
+++ b/packages/logging/package.json
@@ -17,7 +17,7 @@
     "node": ">=14.15.1"
   },
   "dependencies": {
-    "@mongodb-js/device-id": "^0.2.0",
+    "@mongodb-js/device-id": "^0.2.1",
     "@mongodb-js/devtools-connect": "^3.4.1",
     "@mongosh/errors": "2.4.0",
     "@mongosh/history": "2.4.6",

--- a/packages/logging/package.json
+++ b/packages/logging/package.json
@@ -30,6 +30,7 @@
     "@mongodb-js/eslint-config-mongosh": "^1.0.0",
     "@mongodb-js/prettier-config-devtools": "^1.0.1",
     "@mongodb-js/tsconfig-mongosh": "^1.0.0",
+    "@segment/analytics-node": "^2.2.1",
     "depcheck": "^1.4.7",
     "eslint": "^7.25.0",
     "prettier": "^2.8.8",

--- a/packages/logging/src/logging-and-telemetry.spec.ts
+++ b/packages/logging/src/logging-and-telemetry.spec.ts
@@ -320,9 +320,9 @@ describe('MongoshLoggingAndTelemetry', function () {
         [
           'identify',
           {
-            deviceId: 'unknown',
             anonymousId: userId,
             traits: {
+              device_id: 'unknown',
               platform: process.platform,
               arch: process.arch,
               session_id: logId,

--- a/packages/logging/src/logging-and-telemetry.spec.ts
+++ b/packages/logging/src/logging-and-telemetry.spec.ts
@@ -8,9 +8,10 @@ import type { Writable } from 'stream';
 import type { MongoshLoggingAndTelemetry } from '.';
 import { setupLoggingAndTelemetry } from '.';
 import type { LoggingAndTelemetry } from './logging-and-telemetry';
-import { getDeviceId } from './logging-and-telemetry';
 import sinon from 'sinon';
 import type { MongoshLoggingAndTelemetryArguments } from './types';
+import { getDeviceId } from '@mongodb-js/device-id';
+import { getMachineId } from 'native-machine-id';
 
 describe('MongoshLoggingAndTelemetry', function () {
   let logOutput: any[];
@@ -263,7 +264,10 @@ describe('MongoshLoggingAndTelemetry', function () {
 
       bus.emit('mongosh:new-user', { userId, anonymousId: userId });
 
-      const deviceId = await getDeviceId();
+      const deviceId = await getDeviceId({
+        getMachineId: () => getMachineId({ raw: true }),
+        isNodeMachineId: false,
+      }).value;
 
       await (loggingAndTelemetry as LoggingAndTelemetry).setupTelemetryPromise;
 
@@ -1183,14 +1187,5 @@ describe('MongoshLoggingAndTelemetry', function () {
         },
       ],
     ]);
-  });
-
-  describe('getDeviceId()', function () {
-    it('is consistent on the same machine', async function () {
-      const idA = await getDeviceId();
-      const idB = await getDeviceId();
-
-      expect(idA).equals(idB);
-    });
   });
 });

--- a/packages/logging/src/logging-and-telemetry.spec.ts
+++ b/packages/logging/src/logging-and-telemetry.spec.ts
@@ -254,6 +254,7 @@ describe('MongoshLoggingAndTelemetry', function () {
     });
 
     it('automatically sets up device ID for telemetry', async function () {
+      const abortController = new AbortController();
       const loggingAndTelemetry = setupLoggingAndTelemetry({
         ...testLoggingArguments,
         bus,
@@ -266,8 +267,8 @@ describe('MongoshLoggingAndTelemetry', function () {
 
       const deviceId = await getDeviceId({
         getMachineId: () => getMachineId({ raw: true }),
-        isNodeMachineId: false,
-      }).value;
+        abortSignal: abortController.signal,
+      });
 
       await (loggingAndTelemetry as LoggingAndTelemetry).setupTelemetryPromise;
 

--- a/packages/logging/src/logging-and-telemetry.ts
+++ b/packages/logging/src/logging-and-telemetry.ts
@@ -54,7 +54,6 @@ import type {
   MongoshTrackingProperties,
 } from './types';
 import { getDeviceId } from '@mongodb-js/device-id';
-import { getMachineId } from 'native-machine-id';
 
 export function setupLoggingAndTelemetry(
   props: MongoshLoggingAndTelemetryArguments
@@ -139,6 +138,8 @@ export class LoggingAndTelemetry implements MongoshLoggingAndTelemetry {
 
   private async setupTelemetry(): Promise<void> {
     if (!this.deviceId) {
+      // eslint-disable-next-line @typescript-eslint/no-var-requires
+      const getMachineId = require('native-machine-id').getMachineId;
       const { value: deviceId, resolve: resolveDeviceId } = getDeviceId({
         getMachineId: () => getMachineId({ raw: true }),
         isNodeMachineId: false,


### PR DESCRIPTION
This package is meant to minimize code replication and to make sure the approach we're taking with hashing is consistent and timeouts are automatically handled.

See https://github.com/mongodb-js/devtools-shared/pull/532