### PR TITLE
fix: bundle @mongodb-js/mongodb-ts-autocomplete with shell-api so we don't depend on it

### DIFF
--- a/packages/shell-api/api-extractor.json
+++ b/packages/shell-api/api-extractor.json
@@ -8,6 +8,7 @@
     "enabled": false
   },
   "bundledPackages": [
+    "@mongodb-js/mongodb-ts-autocomplete",
     "@mongodb-js/devtools-connect",
     "@mongodb-js/devtools-proxy-support",
     "@mongodb-js/oidc-plugin",


### PR DESCRIPTION
api-processed.d.ts is doing `import type { AutocompletionContext } from '@mongodb-js/mongodb-ts-autocomplete';` which means the autocompleter would have to serve up itself which is not what we want. I don't understand why this didn't happen earlier.