### PR TITLE
chore(cli-repl): try to fix flaky connection string prompt test

### DIFF
--- a/packages/cli-repl/src/run.spec.ts
+++ b/packages/cli-repl/src/run.spec.ts
@@ -74,6 +74,7 @@ describe('CLI entry point', function () {
     let stdout = '';
     let stderr = '';
     let wroteConnectionString = false;
+    let wroteAnyKeyToExit = false;
     proc.stdout.setEncoding('utf8').on('data', (chunk) => {
       stdout += chunk;
       if (
@@ -83,8 +84,9 @@ describe('CLI entry point', function () {
         proc.stdin.write('/\n');
         wroteConnectionString = true;
       }
-      if (stdout.includes('Press any key to exit')) {
+      if (!wroteAnyKeyToExit && stdout.includes('Press any key to exit')) {
         proc.stdin.write('x');
+        wroteAnyKeyToExit = true;
       }
     });
     proc.stderr.setEncoding('utf8').on('data', (chunk) => {


### PR DESCRIPTION
Currently, in CI we receive errors like

    1) CLI entry point
        asks for connection string when configured to do so:
      Uncaught Error: write EPIPE
        at afterWriteDispatched (node:internal/stream_base_commons:161:15)
        at writeGeneric (node:internal/stream_base_commons:152:3)
        at Socket._writeGeneric (node:net:958:11)
        at Socket._write (node:net:970:8)
        at writeOrBuffer (node:internal/streams/writable:572:12)
        at _write (node:internal/streams/writable:501:10)
        at Socket.Writable.write (node:internal/streams/writable:510:10)
        at Socket.<anonymous> (Z:\data\mci\e6e6\src\packages\cli-repl\src\run.spec.ts:87:20)
        at Socket.emit (node:events:524:28)
        at Socket.emit (node:domain:489:12)
        at addChunk (node:internal/streams/readable:561:12)
        at readableAddChunkPushByteMode (node:internal/streams/readable:512:3)
        at Socket.Readable.push (node:internal/streams/readable:392:5)
        at Pipe.onStreamRead (node:internal/stream_base_commons:191:23)
        at Pipe.callbackTrampoline (node:internal/async_hooks:130:17)

(e.g. https://spruce.mongodb.com/task/mongosh_tests_win32_m50xc_n20_test_cli_repl_patch_7fa888fae7921991c99175aad0ebba46751c2954_68907a2301ef2900071ba30e_25_08_04_09_15_17/logs).

The hypothesis here is that the following sequence of events occurs:

1. The test runs normally up to the point where the application prompts for `Press any key to exit`.
2. The test reads that text from the application and sends and `x` key to the mongosh process.
3. The mongosh process reads the `x` key and echoes it back to the terminal (since it is in raw mode).
4. The mongosh process exits (the test passes if this happens *after* the next steps, which is where the flakiness of the test may come from).
5. The test reads the `x` key echoed back in step 3 and, seeing more output coming from mongosh, *repeats* step 2, since its condition is still met.
6. Sending the second `x` key to the process fails with `EPIPE` because the target process has already exited.

Sending the `x` key only once should resolve the flakiness, if this is indeed what happens.