### PR TITLE
chore: bump autocomplete, @types/node

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -46,7 +46,7 @@
         "@pkgjs/nv": "^0.2.2",
         "@types/chai": "^4.2.5",
         "@types/mocha": "^5.2.7",
-        "@types/node": "^14.14.6",
+        "@types/node": "^22.15.30",
         "@types/rimraf": "^3.0.0",
         "@types/semver": "^7.3.4",
         "@types/sinon-chai": "^3.2.4",
@@ -6545,12 +6545,12 @@
       }
     },
     "node_modules/@mongodb-js/mongodb-ts-autocomplete": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/mongodb-ts-autocomplete/-/mongodb-ts-autocomplete-0.4.0.tgz",
-      "integrity": "sha512-2vZFJrOZx6jxtooSwx5sgr9VdnCEc+SGFStgUuaSrYH3wpQI8aS8h3Z6DDdo3HLLYqZ76Wlv1yCI2JA2FR4OkA==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/mongodb-ts-autocomplete/-/mongodb-ts-autocomplete-0.4.1.tgz",
+      "integrity": "sha512-0PMdXcrjyhf9ij280qbjd1j3TU6DL43GeGODbLOJ1yZxnM26zdIb3bFI+eWKLYQ2FLdYp2wz6I2xCY5b7OK5nw==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@mongodb-js/ts-autocomplete": "^0.4.0",
+        "@mongodb-js/ts-autocomplete": "^0.4.1",
         "@mongosh/shell-api": "^3.16.2",
         "debug": "^4.4.0",
         "lodash": "^4.17.21",
@@ -6906,14 +6906,14 @@
       }
     },
     "node_modules/@mongodb-js/ts-autocomplete": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/ts-autocomplete/-/ts-autocomplete-0.4.0.tgz",
-      "integrity": "sha512-IVwnat226hk3+84ysr42rYNz2VXSisiSj64mKoC1jL9taryBgbX5X7a2AAT8UjmygYIO/mnqKXl2NmbIAsOfEQ==",
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/ts-autocomplete/-/ts-autocomplete-0.4.1.tgz",
+      "integrity": "sha512-IH4ZsM0YOjZq7BWBlu0RviIsaCHbabFPuowPwC8hKqYcj7vQeNQiVmCzHN7xX9dIuJ/+pdH+o0JF73ewFw1kZQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "debug": "^4.4.0",
         "lodash": "^4.17.21",
-        "typescript": "^5.0.4"
+        "typescript": "^5.8.2"
       }
     },
     "node_modules/@mongodb-js/ts-autocomplete/node_modules/debug": {
@@ -11469,10 +11469,13 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "14.18.63",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-14.18.63.tgz",
-      "integrity": "sha512-fAtCfv4jJg+ExtXhvCkCqUKZ+4ok/JQk01qDKhL5BDDoS3AxKXhV5/MAVUZyQnSEd2GT92fkgZl0pz0Q0AzcIQ==",
-      "license": "MIT"
+      "version": "22.15.34",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.34.tgz",
+      "integrity": "sha512-8Y6E5WUupYy1Dd0II32BsWAx5MWdcnRd8L84Oys3veg1YrYtNtzgO4CFhiBg6MDSjk7Ay36HYOnU7/tuOzIzcw==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~6.21.0"
+      }
     },
     "node_modules/@types/node-fetch": {
       "version": "2.6.11",
@@ -11494,6 +11497,12 @@
       "dependencies": {
         "@types/node": "*"
       }
+    },
+    "node_modules/@types/node/node_modules/undici-types": {
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "license": "MIT"
     },
     "node_modules/@types/normalize-package-data": {
       "version": "2.4.4",
@@ -34248,7 +34257,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@mongodb-js/mongodb-constants": "^0.10.1",
-        "@mongodb-js/mongodb-ts-autocomplete": "^0.4.0",
+        "@mongodb-js/mongodb-ts-autocomplete": "^0.4.1",
         "@mongosh/shell-api": "^3.16.2",
         "semver": "^7.5.4"
       },
@@ -34714,7 +34723,7 @@
       },
       "devDependencies": {
         "@mongodb-js/eslint-config-mongosh": "^1.0.0",
-        "@mongodb-js/mongodb-ts-autocomplete": "^0.4.0",
+        "@mongodb-js/mongodb-ts-autocomplete": "^0.4.1",
         "@mongodb-js/prettier-config-devtools": "^1.0.1",
         "@mongodb-js/tsconfig-mongosh": "^1.0.0",
         "@mongosh/types": "3.8.2",
@@ -34964,7 +34973,7 @@
         "@types/ansi-escape-sequences": "^4.0.0",
         "@types/chai-as-promised": "^7.1.3",
         "@types/js-yaml": "^4.0.5",
-        "@types/node": "^14.14.6",
+        "@types/node": "^22.15.30",
         "@types/numeral": "^2.0.2",
         "@types/text-table": "^0.2.1",
         "@types/yargs-parser": "^15.0.0",
@@ -35041,7 +35050,7 @@
         "@mongodb-js/prettier-config-devtools": "^1.0.1",
         "@mongodb-js/tsconfig-mongosh": "^1.0.0",
         "@types/chai-as-promised": "^7.1.3",
-        "@types/node": "^14.14.6",
+        "@types/node": "^22.15.30",
         "@types/rimraf": "^3.0.0",
         "bson": "^6.10.3",
         "chai-as-promised": "^7.1.1",
@@ -35612,7 +35621,7 @@
       "devDependencies": {
         "@microsoft/api-extractor": "^7.39.3",
         "@mongodb-js/eslint-config-mongosh": "^1.0.0",
-        "@mongodb-js/mongodb-ts-autocomplete": "^0.4.0",
+        "@mongodb-js/mongodb-ts-autocomplete": "^0.4.1",
         "@mongodb-js/prettier-config-devtools": "^1.0.1",
         "@mongodb-js/tsconfig-mongosh": "^1.0.0",
         "@mongosh/types": "3.8.2",

--- a/package.json
+++ b/package.json
@@ -103,7 +103,7 @@
     "@pkgjs/nv": "^0.2.2",
     "@types/chai": "^4.2.5",
     "@types/mocha": "^5.2.7",
-    "@types/node": "^14.14.6",
+    "@types/node": "^22.15.30",
     "@types/rimraf": "^3.0.0",
     "@types/semver": "^7.3.4",
     "@types/sinon-chai": "^3.2.4",

--- a/packages/autocomplete/package.json
+++ b/packages/autocomplete/package.json
@@ -45,7 +45,7 @@
   "dependencies": {
     "@mongodb-js/mongodb-constants": "^0.10.1",
     "@mongosh/shell-api": "^3.16.2",
-    "@mongodb-js/mongodb-ts-autocomplete": "^0.4.0",
+    "@mongodb-js/mongodb-ts-autocomplete": "^0.4.1",
     "semver": "^7.5.4"
   }
 }

--- a/packages/browser-runtime-core/package.json
+++ b/packages/browser-runtime-core/package.json
@@ -41,7 +41,7 @@
     "@mongodb-js/eslint-config-mongosh": "^1.0.0",
     "@mongodb-js/prettier-config-devtools": "^1.0.1",
     "@mongodb-js/tsconfig-mongosh": "^1.0.0",
-    "@mongodb-js/mongodb-ts-autocomplete": "^0.4.0",
+    "@mongodb-js/mongodb-ts-autocomplete": "^0.4.1",
     "@mongosh/types": "3.8.2",
     "bson": "^6.10.3",
     "depcheck": "^1.4.7",

--- a/packages/cli-repl/package.json
+++ b/packages/cli-repl/package.json
@@ -102,7 +102,7 @@
     "@mongodb-js/tsconfig-mongosh": "^1.0.0",
     "@types/ansi-escape-sequences": "^4.0.0",
     "@types/js-yaml": "^4.0.5",
-    "@types/node": "^14.14.6",
+    "@types/node": "^22.15.30",
     "@types/numeral": "^2.0.2",
     "@types/text-table": "^0.2.1",
     "@types/yargs-parser": "^15.0.0",

--- a/packages/cli-repl/src/cli-repl.spec.ts
+++ b/packages/cli-repl/src/cli-repl.spec.ts
@@ -498,6 +498,8 @@ describe('CliRepl', function () {
           process.env.MONGOSH_SKIP_NODE_VERSION_CHECK;
         delete process.env.MONGOSH_SKIP_NODE_VERSION_CHECK;
         delete (process as any).version;
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        // @ts-ignore version is readonly
         process.version = 'v8.0.0';
 
         try {
@@ -512,6 +514,8 @@ describe('CliRepl', function () {
           expect(e.name).to.equal('MongoshWarning');
           expect((e as any).code).to.equal(CliReplErrors.NodeVersionMismatch);
         } finally {
+          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+          // @ts-ignore version is readonly
           process.version = `v${process.versions.node}`;
           process.env.MONGOSH_SKIP_NODE_VERSION_CHECK =
             origVersionCheckEnvVar || '';
@@ -2861,6 +2865,8 @@ describe('CliRepl', function () {
 
     it('does not print any deprecation warning when CLI is ran with --quiet flag', async function () {
       // Setting all the possible situation for a deprecation warning
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      // @ts-ignore version is readonly
       process.version = '18.20.0';
       process.versions.openssl = '1.1.11';
       cliRepl.getGlibcVersion = () => '1.27';

--- a/packages/cli-repl/src/crypt-library-paths.ts
+++ b/packages/cli-repl/src/crypt-library-paths.ts
@@ -112,14 +112,14 @@ async function ensureMatchingPermissions(
   // the mongosh binary to begin with) and they are not writable by other
   // users.
   if (
-    (stat.uid !== execPathStat.uid && stat.uid !== process.getuid()) ||
-    (stat.gid !== execPathStat.gid && stat.gid !== process.getgid()) ||
+    (stat.uid !== execPathStat.uid && stat.uid !== process.getuid?.()) ||
+    (stat.gid !== execPathStat.gid && stat.gid !== process.getgid?.()) ||
     stat.mode & 0o002 /* world-writable */
   ) {
     return {
       libraryStat: { uid: stat.uid, gid: stat.gid, mode: stat.mode },
       mongoshStat: { uid: execPathStat.uid, gid: stat.gid },
-      currentUser: { uid: process.getuid(), gid: process.getgid() },
+      currentUser: { uid: process.getuid?.(), gid: process.getgid?.() },
     };
   }
   return null;

--- a/packages/cli-repl/src/mongosh-repl.ts
+++ b/packages/cli-repl/src/mongosh-repl.ts
@@ -923,7 +923,7 @@ class MongoshNodeRepl implements EvaluationListener {
     // this is an async interrupt - the evaluation is still running in the background
     // we wait until it finally completes (which should happen immediately)
     await Promise.race([
-      once(this.bus, 'mongosh:eval-interrupted'),
+      once(this.bus as any, 'mongosh:eval-interrupted'),
       new Promise(setImmediate),
     ]);
 

--- a/packages/cli-repl/src/mongosh-repl.ts
+++ b/packages/cli-repl/src/mongosh-repl.ts
@@ -923,7 +923,9 @@ class MongoshNodeRepl implements EvaluationListener {
     // this is an async interrupt - the evaluation is still running in the background
     // we wait until it finally completes (which should happen immediately)
     await Promise.race([
-      once(this.bus as any, 'mongosh:eval-interrupted'),
+      new Promise<void>((resolve) =>
+        this.bus.once('mongosh:eval-interrupted', resolve)
+      ),
       new Promise(setImmediate),
     ]);
 

--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -39,7 +39,7 @@
     "@mongodb-js/prettier-config-devtools": "^1.0.1",
     "@mongodb-js/tsconfig-mongosh": "^1.0.0",
     "@types/chai-as-promised": "^7.1.3",
-    "@types/node": "^14.14.6",
+    "@types/node": "^22.15.30",
     "@types/rimraf": "^3.0.0",
     "bson": "^6.10.3",
     "chai-as-promised": "^7.1.1",

--- a/packages/e2e-tests/test/e2e.spec.ts
+++ b/packages/e2e-tests/test/e2e.spec.ts
@@ -2329,8 +2329,8 @@ describe('e2e', function () {
       it('keeps working when the config file is present but not writable', async function () {
         if (
           process.platform === 'win32' ||
-          process.getuid() === 0 ||
-          process.geteuid() === 0
+          process.getuid?.() === 0 ||
+          process.geteuid?.() === 0
         ) {
           return this.skip(); // There is no meaningful chmod on Windows, and root can ignore permissions.
         }

--- a/packages/shell-api/package.json
+++ b/packages/shell-api/package.json
@@ -64,7 +64,7 @@
   "devDependencies": {
     "@microsoft/api-extractor": "^7.39.3",
     "@mongodb-js/eslint-config-mongosh": "^1.0.0",
-    "@mongodb-js/mongodb-ts-autocomplete": "^0.4.0",
+    "@mongodb-js/mongodb-ts-autocomplete": "^0.4.1",
     "@mongodb-js/prettier-config-devtools": "^1.0.1",
     "@mongodb-js/tsconfig-mongosh": "^1.0.0",
     "@mongosh/types": "3.8.2",

--- a/packages/shell-api/src/integration.spec.ts
+++ b/packages/shell-api/src/integration.spec.ts
@@ -3076,7 +3076,10 @@ describe('Shell API (integration)', function () {
 
   describe('method tracking', function () {
     it('emits an event when a deprecated method is called', async function () {
-      const deprecatedCall = once(instanceState.messageBus, 'mongosh:api-call');
+      const deprecatedCall = once(
+        instanceState.messageBus as any,
+        'mongosh:api-call'
+      );
       try {
         mongo.setSlaveOk();
         expect.fail('Expected error');


### PR DESCRIPTION
This should fix the autocomplete debug output so it is more useful and hopefully make sure Typescript is seeing newer node types.