### PR TITLE
chore(ci): update OpenSSL 1.1 download URL MONGOSH-3316 MONGOSH-3317 MONGOSH-3318

### DIFF
--- a/.evergreen/compile-artifact.sh
+++ b/.evergreen/compile-artifact.sh
@@ -39,7 +39,7 @@ elif uname -a | grep -q 'Darwin.*x86_64'; then
 elif [ -n "$MONGOSH_SHARED_OPENSSL" ]; then
   pushd /tmp/m
   if [ "$MONGOSH_SHARED_OPENSSL" == "openssl11" ]; then
-    curl -sSfLO https://www.openssl.org/source/old/1.1.1/openssl-1.1.1o.tar.gz
+    curl -sSfLO https://github.com/openssl/openssl/releases/download/OpenSSL_1_1_1o/openssl-1.1.1o.tar.gz
     MONGOSH_OPENSSL_LIBNAME=:libcrypto.so.1.1,:libssl.so.1.1
   elif [ "$MONGOSH_SHARED_OPENSSL" == "openssl3" ]; then
     curl -sSfLO https://www.openssl.org/source/old/3.0/openssl-3.0.5.tar.gz


### PR DESCRIPTION
I'm not sure if this was intentional on the OpenSSL side, but the previous download link for the 1.1.1o source tarball was broken. These links are just redirects to Github's CDN anyway, so pointing it at the Github source should be fine.