### PR TITLE
fix: provide license override for cli-table package MONGOSH-2248

### DIFF
--- a/licenses.json
+++ b/licenses.json
@@ -1,5 +1,7 @@
 {
   "ignoredOrgs": ["@mongodb-js", "@leafygreen-ui"],
   "doNotValidatePackages": ["argparse@2.0.1"],
-  "licenseOverrides": {}
+  "licenseOverrides": {
+    "cli-table@0.3.11": "MIT"
+  }
 }


### PR DESCRIPTION
This package has a license file but no `license` specified in its package.json file.

Broken since c8941c12a9457e8029.