### PR TITLE
chore(ci): only sign macnotary during PRs MONGOSH-2163

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -3965,6 +3965,7 @@ functions:
           PACKAGE_VARIANT: ${package_variant}
           MACOS_NOTARY_KEY: ${macos_notary_key}
           MACOS_NOTARY_SECRET: ${macos_notary_secret}
+          REQUESTER: ${requester}
   verify_artifact:
     - command: expansions.write
       type: setup

--- a/.evergreen/evergreen.yml.in
+++ b/.evergreen/evergreen.yml.in
@@ -610,6 +610,7 @@ functions:
           PACKAGE_VARIANT: ${package_variant}
           MACOS_NOTARY_KEY: ${macos_notary_key}
           MACOS_NOTARY_SECRET: ${macos_notary_secret}
+          REQUESTER: ${requester}
   verify_artifact:
     - command: expansions.write
       type: setup


### PR DESCRIPTION
This commit adjusts our Evergreen template to restore the functionality that was originally committed in 5af1c40bb9ed887f873fe19ce274fb96a6512e39 and reverted in 10a20d24491ff863ff7290e1ed4c4b4a7c545f07. Going forward, we should only sign Mac builds on PRs