### PR TITLE
fix: set `chunkFormat: false` in webpack config MONGOSH-2225

### DIFF
--- a/config/webpack.base.config.js
+++ b/config/webpack.base.config.js
@@ -54,6 +54,7 @@ module.exports = {
   },
 
   output: {
+    chunkFormat: false,
     strictModuleErrorHandling: true,
     strictModuleExceptionHandling: true,
   },


### PR DESCRIPTION
The mongosh CLI cannot currently handled chunked input, as the process for building the single-executable application only uses a single file as its input.