### PR TITLE
revert: update node.js (#2717)

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -5542,7 +5542,7 @@ tasks:
       - func: checkout
       - func: compile_ts
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
 
   - name: check
     depends_on:
@@ -5552,10 +5552,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: check
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
 
   - name: check_coverage
     depends_on:
@@ -6189,10 +6189,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: check_coverage
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
 
   ###
   # UNIT TESTS
@@ -6748,7 +6748,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_vscode
         vars:
           task_name: ${task_name}
@@ -6761,10 +6761,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_connectivity
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           task_name: ${task_name}
   - name: test_apistrict
     tags: ["extra-integration-test", "assigned_to_jira_team_mongosh_mongosh"]
@@ -6775,10 +6775,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_apistrict
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           mongosh_server_test_version: "latest-alpha-enterprise"
           mongosh_test_force_api_strict: "1"
           task_name: ${task_name}
@@ -6791,16 +6791,16 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: compile_artifact
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: upload_compiled_artifact
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: upload_first_party_deps_list
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
 
   - name: generate_license_and_vulnerability_report
     tags: ["extra-integration-test"]
@@ -6811,10 +6811,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: generate_license_and_vulnerability_report
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
 
   ###
   # E2E TESTS
@@ -7081,7 +7081,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: "linux-x64"
@@ -7099,13 +7099,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64
       - func: test_connectivity
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           test_mongosh_executable: dist/mongosh
           kerberos_jumphost_dockerfile: "Dockerfile.rocky8"
           task_name: ${task_name}
@@ -7118,13 +7118,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64
       - func: test_connectivity
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           test_mongosh_executable: dist/mongosh
           kerberos_jumphost_dockerfile: "Dockerfile.ubuntu2004"
           task_name: ${task_name}
@@ -7137,13 +7137,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64
       - func: test_connectivity
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           test_mongosh_executable: dist/mongosh
           kerberos_jumphost_dockerfile: "Dockerfile.node20"
           task_name: ${task_name}
@@ -7156,13 +7156,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64
       - func: test_connectivity
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           test_mongosh_executable: dist/mongosh
           kerberos_jumphost_dockerfile: "Dockerfile.rocky9"
           task_name: ${task_name}
@@ -7175,13 +7175,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64
       - func: test_connectivity
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           test_mongosh_executable: dist/mongosh
           kerberos_jumphost_dockerfile: "Dockerfile.rocky10"
           task_name: ${task_name}
@@ -7194,13 +7194,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64
       - func: test_connectivity
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           test_mongosh_executable: dist/mongosh
           kerberos_jumphost_dockerfile: "Dockerfile.ubuntu2204"
           task_name: ${task_name}
@@ -7213,13 +7213,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64-openssl11
       - func: test_connectivity
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           test_mongosh_executable: dist/mongosh
           kerberos_jumphost_dockerfile: "Dockerfile.rocky8"
           task_name: ${task_name}
@@ -7232,13 +7232,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64-openssl11
       - func: test_connectivity
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           test_mongosh_executable: dist/mongosh
           kerberos_jumphost_dockerfile: "Dockerfile.ubuntu2004"
           task_name: ${task_name}
@@ -7251,13 +7251,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64-openssl3
       - func: test_connectivity
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           test_mongosh_executable: dist/mongosh
           kerberos_jumphost_dockerfile: "Dockerfile.node20"
           task_name: ${task_name}
@@ -7270,13 +7270,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64-openssl3
       - func: test_connectivity
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           test_mongosh_executable: dist/mongosh
           kerberos_jumphost_dockerfile: "Dockerfile.rocky9"
           task_name: ${task_name}
@@ -7289,13 +7289,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64-openssl3
       - func: test_connectivity
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           test_mongosh_executable: dist/mongosh
           kerberos_jumphost_dockerfile: "Dockerfile.rocky10"
           task_name: ${task_name}
@@ -7308,13 +7308,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64-openssl3
       - func: test_connectivity
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           test_mongosh_executable: dist/mongosh
           kerberos_jumphost_dockerfile: "Dockerfile.ubuntu2204"
           task_name: ${task_name}
@@ -7327,13 +7327,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64
       - func: test_connectivity
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           test_mongosh_executable: dist/mongosh
           kerberos_jumphost_dockerfile: "Dockerfile.rocky8"
           task_name: ${task_name}
@@ -7346,13 +7346,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64
       - func: test_connectivity
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           test_mongosh_executable: dist/mongosh
           kerberos_jumphost_dockerfile: "Dockerfile.ubuntu2004"
           task_name: ${task_name}
@@ -7365,13 +7365,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64
       - func: test_connectivity
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           test_mongosh_executable: dist/mongosh
           kerberos_jumphost_dockerfile: "Dockerfile.node20"
           task_name: ${task_name}
@@ -7384,13 +7384,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64
       - func: test_connectivity
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           test_mongosh_executable: dist/mongosh
           kerberos_jumphost_dockerfile: "Dockerfile.rocky9"
           task_name: ${task_name}
@@ -7403,13 +7403,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64
       - func: test_connectivity
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           test_mongosh_executable: dist/mongosh
           kerberos_jumphost_dockerfile: "Dockerfile.rocky10"
           task_name: ${task_name}
@@ -7422,13 +7422,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64
       - func: test_connectivity
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           test_mongosh_executable: dist/mongosh
           kerberos_jumphost_dockerfile: "Dockerfile.ubuntu2204"
           task_name: ${task_name}
@@ -7441,13 +7441,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64-openssl11
       - func: test_connectivity
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           test_mongosh_executable: dist/mongosh
           kerberos_jumphost_dockerfile: "Dockerfile.rocky8"
           task_name: ${task_name}
@@ -7460,13 +7460,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64-openssl11
       - func: test_connectivity
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           test_mongosh_executable: dist/mongosh
           kerberos_jumphost_dockerfile: "Dockerfile.ubuntu2004"
           task_name: ${task_name}
@@ -7479,13 +7479,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64-openssl3
       - func: test_connectivity
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           test_mongosh_executable: dist/mongosh
           kerberos_jumphost_dockerfile: "Dockerfile.node20"
           task_name: ${task_name}
@@ -7498,13 +7498,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64-openssl3
       - func: test_connectivity
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           test_mongosh_executable: dist/mongosh
           kerberos_jumphost_dockerfile: "Dockerfile.rocky9"
           task_name: ${task_name}
@@ -7517,13 +7517,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64-openssl3
       - func: test_connectivity
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           test_mongosh_executable: dist/mongosh
           kerberos_jumphost_dockerfile: "Dockerfile.rocky10"
           task_name: ${task_name}
@@ -7536,13 +7536,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64-openssl3
       - func: test_connectivity
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           test_mongosh_executable: dist/mongosh
           kerberos_jumphost_dockerfile: "Dockerfile.ubuntu2204"
           task_name: ${task_name}
@@ -7559,7 +7559,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: darwin-x64
@@ -7583,14 +7583,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: darwin-x64
           extra_upload_tag: -darwin-x64-complete
       - func: package_artifact
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           package_variant: darwin-x64
           executable_os_id: darwin-x64
       - func: put_artifact_url
@@ -7605,14 +7605,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: get_artifact_url
         vars:
           package_variant: darwin-x64
           signature_tag: unsigned
       - func: sign_artifact
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           package_variant: darwin-x64
       - func: papertrail_trace
         vars:
@@ -7642,7 +7642,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: darwin-arm64
@@ -7666,14 +7666,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: darwin-arm64
           extra_upload_tag: -darwin-arm64-complete
       - func: package_artifact
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           package_variant: darwin-arm64
           executable_os_id: darwin-arm64
       - func: put_artifact_url
@@ -7688,14 +7688,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: get_artifact_url
         vars:
           package_variant: darwin-arm64
           signature_tag: unsigned
       - func: sign_artifact
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           package_variant: darwin-arm64
       - func: papertrail_trace
         vars:
@@ -7725,7 +7725,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64
@@ -7749,14 +7749,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64
           extra_upload_tag: -linux-x64-complete
       - func: package_artifact
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           package_variant: linux-x64
           executable_os_id: linux-x64
       - func: put_artifact_url
@@ -7771,14 +7771,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: get_artifact_url
         vars:
           package_variant: linux-x64
           signature_tag: unsigned
       - func: sign_artifact
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           package_variant: linux-x64
       - func: papertrail_trace
         vars:
@@ -7808,7 +7808,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64
@@ -7832,14 +7832,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64
           extra_upload_tag: -deb-x64-complete
       - func: package_artifact
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           package_variant: deb-x64
           executable_os_id: linux-x64
       - func: put_artifact_url
@@ -7854,14 +7854,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: get_artifact_url
         vars:
           package_variant: deb-x64
           signature_tag: unsigned
       - func: sign_artifact
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           package_variant: deb-x64
       - func: papertrail_trace
         vars:
@@ -7891,7 +7891,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64
@@ -7915,14 +7915,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64
           extra_upload_tag: -rpm-x64-complete
       - func: package_artifact
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           package_variant: rpm-x64
           executable_os_id: linux-x64
       - func: put_artifact_url
@@ -7937,14 +7937,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: get_artifact_url
         vars:
           package_variant: rpm-x64
           signature_tag: unsigned
       - func: sign_artifact
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           package_variant: rpm-x64
       - func: papertrail_trace
         vars:
@@ -7974,7 +7974,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64-openssl11
@@ -7998,14 +7998,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64-openssl11
           extra_upload_tag: -linux-x64-openssl11-complete
       - func: package_artifact
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           package_variant: linux-x64-openssl11
           executable_os_id: linux-x64-openssl11
       - func: put_artifact_url
@@ -8020,14 +8020,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: get_artifact_url
         vars:
           package_variant: linux-x64-openssl11
           signature_tag: unsigned
       - func: sign_artifact
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           package_variant: linux-x64-openssl11
       - func: papertrail_trace
         vars:
@@ -8057,7 +8057,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64-openssl11
@@ -8081,14 +8081,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64-openssl11
           extra_upload_tag: -deb-x64-openssl11-complete
       - func: package_artifact
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           package_variant: deb-x64-openssl11
           executable_os_id: linux-x64-openssl11
       - func: put_artifact_url
@@ -8103,14 +8103,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: get_artifact_url
         vars:
           package_variant: deb-x64-openssl11
           signature_tag: unsigned
       - func: sign_artifact
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           package_variant: deb-x64-openssl11
       - func: papertrail_trace
         vars:
@@ -8140,7 +8140,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64-openssl11
@@ -8164,14 +8164,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64-openssl11
           extra_upload_tag: -rpm-x64-openssl11-complete
       - func: package_artifact
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           package_variant: rpm-x64-openssl11
           executable_os_id: linux-x64-openssl11
       - func: put_artifact_url
@@ -8186,14 +8186,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: get_artifact_url
         vars:
           package_variant: rpm-x64-openssl11
           signature_tag: unsigned
       - func: sign_artifact
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           package_variant: rpm-x64-openssl11
       - func: papertrail_trace
         vars:
@@ -8223,7 +8223,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64-openssl3
@@ -8247,14 +8247,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64-openssl3
           extra_upload_tag: -linux-x64-openssl3-complete
       - func: package_artifact
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           package_variant: linux-x64-openssl3
           executable_os_id: linux-x64-openssl3
       - func: put_artifact_url
@@ -8269,14 +8269,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: get_artifact_url
         vars:
           package_variant: linux-x64-openssl3
           signature_tag: unsigned
       - func: sign_artifact
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           package_variant: linux-x64-openssl3
       - func: papertrail_trace
         vars:
@@ -8306,7 +8306,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64-openssl3
@@ -8330,14 +8330,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64-openssl3
           extra_upload_tag: -deb-x64-openssl3-complete
       - func: package_artifact
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           package_variant: deb-x64-openssl3
           executable_os_id: linux-x64-openssl3
       - func: put_artifact_url
@@ -8352,14 +8352,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: get_artifact_url
         vars:
           package_variant: deb-x64-openssl3
           signature_tag: unsigned
       - func: sign_artifact
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           package_variant: deb-x64-openssl3
       - func: papertrail_trace
         vars:
@@ -8389,7 +8389,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64-openssl3
@@ -8413,14 +8413,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64-openssl3
           extra_upload_tag: -rpm-x64-openssl3-complete
       - func: package_artifact
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           package_variant: rpm-x64-openssl3
           executable_os_id: linux-x64-openssl3
       - func: put_artifact_url
@@ -8435,14 +8435,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: get_artifact_url
         vars:
           package_variant: rpm-x64-openssl3
           signature_tag: unsigned
       - func: sign_artifact
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           package_variant: rpm-x64-openssl3
       - func: papertrail_trace
         vars:
@@ -8472,7 +8472,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64
@@ -8496,14 +8496,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64
           extra_upload_tag: -linux-arm64-complete
       - func: package_artifact
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           package_variant: linux-arm64
           executable_os_id: linux-arm64
       - func: put_artifact_url
@@ -8518,14 +8518,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: get_artifact_url
         vars:
           package_variant: linux-arm64
           signature_tag: unsigned
       - func: sign_artifact
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           package_variant: linux-arm64
       - func: papertrail_trace
         vars:
@@ -8555,7 +8555,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64
@@ -8579,14 +8579,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64
           extra_upload_tag: -deb-arm64-complete
       - func: package_artifact
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           package_variant: deb-arm64
           executable_os_id: linux-arm64
       - func: put_artifact_url
@@ -8601,14 +8601,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: get_artifact_url
         vars:
           package_variant: deb-arm64
           signature_tag: unsigned
       - func: sign_artifact
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           package_variant: deb-arm64
       - func: papertrail_trace
         vars:
@@ -8638,7 +8638,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64
@@ -8662,14 +8662,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64
           extra_upload_tag: -rpm-arm64-complete
       - func: package_artifact
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           package_variant: rpm-arm64
           executable_os_id: linux-arm64
       - func: put_artifact_url
@@ -8684,14 +8684,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: get_artifact_url
         vars:
           package_variant: rpm-arm64
           signature_tag: unsigned
       - func: sign_artifact
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           package_variant: rpm-arm64
       - func: papertrail_trace
         vars:
@@ -8721,7 +8721,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64-openssl11
@@ -8745,14 +8745,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64-openssl11
           extra_upload_tag: -linux-arm64-openssl11-complete
       - func: package_artifact
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           package_variant: linux-arm64-openssl11
           executable_os_id: linux-arm64-openssl11
       - func: put_artifact_url
@@ -8767,14 +8767,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: get_artifact_url
         vars:
           package_variant: linux-arm64-openssl11
           signature_tag: unsigned
       - func: sign_artifact
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           package_variant: linux-arm64-openssl11
       - func: papertrail_trace
         vars:
@@ -8804,7 +8804,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64-openssl11
@@ -8828,14 +8828,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64-openssl11
           extra_upload_tag: -deb-arm64-openssl11-complete
       - func: package_artifact
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           package_variant: deb-arm64-openssl11
           executable_os_id: linux-arm64-openssl11
       - func: put_artifact_url
@@ -8850,14 +8850,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: get_artifact_url
         vars:
           package_variant: deb-arm64-openssl11
           signature_tag: unsigned
       - func: sign_artifact
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           package_variant: deb-arm64-openssl11
       - func: papertrail_trace
         vars:
@@ -8887,7 +8887,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64-openssl11
@@ -8911,14 +8911,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64-openssl11
           extra_upload_tag: -rpm-arm64-openssl11-complete
       - func: package_artifact
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           package_variant: rpm-arm64-openssl11
           executable_os_id: linux-arm64-openssl11
       - func: put_artifact_url
@@ -8933,14 +8933,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: get_artifact_url
         vars:
           package_variant: rpm-arm64-openssl11
           signature_tag: unsigned
       - func: sign_artifact
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           package_variant: rpm-arm64-openssl11
       - func: papertrail_trace
         vars:
@@ -8970,7 +8970,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64-openssl3
@@ -8994,14 +8994,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64-openssl3
           extra_upload_tag: -linux-arm64-openssl3-complete
       - func: package_artifact
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           package_variant: linux-arm64-openssl3
           executable_os_id: linux-arm64-openssl3
       - func: put_artifact_url
@@ -9016,14 +9016,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: get_artifact_url
         vars:
           package_variant: linux-arm64-openssl3
           signature_tag: unsigned
       - func: sign_artifact
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           package_variant: linux-arm64-openssl3
       - func: papertrail_trace
         vars:
@@ -9053,7 +9053,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64-openssl3
@@ -9077,14 +9077,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64-openssl3
           extra_upload_tag: -deb-arm64-openssl3-complete
       - func: package_artifact
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           package_variant: deb-arm64-openssl3
           executable_os_id: linux-arm64-openssl3
       - func: put_artifact_url
@@ -9099,14 +9099,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: get_artifact_url
         vars:
           package_variant: deb-arm64-openssl3
           signature_tag: unsigned
       - func: sign_artifact
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           package_variant: deb-arm64-openssl3
       - func: papertrail_trace
         vars:
@@ -9136,7 +9136,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64-openssl3
@@ -9160,14 +9160,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64-openssl3
           extra_upload_tag: -rpm-arm64-openssl3-complete
       - func: package_artifact
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           package_variant: rpm-arm64-openssl3
           executable_os_id: linux-arm64-openssl3
       - func: put_artifact_url
@@ -9182,14 +9182,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: get_artifact_url
         vars:
           package_variant: rpm-arm64-openssl3
           signature_tag: unsigned
       - func: sign_artifact
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           package_variant: rpm-arm64-openssl3
       - func: papertrail_trace
         vars:
@@ -9219,7 +9219,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-ppc64le
@@ -9243,14 +9243,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-ppc64le
           extra_upload_tag: -linux-ppc64le-complete
       - func: package_artifact
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           package_variant: linux-ppc64le
           executable_os_id: linux-ppc64le
       - func: put_artifact_url
@@ -9265,14 +9265,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: get_artifact_url
         vars:
           package_variant: linux-ppc64le
           signature_tag: unsigned
       - func: sign_artifact
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           package_variant: linux-ppc64le
       - func: papertrail_trace
         vars:
@@ -9302,7 +9302,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-ppc64le
@@ -9326,14 +9326,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-ppc64le
           extra_upload_tag: -rpm-ppc64le-complete
       - func: package_artifact
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           package_variant: rpm-ppc64le
           executable_os_id: linux-ppc64le
       - func: put_artifact_url
@@ -9348,14 +9348,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: get_artifact_url
         vars:
           package_variant: rpm-ppc64le
           signature_tag: unsigned
       - func: sign_artifact
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           package_variant: rpm-ppc64le
       - func: papertrail_trace
         vars:
@@ -9385,7 +9385,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-s390x
@@ -9409,14 +9409,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-s390x
           extra_upload_tag: -linux-s390x-complete
       - func: package_artifact
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           package_variant: linux-s390x
           executable_os_id: linux-s390x
       - func: put_artifact_url
@@ -9431,14 +9431,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: get_artifact_url
         vars:
           package_variant: linux-s390x
           signature_tag: unsigned
       - func: sign_artifact
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           package_variant: linux-s390x
       - func: papertrail_trace
         vars:
@@ -9468,7 +9468,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-s390x
@@ -9492,14 +9492,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-s390x
           extra_upload_tag: -rpm-s390x-complete
       - func: package_artifact
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           package_variant: rpm-s390x
           executable_os_id: linux-s390x
       - func: put_artifact_url
@@ -9514,14 +9514,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: get_artifact_url
         vars:
           package_variant: rpm-s390x
           signature_tag: unsigned
       - func: sign_artifact
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           package_variant: rpm-s390x
       - func: papertrail_trace
         vars:
@@ -9551,7 +9551,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: win32
@@ -9575,14 +9575,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: win32
           extra_upload_tag: -win32-x64-complete
       - func: package_artifact
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           package_variant: win32-x64
           executable_os_id: win32
       - func: put_artifact_url
@@ -9597,14 +9597,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: get_artifact_url
         vars:
           package_variant: win32-x64
           signature_tag: unsigned
       - func: sign_artifact
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           package_variant: win32-x64
       - func: papertrail_trace
         vars:
@@ -9634,7 +9634,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: win32
@@ -9658,14 +9658,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: download_compiled_artifact
         vars:
           executable_os_id: win32
           extra_upload_tag: -win32msi-x64-complete
       - func: package_artifact
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           package_variant: win32msi-x64
           executable_os_id: win32
       - func: put_artifact_url
@@ -9680,14 +9680,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: get_artifact_url
         vars:
           package_variant: win32msi-x64
           signature_tag: unsigned
       - func: sign_artifact
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           package_variant: win32msi-x64
       - func: papertrail_trace
         vars:
@@ -9752,10 +9752,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: ubuntu20.04-tgz
           task_name: ${task_name}
   - name: pkg_test_docker_deb_x64_ubuntu18_04_deb
@@ -9772,10 +9772,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: ubuntu18.04-deb
           task_name: ${task_name}
   - name: pkg_test_docker_deb_x64_ubuntu20_04_deb
@@ -9792,10 +9792,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: ubuntu20.04-deb
           task_name: ${task_name}
   - name: pkg_test_docker_deb_x64_ubuntu22_04_deb
@@ -9812,10 +9812,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: ubuntu22.04-deb
           task_name: ${task_name}
   - name: pkg_test_docker_deb_x64_ubuntu22_04_nohome_deb
@@ -9832,10 +9832,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: ubuntu22.04-nohome-deb
           task_name: ${task_name}
   - name: pkg_test_docker_deb_x64_ubuntu22_04_qemu_deb
@@ -9852,10 +9852,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: ubuntu22.04-qemu-deb
           task_name: ${task_name}
   - name: pkg_test_docker_deb_x64_ubuntu24_04_deb
@@ -9872,10 +9872,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: ubuntu24.04-deb
           task_name: ${task_name}
   - name: pkg_test_docker_deb_x64_debian10_deb
@@ -9892,10 +9892,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: debian10-deb
           task_name: ${task_name}
   - name: pkg_test_docker_deb_x64_debian11_deb
@@ -9912,10 +9912,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: debian11-deb
           task_name: ${task_name}
   - name: pkg_test_docker_deb_x64_debian12_deb
@@ -9932,10 +9932,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: debian12-deb
           task_name: ${task_name}
   - name: pkg_test_docker_deb_x64_debian13_deb
@@ -9952,10 +9952,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: debian13-deb
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_x64_centos7_rpm
@@ -9972,10 +9972,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: centos7-rpm
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_x64_amazonlinux2_rpm
@@ -9992,10 +9992,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: amazonlinux2-rpm
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_x64_amazonlinux2023_rpm
@@ -10012,10 +10012,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: amazonlinux2023-rpm
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_x64_rocky8_rpm
@@ -10032,10 +10032,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: rocky8-rpm
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_x64_rocky9_rpm
@@ -10052,10 +10052,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: rocky9-rpm
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_x64_rocky10_rpm
@@ -10072,10 +10072,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: rocky10-rpm
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_x64_fedora34_rpm
@@ -10092,10 +10092,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: fedora34-rpm
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_x64_suse12_rpm
@@ -10112,10 +10112,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: suse12-rpm
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_x64_suse15_rpm
@@ -10132,10 +10132,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: suse15-rpm
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_x64_oraclelinux9_rpm
@@ -10152,10 +10152,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: oraclelinux9-rpm
           task_name: ${task_name}
   - name: pkg_test_docker_deb_x64_openssl11_ubuntu20_04_deb
@@ -10172,10 +10172,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: ubuntu20.04-deb
           task_name: ${task_name}
   - name: pkg_test_docker_deb_x64_openssl11_debian10_deb
@@ -10192,10 +10192,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: debian10-deb
           task_name: ${task_name}
   - name: pkg_test_docker_deb_x64_openssl11_debian11_deb
@@ -10212,10 +10212,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: debian11-deb
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_x64_openssl11_centos7_epel_rpm
@@ -10232,10 +10232,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: centos7-epel-rpm
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_x64_openssl11_amazonlinux2_rpm
@@ -10252,10 +10252,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: amazonlinux2-rpm
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_x64_openssl11_rocky8_rpm
@@ -10272,10 +10272,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: rocky8-rpm
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_x64_openssl11_rocky9_rpm
@@ -10292,10 +10292,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: rocky9-rpm
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_x64_openssl11_fedora34_rpm
@@ -10312,10 +10312,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: fedora34-rpm
           task_name: ${task_name}
   - name: pkg_test_docker_deb_x64_openssl3_ubuntu22_04_deb
@@ -10332,10 +10332,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: ubuntu22.04-deb
           task_name: ${task_name}
   - name: pkg_test_docker_deb_x64_openssl3_ubuntu22_04_fips_deb
@@ -10352,10 +10352,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: ubuntu22.04-fips-deb
           task_name: ${task_name}
   - name: pkg_test_docker_deb_x64_openssl3_debian12_deb
@@ -10372,10 +10372,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: debian12-deb
           task_name: ${task_name}
   - name: pkg_test_docker_deb_x64_openssl3_debian13_deb
@@ -10392,10 +10392,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: debian13-deb
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_x64_openssl3_rocky8_epel_rpm
@@ -10412,10 +10412,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: rocky8-epel-rpm
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_x64_openssl3_rocky9_rpm
@@ -10432,10 +10432,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: rocky9-rpm
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_x64_openssl3_rocky9_fips_rpm
@@ -10452,10 +10452,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: rocky9-fips-rpm
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_x64_openssl3_rocky10_rpm
@@ -10472,10 +10472,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: rocky10-rpm
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_x64_openssl3_amazonlinux2023_rpm
@@ -10492,10 +10492,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: amazonlinux2023-rpm
           task_name: ${task_name}
   - name: pkg_test_docker_linux_arm64_ubuntu20_04_tgz
@@ -10512,10 +10512,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: ubuntu20.04-tgz
           task_name: ${task_name}
   - name: pkg_test_docker_deb_arm64_ubuntu18_04_deb
@@ -10532,10 +10532,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: ubuntu18.04-deb
           task_name: ${task_name}
   - name: pkg_test_docker_deb_arm64_ubuntu20_04_deb
@@ -10552,10 +10552,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: ubuntu20.04-deb
           task_name: ${task_name}
   - name: pkg_test_docker_deb_arm64_ubuntu22_04_deb
@@ -10572,10 +10572,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: ubuntu22.04-deb
           task_name: ${task_name}
   - name: pkg_test_docker_deb_arm64_ubuntu22_04_nohome_deb
@@ -10592,10 +10592,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: ubuntu22.04-nohome-deb
           task_name: ${task_name}
   - name: pkg_test_docker_deb_arm64_ubuntu22_04_qemu_deb
@@ -10612,10 +10612,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: ubuntu22.04-qemu-deb
           task_name: ${task_name}
   - name: pkg_test_docker_deb_arm64_ubuntu24_04_deb
@@ -10632,10 +10632,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: ubuntu24.04-deb
           task_name: ${task_name}
   - name: pkg_test_docker_deb_arm64_debian10_deb
@@ -10652,10 +10652,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: debian10-deb
           task_name: ${task_name}
   - name: pkg_test_docker_deb_arm64_debian11_deb
@@ -10672,10 +10672,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: debian11-deb
           task_name: ${task_name}
   - name: pkg_test_docker_deb_arm64_debian12_deb
@@ -10692,10 +10692,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: debian12-deb
           task_name: ${task_name}
   - name: pkg_test_docker_deb_arm64_debian13_deb
@@ -10712,10 +10712,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: debian13-deb
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_arm64_rocky8_rpm
@@ -10732,10 +10732,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: rocky8-rpm
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_arm64_rocky9_rpm
@@ -10752,10 +10752,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: rocky9-rpm
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_arm64_rocky10_rpm
@@ -10772,10 +10772,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: rocky10-rpm
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_arm64_fedora34_rpm
@@ -10792,10 +10792,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: fedora34-rpm
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_arm64_amazonlinux2_rpm
@@ -10812,10 +10812,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: amazonlinux2-rpm
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_arm64_amazonlinux2023_rpm
@@ -10832,10 +10832,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: amazonlinux2023-rpm
           task_name: ${task_name}
   - name: pkg_test_docker_deb_arm64_openssl11_ubuntu20_04_deb
@@ -10852,10 +10852,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: ubuntu20.04-deb
           task_name: ${task_name}
   - name: pkg_test_docker_deb_arm64_openssl11_debian10_deb
@@ -10872,10 +10872,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: debian10-deb
           task_name: ${task_name}
   - name: pkg_test_docker_deb_arm64_openssl11_debian11_deb
@@ -10892,10 +10892,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: debian11-deb
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_arm64_openssl11_rocky8_rpm
@@ -10912,10 +10912,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: rocky8-rpm
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_arm64_openssl11_rocky9_rpm
@@ -10932,10 +10932,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: rocky9-rpm
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_arm64_openssl11_fedora34_rpm
@@ -10952,10 +10952,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: fedora34-rpm
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_arm64_openssl11_amazonlinux2_rpm
@@ -10972,10 +10972,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: amazonlinux2-rpm
           task_name: ${task_name}
   - name: pkg_test_docker_deb_arm64_openssl3_ubuntu22_04_deb
@@ -10992,10 +10992,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: ubuntu22.04-deb
           task_name: ${task_name}
   - name: pkg_test_docker_deb_arm64_openssl3_ubuntu22_04_fips_deb
@@ -11012,10 +11012,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: ubuntu22.04-fips-deb
           task_name: ${task_name}
   - name: pkg_test_docker_deb_arm64_openssl3_debian12_deb
@@ -11032,10 +11032,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: debian12-deb
           task_name: ${task_name}
   - name: pkg_test_docker_deb_arm64_openssl3_debian13_deb
@@ -11052,10 +11052,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: debian13-deb
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_arm64_openssl3_rocky8_epel_rpm
@@ -11072,10 +11072,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: rocky8-epel-rpm
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_arm64_openssl3_rocky9_rpm
@@ -11092,10 +11092,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: rocky9-rpm
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_arm64_openssl3_rocky9_fips_rpm
@@ -11112,10 +11112,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: rocky9-fips-rpm
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_arm64_openssl3_rocky10_rpm
@@ -11132,10 +11132,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: rocky10-rpm
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_arm64_openssl3_amazonlinux2023_rpm
@@ -11152,10 +11152,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
           dockerfile: amazonlinux2023-rpm
           task_name: ${task_name}
   - name: pkg_test_rpmextract_rpm_ppc64le
@@ -11233,10 +11233,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: create_static_analysis_report
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
 
   ###
   # RELEASE TASKS
@@ -11260,10 +11260,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: release_draft
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
   - name: release_publish_dry_run
     git_tag_only: true
     exec_timeout_secs: 86400
@@ -11273,16 +11273,16 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: release_publish_download_and_list_artifacts
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: papertrail_trace
         vars:
           product: "mongosh-draft"
       - func: release_publish_dry_run
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
   - name: release_publish
     tags: ["publish"]
     git_tag_only: true
@@ -11294,16 +11294,16 @@ tasks:
       - func: checkout_writeable
       - func: install
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: release_publish_download_and_list_artifacts
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
       - func: papertrail_trace
         vars:
           product: "mongosh"
       - func: release_publish
         vars:
-          node_js_version: "24.15.0"
+          node_js_version: "24.14.1"
 
 # Need to run builds for every possible build variant.
 buildvariants:
@@ -11315,7 +11315,7 @@ buildvariants:
     expansions:
       executable_os_id: darwin-arm64
       mongosh_server_test_version: ""
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -11350,7 +11350,7 @@ buildvariants:
     expansions:
       executable_os_id: darwin-arm64
       mongosh_server_test_version: "6.0.x"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -11385,7 +11385,7 @@ buildvariants:
     expansions:
       executable_os_id: darwin-arm64
       mongosh_server_test_version: "6.0.x-enterprise"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -11420,7 +11420,7 @@ buildvariants:
     expansions:
       executable_os_id: darwin-arm64
       mongosh_server_test_version: "7.0.x"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -11455,7 +11455,7 @@ buildvariants:
     expansions:
       executable_os_id: darwin-arm64
       mongosh_server_test_version: "7.0.x-enterprise"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -11490,7 +11490,7 @@ buildvariants:
     expansions:
       executable_os_id: darwin-arm64
       mongosh_server_test_version: "8.0.x"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -11525,7 +11525,7 @@ buildvariants:
     expansions:
       executable_os_id: darwin-arm64
       mongosh_server_test_version: "8.0.x-enterprise"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -11560,7 +11560,7 @@ buildvariants:
     expansions:
       executable_os_id: darwin-arm64
       mongosh_server_test_version: "8.3.0-rc3"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -11595,7 +11595,7 @@ buildvariants:
     expansions:
       executable_os_id: darwin-arm64
       mongosh_server_test_version: "8.3.0-rc3-enterprise"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -11630,7 +11630,7 @@ buildvariants:
     expansions:
       executable_os_id: darwin-arm64
       mongosh_server_test_version: "latest-alpha-enterprise"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -11665,7 +11665,7 @@ buildvariants:
     expansions:
       executable_os_id: darwin-arm64
       mongosh_server_test_version: ""
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -11700,7 +11700,7 @@ buildvariants:
     expansions:
       executable_os_id: darwin-arm64
       mongosh_server_test_version: "4.2.x"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -11735,7 +11735,7 @@ buildvariants:
     expansions:
       executable_os_id: darwin-arm64
       mongosh_server_test_version: "4.4.x"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -11770,7 +11770,7 @@ buildvariants:
     expansions:
       executable_os_id: darwin-arm64
       mongosh_server_test_version: "4.4.x-enterprise"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -11805,7 +11805,7 @@ buildvariants:
     expansions:
       executable_os_id: darwin-arm64
       mongosh_server_test_version: "5.0.x"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -11840,7 +11840,7 @@ buildvariants:
     expansions:
       executable_os_id: darwin-arm64
       mongosh_server_test_version: "5.0.x-enterprise"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -11875,7 +11875,7 @@ buildvariants:
     expansions:
       executable_os_id: darwin-arm64
       mongosh_server_test_version: "6.0.x"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -11910,7 +11910,7 @@ buildvariants:
     expansions:
       executable_os_id: darwin-arm64
       mongosh_server_test_version: "6.0.x-enterprise"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -11945,7 +11945,7 @@ buildvariants:
     expansions:
       executable_os_id: darwin-arm64
       mongosh_server_test_version: "7.0.x"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -11980,7 +11980,7 @@ buildvariants:
     expansions:
       executable_os_id: darwin-arm64
       mongosh_server_test_version: "7.0.x-enterprise"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -12015,7 +12015,7 @@ buildvariants:
     expansions:
       executable_os_id: darwin-arm64
       mongosh_server_test_version: "8.0.x"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -12050,7 +12050,7 @@ buildvariants:
     expansions:
       executable_os_id: darwin-arm64
       mongosh_server_test_version: "8.0.x-enterprise"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -12085,7 +12085,7 @@ buildvariants:
     expansions:
       executable_os_id: darwin-arm64
       mongosh_server_test_version: "8.3.0-rc3"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -12120,7 +12120,7 @@ buildvariants:
     expansions:
       executable_os_id: darwin-arm64
       mongosh_server_test_version: "8.3.0-rc3-enterprise"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -12155,7 +12155,7 @@ buildvariants:
     expansions:
       executable_os_id: darwin-arm64
       mongosh_server_test_version: "latest-alpha-enterprise"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -12190,7 +12190,7 @@ buildvariants:
     expansions:
       executable_os_id: win32
       mongosh_server_test_version: ""
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -12224,7 +12224,7 @@ buildvariants:
     expansions:
       executable_os_id: win32
       mongosh_server_test_version: "4.2.x"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -12258,7 +12258,7 @@ buildvariants:
     expansions:
       executable_os_id: win32
       mongosh_server_test_version: "4.2.x-enterprise"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -12292,7 +12292,7 @@ buildvariants:
     expansions:
       executable_os_id: win32
       mongosh_server_test_version: "4.4.x"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -12326,7 +12326,7 @@ buildvariants:
     expansions:
       executable_os_id: win32
       mongosh_server_test_version: "4.4.x-enterprise"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -12360,7 +12360,7 @@ buildvariants:
     expansions:
       executable_os_id: win32
       mongosh_server_test_version: "5.0.x"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -12394,7 +12394,7 @@ buildvariants:
     expansions:
       executable_os_id: win32
       mongosh_server_test_version: "5.0.x-enterprise"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -12428,7 +12428,7 @@ buildvariants:
     expansions:
       executable_os_id: win32
       mongosh_server_test_version: "6.0.x"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -12462,7 +12462,7 @@ buildvariants:
     expansions:
       executable_os_id: win32
       mongosh_server_test_version: "6.0.x-enterprise"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -12496,7 +12496,7 @@ buildvariants:
     expansions:
       executable_os_id: win32
       mongosh_server_test_version: "7.0.x"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -12530,7 +12530,7 @@ buildvariants:
     expansions:
       executable_os_id: win32
       mongosh_server_test_version: "7.0.x-enterprise"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -12564,7 +12564,7 @@ buildvariants:
     expansions:
       executable_os_id: win32
       mongosh_server_test_version: "8.0.x"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -12598,7 +12598,7 @@ buildvariants:
     expansions:
       executable_os_id: win32
       mongosh_server_test_version: "8.0.x-enterprise"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -12632,7 +12632,7 @@ buildvariants:
     expansions:
       executable_os_id: win32
       mongosh_server_test_version: "8.3.0-rc3"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -12666,7 +12666,7 @@ buildvariants:
     expansions:
       executable_os_id: win32
       mongosh_server_test_version: "8.3.0-rc3-enterprise"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -12700,7 +12700,7 @@ buildvariants:
     expansions:
       executable_os_id: win32
       mongosh_server_test_version: "latest-alpha-enterprise"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -12731,7 +12731,7 @@ buildvariants:
     run_on: rhel70-build
     expansions:
       executable_os_id: "linux-x64"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
     tasks:
       - name: compile_artifact
   - name: build_linux_x64_rhel8
@@ -12739,7 +12739,7 @@ buildvariants:
     run_on: rhel80-build
     expansions:
       executable_os_id: "linux-x64"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
     tasks:
       - name: compile_artifact
   - name: build_linux_x64_openssl11
@@ -12747,7 +12747,7 @@ buildvariants:
     run_on: rhel70-build
     expansions:
       executable_os_id: "linux-x64-openssl11"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_shared_openssl: "openssl11"
     tasks:
       - name: compile_artifact
@@ -12756,7 +12756,7 @@ buildvariants:
     run_on: rhel80-build
     expansions:
       executable_os_id: "linux-x64-openssl11"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_shared_openssl: "openssl11"
     tasks:
       - name: compile_artifact
@@ -12765,7 +12765,7 @@ buildvariants:
     run_on: rhel70-build
     expansions:
       executable_os_id: "linux-x64-openssl3"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_shared_openssl: "openssl3"
     tasks:
       - name: compile_artifact
@@ -12774,7 +12774,7 @@ buildvariants:
     run_on: rhel80-build
     expansions:
       executable_os_id: "linux-x64-openssl3"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_shared_openssl: "openssl3"
     tasks:
       - name: compile_artifact
@@ -12783,7 +12783,7 @@ buildvariants:
     run_on: amazon2-arm64-large
     expansions:
       executable_os_id: "linux-arm64"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
     tasks:
       - name: compile_artifact
   - name: build_linux_arm64_openssl11
@@ -12791,7 +12791,7 @@ buildvariants:
     run_on: amazon2-arm64-large
     expansions:
       executable_os_id: "linux-arm64-openssl11"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_shared_openssl: "openssl11"
     tasks:
       - name: compile_artifact
@@ -12800,7 +12800,7 @@ buildvariants:
     run_on: amazon2-arm64-large
     expansions:
       executable_os_id: "linux-arm64-openssl3"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_shared_openssl: "openssl3"
     tasks:
       - name: compile_artifact
@@ -12809,7 +12809,7 @@ buildvariants:
     run_on: rhel8-power-small
     expansions:
       executable_os_id: "linux-ppc64le"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
     tasks:
       - name: compile_artifact
   - name: build_linux_s390x
@@ -12817,7 +12817,7 @@ buildvariants:
     run_on: rhel7-zseries-large
     expansions:
       executable_os_id: "linux-s390x"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
     tasks:
       - name: compile_artifact
   - name: build_darwin
@@ -12825,7 +12825,7 @@ buildvariants:
     run_on: macos-15-amd64-gui
     expansions:
       executable_os_id: "darwin-x64"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
     tasks:
       - name: compile_artifact
   - name: build_darwin_arm64
@@ -12833,7 +12833,7 @@ buildvariants:
     run_on: macos-15-arm64-gui
     expansions:
       executable_os_id: "darwin-arm64"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
     tasks:
       - name: compile_artifact
   - name: build_win32
@@ -12841,7 +12841,7 @@ buildvariants:
     run_on: windows-2022-latest-small
     expansions:
       executable_os_id: "win32"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
     tasks:
       - name: compile_artifact
   - name: e2e_tests_rhel70_small_m70x
@@ -12850,7 +12850,7 @@ buildvariants:
     tags: ["nightly-driver"]
     expansions:
       executable_os_id: "linux-x64"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_server_test_version: "7.0.x-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -12861,7 +12861,7 @@ buildvariants:
     tags: ["nightly-driver"]
     expansions:
       executable_os_id: "linux-x64"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_server_test_version: "7.0.x-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -12872,7 +12872,7 @@ buildvariants:
     tags: ["nightly-driver"]
     expansions:
       executable_os_id: "linux-x64"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -12883,7 +12883,7 @@ buildvariants:
     tags: ["nightly-driver"]
     expansions:
       executable_os_id: "linux-x64"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_server_test_version: "7.0.x-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -12894,7 +12894,7 @@ buildvariants:
     tags: ["nightly-driver"]
     expansions:
       executable_os_id: "linux-x64"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -12905,7 +12905,7 @@ buildvariants:
     tags: ["nightly-driver"]
     expansions:
       executable_os_id: "linux-x64"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -12916,7 +12916,7 @@ buildvariants:
     tags: ["nightly-driver"]
     expansions:
       executable_os_id: "linux-x64-openssl11"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -12927,7 +12927,7 @@ buildvariants:
     tags: ["nightly-driver"]
     expansions:
       executable_os_id: "linux-x64-openssl11"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: "1"
     tasks:
@@ -12938,7 +12938,7 @@ buildvariants:
     tags: ["nightly-driver"]
     expansions:
       executable_os_id: "linux-x64"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -12949,7 +12949,7 @@ buildvariants:
     tags: ["nightly-driver"]
     expansions:
       executable_os_id: "linux-x64-openssl3"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -12960,7 +12960,7 @@ buildvariants:
     tags: ["nightly-driver"]
     expansions:
       executable_os_id: "linux-x64-openssl3"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: "1"
     tasks:
@@ -12971,7 +12971,7 @@ buildvariants:
     tags: ["nightly-driver"]
     expansions:
       executable_os_id: "linux-x64"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_server_test_version: "6.0.x-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -12982,7 +12982,7 @@ buildvariants:
     tags: ["nightly-driver"]
     expansions:
       executable_os_id: "linux-x64"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -12993,7 +12993,7 @@ buildvariants:
     tags: ["nightly-driver"]
     expansions:
       executable_os_id: "linux-x64-openssl11"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13004,7 +13004,7 @@ buildvariants:
     tags: ["nightly-driver"]
     expansions:
       executable_os_id: "linux-x64"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13015,7 +13015,7 @@ buildvariants:
     tags: ["nightly-driver"]
     expansions:
       executable_os_id: "linux-x64-openssl3"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13026,7 +13026,7 @@ buildvariants:
     tags: ["nightly-driver"]
     expansions:
       executable_os_id: "linux-x64"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13037,7 +13037,7 @@ buildvariants:
     tags: ["nightly-driver"]
     expansions:
       executable_os_id: "linux-x64-openssl3"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13048,7 +13048,7 @@ buildvariants:
     tags: ["nightly-driver"]
     expansions:
       executable_os_id: "linux-x64"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_server_test_version: "6.0.x-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13059,7 +13059,7 @@ buildvariants:
     tags: ["nightly-driver"]
     expansions:
       executable_os_id: "linux-x64-openssl11"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_server_test_version: "6.0.x-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13070,7 +13070,7 @@ buildvariants:
     tags: ["nightly-driver"]
     expansions:
       executable_os_id: "linux-x64"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_server_test_version: "7.0.x-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13081,7 +13081,7 @@ buildvariants:
     tags: ["nightly-driver"]
     expansions:
       executable_os_id: "linux-x64-openssl11"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_server_test_version: "7.0.x-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13092,7 +13092,7 @@ buildvariants:
     tags: ["nightly-driver"]
     expansions:
       executable_os_id: "linux-x64"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_server_test_version: "7.0.x-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13103,7 +13103,7 @@ buildvariants:
     tags: ["nightly-driver"]
     expansions:
       executable_os_id: "linux-x64"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13114,7 +13114,7 @@ buildvariants:
     tags: ["nightly-driver"]
     expansions:
       executable_os_id: "linux-x64"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_server_test_version: "7.0.x-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13125,7 +13125,7 @@ buildvariants:
     tags: ["nightly-driver"]
     expansions:
       executable_os_id: "linux-x64"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13136,7 +13136,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "linux-arm64"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_server_test_version: "6.0.x-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13147,7 +13147,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "linux-arm64"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13158,7 +13158,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "linux-arm64-openssl11"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13169,7 +13169,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "linux-arm64"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13180,7 +13180,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "linux-arm64-openssl3"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13191,7 +13191,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "linux-arm64"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13202,7 +13202,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "linux-arm64-openssl3"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13213,7 +13213,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "linux-arm64-openssl3"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_server_test_version: "8.3.0-rc5-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13224,7 +13224,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "linux-arm64"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_server_test_version: "7.0.x-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13235,7 +13235,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "linux-arm64"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13246,7 +13246,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "linux-arm64"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_server_test_version: "8.3.0-rc5-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13257,7 +13257,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "linux-arm64"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13268,7 +13268,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "linux-arm64"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_server_test_version: "7.0.x-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13279,7 +13279,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "linux-arm64-openssl3"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_server_test_version: "7.0.x-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13290,7 +13290,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "linux-arm64"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13301,7 +13301,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "linux-arm64-openssl3"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13312,7 +13312,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "linux-ppc64le"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13323,7 +13323,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "linux-ppc64le"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13334,7 +13334,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "linux-ppc64le"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_server_test_version: "8.3.0-rc5-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13345,7 +13345,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "linux-s390x"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_server_test_version: "6.0.x-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13356,7 +13356,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "linux-s390x"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13367,7 +13367,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "linux-s390x"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13378,7 +13378,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "linux-s390x"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_server_test_version: "8.3.0-rc5-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13389,7 +13389,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "darwin-x64"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13400,7 +13400,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "darwin-arm64"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13411,7 +13411,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "darwin-arm64"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_server_test_version: "8.2.x-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13422,7 +13422,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "darwin-x64"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13433,7 +13433,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "darwin-arm64"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13444,7 +13444,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "darwin-arm64"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_server_test_version: "8.3.0-rc5-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13455,7 +13455,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "darwin-x64"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_server_test_version: "8.0.5-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13466,7 +13466,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "darwin-arm64"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_server_test_version: "8.0.5-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13481,7 +13481,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "win32"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13492,7 +13492,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "win32"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_server_test_version: "8.2.x-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13503,7 +13503,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "win32"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13516,7 +13516,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "win32"
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
       mongosh_server_test_version: "8.3.0-rc5-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13534,7 +13534,7 @@ buildvariants:
     run_on: ubuntu2004-small
     tags: ["nightly-driver"]
     expansions:
-      node_js_version: "24.15.0"
+      node_js_version: "24.14.1"
     tasks:
       - name: test_vscode
       - name: test_connectivity

--- a/.evergreen/node-24-latest.json
+++ b/.evergreen/node-24-latest.json
@@ -1,8 +1,8 @@
 {
-  "version": "24.15.0",
+  "version": "24.14.1",
   "major": 24,
-  "minor": 15,
-  "patch": 0,
+  "minor": 14,
+  "patch": 1,
   "tag": "",
   "codename": "krypton",
   "versionName": "v24",
@@ -10,11 +10,11 @@
   "lts": "2025-10-28T00:00:00.000Z",
   "maintenance": "2026-10-20T00:00:00.000Z",
   "end": "2028-04-30T00:00:00.000Z",
-  "releaseDate": "2026-04-15T00:00:00.000Z",
+  "releaseDate": "2026-03-24T00:00:00.000Z",
   "isLts": true,
   "isSupported": true,
   "isMaintenance": false,
-  "isSecurity": false,
+  "isSecurity": true,
   "modules": "137",
   "files": [
     "aix-ppc64",
@@ -35,7 +35,7 @@
     "win-x64-zip"
   ],
   "dependencies": {
-    "npm": "11.12.1",
+    "npm": "11.11.0",
     "v8": "13.6.233.17",
     "uv": "1.51.0",
     "zlib": "1.3.1",


### PR DESCRIPTION
This reverts commit 39211baf69361074d573d89352cb4f4383f55135.

It currently introduces a Windows regression so we temporarily revert it to keep CI green.