### PR TITLE
fix(browser-repl): show error violations COMPASS-10637

### DIFF
--- a/packages/browser-repl/src/components/types/error-output.spec.tsx
+++ b/packages/browser-repl/src/components/types/error-output.spec.tsx
@@ -120,6 +120,8 @@ describe('ErrorOutput', function () {
 
       expect(wrapper.text()).to.contain('Violations:');
       expect(wrapper.text()).to.contain('namespace');
+      expect(wrapper.text()).to.contain('db.coll');
+      expect(wrapper.text()).to.contain("'x'");
     });
   });
 });

--- a/packages/browser-repl/src/components/types/error-output.spec.tsx
+++ b/packages/browser-repl/src/components/types/error-output.spec.tsx
@@ -123,5 +123,40 @@ describe('ErrorOutput', function () {
       expect(wrapper.text()).to.contain('db.coll');
       expect(wrapper.text()).to.contain("'x'");
     });
+
+    it('renders writeErrors when expanded', function () {
+      const error = new Error('Bulk write failed.') as any;
+      error.writeErrors = [{ index: 0, code: 11000, errmsg: 'duplicate key' }];
+
+      const wrapper = mount(<ErrorOutput value={error} />);
+      wrapper.find('svg').simulate('click');
+
+      expect(wrapper.text()).to.contain('Write Errors:');
+      expect(wrapper.text()).to.contain('11000');
+      expect(wrapper.text()).to.contain('duplicate key');
+    });
+
+    it('renders cause when expanded - Error cause', function () {
+      const cause = new Error('Underlying failure.');
+      const error = new Error('Wrapper failure.', { cause });
+
+      const wrapper = mount(<ErrorOutput value={error} />);
+      wrapper.find('svg').first().simulate('click');
+
+      expect(wrapper.text()).to.contain('Caused by:');
+      expect(wrapper.text()).to.contain('Underlying failure.');
+    });
+
+    it('renders cause when expanded - non-Error cause', function () {
+      const error = new Error('Wrapper failure.') as any;
+      error.cause = { reason: 'something broke' };
+
+      const wrapper = mount(<ErrorOutput value={error} />);
+      wrapper.find('svg').simulate('click');
+
+      expect(wrapper.text()).to.contain('Caused by:');
+      expect(wrapper.text()).to.contain('reason');
+      expect(wrapper.text()).to.contain('something broke');
+    });
   });
 });

--- a/packages/browser-repl/src/components/types/error-output.spec.tsx
+++ b/packages/browser-repl/src/components/types/error-output.spec.tsx
@@ -110,5 +110,16 @@ describe('ErrorOutput', function () {
     at Object.runInThisContext (vm.js:303:10)
     at ...`);
     });
+
+    it('renders violations when expanded', function () {
+      const error = new Error('Validation failed.') as any;
+      error.violations = [{ namespace: 'db.coll', properties: ['x', 'y'] }];
+
+      const wrapper = mount(<ErrorOutput value={error} />);
+      wrapper.find('svg').simulate('click');
+
+      expect(wrapper.text()).to.contain('Violations:');
+      expect(wrapper.text()).to.contain('namespace');
+    });
   });
 });

--- a/packages/browser-repl/src/components/types/error-output.tsx
+++ b/packages/browser-repl/src/components/types/error-output.tsx
@@ -101,6 +101,18 @@ export class ErrorOutput extends Component<ErrorOutputProps> {
     return undefined;
   }
 
+  formatErrorWriteErrors(): JSX.Element | undefined {
+    if (this.props.value.writeErrors) {
+      return (
+        <div>
+          Write Errors:
+          <SimpleTypeOutput value={this.props.value.writeErrors} />
+        </div>
+      );
+    }
+    return undefined;
+  }
+
   formatErrorViolations(): JSX.Element | undefined {
     if (this.props.value.violations) {
       return (
@@ -113,6 +125,23 @@ export class ErrorOutput extends Component<ErrorOutputProps> {
     return undefined;
   }
 
+  formatErrorCause(): JSX.Element | undefined {
+    const { cause } = this.props.value;
+    if (!cause) {
+      return undefined;
+    }
+    return (
+      <div>
+        Caused by:
+        {Object.prototype.toString.call(cause) === '[object Error]' ? (
+          <ErrorOutput value={cause} />
+        ) : (
+          <SimpleTypeOutput value={cause} />
+        )}
+      </div>
+    );
+  }
+
   renderExpanded(toggle: () => void): JSX.Element {
     return (
       <div>
@@ -121,7 +150,9 @@ export class ErrorOutput extends Component<ErrorOutputProps> {
           {this.formatErrorBugReportInfo()}
           {this.formatErrorInfo()}
           {this.formatErrorResult()}
+          {this.formatErrorWriteErrors()}
           {this.formatErrorViolations()}
+          {this.formatErrorCause()}
           <pre className={errInfoCss}>{this.formatStack()}</pre>
         </div>
       </div>

--- a/packages/browser-repl/src/components/types/error-output.tsx
+++ b/packages/browser-repl/src/components/types/error-output.tsx
@@ -101,6 +101,18 @@ export class ErrorOutput extends Component<ErrorOutputProps> {
     return undefined;
   }
 
+  formatErrorViolations(): JSX.Element | undefined {
+    if (this.props.value.violations) {
+      return (
+        <div>
+          Violations:
+          <SimpleTypeOutput value={this.props.value.violations} />
+        </div>
+      );
+    }
+    return undefined;
+  }
+
   renderExpanded(toggle: () => void): JSX.Element {
     return (
       <div>
@@ -109,6 +121,7 @@ export class ErrorOutput extends Component<ErrorOutputProps> {
           {this.formatErrorBugReportInfo()}
           {this.formatErrorInfo()}
           {this.formatErrorResult()}
+          {this.formatErrorViolations()}
           <pre className={errInfoCss}>{this.formatStack()}</pre>
         </div>
       </div>

--- a/packages/browser-repl/src/sandbox.tsx
+++ b/packages/browser-repl/src/sandbox.tsx
@@ -17,6 +17,7 @@ import { IframeRuntime } from './iframe-runtime';
 import { Shell } from './index';
 import type { ShellOutputEntry } from './components/shell-output-line';
 import type { ConnectionInfo } from '@mongosh/service-provider-core';
+import * as bson from 'bson';
 
 injectGlobal({
   body: {
@@ -89,6 +90,8 @@ const delay = (msecs = 0): Promise<void> =>
   });
 
 class DemoServiceProvider {
+  bsonLibrary = bson;
+
   async buildInfo(): Promise<object> {
     await delay();
     return {


### PR DESCRIPTION
We are not showing violations currently on `browser-repl` if server reports them. 

<img width="676" height="100" alt="image" src="https://github.com/user-attachments/assets/f82636c6-a12a-4a41-bde5-8542e3789576" />
