### PR TITLE
fix a semver check in old autocomplete

### DIFF
--- a/packages/autocomplete/src/index.ts
+++ b/packages/autocomplete/src/index.ts
@@ -290,6 +290,12 @@ export async function completer(
   return [[], line];
 }
 
+// from https://github.com/mongodb-js/devtools-shared/commit/e4a5b00a83b19a76bdf380799a421511230168db
+function satisfiesVersion(v1: string, v2: string): boolean {
+  const isGTECheck = /^\d+?\.\d+?\.\d+?$/.test(v2);
+  return semver.satisfies(v1, isGTECheck ? `>=${v2}` : v2);
+}
+
 function isAcceptable(
   params: AutocompleteParameters,
   entry: {
@@ -310,7 +316,10 @@ function isAcceptable(
       !entry[versionKey] ||
       // TODO: when https://jira.mongodb.org/browse/SPM-2327 is done we can rely on server_version being present
       !connectionInfo?.server_version ||
-      semver.gte(connectionInfo.server_version, entry[versionKey] as string);
+      satisfiesVersion(
+        connectionInfo.server_version,
+        entry[versionKey] as string
+      );
   }
   const isAcceptableEnvironment =
     !entry.env ||


### PR DESCRIPTION
I was comparing old and new autocomplete when I noticed this bug in old autocomplete.

type:

```
db.test.aggregate({<tab>
```

and you get this error:

```
replSet-cc08112a-19c0-4a5d-9c59-9022c9b28c9c [direct: primary] test> db.test.aggregate({Tab completion error: TypeError: Invalid Version: >=6.0.10 <7.0.0 || >=7.0.2
    at new SemVer (/Users/leroux.bodenstein/mongo/mongosh/node_modules/semver/classes/semver.js:40:13)
    at compare (/Users/leroux.bodenstein/mongo/mongosh/node_modules/semver/functions/compare.js:5:32)
    at Object.gte (/Users/leroux.bodenstein/mongo/mongosh/node_modules/semver/functions/gte.js:4:30)
    at isAcceptable (/Users/leroux.bodenstein/mongo/mongosh/packages/autocomplete/lib/index.js:194:34)
    at /Users/leroux.bodenstein/mongo/mongosh/packages/autocomplete/lib/index.js:218:56
    at eval (eval at innerEval (/Users/leroux.bodenstein/mongo/mongosh/packages/shell-evaluator/lib/shell-evaluator.js:69:17), <anonymous>:104:40)
    at _cr2.filter (eval at innerEval (/Users/leroux.bodenstein/mongo/mongosh/packages/shell-evaluator/lib/shell-evaluator.js:69:17), <anonymous>:106:184)
    at filterQueries (/Users/leroux.bodenstein/mongo/mongosh/packages/autocomplete/lib/index.js:217:30)
    at completer (/Users/leroux.bodenstein/mongo/mongosh/packages/autocomplete/lib/index.js:151:26)
    at /Users/leroux.bodenstein/mongo/mongosh/packages/cli-repl/lib/mongosh-repl.js:263:32
    at innerCompleter (/Users/leroux.bodenstein/mongo/mongosh/packages/cli-repl/lib/mongosh-repl.js:265:19)
    at PrettyREPLServer.<anonymous> (/Users/leroux.bodenstein/mongo/mongosh/packages/cli-repl/lib/mongosh-repl.js:281:51)
    at PrettyREPLServer.Callbackified [as completer] (node:util:386:5)
    at Interface._tabComplete (node:readline:440:8)
    at [_ttyWrite] [as _ttyWrite] (node:internal/readline/interface:1325:31)
    at REPLServer.self._ttyWrite (node:repl:1019:9)
    at LineByLineInput.onkeypress (node:internal/readline/interface:267:20)
    at LineByLineInput.emit (node:events:530:35)
    at LineByLineInput.emit (node:domain:489:12)
    at emitKeys (node:internal/readline/utils:370:14)
    at emitKeys.next (<anonymous>)
    at LineByLineInput.onData (node:internal/readline/emitKeypressEvents:64:36)
    at LineByLineInput.emit (node:events:518:28)
    at LineByLineInput.emit (node:domain:489:12)
    at addChunk (node:internal/streams/readable:561:12)
    at readableAddChunkPushByteMode (node:internal/streams/readable:512:3)
    at Readable.push (node:internal/streams/readable:392:5)
    at LineByLineInput.push (/Users/leroux.bodenstein/mongo/mongosh/packages/cli-repl/lib/line-by-line-input.js:136:26)
    at LineByLineInput._flush (/Users/leroux.bodenstein/mongo/mongosh/packages/cli-repl/lib/line-by-line-input.js:115:18)
    at LineByLineInput._forwardAndBlockOnNewline (/Users/leroux.bodenstein/mongo/mongosh/packages/cli-repl/lib/line-by-line-input.js:89:14)
    at LineByLineInput._onData (/Users/leroux.bodenstein/mongo/mongosh/packages/cli-repl/lib/line-by-line-input.js:14:29)
    at ReadStream.<anonymous> (/Users/leroux.bodenstein/mongo/mongosh/packages/cli-repl/lib/line-by-line-input.js:51:56)
    at ReadStream.emit (node:events:518:28)
    at ReadStream.emit (node:domain:489:12)
    at addChunk (node:internal/streams/readable:561:12)
    at readableAddChunkPushByteMode (node:internal/streams/readable:512:3)
    at Readable.push (node:internal/streams/readable:392:5)
    at TTY.onStreamRead (node:internal/stream_base_commons:189:23)
    at TTY.callbackTrampoline (node:internal/async_hooks:130:17)
```