### PR TITLE
chore(ci): partially fix vscode test

### DIFF
--- a/testing/test-vscode.sh
+++ b/testing/test-vscode.sh
@@ -13,8 +13,13 @@ cd "$test_root_dir"
 git clone --depth=10 https://github.com/mongodb-js/vscode.git
 cd vscode
 npm install --force
-rm -rf node_modules/@mongosh node_modules/mongodb
-(cd node_modules && ln -s "$mongosh_root_dir/packages" @mongosh && ln -s "$mongosh_root_dir/node_modules/mongodb" mongodb)
+rm -rf node_modules/@mongosh node_modules/mongodb node_modules/@mongodb-js/devtools-connect node_modules/@mongodb-js/devtools-proxy-support
+(cd node_modules && \
+  ln -s "$mongosh_root_dir/packages" @mongosh && \
+  ln -s "$mongosh_root_dir/node_modules/mongodb" mongodb && \
+  cd @mongodb-js && \
+  ln -s "$mongosh_root_dir/node_modules/@mongodb-js/devtools-connect" devtools-connect && \
+  ln -s "$mongosh_root_dir/node_modules/@mongodb-js/devtools-proxy-support" devtools-proxy-support)
 # This test can require a lot of memory so we bump the maximum size.
 NODE_OPTIONS=--max-old-space-size=4096 npm test
 cd /tmp


### PR DESCRIPTION
Right now, the VSCode test is failing in CI because the versions of `@mongodb-js/devtools-connect` mismatch. We can align them the same way we aligned the driver versions.

This does not turn the task green yet, but it is a necessary step (the next one would be adjusting the VSCode source code for the removal of the argument to `serviceProvider.close()` from c8e2697e).