### PR TITLE
chore(ci): use startsWith instead of regex match

### DIFF
--- a/.github/workflows/merge-release-tag.yml
+++ b/.github/workflows/merge-release-tag.yml
@@ -9,7 +9,7 @@ permissions:
 
 jobs:
   merge-release-tag:
-    if: ${{ github.ref =~ '^refs/tags/mongosh@[0-9]+\.[0-9]+\.[0-9]+(-rc\.[0-9]+)?$' }}
+    if: ${{ startsWith(github.ref, 'refs/tags/mongosh@') }}
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
Seems like regex matching syntax doesn't exist in conditions like this... So we have to keep it simple