### PR TITLE
chore: also bundle mongodb-schema and json-schema

### DIFF
--- a/packages/shell-api/api-extractor.json
+++ b/packages/shell-api/api-extractor.json
@@ -15,7 +15,9 @@
     "@mongosh/arg-parser",
     "@mongosh/service-provider-core",
     "@mongosh/types",
-    "mongodb"
+    "mongodb",
+    "mongodb-schema",
+    "@types/json-schema"
   ],
   "dtsRollup": {
     "enabled": true,


### PR DESCRIPTION
This came up once I bundled `@mongodb-js/mongodb-ts-autocomplete`