### PR TITLE
chore(ci): give the VS Code extension test container a larger /dev/shm MONGOSH-3410

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -4116,8 +4116,10 @@ functions:
           export NODE_VERSION=$(curl -fsSL https://raw.githubusercontent.com/microsoft/vscode/refs/heads/main/.nvmrc | tr -d '[:space:]' || echo "22.20.0")
           echo "Using Node.js version for VS Code extension tests: $NODE_VERSION"
           (cd scripts/docker && docker build --build-arg NODE_JS_VERSION="$NODE_VERSION" -t ubuntu24.04-xvfb -f ubuntu24.04-xvfb.Dockerfile .)
+          # The VS Code extension tests drive a headless Chromium, which crashes
+          # (renderer exits with code 133) on Docker's default 64MB /dev/shm.
           docker run \
-            --rm -v $PWD:/tmp/build ubuntu24.04-xvfb \
+            --shm-size=2g --rm -v $PWD:/tmp/build ubuntu24.04-xvfb \
             -c 'cd /tmp/build && ./scripts/test-vscode.sh'
           }
   test_connectivity:

--- a/.evergreen/evergreen.yml.in
+++ b/.evergreen/evergreen.yml.in
@@ -336,8 +336,10 @@ functions:
           export NODE_VERSION=$(curl -fsSL https://raw.githubusercontent.com/microsoft/vscode/refs/heads/main/.nvmrc | tr -d '[:space:]' || echo "22.20.0")
           echo "Using Node.js version for VS Code extension tests: $NODE_VERSION"
           (cd scripts/docker && docker build --build-arg NODE_JS_VERSION="$NODE_VERSION" -t ubuntu24.04-xvfb -f ubuntu24.04-xvfb.Dockerfile .)
+          # The VS Code extension tests drive a headless Chromium, which crashes
+          # (renderer exits with code 133) on Docker's default 64MB /dev/shm.
           docker run \
-            --rm -v $PWD:/tmp/build ubuntu24.04-xvfb \
+            --shm-size=2g --rm -v $PWD:/tmp/build ubuntu24.04-xvfb \
             -c 'cd /tmp/build && ./scripts/test-vscode.sh'
           }
   test_connectivity:


### PR DESCRIPTION
## What

Run the VS Code extension test container with `--shm-size=2g`.

## Why

The VS Code extension tests drive a headless Chromium inside the `ubuntu24.04-xvfb` container. Docker's default `/dev/shm` is only 64MB, which is too small for the Chromium renderer — it intermittently crashes (renderer process exits with **code 133**) partway through the suite, failing `test_vscode` even though the mongosh tests themselves were passing.

Giving the container a 2g `/dev/shm` removes that crash.

## Notes

- Edited `.evergreen/evergreen.yml.in` and regenerated `.evergreen.yml` (`npm run update-evergreen-config`); the two changes are identical.
- This is the first focused piece extracted from #2736, which is being split into smaller, independently-reviewable PRs.