### PR TITLE
chore: mongodb-ts-autocomplete 0.4 MONGOSH-2170

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -6544,6 +6544,44 @@
         "tar": "^6.1.15"
       }
     },
+    "node_modules/@mongodb-js/mongodb-ts-autocomplete": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/mongodb-ts-autocomplete/-/mongodb-ts-autocomplete-0.4.0.tgz",
+      "integrity": "sha512-2vZFJrOZx6jxtooSwx5sgr9VdnCEc+SGFStgUuaSrYH3wpQI8aS8h3Z6DDdo3HLLYqZ76Wlv1yCI2JA2FR4OkA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mongodb-js/ts-autocomplete": "^0.4.0",
+        "@mongosh/shell-api": "^3.16.2",
+        "debug": "^4.4.0",
+        "lodash": "^4.17.21",
+        "mongodb-schema": "^12.6.2",
+        "node-cache": "^5.1.2",
+        "typescript": "^5.0.4"
+      }
+    },
+    "node_modules/@mongodb-js/mongodb-ts-autocomplete/node_modules/debug": {
+      "version": "4.4.1",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
+      "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@mongodb-js/mongodb-ts-autocomplete/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
+    },
     "node_modules/@mongodb-js/monorepo-tools": {
       "version": "1.1.16",
       "resolved": "https://registry.npmjs.org/@mongodb-js/monorepo-tools/-/monorepo-tools-1.1.16.tgz",
@@ -6868,9 +6906,9 @@
       }
     },
     "node_modules/@mongodb-js/ts-autocomplete": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/ts-autocomplete/-/ts-autocomplete-0.3.1.tgz",
-      "integrity": "sha512-2ui9y88PM+PIad/3htoGn/8kiNK8V4vVTrqicgAt1Bozt0AwCUqJFUfnpqf40eJVD20XbPWfeKPjPMPkA7SruQ==",
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/ts-autocomplete/-/ts-autocomplete-0.4.0.tgz",
+      "integrity": "sha512-IVwnat226hk3+84ysr42rYNz2VXSisiSj64mKoC1jL9taryBgbX5X7a2AAT8UjmygYIO/mnqKXl2NmbIAsOfEQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "debug": "^4.4.0",
@@ -34210,7 +34248,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@mongodb-js/mongodb-constants": "^0.10.1",
-        "@mongodb-js/mongodb-ts-autocomplete": "^0.2.5",
+        "@mongodb-js/mongodb-ts-autocomplete": "^0.4.0",
         "@mongosh/shell-api": "^3.16.2",
         "semver": "^7.5.4"
       },
@@ -34225,21 +34263,6 @@
       },
       "engines": {
         "node": ">=14.15.1"
-      }
-    },
-    "packages/autocomplete/node_modules/@mongodb-js/mongodb-ts-autocomplete": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/mongodb-ts-autocomplete/-/mongodb-ts-autocomplete-0.2.5.tgz",
-      "integrity": "sha512-9Os75QCF+lSLBP7Wank37bCrFTX27Y6GI4HP889TZ88ArLOyKpboS4BK43ARgB0Rg4/mhog8d7jT6OlVb6VwYA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@mongodb-js/ts-autocomplete": "^0.3.1",
-        "mongodb-schema": "^12.6.2",
-        "node-cache": "^5.1.2",
-        "typescript": "^5.0.4"
-      },
-      "peerDependencies": {
-        "@mongosh/shell-api": "^3.11.0"
       }
     },
     "packages/browser-repl": {
@@ -34691,7 +34714,7 @@
       },
       "devDependencies": {
         "@mongodb-js/eslint-config-mongosh": "^1.0.0",
-        "@mongodb-js/mongodb-ts-autocomplete": "^0.2.5",
+        "@mongodb-js/mongodb-ts-autocomplete": "^0.4.0",
         "@mongodb-js/prettier-config-devtools": "^1.0.1",
         "@mongodb-js/tsconfig-mongosh": "^1.0.0",
         "@mongosh/types": "3.8.2",
@@ -34703,22 +34726,6 @@
       },
       "engines": {
         "node": ">=14.15.1"
-      }
-    },
-    "packages/browser-runtime-core/node_modules/@mongodb-js/mongodb-ts-autocomplete": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/mongodb-ts-autocomplete/-/mongodb-ts-autocomplete-0.2.5.tgz",
-      "integrity": "sha512-9Os75QCF+lSLBP7Wank37bCrFTX27Y6GI4HP889TZ88ArLOyKpboS4BK43ARgB0Rg4/mhog8d7jT6OlVb6VwYA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@mongodb-js/ts-autocomplete": "^0.3.1",
-        "mongodb-schema": "^12.6.2",
-        "node-cache": "^5.1.2",
-        "typescript": "^5.0.4"
-      },
-      "peerDependencies": {
-        "@mongosh/shell-api": "^3.11.0"
       }
     },
     "packages/browser-runtime-electron": {
@@ -35605,7 +35612,7 @@
       "devDependencies": {
         "@microsoft/api-extractor": "^7.39.3",
         "@mongodb-js/eslint-config-mongosh": "^1.0.0",
-        "@mongodb-js/mongodb-ts-autocomplete": "^0.2.5",
+        "@mongodb-js/mongodb-ts-autocomplete": "^0.4.0",
         "@mongodb-js/prettier-config-devtools": "^1.0.1",
         "@mongodb-js/tsconfig-mongosh": "^1.0.0",
         "@mongosh/types": "3.8.2",
@@ -35618,22 +35625,6 @@
       },
       "engines": {
         "node": ">=14.15.1"
-      }
-    },
-    "packages/shell-api/node_modules/@mongodb-js/mongodb-ts-autocomplete": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/mongodb-ts-autocomplete/-/mongodb-ts-autocomplete-0.2.5.tgz",
-      "integrity": "sha512-9Os75QCF+lSLBP7Wank37bCrFTX27Y6GI4HP889TZ88ArLOyKpboS4BK43ARgB0Rg4/mhog8d7jT6OlVb6VwYA==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@mongodb-js/ts-autocomplete": "^0.3.1",
-        "mongodb-schema": "^12.6.2",
-        "node-cache": "^5.1.2",
-        "typescript": "^5.0.4"
-      },
-      "peerDependencies": {
-        "@mongosh/shell-api": "^3.11.0"
       }
     },
     "packages/shell-api/node_modules/mongodb-redact": {

--- a/packages/autocomplete/package.json
+++ b/packages/autocomplete/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "@mongodb-js/mongodb-constants": "^0.10.1",
     "@mongosh/shell-api": "^3.16.2",
-    "@mongodb-js/mongodb-ts-autocomplete": "^0.2.5",
+    "@mongodb-js/mongodb-ts-autocomplete": "^0.4.0",
     "semver": "^7.5.4"
   }
 }

--- a/packages/browser-runtime-core/package.json
+++ b/packages/browser-runtime-core/package.json
@@ -41,7 +41,7 @@
     "@mongodb-js/eslint-config-mongosh": "^1.0.0",
     "@mongodb-js/prettier-config-devtools": "^1.0.1",
     "@mongodb-js/tsconfig-mongosh": "^1.0.0",
-    "@mongodb-js/mongodb-ts-autocomplete": "^0.2.5",
+    "@mongodb-js/mongodb-ts-autocomplete": "^0.4.0",
     "@mongosh/types": "3.8.2",
     "bson": "^6.10.3",
     "depcheck": "^1.4.7",

--- a/packages/shell-api/package.json
+++ b/packages/shell-api/package.json
@@ -64,7 +64,7 @@
   "devDependencies": {
     "@microsoft/api-extractor": "^7.39.3",
     "@mongodb-js/eslint-config-mongosh": "^1.0.0",
-    "@mongodb-js/mongodb-ts-autocomplete": "^0.2.5",
+    "@mongodb-js/mongodb-ts-autocomplete": "^0.4.0",
     "@mongodb-js/prettier-config-devtools": "^1.0.1",
     "@mongodb-js/tsconfig-mongosh": "^1.0.0",
     "@mongosh/types": "3.8.2",


### PR DESCRIPTION
You can now test the full new autocomplete like:

```
~/mongo/mongosh % USE_NEW_AUTOCOMPLETE=true npm run start
```

```
> db.test.find()
[
  { _id: ObjectId('685970c3703936f193f6cfc1'), foo: 1 },
  { _id: ObjectId('685be9d6b2cc3f925bac717b'), myField: 'some string' }
]
# here I typed myF<tab><tab> and it autocompletes as:
> db.test.find({ myField
```