### PR TITLE
feat: allow opting out of schema sampling with config disableSchemaSampling=true MONGOSH-2370

### DIFF
--- a/packages/autocomplete/src/index.ts
+++ b/packages/autocomplete/src/index.ts
@@ -293,7 +293,9 @@ export async function completer(
 // from https://github.com/mongodb-js/devtools-shared/commit/e4a5b00a83b19a76bdf380799a421511230168db
 function satisfiesVersion(v1: string, v2: string): boolean {
   const isGTECheck = /^\d+?\.\d+?\.\d+?$/.test(v2);
-  return semver.satisfies(v1, isGTECheck ? `>=${v2}` : v2);
+  return semver.satisfies(v1, isGTECheck ? `>=${v2}` : v2, {
+    includePrerelease: true,
+  });
 }
 
 function isAcceptable(

--- a/packages/autocomplete/src/index.ts
+++ b/packages/autocomplete/src/index.ts
@@ -332,11 +332,6 @@ function isAcceptable(
       ? entry.env.includes(ATLAS)
       : entry.env.includes(ON_PREM));
 
-  console.log({
-    isAcceptableVersion,
-    isAcceptableEnvironment,
-    serverVersion: connectionInfo?.server_version,
-  });
   return isAcceptableVersion && isAcceptableEnvironment;
 }
 

--- a/packages/autocomplete/src/index.ts
+++ b/packages/autocomplete/src/index.ts
@@ -412,7 +412,7 @@ function filterShellAPI(
 type AutocompleteShellInstanceState = {
   getAutocompleteParameters: () => AutocompleteParameters;
   getAutocompletionContext: (options: {
-    disableSchemaSampling?: boolean;
+    disableSchemaSampling?: () => Promise<boolean>;
   }) => AutocompletionContext;
 };
 
@@ -433,9 +433,9 @@ export async function initNewAutocompleter(
     'getAutocompletionContext'
   >,
   {
-    disableSchemaSampling = false,
+    disableSchemaSampling,
   }: {
-    disableSchemaSampling?: boolean;
+    disableSchemaSampling?: () => Promise<boolean>;
   }
 ): Promise<(text: string) => Promise<CompletionResults>> {
   // only import the autocompleter code the first time we need it to

--- a/packages/autocomplete/src/index.ts
+++ b/packages/autocomplete/src/index.ts
@@ -411,9 +411,7 @@ function filterShellAPI(
 
 type AutocompleteShellInstanceState = {
   getAutocompleteParameters: () => AutocompleteParameters;
-  getAutocompletionContext: (options: {
-    disableSchemaSampling?: () => Promise<boolean>;
-  }) => AutocompletionContext;
+  getAutocompletionContext: () => AutocompletionContext;
 };
 
 function transformAutocompleteResults(
@@ -431,12 +429,7 @@ export async function initNewAutocompleter(
   instanceState: Pick<
     AutocompleteShellInstanceState,
     'getAutocompletionContext'
-  >,
-  {
-    disableSchemaSampling,
-  }: {
-    disableSchemaSampling?: () => Promise<boolean>;
-  }
+  >
 ): Promise<(text: string) => Promise<CompletionResults>> {
   // only import the autocompleter code the first time we need it to
   // hide the time it takes from the initial startup time
@@ -444,9 +437,7 @@ export async function initNewAutocompleter(
     '@mongodb-js/mongodb-ts-autocomplete'
   );
 
-  const autocompletionContext = instanceState.getAutocompletionContext({
-    disableSchemaSampling,
-  });
+  const autocompletionContext = instanceState.getAutocompletionContext();
   const mongoDBCompleter = new MongoDBAutocompleter({
     context: autocompletionContext,
   });

--- a/packages/autocomplete/src/index.ts
+++ b/packages/autocomplete/src/index.ts
@@ -411,7 +411,9 @@ function filterShellAPI(
 
 type AutocompleteShellInstanceState = {
   getAutocompleteParameters: () => AutocompleteParameters;
-  getAutocompletionContext: () => AutocompletionContext;
+  getAutocompletionContext: (options: {
+    disableSchemaSampling?: boolean;
+  }) => AutocompletionContext;
 };
 
 function transformAutocompleteResults(
@@ -429,7 +431,12 @@ export async function initNewAutocompleter(
   instanceState: Pick<
     AutocompleteShellInstanceState,
     'getAutocompletionContext'
-  >
+  >,
+  {
+    disableSchemaSampling = false,
+  }: {
+    disableSchemaSampling?: boolean;
+  }
 ): Promise<(text: string) => Promise<CompletionResults>> {
   // only import the autocompleter code the first time we need it to
   // hide the time it takes from the initial startup time
@@ -437,7 +444,9 @@ export async function initNewAutocompleter(
     '@mongodb-js/mongodb-ts-autocomplete'
   );
 
-  const autocompletionContext = instanceState.getAutocompletionContext();
+  const autocompletionContext = instanceState.getAutocompletionContext({
+    disableSchemaSampling,
+  });
   const mongoDBCompleter = new MongoDBAutocompleter({
     context: autocompletionContext,
   });

--- a/packages/autocomplete/src/index.ts
+++ b/packages/autocomplete/src/index.ts
@@ -329,6 +329,12 @@ function isAcceptable(
       : connectionInfo.is_atlas || connectionInfo.is_local_atlas
       ? entry.env.includes(ATLAS)
       : entry.env.includes(ON_PREM));
+
+  console.log({
+    isAcceptableVersion,
+    isAcceptableEnvironment,
+    serverVersion: connectionInfo?.server_version,
+  });
   return isAcceptableVersion && isAcceptableEnvironment;
 }
 

--- a/packages/cli-repl/src/cli-repl.spec.ts
+++ b/packages/cli-repl/src/cli-repl.spec.ts
@@ -2529,6 +2529,29 @@ describe('CliRepl', function () {
       });
 
       it(`${
+        wantQueryOperators ? 'completes' : 'does not complete'
+      } query operators`, async function () {
+        input.write('db.movies.find({year: {$g');
+        await tabCompletion();
+
+        if (wantQueryOperators) {
+          if (process.env.USE_NEW_AUTOCOMPLETE) {
+            // wait for the documents to finish loading to be sure that the next
+            // tabCompletion() call will work
+            await docsLoadedPromise;
+          }
+        }
+
+        await tabCompletion();
+
+        if (wantQueryOperators) {
+          expect(output).to.include('db.movies.find({year: {$gte');
+        } else {
+          expect(output).to.not.include('db.movies.find({year: {$gte');
+        }
+      });
+
+      it(`${
         wantWatch ? 'completes' : 'does not complete'
       } the watch method`, async function () {
         if (process.env.MONGOSH_TEST_FORCE_API_STRICT) {
@@ -2649,31 +2672,6 @@ describe('CliRepl', function () {
         input.write('use adm');
         await tabCompletion();
         expect(output).to.include('use admin');
-      });
-
-      it(`${
-        wantQueryOperators ? 'completes' : 'does not complete'
-      } query operators`, async function () {
-        input.write('db.movies.find({year: {$g');
-        await tabCompletion();
-
-        if (wantQueryOperators) {
-          if (process.env.USE_NEW_AUTOCOMPLETE) {
-            // wait for the documents to finish loading to be sure that the next
-            // tabCompletion() call will work
-            await docsLoadedPromise;
-          }
-        }
-
-        await tabCompletion();
-
-        await new Promise((resolve) => setTimeout(resolve, 1000));
-
-        if (wantQueryOperators) {
-          expect(output).to.include('db.movies.find({year: {$gte');
-        } else {
-          expect(output).to.not.include('db.movies.find({year: {$gte');
-        }
       });
 
       it('completes properties of shell API result types', async function () {

--- a/packages/cli-repl/src/cli-repl.spec.ts
+++ b/packages/cli-repl/src/cli-repl.spec.ts
@@ -2652,14 +2652,12 @@ describe('CliRepl', function () {
       it(`${
         wantQueryOperators ? 'completes' : 'does not complete'
       } query operators`, async function () {
-        // for new autocomplete make sure it loads the schema for the movies collection
-        input.write('db.movies.find({\n');
-        await waitEval(cliRepl.bus);
-
         input.write('db.movies.find({year: {$g');
         await tabCompletion();
-        if (process.env.USE_NEW_AUTOCOMPLETE && wantQueryOperators) {
-          await docsLoadedPromise;
+        if (wantQueryOperators) {
+          if (process.env.USE_NEW_AUTOCOMPLETE) {
+            await docsLoadedPromise;
+          }
         }
         await tabCompletion();
         if (wantQueryOperators) {

--- a/packages/cli-repl/src/cli-repl.spec.ts
+++ b/packages/cli-repl/src/cli-repl.spec.ts
@@ -2666,6 +2666,8 @@ describe('CliRepl', function () {
 
         await tabCompletion();
 
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+
         if (wantQueryOperators) {
           expect(output).to.include('db.movies.find({year: {$gte');
         } else {

--- a/packages/cli-repl/src/cli-repl.spec.ts
+++ b/packages/cli-repl/src/cli-repl.spec.ts
@@ -2507,6 +2507,7 @@ describe('CliRepl', function () {
         if (!(testServer as any)?._opts.args?.includes('--auth')) {
           // make sure there are some collections we can autocomplete on below
           input.write('db.coll.insertOne({})\n');
+          await waitEval(cliRepl.bus);
           input.write('db.movies.insertOne({ year: 1 })\n');
           await waitEval(cliRepl.bus);
         }
@@ -2654,12 +2655,17 @@ describe('CliRepl', function () {
       } query operators`, async function () {
         input.write('db.movies.find({year: {$g');
         await tabCompletion();
+
         if (wantQueryOperators) {
           if (process.env.USE_NEW_AUTOCOMPLETE) {
+            // wait for the documents to finish loading to be sure that the next
+            // tabCompletion() call will work
             await docsLoadedPromise;
           }
         }
+
         await tabCompletion();
+
         if (wantQueryOperators) {
           expect(output).to.include('db.movies.find({year: {$gte');
         } else {

--- a/packages/cli-repl/src/cli-repl.spec.ts
+++ b/packages/cli-repl/src/cli-repl.spec.ts
@@ -2491,9 +2491,6 @@ describe('CliRepl', function () {
         await waitCompletion(cliRepl.bus);
       };
 
-      // eslint-disable-next-line @typescript-eslint/no-unused-vars
-      let databasesLoadedPromise: Promise<void>;
-      let collectionsLoadedPromise: Promise<void>;
       let docsLoadedPromise: Promise<void>;
 
       beforeEach(async function () {
@@ -2514,16 +2511,6 @@ describe('CliRepl', function () {
           await waitEval(cliRepl.bus);
         }
 
-        databasesLoadedPromise = new Promise<void>((resolve) => {
-          cliRepl.bus.once('mongosh:load-databases-complete', () => {
-            resolve();
-          });
-        });
-        collectionsLoadedPromise = new Promise<void>((resolve) => {
-          cliRepl.bus.once('mongosh:load-collections-complete', () => {
-            resolve();
-          });
-        });
         docsLoadedPromise = new Promise<void>((resolve) => {
           cliRepl.bus.once('mongosh:load-sample-docs-complete', () => {
             resolve();
@@ -2598,7 +2585,6 @@ describe('CliRepl', function () {
         output = '';
         input.write('db.coll.getShardDis');
         await tabCompletion();
-        await collectionsLoadedPromise;
         await tabCompletion();
         if (wantShardDistribution) {
           expect(output).to.include('db.coll.getShardDistribution');
@@ -2618,7 +2604,6 @@ describe('CliRepl', function () {
         output = '';
         input.write('db.testcoll');
         await tabCompletion();
-        await collectionsLoadedPromise;
         await tabCompletion();
         expect(output).to.include(collname);
 
@@ -2717,7 +2702,6 @@ describe('CliRepl', function () {
         output = '';
         input.write('db.actestc');
         await tabCompletion();
-        await collectionsLoadedPromise;
         await tabCompletion();
         expect(output).to.include('db.actestcoll1');
         expect(output).to.not.include('db.actestcoll2');

--- a/packages/cli-repl/src/cli-repl.spec.ts
+++ b/packages/cli-repl/src/cli-repl.spec.ts
@@ -2489,6 +2489,7 @@ describe('CliRepl', function () {
         await tick();
         input.write('\u0009');
         await waitCompletion(cliRepl.bus);
+        await tick();
       };
 
       let docsLoadedPromise: Promise<void>;

--- a/packages/cli-repl/src/cli-repl.spec.ts
+++ b/packages/cli-repl/src/cli-repl.spec.ts
@@ -309,6 +309,7 @@ describe('CliRepl', function () {
           'maxTimeMS',
           'enableTelemetry',
           'editor',
+          'disableSchemaSampling',
           'snippetIndexSourceURLs',
           'snippetRegistryURL',
           'snippetAutoload',

--- a/packages/cli-repl/src/mongosh-repl.spec.ts
+++ b/packages/cli-repl/src/mongosh-repl.spec.ts
@@ -485,7 +485,7 @@ describe('MongoshNodeRepl', function () {
         it('autocompletes collection schema fields', async function () {
           if (!process.env.USE_NEW_AUTOCOMPLETE) {
             // auto-completing collection field names only supported by new autocomplete
-            this.skip();
+            return this.skip();
           }
           input.write('db.coll.find({fo');
           await tabtab();
@@ -497,7 +497,7 @@ describe('MongoshNodeRepl', function () {
         it('does not autocomplete collection schema fields if disableSchemaSampling=true', async function () {
           if (!process.env.USE_NEW_AUTOCOMPLETE) {
             // auto-completing collection field names only supported by new autocomplete
-            this.skip();
+            return this.skip();
           }
           await mongoshRepl.setConfig('disableSchemaSampling', true);
           try {

--- a/packages/cli-repl/src/mongosh-repl.ts
+++ b/packages/cli-repl/src/mongosh-repl.ts
@@ -466,11 +466,6 @@ class MongoshNodeRepl implements EvaluationListener {
           }
         })(),
       ]);
-      this.bus.emit(
-        'mongosh:autocompletion-complete',
-        replResults,
-        mongoshResults
-      ); // For testing.
 
       // Sometimes the mongosh completion knows that what it is doing is right,
       // and that autocompletion based on inspecting the actual objects that
@@ -510,6 +505,8 @@ class MongoshNodeRepl implements EvaluationListener {
           results = results.filter(
             (result) => !CONTROL_CHAR_REGEXP.test(result)
           );
+          // emit here so that on nextTick the results should be output
+          this.bus.emit('mongosh:autocompletion-complete'); // For testing.
           return [results, completeOn];
         } finally {
           this.insideAutoCompleteOrGetPrompt = false;

--- a/packages/cli-repl/src/mongosh-repl.ts
+++ b/packages/cli-repl/src/mongosh-repl.ts
@@ -457,10 +457,7 @@ class MongoshNodeRepl implements EvaluationListener {
         (async () => {
           if (process.env.USE_NEW_AUTOCOMPLETE) {
             if (!newMongoshCompleter) {
-              newMongoshCompleter = await initNewAutocompleter(instanceState, {
-                disableSchemaSampling: async () =>
-                  (await this.getConfig('disableSchemaSampling')) ?? false,
-              });
+              newMongoshCompleter = await initNewAutocompleter(instanceState);
             }
 
             return newMongoshCompleter(text);

--- a/packages/cli-repl/src/mongosh-repl.ts
+++ b/packages/cli-repl/src/mongosh-repl.ts
@@ -458,9 +458,8 @@ class MongoshNodeRepl implements EvaluationListener {
           if (process.env.USE_NEW_AUTOCOMPLETE) {
             if (!newMongoshCompleter) {
               newMongoshCompleter = await initNewAutocompleter(instanceState, {
-                disableSchemaSampling: await this.getConfig(
-                  'disableSchemaSampling'
-                ),
+                disableSchemaSampling: async () =>
+                  (await this.getConfig('disableSchemaSampling')) ?? false,
               });
             }
 

--- a/packages/cli-repl/src/mongosh-repl.ts
+++ b/packages/cli-repl/src/mongosh-repl.ts
@@ -457,7 +457,11 @@ class MongoshNodeRepl implements EvaluationListener {
         (async () => {
           if (process.env.USE_NEW_AUTOCOMPLETE) {
             if (!newMongoshCompleter) {
-              newMongoshCompleter = await initNewAutocompleter(instanceState);
+              newMongoshCompleter = await initNewAutocompleter(instanceState, {
+                disableSchemaSampling: await this.getConfig(
+                  'disableSchemaSampling'
+                ),
+              });
             }
 
             return newMongoshCompleter(text);

--- a/packages/cli-repl/test/repl-helpers.ts
+++ b/packages/cli-repl/test/repl-helpers.ts
@@ -71,10 +71,7 @@ async function waitEval(bus: MongoshBus) {
 }
 
 async function waitCompletion(bus: MongoshBus) {
-  await Promise.race([
-    waitBus(bus, 'mongosh:autocompletion-complete'),
-    new Promise((resolve) => setTimeout(resolve, 10_000)?.unref?.()),
-  ]);
+  await waitBus(bus, 'mongosh:autocompletion-complete');
   await tick();
 }
 

--- a/packages/shell-api/src/collection.ts
+++ b/packages/shell-api/src/collection.ts
@@ -2590,7 +2590,11 @@ export class Collection<
   async _getSampleDocsForCompletion(): Promise<Document[]> {
     return await Promise.race([
       (async () => {
-        return await this._getSampleDocs();
+        const result = await this._getSampleDocs();
+        this._mongo._instanceState.messageBus.emit(
+          'mongosh:load-sample-docs-complete'
+        );
+        return result;
       })(),
       (async () => {
         // 200ms should be a good compromise between giving the server a chance

--- a/packages/shell-api/src/database.ts
+++ b/packages/shell-api/src/database.ts
@@ -295,9 +295,13 @@ export class Database<
   async _getCollectionNamesForCompletion(): Promise<string[]> {
     return await Promise.race([
       (async () => {
-        return await this._getCollectionNames({
+        const result = await this._getCollectionNames({
           readPreference: 'primaryPreferred',
         });
+        this._mongo._instanceState.messageBus.emit(
+          'mongosh:load-collections-complete'
+        );
+        return result;
       })(),
       (async () => {
         // 200ms should be a good compromise between giving the server a chance

--- a/packages/shell-api/src/mongo.ts
+++ b/packages/shell-api/src/mongo.ts
@@ -362,9 +362,12 @@ export default class Mongo<
   async _getDatabaseNamesForCompletion(): Promise<string[]> {
     return await Promise.race([
       (async () => {
-        return (
+        const result = (
           await this._listDatabases({ readPreference: 'primaryPreferred' })
         ).databases.map((db) => db.name);
+
+        this._instanceState.messageBus.emit('mongosh:load-databases-complete');
+        return result;
       })(),
       (async () => {
         // See the comment in _getCollectionNamesForCompletion/database.ts

--- a/packages/shell-api/src/shell-api.spec.ts
+++ b/packages/shell-api/src/shell-api.spec.ts
@@ -916,6 +916,7 @@ describe('ShellApi', function () {
             ['maxTimeMS', null],
             ['enableTelemetry', false],
             ['editor', null],
+            ['disableSchemaSampling', false],
           ] as any);
 
           expect(shellResult.printable).to.deep.equal(expectedResult);

--- a/packages/shell-api/src/shell-instance-state.ts
+++ b/packages/shell-api/src/shell-instance-state.ts
@@ -572,11 +572,13 @@ export class ShellInstanceState {
         try {
           const collectionNames =
             await this.currentDb._getCollectionNamesForCompletion();
-          return collectionNames.filter(
+          const result = collectionNames.filter(
             (name) =>
               name.toLowerCase().startsWith(collName.toLowerCase()) &&
               !CONTROL_CHAR_REGEXP.test(name)
           );
+          this.messageBus.emit('mongosh:load-collections-complete');
+          return result;
         } catch (err: any) {
           if (
             err?.code === ShellApiErrors.NotConnected ||
@@ -591,11 +593,13 @@ export class ShellInstanceState {
         try {
           const dbNames =
             await this.currentDb._mongo._getDatabaseNamesForCompletion();
-          return dbNames.filter(
+          const result = dbNames.filter(
             (name) =>
               name.toLowerCase().startsWith(dbName.toLowerCase()) &&
               !CONTROL_CHAR_REGEXP.test(name)
           );
+          this.messageBus.emit('mongosh:load-databases-complete');
+          return result;
         } catch (err: any) {
           if (
             err?.code === ShellApiErrors.NotConnected ||

--- a/packages/shell-api/src/shell-instance-state.ts
+++ b/packages/shell-api/src/shell-instance-state.ts
@@ -415,7 +415,11 @@ export class ShellInstanceState {
     throw new Error(`mongo with connection id ${connectionId} not found`);
   }
 
-  public getAutocompletionContext(): AutocompletionContext {
+  public getAutocompletionContext({
+    disableSchemaSampling = false,
+  }: {
+    disableSchemaSampling?: boolean;
+  }): AutocompletionContext {
     return {
       currentDatabaseAndConnection: ():
         | {
@@ -483,17 +487,19 @@ export class ShellInstanceState {
       ): Promise<JSONSchema> => {
         const mongo = this.getMongoByConnectionId(connectionId);
         let docs: Document[] = [];
-        try {
-          docs = await mongo
-            ._getDb(databaseName)
-            .getCollection(collectionName)
-            ._getSampleDocsForCompletion();
-        } catch (err: any) {
-          if (
-            err?.code !== ShellApiErrors.NotConnected &&
-            err?.codeName !== 'Unauthorized'
-          ) {
-            throw err;
+        if (!disableSchemaSampling) {
+          try {
+            docs = await mongo
+              ._getDb(databaseName)
+              .getCollection(collectionName)
+              ._getSampleDocsForCompletion();
+          } catch (err: any) {
+            if (
+              err?.code !== ShellApiErrors.NotConnected &&
+              err?.codeName !== 'Unauthorized'
+            ) {
+              throw err;
+            }
           }
         }
 

--- a/packages/shell-api/src/shell-instance-state.ts
+++ b/packages/shell-api/src/shell-instance-state.ts
@@ -415,11 +415,7 @@ export class ShellInstanceState {
     throw new Error(`mongo with connection id ${connectionId} not found`);
   }
 
-  public getAutocompletionContext({
-    disableSchemaSampling,
-  }: {
-    disableSchemaSampling?: () => Promise<boolean>;
-  }): AutocompletionContext {
+  public getAutocompletionContext(): AutocompletionContext {
     return {
       currentDatabaseAndConnection: ():
         | {
@@ -487,7 +483,11 @@ export class ShellInstanceState {
       ): Promise<JSONSchema> => {
         const mongo = this.getMongoByConnectionId(connectionId);
         let docs: Document[] = [];
-        if (!(disableSchemaSampling ? await disableSchemaSampling() : false)) {
+        if (
+          (await this.evaluationListener.getConfig?.(
+            'disableSchemaSampling'
+          )) !== true
+        ) {
           try {
             docs = await mongo
               ._getDb(databaseName)

--- a/packages/shell-api/src/shell-instance-state.ts
+++ b/packages/shell-api/src/shell-instance-state.ts
@@ -416,9 +416,9 @@ export class ShellInstanceState {
   }
 
   public getAutocompletionContext({
-    disableSchemaSampling = false,
+    disableSchemaSampling,
   }: {
-    disableSchemaSampling?: boolean;
+    disableSchemaSampling?: () => Promise<boolean>;
   }): AutocompletionContext {
     return {
       currentDatabaseAndConnection: ():
@@ -487,7 +487,7 @@ export class ShellInstanceState {
       ): Promise<JSONSchema> => {
         const mongo = this.getMongoByConnectionId(connectionId);
         let docs: Document[] = [];
-        if (!disableSchemaSampling) {
+        if (!(disableSchemaSampling ? await disableSchemaSampling() : false)) {
           try {
             docs = await mongo
               ._getDb(databaseName)

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -428,6 +428,7 @@ export class ShellUserConfig {
   enableTelemetry = false;
   editor: string | null = null;
   logLocation: string | undefined;
+  disableSchemaSampling = false;
 }
 
 export class ShellUserConfigValidator {
@@ -447,6 +448,7 @@ export class ShellUserConfigValidator {
           return `${key} must be null or a positive integer`;
         }
         return null;
+      case 'disableSchemaSampling':
       case 'enableTelemetry':
         if (typeof value !== 'boolean') {
           return `${key} must be a boolean`;
@@ -520,7 +522,6 @@ export class CliUserConfig extends SnippetShellUserConfig {
   logMaxFileCount = 100;
   logCompressionEnabled = false;
   logRetentionGB: number | undefined = undefined;
-  disableSchemaSampling = false;
 }
 
 export class CliUserConfigValidator extends SnippetShellUserConfigValidator {
@@ -558,7 +559,6 @@ export class CliUserConfigValidator extends SnippetShellUserConfigValidator {
       case 'forceDisableTelemetry':
       case 'showStackTraces':
       case 'logCompressionEnabled':
-      case 'disableSchemaSampling':
         if (typeof value !== 'boolean') {
           return `${key} must be a boolean`;
         }

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -335,10 +335,7 @@ export interface MongoshBusEventsMap extends ConnectEventMap {
    * Signals the completion of the autocomplete suggestion providers.
    * _ONLY AVAILABLE FOR TESTING._
    */
-  'mongosh:autocompletion-complete': (
-    replResults: string[],
-    mongoshResults: string[]
-  ) => void;
+  'mongosh:autocompletion-complete': () => void;
   /**
    * Signals the completion of the autocomplete helper.
    * _ONLY AVAILABLE FOR TESTING._

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -340,6 +340,21 @@ export interface MongoshBusEventsMap extends ConnectEventMap {
     mongoshResults: string[]
   ) => void;
   /**
+   * Signals the completion of the autocomplete helper.
+   * _ONLY AVAILABLE FOR TESTING._
+   */
+  'mongosh:load-databases-complete': () => void;
+  /**
+   * Signals the completion of the autocomplete helper.
+   * _ONLY AVAILABLE FOR TESTING._
+   */
+  'mongosh:load-collections-complete': () => void;
+  /**
+   * Signals the completion of the autocomplete helper.
+   * _ONLY AVAILABLE FOR TESTING._
+   */
+  'mongosh:load-sample-docs-complete': () => void;
+  /**
    * Signals the completion of the asynchronous interrupt handler in MongoshRepl. Not fired for interrupts of _synchronous_ code.
    * _ONLY AVAILABLE FOR TESTING._
    */

--- a/packages/types/src/index.ts
+++ b/packages/types/src/index.ts
@@ -520,6 +520,7 @@ export class CliUserConfig extends SnippetShellUserConfig {
   logMaxFileCount = 100;
   logCompressionEnabled = false;
   logRetentionGB: number | undefined = undefined;
+  disableSchemaSampling = false;
 }
 
 export class CliUserConfigValidator extends SnippetShellUserConfigValidator {
@@ -557,6 +558,7 @@ export class CliUserConfigValidator extends SnippetShellUserConfigValidator {
       case 'forceDisableTelemetry':
       case 'showStackTraces':
       case 'logCompressionEnabled':
+      case 'disableSchemaSampling':
         if (typeof value !== 'boolean') {
           return `${key} must be a boolean`;
         }


### PR DESCRIPTION
This is only relevant for the new autocompleter which is currently feature-flagged and only accessible if you run mongosh with the environment variable USE_NEW_AUTOCOMPLETE=true

Without it set we'll still read database and collection names like we've always done. With this set we'll just assume an empty collection/schema, so you won't see field names autocomplete.