### PR TITLE
chore: automatic release tag merging

### DIFF
--- a/.github/workflows/merge-release-tag.yml
+++ b/.github/workflows/merge-release-tag.yml
@@ -3,8 +3,7 @@ name: Merge Release Tag
 on:
   push:
     tags:
-      - 'mongosh@[0-9]+.[0-9]+.[0-9]+'
-      - 'mongosh@[0-9]+.[0-9]+.[0-9]-rc.[0-9]+'
+      - 'mongosh@[0-9]+.[0-9]+.[0-9]+*'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
One of my guesses here is that `-rc...` pattern somehow messes with how GitHub does matching because of their usage of glob matching instead of actual regex. I'm not fully convinced by this but I can't find any other discrepancy here at the moment.

Using a wildcard after is [used in some GitHub projects](https://github.com/search?q=+%40%5B0-9%5D%2B.%5B0-9%5D%2B.%5B0-9%5D%2B*&type=code) so hopefully that will do the trick.