### PR TITLE
fix: use on create with tags

### DIFF
--- a/.github/workflows/merge-release-tag.yml
+++ b/.github/workflows/merge-release-tag.yml
@@ -2,13 +2,6 @@ name: Merge Release Tag
 
 on:
   create:
-    tags:
-      - 'mongosh@[0-9]+.[0-9]+.[0-9]+'
-      - 'mongosh@[0-9]+.[0-9]+.[0-9]-rc.[0-9]+'
-  push:
-    tags:
-      - 'mongosh@[0-9]+.[0-9]+.[0-9]+'
-      - 'mongosh@[0-9]+.[0-9]+.[0-9]-rc.[0-9]+'
   workflow_dispatch:
 
 permissions:
@@ -16,6 +9,7 @@ permissions:
 
 jobs:
   merge-release-tag:
+    if: ${{ github.ref =~ '^refs/tags/mongosh@[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$' }}
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/merge-release-tag.yml
+++ b/.github/workflows/merge-release-tag.yml
@@ -1,9 +1,14 @@
 name: Merge Release Tag
 
 on:
+  create:
+    tags:
+      - 'mongosh@[0-9]+.[0-9]+.[0-9]+'
+      - 'mongosh@[0-9]+.[0-9]+.[0-9]-rc.[0-9]+'
   push:
     tags:
-      - 'mongosh@[0-9]+.[0-9]+.[0-9]+*'
+      - 'mongosh@[0-9]+.[0-9]+.[0-9]+'
+      - 'mongosh@[0-9]+.[0-9]+.[0-9]-rc.[0-9]+'
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
That was not it. 

Though I am not sure why pushing isn't covered (I suppose it'd need to be a push into an existing tag?), the fun long thread of issues people have been running into with https://github.com/actions/runner/issues/1007 seems relevant here.

Incorporated https://github.com/actions/runner/issues/1007#issuecomment-808904408 into our setup 🤞 