### PR TITLE
chore(release) fix iam role used for dry run releases DEVPROD-21408

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -4810,6 +4810,9 @@ functions:
       params:
         file: tmp/expansions.yaml
         redacted: true
+    - command: ec2.assume_role
+      params:
+        role_arn: "arn:aws:iam::119629040606:role/s3-access.cdn-origin-compass"
     - command: shell.exec
       # silent: true
       params:
@@ -4818,6 +4821,9 @@ functions:
         env:
           devtoolsbot_npm_token: ${devtoolsbot_npm_token}
           node_js_version: ${node_js_version}
+          DOWNLOAD_CENTER_AWS_KEY_ARTIFACTS: ${AWS_ACCESS_KEY_ID}
+          DOWNLOAD_CENTER_AWS_SECRET_ARTIFACTS: ${AWS_SECRET_ACCESS_KEY}
+          DOWNLOAD_CENTER_AWS_SESSION_TOKEN_ARTIFACTS: ${AWS_SESSION_TOKEN}
         script: |
           set -e
           .evergreen/run-evergreen-release.sh publish -- --dry-run

--- a/.evergreen/evergreen.yml.in
+++ b/.evergreen/evergreen.yml.in
@@ -1007,6 +1007,9 @@ functions:
       params:
         file: tmp/expansions.yaml
         redacted: true
+    - command: ec2.assume_role
+      params:
+        role_arn: "arn:aws:iam::119629040606:role/s3-access.cdn-origin-compass"
     - command: shell.exec
       # silent: true
       params:
@@ -1015,6 +1018,9 @@ functions:
         env:
           devtoolsbot_npm_token: ${devtoolsbot_npm_token}
           node_js_version: ${node_js_version}
+          DOWNLOAD_CENTER_AWS_KEY_ARTIFACTS: ${AWS_ACCESS_KEY_ID}
+          DOWNLOAD_CENTER_AWS_SECRET_ARTIFACTS: ${AWS_SECRET_ACCESS_KEY}
+          DOWNLOAD_CENTER_AWS_SESSION_TOKEN_ARTIFACTS: ${AWS_SESSION_TOKEN}
         script: |
           set -e
           .evergreen/run-evergreen-release.sh publish -- --dry-run


### PR DESCRIPTION
This commit adjusts our release dry run task to use the correct IAM role for its operations. The non-dry-run release task was using the expected role, but dry-run wasn't assuming the role we need to use.