### PR TITLE
fix(browser-repl): use block: nearest for scrollIntoView vertical alignment behavior COMPASS-9417

### DIFF
--- a/packages/browser-repl/src/components/shell.tsx
+++ b/packages/browser-repl/src/components/shell.tsx
@@ -446,7 +446,11 @@ const _Shell: ForwardRefRenderFunction<EditorRef | null, ShellProps> = (
       return;
     }
 
-    shellInputContainerRef.current.scrollIntoView();
+    shellInputContainerRef.current.scrollIntoView({
+      // Scroll to the bottom of the shell input container.
+      // Or maintain scroll if already in the input.
+      block: 'nearest',
+    });
   }, [shellInputContainerRef]);
 
   const onShellClicked = useCallback(


### PR DESCRIPTION
COMPASS-9417

https://developer.mozilla.org/en-US/docs/Web/API/Element/scrollIntoView#block

Previously it would scroll to the top of the input, which would be cumbersome when doing multi-line editing. With these changes we make sure it's in view, but won't scroll to the top if they're already in it.