### PR TITLE
chore(cli-repl): move FIPS enabling into separate file

### DIFF
--- a/packages/cli-repl/src/enable-fips.ts
+++ b/packages/cli-repl/src/enable-fips.ts
@@ -1,0 +1,16 @@
+export let fipsError: Error | undefined;
+export function enableFipsIfRequested() {
+  if (process.argv.includes('--tlsFIPSMode')) {
+    // FIPS mode should be enabled before we run any other code, including any dependencies.
+    // We still wrap this into a function so we can also call it immediately after
+    // entering the snapshot main function.
+    // Similarly, this file is imported first at the very startup of mongosh, so that
+    // it runs even before any other imported files have a chance to do so.
+    try {
+      require('crypto').setFips(1);
+    } catch (err: any) {
+      fipsError ??= err;
+    }
+  }
+}
+enableFipsIfRequested();

--- a/packages/cli-repl/src/run.ts
+++ b/packages/cli-repl/src/run.ts
@@ -1,17 +1,9 @@
-let fipsError: Error | undefined;
-function enableFipsIfRequested() {
-  if (process.argv.includes('--tlsFIPSMode')) {
-    // FIPS mode should be enabled before we run any other code, including any dependencies.
-    // We still wrap this into a function so we can also call it immediately after
-    // entering the snapshot main function.
-    try {
-      require('crypto').setFips(1);
-    } catch (err: any) {
-      fipsError ??= err;
-    }
-  }
-}
-enableFipsIfRequested();
+// This import must remain first -- it enables FIPS mode at startup before any other code runs.
+// (Despite being an `import`, it also calls `enableFipsIfRequested()` once).
+import {
+  fipsError as startupFipsError,
+  enableFipsIfRequested,
+} from './enable-fips';
 
 import { markTime } from './startup-timing';
 import { CliRepl } from './cli-repl';
@@ -97,6 +89,7 @@ async function main() {
     const { version } = require('../package.json');
 
     if (options.tlsFIPSMode) {
+      let fipsError = startupFipsError;
       if (!fipsError && !crypto.getFips()) {
         // We can end up here if somebody used an unsual spelling of
         // --tlsFIPSMode that our arg parser recognizes, but not the


### PR DESCRIPTION
This ensures that even when mongosh is run as ESM instead of (as it currently is) being transpiled naïvely to CJS, enabling FIPS still happens as the first action when mongosh-owned code takes control of the process; in particular, it runs this code before other modules are loaded.