### PR TITLE
feat(release): set acls to private for new uploads MONGOSH-2124

### DIFF
--- a/packages/build/src/download-center/artifacts.ts
+++ b/packages/build/src/download-center/artifacts.ts
@@ -41,6 +41,9 @@ export async function uploadArtifactToDownloadCenterNew(
 
   await dlcenter.uploadAsset(
     `${ARTIFACTS_FOLDER}/${path.basename(filePath)}`,
-    fs.createReadStream(filePath)
+    fs.createReadStream(filePath),
+    {
+      acl: 'private',
+    }
   );
 }

--- a/packages/build/src/download-center/config.ts
+++ b/packages/build/src/download-center/config.ts
@@ -149,7 +149,10 @@ export async function createAndPublishDownloadCenterConfig(
 
   await dlcenterArtifactsNew.uploadAsset(
     JSON_FEED_ARTIFACT_KEY,
-    JSON.stringify(newJsonFeed, null, 2)
+    JSON.stringify(newJsonFeed, null, 2),
+    {
+      acl: 'private',
+    }
   );
 }
 
@@ -193,7 +196,10 @@ export async function updateJsonFeedCTA(
   await dlcenterArtifacts.uploadAsset(JSON_FEED_ARTIFACT_KEY, patchedJsonFeed);
   await dlcenterArtifactsNew.uploadAsset(
     JSON_FEED_ARTIFACT_KEY,
-    patchedJsonFeed
+    patchedJsonFeed,
+    {
+      acl: 'private',
+    }
   );
 }
 


### PR DESCRIPTION
This commit adjusts our uploads to the new bucket to be private. Access to these buckets will come via CDN only, so it is unnecessarily to set ACLs.