### PR TITLE
fix(cli-repl): fix lint error

### DIFF
--- a/packages/cli-repl/src/update-notification-manager.ts
+++ b/packages/cli-repl/src/update-notification-manager.ts
@@ -82,10 +82,7 @@ export class UpdateNotificationManager {
     onInvalidMatchPattern?: (err: unknown) => void;
   } = {}) {
     this.fetch =
-      fetch ??
-      (async () => {
-        throw new Error('no fetch provided');
-      });
+      fetch ?? (() => Promise.reject(new Error('no fetch provided')));
     this.onInvalidMatchPattern = onInvalidMatchPattern ?? (() => {});
   }
 


### PR DESCRIPTION
Fixes `Async arrow function has no 'await' expression` from 88ede3e9c31a.