### PR TITLE
fix(shell-api,shell-bson): increase runtime independence

### DIFF
--- a/packages/service-provider-node-driver/src/node-driver-service-provider.ts
+++ b/packages/service-provider-node-driver/src/node-driver-service-provider.ts
@@ -109,6 +109,7 @@ const bsonlib = () => {
     Decimal128,
     BSONSymbol,
     BSONRegExp,
+    UUID,
     BSON,
   } = driver;
   return {
@@ -126,6 +127,7 @@ const bsonlib = () => {
     BSONSymbol,
     calculateObjectSize: BSON.calculateObjectSize,
     EJSON: BSON.EJSON,
+    UUID,
     BSONRegExp,
   };
 };

--- a/packages/shell-api/src/runtime-independence.spec.ts
+++ b/packages/shell-api/src/runtime-independence.spec.ts
@@ -20,7 +20,7 @@ describe('Runtime independence', function () {
     // for other environments, but which we should still ideally remove in the
     // long run (and definitely not add anything here).
     // Guaranteed bonusly for anyone who removes a package from this list!
-    const allowedNodeBuiltins = ['crypto', 'util', 'events', 'path'];
+    const allowedNodeBuiltins = ['events', 'path'];
     // Our TextDecoder/TextEncoder polyfills require this, unfortunately.
     context.Buffer = Buffer;
 

--- a/packages/shell-api/src/shell-api.ts
+++ b/packages/shell-api/src/shell-api.ts
@@ -31,7 +31,6 @@ import {
   MongoshInternalError,
 } from '@mongosh/errors';
 import { DBQuery } from './dbquery';
-import { promisify } from 'util';
 import type { ClientSideFieldLevelEncryptionOptions } from './field-level-encryption';
 import { dirname } from 'path';
 import { ShellUserConfig } from '@mongosh/types';
@@ -422,7 +421,7 @@ export default class ShellApi extends ShellApiClass {
 
   @returnsPromise
   async sleep(ms: number): Promise<void> {
-    return await promisify(setTimeout)(ms);
+    return await new Promise<void>((resolve) => setTimeout(resolve, ms));
   }
 
   private async _print(

--- a/packages/shell-bson/src/bson-export.ts
+++ b/packages/shell-bson/src/bson-export.ts
@@ -13,6 +13,7 @@ import type {
   calculateObjectSize,
   Double,
   EJSON,
+  UUID,
   BSONRegExp,
 } from 'bson';
 export type {
@@ -29,6 +30,7 @@ export type {
   Binary,
   Double,
   EJSON,
+  UUID,
   BSONRegExp,
   calculateObjectSize,
 };
@@ -45,6 +47,7 @@ export type BSON = {
   Binary: typeof Binary;
   Double: typeof Double;
   EJSON: typeof EJSON;
+  UUID: typeof UUID;
   BSONRegExp: typeof BSONRegExp;
   BSONSymbol: typeof BSONSymbol;
   calculateObjectSize: typeof calculateObjectSize;

--- a/packages/shell-bson/src/shell-bson.ts
+++ b/packages/shell-bson/src/shell-bson.ts
@@ -10,7 +10,6 @@ import {
   assignAll,
   pickWithExactKeyMatch,
 } from './helpers';
-import { randomBytes } from 'crypto';
 
 type LongWithoutAccidentallyExposedMethods = Omit<
   typeof Long,
@@ -327,11 +326,10 @@ export function constructShellBson<
     UUID: assignAll(
       function UUID(hexstr?: string): BinaryType {
         if (hexstr === undefined) {
-          // Generate a version 4, variant 1 UUID, like the old shell did.
-          const uuid = randomBytes(16);
-          uuid[6] = (uuid[6] & 0x0f) | 0x40;
-          uuid[8] = (uuid[8] & 0x3f) | 0x80;
-          hexstr = uuid.toString('hex');
+          // TODO(MONGOSH-2710): Actually use UUID instances from `bson`
+          // (but then also be consistent about that when we e.g. receive
+          // them from the server).
+          hexstr = new bson.UUID().toString();
         }
         assertArgsDefinedType([hexstr], ['string'], 'UUID');
         // Strip any dashes, as they occur in the standard UUID formatting


### PR DESCRIPTION
Make the `shell-bson` and `shell-api` packages more runtime-independent (as they are supposed to be) by using `util` and `crypto` as progressive enhancement enablers rather than required packages.

This specifically makes `shell-bson` fully usable in a bare-bones JS environment.