### PR TITLE
fix: unsafe shell command constructed from library input

### DIFF
--- a/packages/editor/src/editor.ts
+++ b/packages/editor/src/editor.ts
@@ -240,10 +240,9 @@ export class Editor {
     const { spawn } =
       // eslint-disable-next-line
       require('child_process') as typeof import('child_process');
-    const proc = spawn(editor, [path.basename(tmpDoc)], {
+    const proc = spawn(editor, [tmpDoc], {
       stdio: 'inherit',
       cwd: path.dirname(tmpDoc),
-      shell: true,
     });
 
     // Pause the parent readable stream to stop emitting data events


### PR DESCRIPTION
https://github.com/mongodb-js/mongosh/blob/e9bfb2b3cc9575da07ec0ea2ab4b54867a1901ce/packages/editor/src/editor.ts#L243-L246


fix the issue should avoid using `shell: true` and instead pass the command and its arguments as an array to the `spawn` function. This ensures that the arguments are not interpreted by the shell, mitigating the risk of shell injection. Specifically:
1. Replace the `spawn` call with a version that does not use `shell: true`.
2. Pass the full path to the editor and the temporary file as separate arguments to `spawn`.

This approach ensures that the command is executed directly without shell interpretation, making it safe from injection attacks.