### PR TITLE
fix: shell command built from environment values

### DIFF
--- a/scripts/generate-authors.ts
+++ b/scripts/generate-authors.ts
@@ -15,7 +15,8 @@ const packageRootPath = path.resolve(__dirname, '..');
 
 function getAuthorsGitLog(packagePath: string): string[] {
   return execSync(
-    `git log --reverse --format='%aN <%aE>' --use-mailmap -- ${packagePath}`,
+    'git',
+    ['log', '--reverse', '--format=%aN <%aE>', '--use-mailmap', '--', packagePath],
     { cwd: packageRootPath }
   ).toString().trim().split('\n');
 }
@@ -40,7 +41,8 @@ interface Package {
 function getAllPackages(): Package[] {
   return JSON.parse(
     execSync(
-      `lerna list -a --loglevel=error --json`,
+      'lerna',
+      ['list', '-a', '--loglevel=error', '--json'],
       { cwd: packageRootPath }
     ).toString().trim()
   );


### PR DESCRIPTION
https://github.com/mongodb-js/mongosh/blob/53febd4b325f1e0642f370d864b46a82c04bbe4e/scripts/generate-authors.ts#L18-L18

https://github.com/mongodb-js/mongosh/blob/53febd4b325f1e0642f370d864b46a82c04bbe4e/scripts/generate-authors.ts#L43-L43

To fix the issue, we will replace the use of `execSync` with a dynamically constructed shell command by using `execFileSync`. This method allows us to pass the command and its arguments as separate parameters, avoiding interpretation by the shell. Specifically:
1. Replace the dynamic command string `` `git log --reverse --format='%aN <%aE>' --use-mailmap -- ${packagePath}` `` with a static command (`git log`) and an array of arguments.
2. Pass `packagePath` as an argument in the array, ensuring it is treated as a literal value and not interpreted by the shell.

This change will ensure that special characters in `packagePath` do not alter the behavior of the command.

---

Dynamically constructing a shell command with values from the local environment, such as file paths, may inadvertently change the meaning of the shell command. Such changes can occur when an environment value contains characters that the shell interprets in a special way, for instance quotes and spaces. This can result in the shell command misbehaving, or even allowing a malicious user to execute arbitrary commands on the system.

## POC
The following shows a dynamically constructed shell command that recursively removes a temporary directory that is located next to the currently executing JavaScript file. Such utilities are often found in custom build scripts.
```ts
var cp = require("child_process"),
  path = require("path");
function cleanupTemp() {
  let cmd = "rm -rf " + path.join(__dirname, "temp");
  cp.execSync(cmd); // BAD
}
```
The shell command will, however, fail to work as intended if the absolute path of the script's directory contains spaces. In that case, the shell command will interpret the absolute path as multiple paths, instead of a single path. if the absolute path of the temporary directory is `/home/username/important project/temp`, then the shell command will recursively delete `/home/username/important` and `project/temp`, where the latter path gets resolved relative to the working directory of the JavaScript process.

Even worse, although less likely, a malicious user could provide the path `/home/username/; cat /etc/passwd #/important project/temp` in order to execute the command `cat /etc/passwd`. To avoid such potentially catastrophic behaviors, provide the directory as an argument that does not get interpreted by a shell:
```ts
var cp = require("child_process"),
  path = require("path");
function cleanupTemp() {
  let cmd = "rm",
    args = ["-rf", path.join(__dirname, "temp")];
  cp.execFileSync(cmd, args); // GOOD
}
```
## References
[Command Injection](https://www.owasp.org/index.php/Command_Injection)
[CWE-78](https://cwe.mitre.org/data/definitions/78.html)
[CWE-88](https://cwe.mitre.org/data/definitions/88.html)

