### PR TITLE
test(e2e-tests): add regression test for oid randomness saved to snapshot MONGOSH-3277

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -14601,9 +14601,9 @@
       }
     },
     "node_modules/bson": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/bson/-/bson-7.3.0.tgz",
-      "integrity": "sha512-WmjjMEwFwZHmGnAb7wn90MhkiT+mTm4x/rLj7dvAPWfwnVWDXhLun2e+UM88MJoDGW624yzZglVX/zTBy9ZZMw==",
+      "version": "7.3.1",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-7.3.1.tgz",
+      "integrity": "sha512-h/C0qe6857pQhcSJHLfsR1uYGj98Ge3wKAD3Ed9KqH3wcVh+BM4Jq4xISD7vs9OPuT07n+q3QQVjslJ286j6ag==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20.19.0"
@@ -34673,7 +34673,7 @@
         "@mongosh/node-runtime-worker-thread": "5.2.11",
         "@mongosh/service-provider-core": "5.0.6",
         "@mongosh/shell-bson": "3.0.6",
-        "bson": "^7.3.0",
+        "bson": "^7.3.1",
         "numeral": "^2.0.6",
         "text-table": "^0.2.0"
       },
@@ -36012,7 +36012,7 @@
         "@mongodb-js/prettier-config-devtools": "^1.0.1",
         "@mongodb-js/tsconfig-mongosh": "^1.0.0",
         "@mongosh/types": "^5.0.5",
-        "bson": "^7.3.0",
+        "bson": "^7.3.1",
         "eslint": "^7.25.0",
         "prettier": "^2.8.8",
         "rimraf": "^3.0.2"
@@ -36035,7 +36035,7 @@
         "@mongodb-js/prettier-config-devtools": "^1.0.1",
         "@mongodb-js/tsconfig-mongosh": "^1.0.0",
         "@mongosh/service-provider-node-driver": "^5.0.15",
-        "bson": "^7.3.0",
+        "bson": "^7.3.1",
         "eslint": "^7.25.0",
         "prettier": "^2.8.8",
         "rimraf": "^3.0.2"
@@ -36213,7 +36213,7 @@
         "ansi-escape-sequences": "^5.1.2",
         "askcharacter": "^2.0.4",
         "askpassword": "^2.0.2",
-        "bson": "^7.3.0",
+        "bson": "^7.3.1",
         "escape-string-regexp": "^4.0.0",
         "is-recoverable-error": "^1.0.3",
         "js-yaml": "^4.2.0",
@@ -36322,7 +36322,7 @@
         "@types/chai-as-promised": "^8.0.2",
         "@types/node": "^22.15.30",
         "@types/rimraf": "^3.0.0",
-        "bson": "^7.3.0",
+        "bson": "^7.3.1",
         "chai-as-promised": "^8.0.2",
         "eslint": "^7.25.0",
         "lodash": "^4.18.1",
@@ -36386,7 +36386,7 @@
         "@mongosh/shell-api": "^5.3.2",
         "@mongosh/shell-evaluator": "^5.3.2",
         "@mongosh/types": "^5.0.5",
-        "bson": "^7.3.0",
+        "bson": "^7.3.1",
         "js-beautify": "^1.15.1"
       },
       "devDependencies": {
@@ -36464,7 +36464,7 @@
         "@mongosh/cli-repl": "2.9.1",
         "@mongosh/testing": "2.0.14",
         "assert": "^1.5.0",
-        "bson": "^7.3.0",
+        "bson": "^7.3.1",
         "buffer": "^6.0.3",
         "crypto-browserify": "^3.12.0",
         "https-browserify": "^1.0.0",
@@ -36602,7 +36602,7 @@
         "@mongosh/service-provider-node-driver": "^5.0.15",
         "@mongosh/testing": "2.0.14",
         "@mongosh/types": "^5.0.5",
-        "bson": "^7.3.0",
+        "bson": "^7.3.1",
         "eslint": "^7.25.0",
         "mocha": "^11.7.5",
         "postmsg-rpc": "^2.4.0",
@@ -36621,7 +36621,7 @@
       "dependencies": {
         "@mongosh/errors": "2.4.7",
         "@mongosh/shell-bson": "3.0.6",
-        "bson": "^7.3.0",
+        "bson": "^7.3.1",
         "mongodb": "^7.3.0",
         "mongodb-build-info": "^1.9.5",
         "mongodb-connection-string-url": "^7.0.1"
@@ -36695,7 +36695,7 @@
         "@mongosh/testing": "2.0.14",
         "@mongosh/types": "^5.0.5",
         "@types/babel__core": "^7.20.5",
-        "bson": "^7.3.0",
+        "bson": "^7.3.1",
         "eslint": "^7.25.0",
         "mongodb": "^7.3.0",
         "prettier": "^2.8.8",
@@ -36716,7 +36716,7 @@
         "@mongodb-js/eslint-config-mongosh": "^1.0.0",
         "@mongodb-js/prettier-config-devtools": "^1.0.1",
         "@mongodb-js/tsconfig-mongosh": "^1.0.0",
-        "bson": "^7.3.0",
+        "bson": "^7.3.1",
         "eslint": "^7.25.0",
         "prettier": "^2.8.8"
       },
@@ -36757,7 +36757,7 @@
         "@mongosh/errors": "2.4.7",
         "@mongosh/shell-api": "^5.3.2",
         "@mongosh/types": "^5.0.5",
-        "bson": "^7.3.0",
+        "bson": "^7.3.1",
         "cross-spawn": "^7.0.5",
         "escape-string-regexp": "^4.0.0",
         "tar": "^7.5.11",

--- a/packages/browser-repl/package.json
+++ b/packages/browser-repl/package.json
@@ -64,7 +64,7 @@
     "@mongosh/node-runtime-worker-thread": "5.2.11",
     "@mongosh/service-provider-core": "5.0.6",
     "@mongosh/shell-bson": "3.0.6",
-    "bson": "^7.3.0",
+    "bson": "^7.3.1",
     "numeral": "^2.0.6",
     "text-table": "^0.2.0"
   },

--- a/packages/browser-runtime-core/package.json
+++ b/packages/browser-runtime-core/package.json
@@ -42,7 +42,7 @@
     "@mongodb-js/tsconfig-mongosh": "^1.0.0",
     "@mongodb-js/mongodb-ts-autocomplete": "^0.6.17",
     "@mongosh/types": "^5.0.5",
-    "bson": "^7.3.0",
+    "bson": "^7.3.1",
     "eslint": "^7.25.0",
     "prettier": "^2.8.8",
     "rimraf": "^3.0.2"

--- a/packages/browser-runtime-electron/package.json
+++ b/packages/browser-runtime-electron/package.json
@@ -41,7 +41,7 @@
     "@mongodb-js/prettier-config-devtools": "^1.0.1",
     "@mongodb-js/tsconfig-mongosh": "^1.0.0",
     "@mongosh/service-provider-node-driver": "^5.0.15",
-    "bson": "^7.3.0",
+    "bson": "^7.3.1",
     "eslint": "^7.25.0",
     "prettier": "^2.8.8",
     "rimraf": "^3.0.2"

--- a/packages/cli-repl/package.json
+++ b/packages/cli-repl/package.json
@@ -86,7 +86,7 @@
     "ansi-escape-sequences": "^5.1.2",
     "askcharacter": "^2.0.4",
     "askpassword": "^2.0.2",
-    "bson": "^7.3.0",
+    "bson": "^7.3.1",
     "escape-string-regexp": "^4.0.0",
     "is-recoverable-error": "^1.0.3",
     "js-yaml": "^4.2.0",

--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -37,7 +37,7 @@
     "@types/chai-as-promised": "^8.0.2",
     "@types/node": "^22.15.30",
     "@types/rimraf": "^3.0.0",
-    "bson": "^7.3.0",
+    "bson": "^7.3.1",
     "chai-as-promised": "^8.0.2",
     "eslint": "^7.25.0",
     "lodash": "^4.18.1",

--- a/packages/e2e-tests/test/e2e-snapshot.spec.ts
+++ b/packages/e2e-tests/test/e2e-snapshot.spec.ts
@@ -158,4 +158,31 @@ describe('e2e snapshot support', function () {
       );
     });
   });
+
+  context('ObjectId per-process randomness', function () {
+    it('generate a different ObjectId process-random value on each launch (MONGOSH-3421)', async function () {
+      const args = [
+        '--nodb',
+        '--quiet',
+        '--json=relaxed',
+        '--eval',
+        'new ObjectId()',
+      ];
+      const [firstOid, secondOid] = (
+        await Promise.all([
+          startTestShell(this, { args }).waitForCleanOutput(),
+          startTestShell(this, { args }).waitForCleanOutput(),
+        ])
+      ).map((output) => (JSON.parse(output) as { $oid: string }).$oid);
+
+      expect(firstOid).to.match(/^[0-9a-f]{24}$/);
+      expect(secondOid).to.match(/^[0-9a-f]{24}$/);
+      // An ObjectId is a 4-byte timestamp, a 5-byte per-process random value
+      // and a 3-byte counter that starts at a per-process random value. If
+      // either random value is generated while building the startup snapshot
+      // rather than at runtime, every mongosh invocation shares it.
+      expect(firstOid.slice(8, 18)).to.not.equal(secondOid.slice(8, 18));
+      expect(firstOid.slice(18)).to.not.equal(secondOid.slice(18));
+    });
+  });
 });

--- a/packages/editor/package.json
+++ b/packages/editor/package.json
@@ -38,7 +38,7 @@
     "@mongosh/shell-api": "^5.3.2",
     "@mongosh/shell-evaluator": "^5.3.2",
     "@mongosh/types": "^5.0.5",
-    "bson": "^7.3.0",
+    "bson": "^7.3.1",
     "js-beautify": "^1.15.1"
   },
   "devDependencies": {

--- a/packages/java-shell/package.json
+++ b/packages/java-shell/package.json
@@ -31,7 +31,7 @@
     "util": "^0.12.5",
     "webpack-merge": "^5.8.0",
     "@mongosh/testing": "2.0.14",
-    "bson": "^7.3.0"
+    "bson": "^7.3.1"
   },
   "license": "SSPL",
   "publishConfig": {

--- a/packages/node-runtime-worker-thread/package.json
+++ b/packages/node-runtime-worker-thread/package.json
@@ -45,7 +45,7 @@
     "@mongosh/service-provider-core": "5.0.6",
     "@mongosh/service-provider-node-driver": "^5.0.15",
     "@mongosh/types": "^5.0.5",
-    "bson": "^7.3.0",
+    "bson": "^7.3.1",
     "eslint": "^7.25.0",
     "mocha": "^11.7.5",
     "postmsg-rpc": "^2.4.0",

--- a/packages/service-provider-core/package.json
+++ b/packages/service-provider-core/package.json
@@ -37,7 +37,7 @@
   "dependencies": {
     "@mongosh/errors": "2.4.7",
     "@mongosh/shell-bson": "3.0.6",
-    "bson": "^7.3.0",
+    "bson": "^7.3.1",
     "mongodb": "^7.3.0",
     "mongodb-build-info": "^1.9.5",
     "mongodb-connection-string-url": "^7.0.1"

--- a/packages/shell-api/package.json
+++ b/packages/shell-api/package.json
@@ -66,7 +66,7 @@
     "@mongodb-js/prettier-config-devtools": "^1.0.1",
     "@mongodb-js/tsconfig-mongosh": "^1.0.0",
     "@mongosh/types": "^5.0.5",
-    "bson": "^7.3.0",
+    "bson": "^7.3.1",
     "eslint": "^7.25.0",
     "mongodb": "^7.3.0",
     "prettier": "^2.8.8",

--- a/packages/shell-bson/package.json
+++ b/packages/shell-bson/package.json
@@ -45,7 +45,7 @@
     "@mongodb-js/eslint-config-mongosh": "^1.0.0",
     "@mongodb-js/prettier-config-devtools": "^1.0.1",
     "@mongodb-js/tsconfig-mongosh": "^1.0.0",
-    "bson": "^7.3.0",
+    "bson": "^7.3.1",
     "eslint": "^7.25.0",
     "prettier": "^2.8.8"
   }

--- a/packages/snippet-manager/package.json
+++ b/packages/snippet-manager/package.json
@@ -37,7 +37,7 @@
     "@mongosh/errors": "2.4.7",
     "@mongosh/shell-api": "^5.3.2",
     "@mongosh/types": "^5.0.5",
-    "bson": "^7.3.0",
+    "bson": "^7.3.1",
     "cross-spawn": "^7.0.5",
     "escape-string-regexp": "^4.0.0",
     "tar": "^7.5.11",


### PR DESCRIPTION
- regression test
- bump bson - there's nothing in this for us, we just did a small fix to make bson not fail on other runtimes, just bumping to bump.