### PR TITLE
fix: set `generate-authors` shell command built from environment values

### DIFF
--- a/scripts/generate-authors.ts
+++ b/scripts/generate-authors.ts
@@ -7,15 +7,16 @@
  * names / emails.
  */
 
-import { execSync } from 'child_process';
+import { execFileSync, execSync } from 'child_process';
 import path from 'path';
 import fs from 'fs';
 
 const packageRootPath = path.resolve(__dirname, '..');
 
 function getAuthorsGitLog(packagePath: string): string[] {
-  return execSync(
-    `git log --reverse --format='%aN <%aE>' --use-mailmap -- ${packagePath}`,
+  return execFileSync(
+    'git',
+    ['log', '--reverse', '--format=%aN <%aE>', '--use-mailmap', '--', packagePath],
     { cwd: packageRootPath }
   ).toString().trim().split('\n');
 }


### PR DESCRIPTION

https://github.com/mongodb-js/mongosh/blob/af7658f4ffc2bb328dc3203ceebca652f1029102/scripts/generate-authors.ts#L10-L10
https://github.com/mongodb-js/mongosh/blob/af7658f4ffc2bb328dc3203ceebca652f1029102/scripts/generate-authors.ts#L17-L18

Fix the issue should avoid dynamically constructing the shell command as a single string. Instead, we can use `execFileSync`, which allows us to pass the command and its arguments separately. This approach ensures that the arguments are not interpreted by the shell, mitigating the risk of command injection.

Specifically:
1. Replace the use of `execSync` with `execFileSync` in the `getAuthorsGitLog` function.
2. Pass the `git` command and its arguments as separate parameters to `execFileSync`.
3. Ensure that `packagePath` is passed as an argument, rather than interpolated into the command string.