### PR TITLE
fix(e2e-tests): add another kerberos error message MONGOSH-2252

### DIFF
--- a/packages/e2e-tests/test/e2e-auth.spec.ts
+++ b/packages/e2e-tests/test/e2e-auth.spec.ts
@@ -1129,6 +1129,7 @@ describe('Auth e2e', function () {
           'Miscellaneous failure (see text): no credential for',
           "Unsupported mechanism 'GSSAPI' on authentication database '$external'",
           'The specified target is unknown or unreachable',
+          'Server not found in Kerberos database',
         ];
         expect(messages.some((msg) => shell.output.includes(msg))).to.equal(
           true,


### PR DESCRIPTION
This recently started popping up in our macOS e2e tests.