### PR TITLE
feat: port autocomplete direct commands and browser-runtime-core to the new autocomplete MONGOSH-2205 MONGOSH-2035 MONGOSH-2206

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -33886,7 +33886,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@mongodb-js/mongodb-constants": "^0.10.1",
-        "@mongodb-js/mongodb-ts-autocomplete": "^0.2.4",
+        "@mongodb-js/mongodb-ts-autocomplete": "^0.2.5",
         "@mongosh/shell-api": "^3.11.0",
         "semver": "^7.5.4"
       },
@@ -33904,9 +33904,9 @@
       }
     },
     "packages/autocomplete/node_modules/@mongodb-js/mongodb-ts-autocomplete": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/mongodb-ts-autocomplete/-/mongodb-ts-autocomplete-0.2.4.tgz",
-      "integrity": "sha512-CuE9NnAP8outZY6VS6fZV4hBZGnrVQyhDMCaL+bgoR5dg6nDcrZtNNVbxc976eUVDi0MZhZmYOB/z7sLvi1xFQ==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/mongodb-ts-autocomplete/-/mongodb-ts-autocomplete-0.2.5.tgz",
+      "integrity": "sha512-9Os75QCF+lSLBP7Wank37bCrFTX27Y6GI4HP889TZ88ArLOyKpboS4BK43ARgB0Rg4/mhog8d7jT6OlVb6VwYA==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mongodb-js/ts-autocomplete": "^0.3.1",
@@ -34123,7 +34123,7 @@
       },
       "devDependencies": {
         "@mongodb-js/eslint-config-mongosh": "^1.0.0",
-        "@mongodb-js/mongodb-ts-autocomplete": "^0.2.4",
+        "@mongodb-js/mongodb-ts-autocomplete": "^0.2.5",
         "@mongodb-js/prettier-config-devtools": "^1.0.1",
         "@mongodb-js/tsconfig-mongosh": "^1.0.0",
         "@mongosh/types": "3.6.2",
@@ -34138,9 +34138,9 @@
       }
     },
     "packages/browser-runtime-core/node_modules/@mongodb-js/mongodb-ts-autocomplete": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/mongodb-ts-autocomplete/-/mongodb-ts-autocomplete-0.2.4.tgz",
-      "integrity": "sha512-CuE9NnAP8outZY6VS6fZV4hBZGnrVQyhDMCaL+bgoR5dg6nDcrZtNNVbxc976eUVDi0MZhZmYOB/z7sLvi1xFQ==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/mongodb-ts-autocomplete/-/mongodb-ts-autocomplete-0.2.5.tgz",
+      "integrity": "sha512-9Os75QCF+lSLBP7Wank37bCrFTX27Y6GI4HP889TZ88ArLOyKpboS4BK43ARgB0Rg4/mhog8d7jT6OlVb6VwYA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -35125,7 +35125,7 @@
       "devDependencies": {
         "@microsoft/api-extractor": "^7.39.3",
         "@mongodb-js/eslint-config-mongosh": "^1.0.0",
-        "@mongodb-js/mongodb-ts-autocomplete": "^0.2.4",
+        "@mongodb-js/mongodb-ts-autocomplete": "^0.2.5",
         "@mongodb-js/prettier-config-devtools": "^1.0.1",
         "@mongodb-js/tsconfig-mongosh": "^1.0.0",
         "@mongosh/types": "3.6.2",
@@ -35141,9 +35141,9 @@
       }
     },
     "packages/shell-api/node_modules/@mongodb-js/mongodb-ts-autocomplete": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/mongodb-ts-autocomplete/-/mongodb-ts-autocomplete-0.2.4.tgz",
-      "integrity": "sha512-CuE9NnAP8outZY6VS6fZV4hBZGnrVQyhDMCaL+bgoR5dg6nDcrZtNNVbxc976eUVDi0MZhZmYOB/z7sLvi1xFQ==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/mongodb-ts-autocomplete/-/mongodb-ts-autocomplete-0.2.5.tgz",
+      "integrity": "sha512-9Os75QCF+lSLBP7Wank37bCrFTX27Y6GI4HP889TZ88ArLOyKpboS4BK43ARgB0Rg4/mhog8d7jT6OlVb6VwYA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -6545,20 +6545,6 @@
         "tar": "^6.1.15"
       }
     },
-    "node_modules/@mongodb-js/mongodb-ts-autocomplete": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/mongodb-ts-autocomplete/-/mongodb-ts-autocomplete-0.2.2.tgz",
-      "integrity": "sha512-5GwS2zm8OKJeWFK25PalpstMimIrnif1T07Ur+HECOCFhndTQmIV7VJve86GBwrnmM5Cy4P4Pv7FrjwvfE222A==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@mongodb-js/ts-autocomplete": "^0.3.1",
-        "@mongosh/shell-api": "^3.11.0",
-        "mongodb-schema": "^12.6.2",
-        "node-cache": "^5.1.2",
-        "typescript": "^5.0.4"
-      }
-    },
     "node_modules/@mongodb-js/monorepo-tools": {
       "version": "1.1.16",
       "resolved": "https://registry.npmjs.org/@mongodb-js/monorepo-tools/-/monorepo-tools-1.1.16.tgz",
@@ -33900,6 +33886,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@mongodb-js/mongodb-constants": "^0.10.1",
+        "@mongodb-js/mongodb-ts-autocomplete": "^0.2.4",
         "@mongosh/shell-api": "^3.11.0",
         "semver": "^7.5.4"
       },
@@ -33914,6 +33901,21 @@
       },
       "engines": {
         "node": ">=14.15.1"
+      }
+    },
+    "packages/autocomplete/node_modules/@mongodb-js/mongodb-ts-autocomplete": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/mongodb-ts-autocomplete/-/mongodb-ts-autocomplete-0.2.4.tgz",
+      "integrity": "sha512-CuE9NnAP8outZY6VS6fZV4hBZGnrVQyhDMCaL+bgoR5dg6nDcrZtNNVbxc976eUVDi0MZhZmYOB/z7sLvi1xFQ==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mongodb-js/ts-autocomplete": "^0.3.1",
+        "mongodb-schema": "^12.6.2",
+        "node-cache": "^5.1.2",
+        "typescript": "^5.0.4"
+      },
+      "peerDependencies": {
+        "@mongosh/shell-api": "^3.11.0"
       }
     },
     "packages/browser-repl": {
@@ -34121,6 +34123,7 @@
       },
       "devDependencies": {
         "@mongodb-js/eslint-config-mongosh": "^1.0.0",
+        "@mongodb-js/mongodb-ts-autocomplete": "^0.2.4",
         "@mongodb-js/prettier-config-devtools": "^1.0.1",
         "@mongodb-js/tsconfig-mongosh": "^1.0.0",
         "@mongosh/types": "3.6.2",
@@ -34132,6 +34135,22 @@
       },
       "engines": {
         "node": ">=14.15.1"
+      }
+    },
+    "packages/browser-runtime-core/node_modules/@mongodb-js/mongodb-ts-autocomplete": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/mongodb-ts-autocomplete/-/mongodb-ts-autocomplete-0.2.4.tgz",
+      "integrity": "sha512-CuE9NnAP8outZY6VS6fZV4hBZGnrVQyhDMCaL+bgoR5dg6nDcrZtNNVbxc976eUVDi0MZhZmYOB/z7sLvi1xFQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mongodb-js/ts-autocomplete": "^0.3.1",
+        "mongodb-schema": "^12.6.2",
+        "node-cache": "^5.1.2",
+        "typescript": "^5.0.4"
+      },
+      "peerDependencies": {
+        "@mongosh/shell-api": "^3.11.0"
       }
     },
     "packages/browser-runtime-electron": {
@@ -34329,7 +34348,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@mongodb-js/devtools-proxy-support": "^0.4.2",
-        "@mongodb-js/mongodb-ts-autocomplete": "^0.2.4",
         "@mongosh/arg-parser": "^3.10.3",
         "@mongosh/autocomplete": "^3.11.0",
         "@mongosh/editor": "^3.11.0",
@@ -34392,21 +34410,6 @@
         "macos-export-certificate-and-key": "^1.2.4",
         "mongodb-crypt-library-version": "^1.0.5",
         "win-export-certificate-and-key": "^2.1.0"
-      }
-    },
-    "packages/cli-repl/node_modules/@mongodb-js/mongodb-ts-autocomplete": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/mongodb-ts-autocomplete/-/mongodb-ts-autocomplete-0.2.4.tgz",
-      "integrity": "sha512-CuE9NnAP8outZY6VS6fZV4hBZGnrVQyhDMCaL+bgoR5dg6nDcrZtNNVbxc976eUVDi0MZhZmYOB/z7sLvi1xFQ==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@mongodb-js/ts-autocomplete": "^0.3.1",
-        "mongodb-schema": "^12.6.2",
-        "node-cache": "^5.1.2",
-        "typescript": "^5.0.4"
-      },
-      "peerDependencies": {
-        "@mongosh/shell-api": "^3.11.0"
       }
     },
     "packages/cli-repl/node_modules/argparse": {
@@ -35122,7 +35125,7 @@
       "devDependencies": {
         "@microsoft/api-extractor": "^7.39.3",
         "@mongodb-js/eslint-config-mongosh": "^1.0.0",
-        "@mongodb-js/mongodb-ts-autocomplete": "^0.2.2",
+        "@mongodb-js/mongodb-ts-autocomplete": "^0.2.4",
         "@mongodb-js/prettier-config-devtools": "^1.0.1",
         "@mongodb-js/tsconfig-mongosh": "^1.0.0",
         "@mongosh/types": "3.6.2",
@@ -35135,6 +35138,22 @@
       },
       "engines": {
         "node": ">=14.15.1"
+      }
+    },
+    "packages/shell-api/node_modules/@mongodb-js/mongodb-ts-autocomplete": {
+      "version": "0.2.4",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/mongodb-ts-autocomplete/-/mongodb-ts-autocomplete-0.2.4.tgz",
+      "integrity": "sha512-CuE9NnAP8outZY6VS6fZV4hBZGnrVQyhDMCaL+bgoR5dg6nDcrZtNNVbxc976eUVDi0MZhZmYOB/z7sLvi1xFQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mongodb-js/ts-autocomplete": "^0.3.1",
+        "mongodb-schema": "^12.6.2",
+        "node-cache": "^5.1.2",
+        "typescript": "^5.0.4"
+      },
+      "peerDependencies": {
+        "@mongosh/shell-api": "^3.11.0"
       }
     },
     "packages/shell-api/node_modules/mongodb-redact": {

--- a/packages/autocomplete/package.json
+++ b/packages/autocomplete/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "@mongodb-js/mongodb-constants": "^0.10.1",
     "@mongosh/shell-api": "^3.11.0",
-    "@mongodb-js/mongodb-ts-autocomplete": "^0.2.4",
+    "@mongodb-js/mongodb-ts-autocomplete": "^0.2.5",
     "semver": "^7.5.4"
   }
 }

--- a/packages/autocomplete/package.json
+++ b/packages/autocomplete/package.json
@@ -45,6 +45,7 @@
   "dependencies": {
     "@mongodb-js/mongodb-constants": "^0.10.1",
     "@mongosh/shell-api": "^3.11.0",
+    "@mongodb-js/mongodb-ts-autocomplete": "^0.2.4",
     "semver": "^7.5.4"
   }
 }

--- a/packages/autocomplete/src/direct-command-completer.ts
+++ b/packages/autocomplete/src/direct-command-completer.ts
@@ -1,0 +1,52 @@
+import type { AutocompletionContext } from '@mongodb-js/mongodb-ts-autocomplete';
+import type { TypeSignature } from '@mongosh/shell-api';
+import { signatures as shellSignatures } from '@mongosh/shell-api';
+
+type TypeSignatureAttributes = { [key: string]: TypeSignature };
+
+export async function directCommandCompleter(
+  context: AutocompletionContext,
+  line: string
+): Promise<string[]> {
+  const SHELL_COMPLETIONS = shellSignatures.ShellApi
+    .attributes as TypeSignatureAttributes;
+
+  // Split at space-to-non-space transitions when looking at this as a command,
+  // because multiple spaces (e.g. 'show  collections') are valid in commands.
+  // This split keeps the spaces intact so we can join them back later.
+  const splitLineWhitespace = line.split(/(?<!\S)(?=\S)/);
+  const command = splitLineWhitespace[0].trim();
+  if (!SHELL_COMPLETIONS[command]?.isDirectShellCommand) {
+    return [];
+  }
+
+  // If the shell API provides us with a completer, use it.
+  // examples: use, show, snippet
+  const completer = SHELL_COMPLETIONS[command].newShellCommandCompleter;
+  if (!completer) {
+    // examples without a custom completer: exit, quit, it, cls
+    return [line];
+  }
+
+  if (splitLineWhitespace.length === 1) {
+    if (splitLineWhitespace[0].trimEnd() === splitLineWhitespace[0]) {
+      // Treat e.g. 'show' like 'show '.
+      splitLineWhitespace[0] += ' ';
+    }
+
+    // Complete the first argument after the command.
+    splitLineWhitespace.push('');
+  }
+  const hits =
+    (await completer(
+      context,
+      splitLineWhitespace.map((item) => item.trim())
+    )) || [];
+  // Adjust to full input, because `completer` only completed the last item
+  // in the line, e.g. ['profile'] -> ['show profile']
+  const fullLineHits = hits.map((hit) =>
+    [...splitLineWhitespace.slice(0, -1), hit].join('')
+  );
+
+  return fullLineHits;
+}

--- a/packages/autocomplete/src/index.spec.ts
+++ b/packages/autocomplete/src/index.spec.ts
@@ -1,4 +1,4 @@
-import completer, { BASE_COMPLETIONS } from './';
+import { completer, BASE_COMPLETIONS } from './';
 import { signatures as shellSignatures, Topologies } from '@mongosh/shell-api';
 
 import { expect } from 'chai';

--- a/packages/browser-runtime-core/package.json
+++ b/packages/browser-runtime-core/package.json
@@ -41,6 +41,7 @@
     "@mongodb-js/eslint-config-mongosh": "^1.0.0",
     "@mongodb-js/prettier-config-devtools": "^1.0.1",
     "@mongodb-js/tsconfig-mongosh": "^1.0.0",
+    "@mongodb-js/mongodb-ts-autocomplete": "^0.2.4",
     "@mongosh/types": "3.6.2",
     "bson": "^6.10.3",
     "depcheck": "^1.4.7",

--- a/packages/browser-runtime-core/package.json
+++ b/packages/browser-runtime-core/package.json
@@ -41,7 +41,7 @@
     "@mongodb-js/eslint-config-mongosh": "^1.0.0",
     "@mongodb-js/prettier-config-devtools": "^1.0.1",
     "@mongodb-js/tsconfig-mongosh": "^1.0.0",
-    "@mongodb-js/mongodb-ts-autocomplete": "^0.2.4",
+    "@mongodb-js/mongodb-ts-autocomplete": "^0.2.5",
     "@mongosh/types": "3.6.2",
     "bson": "^6.10.3",
     "depcheck": "^1.4.7",

--- a/packages/browser-runtime-core/src/autocompleter/shell-api-autocompleter.spec.ts
+++ b/packages/browser-runtime-core/src/autocompleter/shell-api-autocompleter.spec.ts
@@ -1,8 +1,10 @@
 import { ShellApiAutocompleter } from './shell-api-autocompleter';
 import { expect } from 'chai';
 import { Topologies } from '@mongosh/shell-api';
+import type { AutocompleteParameters } from '@mongosh/autocomplete';
+import type { AutocompletionContext } from '@mongodb-js/mongodb-ts-autocomplete';
 
-const standalone440 = {
+const standalone440Parameters: AutocompleteParameters = {
   topology: () => Topologies.Standalone,
   apiVersionInfo: () => undefined,
   connectionInfo: () => ({
@@ -11,8 +13,23 @@ const standalone440 = {
     server_version: '4.4.0',
     is_local_atlas: false,
   }),
-  getCollectionCompletionsForCurrentDb: () => ['bananas'],
-  getDatabaseCompletions: () => ['databaseOne'],
+  getCollectionCompletionsForCurrentDb: () => Promise.resolve(['bananas']),
+  getDatabaseCompletions: () => Promise.resolve(['databaseOne']),
+};
+
+const standalone440Context: AutocompletionContext = {
+  currentDatabaseAndConnection: () => ({
+    connectionId: 'connection-1',
+    databaseName: 'databaseOne',
+  }),
+  databasesForConnection: () => Promise.resolve(['databaseOne']),
+  collectionsForDatabase: () => Promise.resolve(['bananas', 'coll1']),
+  schemaInformationForCollection: () => Promise.resolve({}),
+};
+
+const shellInstanceState = {
+  getAutocompleteParameters: () => standalone440Parameters,
+  getAutocompletionContext: () => standalone440Context,
 };
 
 describe('Autocompleter', function () {
@@ -20,7 +37,7 @@ describe('Autocompleter', function () {
     let autocompleter: ShellApiAutocompleter;
 
     beforeEach(function () {
-      autocompleter = new ShellApiAutocompleter(standalone440);
+      autocompleter = new ShellApiAutocompleter(shellInstanceState);
     });
 
     it('returns completions for text before cursor', async function () {

--- a/packages/browser-runtime-core/src/open-context-runtime.ts
+++ b/packages/browser-runtime-core/src/open-context-runtime.ts
@@ -29,7 +29,6 @@ export interface InterpreterEnvironment {
  */
 export class OpenContextRuntime implements Runtime {
   private interpreterEnvironment: InterpreterEnvironment;
-  // TODO(MONGOSH-2205): we have to also port this to the new autocomplete
   private autocompleter: ShellApiAutocompleter | null = null;
   private shellEvaluator: ShellEvaluator;
   private instanceState: ShellInstanceState;
@@ -53,9 +52,7 @@ export class OpenContextRuntime implements Runtime {
 
   async getCompletions(code: string): Promise<Completion[]> {
     if (!this.autocompleter) {
-      this.autocompleter = new ShellApiAutocompleter(
-        this.instanceState.getAutocompleteParameters()
-      );
+      this.autocompleter = new ShellApiAutocompleter(this.instanceState);
       this.updatedConnectionInfoPromise ??=
         this.instanceState.fetchConnectionInfo();
       await this.updatedConnectionInfoPromise;

--- a/packages/cli-repl/package.json
+++ b/packages/cli-repl/package.json
@@ -77,7 +77,6 @@
     "@mongosh/shell-evaluator": "^3.11.0",
     "@mongosh/snippet-manager": "^3.11.0",
     "@mongosh/types": "3.6.2",
-    "@mongodb-js/mongodb-ts-autocomplete": "^0.2.4",
     "@segment/analytics-node": "^1.3.0",
     "ansi-escape-sequences": "^5.1.2",
     "askcharacter": "^2.0.4",

--- a/packages/cli-repl/src/cli-repl.spec.ts
+++ b/packages/cli-repl/src/cli-repl.spec.ts
@@ -2620,11 +2620,6 @@ describe('CliRepl', function () {
       });
 
       it('completes shell commands', async function () {
-        if (process.env.USE_NEW_AUTOCOMPLETE) {
-          // TODO(MONGOSH-2035): not supported yet
-          this.skip();
-        }
-
         input.write('const dSomeVariableStartingWithD = 10;\n');
         await waitEval(cliRepl.bus);
 
@@ -2636,11 +2631,6 @@ describe('CliRepl', function () {
       });
 
       it('completes use <db>', async function () {
-        if (process.env.USE_NEW_AUTOCOMPLETE) {
-          // TODO(MONGOSH-2035): not supported yet
-          this.skip();
-        }
-
         if (!hasDatabaseNames) return this.skip();
         input.write('db.getMongo()._listDatabases()\n'); // populate database cache
         await waitEval(cliRepl.bus);

--- a/packages/e2e-tests/test/e2e-snapshot.spec.ts
+++ b/packages/e2e-tests/test/e2e-snapshot.spec.ts
@@ -156,7 +156,7 @@ describe('e2e snapshot support', function () {
       );
       verifyAllThatMatchAreInCategory(
         'snapshot',
-        /^node_modules\/(@babel\/types|@babel\/traverse|@mongodb-js\/devtools-connect|mongodb)\/|^packages\/(?!(shell-api\/lib\/api-export\.js|cli-repl\/node_modules\/@mongodb-js\/mongodb-ts-autocomplete\/))/
+        /^node_modules\/(@babel\/types|@babel\/traverse|@mongodb-js\/devtools-connect|mongodb)\/|^packages\/(?!(shell-api\/lib\/api-export\.js|autocomplete\/node_modules\/@mongodb-js\/mongodb-ts-autocomplete\/))/
       );
     });
   });

--- a/packages/shell-api/package.json
+++ b/packages/shell-api/package.json
@@ -64,7 +64,7 @@
   "devDependencies": {
     "@microsoft/api-extractor": "^7.39.3",
     "@mongodb-js/eslint-config-mongosh": "^1.0.0",
-    "@mongodb-js/mongodb-ts-autocomplete": "^0.2.4",
+    "@mongodb-js/mongodb-ts-autocomplete": "^0.2.5",
     "@mongodb-js/prettier-config-devtools": "^1.0.1",
     "@mongodb-js/tsconfig-mongosh": "^1.0.0",
     "@mongosh/types": "3.6.2",

--- a/packages/shell-api/package.json
+++ b/packages/shell-api/package.json
@@ -64,7 +64,7 @@
   "devDependencies": {
     "@microsoft/api-extractor": "^7.39.3",
     "@mongodb-js/eslint-config-mongosh": "^1.0.0",
-    "@mongodb-js/mongodb-ts-autocomplete": "^0.2.2",
+    "@mongodb-js/mongodb-ts-autocomplete": "^0.2.4",
     "@mongodb-js/prettier-config-devtools": "^1.0.1",
     "@mongodb-js/tsconfig-mongosh": "^1.0.0",
     "@mongosh/types": "3.6.2",

--- a/packages/shell-api/src/aggregation-cursor.spec.ts
+++ b/packages/shell-api/src/aggregation-cursor.spec.ts
@@ -45,6 +45,7 @@ describe('AggregationCursor', function () {
         isDirectShellCommand: false,
         acceptsRawInput: false,
         shellCommandCompleter: undefined,
+        newShellCommandCompleter: undefined,
       });
     });
   });

--- a/packages/shell-api/src/bulk.spec.ts
+++ b/packages/shell-api/src/bulk.spec.ts
@@ -52,6 +52,7 @@ describe('Bulk API', function () {
           isDirectShellCommand: false,
           acceptsRawInput: false,
           shellCommandCompleter: undefined,
+          newShellCommandCompleter: undefined,
         });
       });
     });
@@ -272,6 +273,7 @@ describe('Bulk API', function () {
           isDirectShellCommand: false,
           acceptsRawInput: false,
           shellCommandCompleter: undefined,
+          newShellCommandCompleter: undefined,
         });
       });
     });

--- a/packages/shell-api/src/change-stream-cursor.spec.ts
+++ b/packages/shell-api/src/change-stream-cursor.spec.ts
@@ -52,6 +52,7 @@ describe('ChangeStreamCursor', function () {
         isDirectShellCommand: false,
         acceptsRawInput: false,
         shellCommandCompleter: undefined,
+        newShellCommandCompleter: undefined,
       });
     });
   });

--- a/packages/shell-api/src/collection.spec.ts
+++ b/packages/shell-api/src/collection.spec.ts
@@ -63,6 +63,7 @@ describe('Collection', function () {
         isDirectShellCommand: false,
         acceptsRawInput: false,
         shellCommandCompleter: undefined,
+        newShellCommandCompleter: undefined,
       });
     });
   });

--- a/packages/shell-api/src/cursor.spec.ts
+++ b/packages/shell-api/src/cursor.spec.ts
@@ -64,6 +64,7 @@ describe('Cursor', function () {
         isDirectShellCommand: false,
         acceptsRawInput: false,
         shellCommandCompleter: undefined,
+        newShellCommandCompleter: undefined,
       });
     });
   });

--- a/packages/shell-api/src/database.spec.ts
+++ b/packages/shell-api/src/database.spec.ts
@@ -111,6 +111,7 @@ describe('Database', function () {
         isDirectShellCommand: false,
         acceptsRawInput: false,
         shellCommandCompleter: undefined,
+        newShellCommandCompleter: undefined,
       });
     });
   });

--- a/packages/shell-api/src/explainable-cursor.spec.ts
+++ b/packages/shell-api/src/explainable-cursor.spec.ts
@@ -40,6 +40,7 @@ describe('ExplainableCursor', function () {
         isDirectShellCommand: false,
         acceptsRawInput: false,
         shellCommandCompleter: undefined,
+        newShellCommandCompleter: undefined,
       });
     });
   });

--- a/packages/shell-api/src/explainable.spec.ts
+++ b/packages/shell-api/src/explainable.spec.ts
@@ -44,6 +44,7 @@ describe('Explainable', function () {
         isDirectShellCommand: false,
         acceptsRawInput: false,
         shellCommandCompleter: undefined,
+        newShellCommandCompleter: undefined,
       });
     });
   });

--- a/packages/shell-api/src/field-level-encryption.spec.ts
+++ b/packages/shell-api/src/field-level-encryption.spec.ts
@@ -166,6 +166,7 @@ describe('Field Level Encryption', function () {
         isDirectShellCommand: false,
         acceptsRawInput: false,
         shellCommandCompleter: undefined,
+        newShellCommandCompleter: undefined,
       });
       expect(signatures.ClientEncryption.attributes?.encrypt).to.deep.equal({
         type: 'function',
@@ -179,6 +180,7 @@ describe('Field Level Encryption', function () {
         isDirectShellCommand: false,
         acceptsRawInput: false,
         shellCommandCompleter: undefined,
+        newShellCommandCompleter: undefined,
       });
     });
   });

--- a/packages/shell-api/src/integration.spec.ts
+++ b/packages/shell-api/src/integration.spec.ts
@@ -2782,8 +2782,11 @@ describe('Shell API (integration)', function () {
 
       it('returns information for autocomplete', async function () {
         const context = instanceState.getAutocompletionContext();
-        const { connectionId, databaseName } =
-          context.currentDatabaseAndConnection();
+        const dbAndConnection = context.currentDatabaseAndConnection();
+        if (!dbAndConnection) {
+          throw new Error('No current database and connection found');
+        }
+        const { connectionId, databaseName } = dbAndConnection;
         const databaseNames = await context.databasesForConnection(
           connectionId
         );

--- a/packages/shell-api/src/mongo.spec.ts
+++ b/packages/shell-api/src/mongo.spec.ts
@@ -69,6 +69,7 @@ describe('Mongo', function () {
         isDirectShellCommand: false,
         acceptsRawInput: false,
         shellCommandCompleter: undefined,
+        newShellCommandCompleter: undefined,
       });
     });
   });

--- a/packages/shell-api/src/plan-cache.spec.ts
+++ b/packages/shell-api/src/plan-cache.spec.ts
@@ -32,6 +32,7 @@ describe('PlanCache', function () {
         isDirectShellCommand: false,
         acceptsRawInput: false,
         shellCommandCompleter: undefined,
+        newShellCommandCompleter: undefined,
       });
     });
   });

--- a/packages/shell-api/src/replica-set.spec.ts
+++ b/packages/shell-api/src/replica-set.spec.ts
@@ -83,6 +83,7 @@ describe('ReplicaSet', function () {
         isDirectShellCommand: false,
         acceptsRawInput: false,
         shellCommandCompleter: undefined,
+        newShellCommandCompleter: undefined,
       });
     });
   });

--- a/packages/shell-api/src/session.spec.ts
+++ b/packages/shell-api/src/session.spec.ts
@@ -55,6 +55,7 @@ describe('Session', function () {
         isDirectShellCommand: false,
         acceptsRawInput: false,
         shellCommandCompleter: undefined,
+        newShellCommandCompleter: undefined,
       });
     });
   });

--- a/packages/shell-api/src/shard.spec.ts
+++ b/packages/shell-api/src/shard.spec.ts
@@ -70,6 +70,7 @@ describe('Shard', function () {
         isDirectShellCommand: false,
         acceptsRawInput: false,
         shellCommandCompleter: undefined,
+        newShellCommandCompleter: undefined,
       });
     });
   });

--- a/packages/shell-api/src/shell-api.spec.ts
+++ b/packages/shell-api/src/shell-api.spec.ts
@@ -60,6 +60,8 @@ describe('ShellApi', function () {
         acceptsRawInput: false,
         shellCommandCompleter:
           signatures.ShellApi.attributes?.use.shellCommandCompleter,
+        newShellCommandCompleter:
+          signatures.ShellApi.attributes?.use.newShellCommandCompleter,
       });
       expect(signatures.ShellApi.attributes?.show).to.deep.equal({
         type: 'function',
@@ -74,6 +76,8 @@ describe('ShellApi', function () {
         acceptsRawInput: false,
         shellCommandCompleter:
           signatures.ShellApi.attributes?.show.shellCommandCompleter,
+        newShellCommandCompleter:
+          signatures.ShellApi.attributes?.show.newShellCommandCompleter,
       });
       expect(signatures.ShellApi.attributes?.exit).to.deep.equal({
         type: 'function',
@@ -87,6 +91,7 @@ describe('ShellApi', function () {
         isDirectShellCommand: true,
         acceptsRawInput: false,
         shellCommandCompleter: undefined,
+        newShellCommandCompleter: undefined,
       });
       expect(signatures.ShellApi.attributes?.it).to.deep.equal({
         type: 'function',
@@ -100,6 +105,7 @@ describe('ShellApi', function () {
         isDirectShellCommand: true,
         acceptsRawInput: false,
         shellCommandCompleter: undefined,
+        newShellCommandCompleter: undefined,
       });
       expect(signatures.ShellApi.attributes?.print).to.deep.equal({
         type: 'function',
@@ -113,6 +119,7 @@ describe('ShellApi', function () {
         isDirectShellCommand: false,
         acceptsRawInput: false,
         shellCommandCompleter: undefined,
+        newShellCommandCompleter: undefined,
       });
       expect(signatures.ShellApi.attributes?.printjson).to.deep.equal({
         type: 'function',
@@ -126,6 +133,7 @@ describe('ShellApi', function () {
         isDirectShellCommand: false,
         acceptsRawInput: false,
         shellCommandCompleter: undefined,
+        newShellCommandCompleter: undefined,
       });
       expect(signatures.ShellApi.attributes?.sleep).to.deep.equal({
         type: 'function',
@@ -139,6 +147,7 @@ describe('ShellApi', function () {
         isDirectShellCommand: false,
         acceptsRawInput: false,
         shellCommandCompleter: undefined,
+        newShellCommandCompleter: undefined,
       });
       expect(signatures.ShellApi.attributes?.cls).to.deep.equal({
         type: 'function',
@@ -152,6 +161,7 @@ describe('ShellApi', function () {
         isDirectShellCommand: true,
         acceptsRawInput: false,
         shellCommandCompleter: undefined,
+        newShellCommandCompleter: undefined,
       });
       expect(signatures.ShellApi.attributes?.Mongo).to.deep.equal({
         type: 'function',
@@ -165,6 +175,7 @@ describe('ShellApi', function () {
         isDirectShellCommand: false,
         acceptsRawInput: false,
         shellCommandCompleter: undefined,
+        newShellCommandCompleter: undefined,
       });
       expect(signatures.ShellApi.attributes?.connect).to.deep.equal({
         type: 'function',
@@ -178,6 +189,7 @@ describe('ShellApi', function () {
         isDirectShellCommand: false,
         acceptsRawInput: false,
         shellCommandCompleter: undefined,
+        newShellCommandCompleter: undefined,
       });
     });
   });

--- a/packages/shell-api/src/shell-api.ts
+++ b/packages/shell-api/src/shell-api.ts
@@ -145,16 +145,11 @@ async function newUseCompleter(
 ): Promise<string[] | undefined> {
   if (args.length > 2) return undefined;
 
-  let connectionId: string;
-
-  try {
-    ({ connectionId } = context.currentDatabaseAndConnection());
-  } catch (err: any) {
-    if (err.name === 'MongoshInvalidInputError') {
-      return [];
-    }
-    throw err;
+  const dbAndConnection = context.currentDatabaseAndConnection();
+  if (!dbAndConnection) {
+    return [];
   }
+  const { connectionId } = dbAndConnection;
 
   const dbNames = await context.databasesForConnection(connectionId);
 

--- a/packages/shell-api/src/shell-api.ts
+++ b/packages/shell-api/src/shell-api.ts
@@ -1,6 +1,7 @@
 import type {
   ShellResult,
   ShellCommandAutocompleteParameters,
+  NewShellCommandAutocompleteParameters,
 } from './decorators';
 import {
   shellApiClassDefault,
@@ -135,16 +136,38 @@ async function useCompleter(
   return await params.getDatabaseCompletions(args[1] ?? '');
 }
 
-/**
- * Complete a `show` subcommand.
- */
-// eslint-disable-next-line @typescript-eslint/require-await
-async function showCompleter(
-  params: ShellCommandAutocompleteParameters,
+// eslint-disable-next-line no-control-regex
+const CONTROL_CHAR_REGEXP = /[\x00-\x1F\x7F-\x9F]/g;
+
+async function newUseCompleter(
+  context: NewShellCommandAutocompleteParameters,
   args: string[]
 ): Promise<string[] | undefined> {
   if (args.length > 2) return undefined;
-  if (args[1] === 'd') {
+
+  let connectionId: string;
+
+  try {
+    ({ connectionId } = context.currentDatabaseAndConnection());
+  } catch (err: any) {
+    if (err.name === 'MongoshInvalidInputError') {
+      return [];
+    }
+    throw err;
+  }
+
+  const dbNames = await context.databasesForConnection(connectionId);
+
+  const prefix = (args[1] ?? '').toLowerCase();
+
+  return dbNames.filter(
+    (name) =>
+      name.toLowerCase().startsWith(prefix) && !CONTROL_CHAR_REGEXP.test(name)
+  );
+}
+
+function completeShowCommand(prefix: string): string[] {
+  if (prefix === 'd') {
     // Special-case: The user might want `show dbs` or `show databases`, but they won't care about which they get.
     return ['databases'];
   }
@@ -162,7 +185,28 @@ async function showCompleter(
     'automationNotices',
     'nonGenuineMongoDBCheck',
   ];
-  return candidates.filter((str) => str.startsWith(args[1] ?? ''));
+  return candidates.filter((str) => str.startsWith(prefix));
+}
+
+/**
+ * Complete a `show` subcommand.
+ */
+// eslint-disable-next-line @typescript-eslint/require-await
+async function showCompleter(
+  params: ShellCommandAutocompleteParameters,
+  args: string[]
+): Promise<string[] | undefined> {
+  if (args.length > 2) return undefined;
+  return completeShowCommand(args[1] ?? '');
+}
+
+// eslint-disable-next-line @typescript-eslint/require-await
+async function newShowCompleter(
+  context: NewShellCommandAutocompleteParameters,
+  args: string[]
+): Promise<string[] | undefined> {
+  if (args.length > 2) return undefined;
+  return completeShowCommand(args[1] ?? '');
 }
 
 /**
@@ -206,14 +250,14 @@ export default class ShellApi extends ShellApiClass {
   }
 
   @directShellCommand
-  @shellCommandCompleter(useCompleter)
+  @shellCommandCompleter(useCompleter, newUseCompleter)
   use(db: string): any {
     return this._instanceState.currentDb._mongo.use(db);
   }
 
   @directShellCommand
   @returnsPromise
-  @shellCommandCompleter(showCompleter)
+  @shellCommandCompleter(showCompleter, newShowCompleter)
   async show(cmd: string, arg?: string): Promise<CommandResult> {
     return await this._instanceState.currentDb._mongo.show(cmd, arg);
   }

--- a/packages/shell-api/src/shell-instance-state.ts
+++ b/packages/shell-api/src/shell-instance-state.ts
@@ -417,14 +417,23 @@ export class ShellInstanceState {
 
   public getAutocompletionContext(): AutocompletionContext {
     return {
-      currentDatabaseAndConnection: (): {
-        connectionId: string;
-        databaseName: string;
-      } => {
-        return {
-          connectionId: this.currentDb.getMongo()._getConnectionId(),
-          databaseName: this.currentDb.getName(),
-        };
+      currentDatabaseAndConnection: ():
+        | {
+            connectionId: string;
+            databaseName: string;
+          }
+        | undefined => {
+        try {
+          return {
+            connectionId: this.currentDb.getMongo()._getConnectionId(),
+            databaseName: this.currentDb.getName(),
+          };
+        } catch (err: any) {
+          if (err.name === 'MongoshInvalidInputError') {
+            return undefined;
+          }
+          throw err;
+        }
       },
       databasesForConnection: async (
         connectionId: string

--- a/packages/snippet-manager/src/snippet-manager.ts
+++ b/packages/snippet-manager/src/snippet-manager.ts
@@ -83,6 +83,36 @@ async function packBSON(data: any): Promise<Buffer> {
   return await brotliCompress(bson.serialize(data));
 }
 
+function completeSnippetsCommand(
+  args: string[],
+  snippets: SnippetManager['snippets']
+) {
+  const plainCommands = [
+    'update',
+    'search',
+    'ls',
+    'outdated',
+    'info',
+    'refresh',
+    'load-all',
+  ];
+  const pkgCommands = ['install', 'uninstall', 'help'];
+  if (args.length >= 2 && pkgCommands.includes(args[1])) {
+    const allSnippetNames = snippets.map(({ snippetName }) => snippetName);
+    if (args.length === 2) {
+      return allSnippetNames.map((str) => `${args[1]} ${str}`);
+    }
+    return allSnippetNames.filter((str) =>
+      str.startsWith(args[args.length - 1] ?? '')
+    );
+  } else if (args.length === 2) {
+    return [...plainCommands, ...pkgCommands].filter((str) =>
+      str.startsWith(args[1] ?? '')
+    );
+  }
+  return undefined;
+}
+
 export class SnippetManager implements ShellPlugin {
   _instanceState: ShellInstanceState;
   installdir: string;
@@ -143,32 +173,14 @@ export class SnippetManager implements ShellPlugin {
         args: string[]
         // eslint-disable-next-line @typescript-eslint/require-await
       ): Promise<string[] | undefined> => {
-        const plainCommands = [
-          'update',
-          'search',
-          'ls',
-          'outdated',
-          'info',
-          'refresh',
-          'load-all',
-        ];
-        const pkgCommands = ['install', 'uninstall', 'help'];
-        if (args.length >= 2 && pkgCommands.includes(args[1])) {
-          const allSnippetNames = this.snippets.map(
-            ({ snippetName }) => snippetName
-          );
-          if (args.length === 2) {
-            return allSnippetNames.map((str) => `${args[1]} ${str}`);
-          }
-          return allSnippetNames.filter((str) =>
-            str.startsWith(args[args.length - 1] ?? '')
-          );
-        } else if (args.length === 2) {
-          return [...plainCommands, ...pkgCommands].filter((str) =>
-            str.startsWith(args[1] ?? '')
-          );
-        }
-        return undefined;
+        return completeSnippetsCommand(args, this.snippets);
+      },
+      newShellCommandCompleter: async (
+        context: unknown,
+        args: string[]
+        // eslint-disable-next-line @typescript-eslint/require-await
+      ): Promise<string[] | undefined> => {
+        return completeSnippetsCommand(args, this.snippets);
       },
     } as TypeSignature;
     instanceState.registerPlugin(this);

--- a/packages/snippet-manager/src/snippet-manager.ts
+++ b/packages/snippet-manager/src/snippet-manager.ts
@@ -85,7 +85,7 @@ async function packBSON(data: any): Promise<Buffer> {
 
 function completeSnippetsCommand(
   args: string[],
-  snippets: SnippetManager['snippets']
+  snippets: SnippetDescription[]
 ) {
   const plainCommands = [
     'update',


### PR DESCRIPTION
This essentially reuses (as in makes a copy of) the existing direct shell command autocompleter and then ports it to use the new AutocompleteContext vs the old AutocompleteParams. Unfortunately it meant more duplicate types and props between the old and new than I'd really like, but this way at least means we can have the feature flag and keep the old way around for now. But I'm open to suggestion.

I also fixed up the code that initialises the autocompleter and uses it, moving to packages/autocomplete in the process. This way the common code can be reused between the cli and browser repls. It lives in packages/autocomplete. The idea is we'd remove the old autocomplete code from there and keep this new wrapper.

Then to validate that the above design works I ported usage of autocomplete in browser-runtime-core to do the same thing we do in cli-repl. I ported its tests too, so you can do:

```
~/mongo/mongosh/packages/browser-runtime-core % USE_NEW_AUTOCOMPLETE=true npm test
```

I also narrowed some types along the way just to make porting tests a bit easier without requiring all of ShellInstanceState, for example.
