### PR TITLE
chore: bump @mongodb-js/mongodb-ts-autocomplete

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7134,13 +7134,13 @@
       }
     },
     "node_modules/@mongodb-js/mongodb-ts-autocomplete": {
-      "version": "0.6.6",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/mongodb-ts-autocomplete/-/mongodb-ts-autocomplete-0.6.6.tgz",
-      "integrity": "sha512-pbuTjUuujpL6AS6EiXA4yV3J72PALc+nX2g2NmMpPJC21aKOk41p+7gxvgUy4ckRcLoKWxgfxRDbRwd0MuL09A==",
+      "version": "0.6.17",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/mongodb-ts-autocomplete/-/mongodb-ts-autocomplete-0.6.17.tgz",
+      "integrity": "sha512-Vze1NhvefTxfMUtM7aMswWhRKXHghXTNUO4iqIOAPm5zh3AVEM9e5FqClGm+Sa4HTTF//roxfLArtrAtZCemjQ==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@mongodb-js/ts-autocomplete": "^0.5.7",
-        "@mongosh/shell-api": "^5.0.0",
+        "@mongodb-js/ts-autocomplete": "^0.5.12",
+        "@mongosh/shell-api": "^5.1.6",
         "debug": "^4.4.0",
         "lodash": "^4.17.21",
         "mongodb-schema": "^12.6.2",
@@ -7621,9 +7621,9 @@
       }
     },
     "node_modules/@mongodb-js/ts-autocomplete": {
-      "version": "0.5.7",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/ts-autocomplete/-/ts-autocomplete-0.5.7.tgz",
-      "integrity": "sha512-jMZogA3QuLMwPkBbXmXmeCkmvbhJJ6+K9tky3PhUGv47x56kmYeXx0i9umhbb7QezEh8VPCFmBdnIzhcA7AOGA==",
+      "version": "0.5.12",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/ts-autocomplete/-/ts-autocomplete-0.5.12.tgz",
+      "integrity": "sha512-5tSGDhK87ArvyL5cUXYqZSVpycYn6/NjHIFUiKk5awDfChHCnaAsiiESkL3LAps+41bxXTSa3O/HguwAu9zNTA==",
       "license": "Apache-2.0",
       "dependencies": {
         "debug": "^4.4.0",
@@ -34608,7 +34608,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@mongodb-js/mongodb-constants": "^0.20.1",
-        "@mongodb-js/mongodb-ts-autocomplete": "^0.6.5",
+        "@mongodb-js/mongodb-ts-autocomplete": "^0.6.17",
         "@mongosh/shell-api": "^5.3.2",
         "semver": "^7.5.4"
       },
@@ -35971,7 +35971,7 @@
       },
       "devDependencies": {
         "@mongodb-js/eslint-config-mongosh": "^1.0.0",
-        "@mongodb-js/mongodb-ts-autocomplete": "^0.6.5",
+        "@mongodb-js/mongodb-ts-autocomplete": "^0.6.17",
         "@mongodb-js/prettier-config-devtools": "^1.0.1",
         "@mongodb-js/tsconfig-mongosh": "^1.0.0",
         "@mongosh/types": "^5.0.5",
@@ -36861,7 +36861,7 @@
         "@babel/types": "^7.26.10",
         "@microsoft/api-extractor": "^7.39.3",
         "@mongodb-js/eslint-config-mongosh": "^1.0.0",
-        "@mongodb-js/mongodb-ts-autocomplete": "^0.6.5",
+        "@mongodb-js/mongodb-ts-autocomplete": "^0.6.17",
         "@mongodb-js/prettier-config-devtools": "^1.0.1",
         "@mongodb-js/tsconfig-mongosh": "^1.0.0",
         "@mongosh/testing": "2.0.14",

--- a/packages/autocomplete/package.json
+++ b/packages/autocomplete/package.json
@@ -43,7 +43,7 @@
   "dependencies": {
     "@mongodb-js/mongodb-constants": "^0.20.1",
     "@mongosh/shell-api": "^5.3.2",
-    "@mongodb-js/mongodb-ts-autocomplete": "^0.6.5",
+    "@mongodb-js/mongodb-ts-autocomplete": "^0.6.17",
     "semver": "^7.5.4"
   }
 }

--- a/packages/browser-runtime-core/package.json
+++ b/packages/browser-runtime-core/package.json
@@ -40,7 +40,7 @@
     "@mongodb-js/eslint-config-mongosh": "^1.0.0",
     "@mongodb-js/prettier-config-devtools": "^1.0.1",
     "@mongodb-js/tsconfig-mongosh": "^1.0.0",
-    "@mongodb-js/mongodb-ts-autocomplete": "^0.6.5",
+    "@mongodb-js/mongodb-ts-autocomplete": "^0.6.17",
     "@mongosh/types": "^5.0.5",
     "bson": "^7.3.0",
     "eslint": "^7.25.0",

--- a/packages/shell-api/package.json
+++ b/packages/shell-api/package.json
@@ -62,7 +62,7 @@
     "@microsoft/api-extractor": "^7.39.3",
     "@mongosh/testing": "2.0.14",
     "@mongodb-js/eslint-config-mongosh": "^1.0.0",
-    "@mongodb-js/mongodb-ts-autocomplete": "^0.6.5",
+    "@mongodb-js/mongodb-ts-autocomplete": "^0.6.17",
     "@mongodb-js/prettier-config-devtools": "^1.0.1",
     "@mongodb-js/tsconfig-mongosh": "^1.0.0",
     "@mongosh/types": "^5.0.5",


### PR DESCRIPTION
Some types changed [here](https://github.com/mongodb-js/devtools-shared/pull/649) which might affect autocomplete so I'm just bumping it now rather than someone else dealing with it later.