### PR TITLE
chore: pass --fix to the eslint command rather than npm

### DIFF
--- a/packages/async-rewriter2/package.json
+++ b/packages/async-rewriter2/package.json
@@ -17,7 +17,7 @@
     "compile": "node bin/make-runtime-support.js --firstpass && tsc -p tsconfig.json && node bin/make-runtime-support.js --secondpass && tsc -p tsconfig.json",
     "prepublish": "npm run compile",
     "prettier": "prettier",
-    "reformat": "npm run prettier -- --write . && npm run eslint --fix"
+    "reformat": "npm run prettier -- --write . && npm run eslint -- --fix"
   },
   "bin": {
     "async-rewrite": "bin/async-rewrite.js"

--- a/packages/autocomplete/package.json
+++ b/packages/autocomplete/package.json
@@ -28,7 +28,7 @@
     "compile": "tsc -p tsconfig.json",
     "prepublish": "npm run compile",
     "prettier": "prettier",
-    "reformat": "npm run prettier -- --write . && npm run eslint --fix"
+    "reformat": "npm run prettier -- --write . && npm run eslint -- --fix"
   },
   "mongosh": {
     "unitTestsOnly": true

--- a/packages/browser-repl/package.json
+++ b/packages/browser-repl/package.json
@@ -35,7 +35,7 @@
     "depcheck": "depcheck",
     "compile": "tsc -p tsconfig.json",
     "prettier": "prettier",
-    "reformat": "npm run prettier -- --write . && npm run eslint --fix",
+    "reformat": "npm run prettier -- --write . && npm run eslint -- --fix",
     "sync-to-compass": "node scripts/sync-to-compass.js"
   },
   "config": {

--- a/packages/browser-runtime-core/package.json
+++ b/packages/browser-runtime-core/package.json
@@ -27,7 +27,7 @@
     "prepublish": "npm run compile",
     "compile": "tsc -p tsconfig.json",
     "prettier": "prettier",
-    "reformat": "npm run prettier -- --write . && npm run eslint --fix"
+    "reformat": "npm run prettier -- --write . && npm run eslint -- --fix"
   },
   "author": "",
   "license": "Apache-2.0",

--- a/packages/browser-runtime-electron/package.json
+++ b/packages/browser-runtime-electron/package.json
@@ -27,7 +27,7 @@
     "prepublish": "npm run compile",
     "compile": "tsc -p tsconfig.json",
     "prettier": "prettier",
-    "reformat": "npm run prettier -- --write . && npm run eslint --fix"
+    "reformat": "npm run prettier -- --write . && npm run eslint -- --fix"
   },
   "author": "",
   "license": "Apache-2.0",

--- a/packages/build/package.json
+++ b/packages/build/package.json
@@ -30,7 +30,7 @@
     "publish": "ts-node src/index.ts publish",
     "bump-auxiliary": "ts-node src/index.ts bump --auxiliary",
     "publish-auxiliary": "ts-node src/index.ts publish --auxiliary",
-    "reformat": "npm run prettier -- --write . && npm run eslint --fix",
+    "reformat": "npm run prettier -- --write . && npm run eslint -- --fix",
     "update-cta": "ts-node src/index.ts update-cta"
   },
   "license": "Apache-2.0",

--- a/packages/cli-repl/package.json
+++ b/packages/cli-repl/package.json
@@ -36,7 +36,7 @@
     "webpack-build-dev": "npm run compile && webpack --mode development && cat dist/add-module-mapping.js >> dist/mongosh.js",
     "start-snapshot": "rm -f snapshot.blob && node --snapshot-blob snapshot.blob --build-snapshot dist/mongosh.js && node --snapshot-blob snapshot.blob dist/mongosh.js",
     "prettier": "prettier",
-    "reformat": "npm run prettier -- --write . && npm run eslint --fix"
+    "reformat": "npm run prettier -- --write . && npm run eslint -- --fix"
   },
   "license": "Apache-2.0",
   "publishConfig": {

--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -20,7 +20,7 @@
     "check": "npm run lint && npm run depcheck",
     "depcheck": "depcheck",
     "prettier": "prettier",
-    "reformat": "npm run prettier -- --write . && npm run eslint --fix"
+    "reformat": "npm run prettier -- --write . && npm run eslint -- --fix"
   },
   "license": "Apache-2.0",
   "engines": {

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -22,7 +22,7 @@
     "compile": "tsc -p tsconfig.json",
     "prepublish": "npm run compile",
     "prettier": "prettier",
-    "reformat": "npm run prettier -- --write . && npm run eslint --fix"
+    "reformat": "npm run prettier -- --write . && npm run eslint -- --fix"
   },
   "license": "Apache-2.0",
   "publishConfig": {

--- a/packages/errors/package.json
+++ b/packages/errors/package.json
@@ -29,7 +29,7 @@
     "prepublish": "npm run compile",
     "generate-error-overview": "ts-node scripts/extract-errors.ts .. generated/error-overview.md generated/error-overview.rst && npm run reformat",
     "prettier": "prettier",
-    "reformat": "npm run prettier -- --write . && npm run eslint --fix"
+    "reformat": "npm run prettier -- --write . && npm run eslint -- --fix"
   },
   "mongosh": {
     "unitTestsOnly": true

--- a/packages/history/package.json
+++ b/packages/history/package.json
@@ -22,7 +22,7 @@
     "compile": "tsc -p tsconfig.json",
     "prepublish": "npm run compile",
     "prettier": "prettier",
-    "reformat": "npm run prettier -- --write . && npm run eslint --fix"
+    "reformat": "npm run prettier -- --write . && npm run eslint -- --fix"
   },
   "license": "Apache-2.0",
   "publishConfig": {

--- a/packages/i18n/package.json
+++ b/packages/i18n/package.json
@@ -23,7 +23,7 @@
     "check": "npm run lint && npm run depcheck",
     "depcheck": "depcheck",
     "prettier": "prettier",
-    "reformat": "npm run prettier -- --write . && npm run eslint --fix"
+    "reformat": "npm run prettier -- --write . && npm run eslint -- --fix"
   },
   "license": "Apache-2.0",
   "publishConfig": {

--- a/packages/js-multiline-to-singleline/package.json
+++ b/packages/js-multiline-to-singleline/package.json
@@ -22,7 +22,7 @@
     "compile": "tsc -p tsconfig.json",
     "prepublish": "npm run compile",
     "prettier": "prettier",
-    "reformat": "npm run prettier -- --write . && npm run eslint --fix"
+    "reformat": "npm run prettier -- --write . && npm run eslint -- --fix"
   },
   "license": "Apache-2.0",
   "publishConfig": {

--- a/packages/logging/package.json
+++ b/packages/logging/package.json
@@ -48,7 +48,7 @@
     "compile": "tsc -p tsconfig.json",
     "prepublish": "npm run compile",
     "prettier": "prettier",
-    "reformat": "npm run prettier -- --write . && npm run eslint --fix"
+    "reformat": "npm run prettier -- --write . && npm run eslint -- --fix"
   },
   "mongosh": {
     "unitTestsOnly": true

--- a/packages/node-runtime-worker-thread/package.json
+++ b/packages/node-runtime-worker-thread/package.json
@@ -31,7 +31,7 @@
     "compile": "tsc -p tsconfig.json",
     "prepublish": "npm run webpack-build && npm run create-purls-file",
     "prettier": "prettier",
-    "reformat": "npm run prettier -- --write . && npm run eslint --fix",
+    "reformat": "npm run prettier -- --write . && npm run eslint -- --fix",
     "create-purls-file": "npm run write-node-js-dep && node ../../scripts/create-purls.js .sbom/dependencies.json .sbom/node-js-dep.json > dist/purls.txt",
     "write-node-js-dep": "mkdir -p .sbom && node ../../scripts/write-nodejs-dep > .sbom/node-js-dep.json"
   },

--- a/packages/service-provider-core/package.json
+++ b/packages/service-provider-core/package.json
@@ -23,7 +23,7 @@
     "check": "npm run lint && npm run depcheck",
     "depcheck": "depcheck",
     "prettier": "prettier",
-    "reformat": "npm run prettier -- --write . && npm run eslint --fix"
+    "reformat": "npm run prettier -- --write . && npm run eslint -- --fix"
   },
   "license": "Apache-2.0",
   "publishConfig": {

--- a/packages/service-provider-node-driver/package.json
+++ b/packages/service-provider-node-driver/package.json
@@ -23,7 +23,7 @@
     "check": "npm run lint && npm run depcheck",
     "depcheck": "depcheck",
     "prettier": "prettier",
-    "reformat": "npm run prettier -- --write . && npm run eslint --fix"
+    "reformat": "npm run prettier -- --write . && npm run eslint -- --fix"
   },
   "license": "Apache-2.0",
   "publishConfig": {

--- a/packages/shell-api/package.json
+++ b/packages/shell-api/package.json
@@ -38,7 +38,7 @@
     "test-apistrict-ci": "cross-env MONGOSH_TEST_FORCE_API_STRICT=1 npm run test-ci",
     "prepublish": "npm run compile",
     "prettier": "prettier",
-    "reformat": "npm run prettier -- --write . && npm run eslint --fix"
+    "reformat": "npm run prettier -- --write . && npm run eslint -- --fix"
   },
   "license": "Apache-2.0",
   "publishConfig": {

--- a/packages/shell-evaluator/package.json
+++ b/packages/shell-evaluator/package.json
@@ -15,7 +15,7 @@
     "compile": "tsc -p tsconfig.json",
     "prepublish": "npm run compile",
     "prettier": "prettier",
-    "reformat": "npm run prettier -- --write . && npm run eslint --fix"
+    "reformat": "npm run prettier -- --write . && npm run eslint -- --fix"
   },
   "config": {
     "unsafe-perm": true

--- a/packages/snippet-manager/package.json
+++ b/packages/snippet-manager/package.json
@@ -22,7 +22,7 @@
     "compile": "tsc -p tsconfig.json",
     "prepublish": "npm run compile",
     "prettier": "prettier",
-    "reformat": "npm run prettier -- --write . && npm run eslint --fix"
+    "reformat": "npm run prettier -- --write . && npm run eslint -- --fix"
   },
   "license": "Apache-2.0",
   "publishConfig": {

--- a/packages/types/package.json
+++ b/packages/types/package.json
@@ -29,7 +29,7 @@
     "test-coverage": "nyc --no-clean --cwd ../.. --reporter=none npm run test",
     "test-ci-coverage": "nyc --no-clean --cwd ../.. --reporter=none npm run test-ci",
     "prettier": "prettier",
-    "reformat": "npm run prettier -- --write . && npm run eslint --fix"
+    "reformat": "npm run prettier -- --write . && npm run eslint -- --fix"
   },
   "bugs": {
     "url": "https://github.com/mongodb-js/mongosh/issues"


### PR DESCRIPTION
Noticed that we're not passing the `--fix` option to eslint correctly.