### PR TITLE
feat(autocomplete): add MongoDB 8.3 arrayIndexAs and $$IDX support MONGOSH-3244

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7146,10 +7146,9 @@
       }
     },
     "node_modules/@mongodb-js/mongodb-ts-autocomplete": {
-      "version": "0.6.17",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/mongodb-ts-autocomplete/-/mongodb-ts-autocomplete-0.6.17.tgz",
-      "integrity": "sha512-Vze1NhvefTxfMUtM7aMswWhRKXHghXTNUO4iqIOAPm5zh3AVEM9e5FqClGm+Sa4HTTF//roxfLArtrAtZCemjQ==",
-      "dev": true,
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/mongodb-ts-autocomplete/-/mongodb-ts-autocomplete-0.7.3.tgz",
+      "integrity": "sha512-lVRnJTLm3KarjJHAVKMdK0kIVrORmcsMAOfSgTMN4m2tgWTrObhisngKcWvky8yVhBgnQp2nwm/ykKdbv/XTTg==",
       "license": "Apache-2.0",
       "dependencies": {
         "@mongodb-js/ts-autocomplete": "^0.5.12",
@@ -7165,7 +7164,6 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
       "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -7183,7 +7181,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/@mongodb-js/monorepo-tools": {
@@ -34636,44 +34633,6 @@
         "node": ">=14.15.1"
       }
     },
-    "packages/autocomplete/node_modules/@mongodb-js/mongodb-ts-autocomplete": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/mongodb-ts-autocomplete/-/mongodb-ts-autocomplete-0.7.3.tgz",
-      "integrity": "sha512-lVRnJTLm3KarjJHAVKMdK0kIVrORmcsMAOfSgTMN4m2tgWTrObhisngKcWvky8yVhBgnQp2nwm/ykKdbv/XTTg==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "@mongodb-js/ts-autocomplete": "^0.5.12",
-        "@mongosh/shell-api": "^5.1.6",
-        "debug": "^4.4.0",
-        "lodash": "^4.17.21",
-        "mongodb-schema": "^12.6.2",
-        "node-cache": "^5.1.2",
-        "typescript": "^5.9.3"
-      }
-    },
-    "packages/autocomplete/node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "packages/autocomplete/node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "license": "MIT"
-    },
     "packages/browser-repl": {
       "name": "@mongosh/browser-repl",
       "version": "5.5.2",
@@ -36021,7 +35980,7 @@
       },
       "devDependencies": {
         "@mongodb-js/eslint-config-mongosh": "^1.0.0",
-        "@mongodb-js/mongodb-ts-autocomplete": "^0.6.17",
+        "@mongodb-js/mongodb-ts-autocomplete": "^0.7.3",
         "@mongodb-js/prettier-config-devtools": "^1.0.1",
         "@mongodb-js/tsconfig-mongosh": "^1.0.0",
         "@mongosh/types": "^5.0.5",
@@ -36911,7 +36870,7 @@
         "@babel/types": "^7.26.10",
         "@microsoft/api-extractor": "^7.39.3",
         "@mongodb-js/eslint-config-mongosh": "^1.0.0",
-        "@mongodb-js/mongodb-ts-autocomplete": "^0.6.17",
+        "@mongodb-js/mongodb-ts-autocomplete": "^0.7.3",
         "@mongodb-js/prettier-config-devtools": "^1.0.1",
         "@mongodb-js/tsconfig-mongosh": "^1.0.0",
         "@mongosh/testing": "2.0.14",

--- a/package-lock.json
+++ b/package-lock.json
@@ -7046,15 +7046,27 @@
       "link": true
     },
     "node_modules/@mongodb-js/mongodb-constants": {
-      "version": "0.20.1",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/mongodb-constants/-/mongodb-constants-0.20.1.tgz",
-      "integrity": "sha512-zes9Ays51BkF/OP9ATFbHbLw5UWKv7V0NnPfDDj/TMgdjPMQvnf0yqu1Bwb7VIr1cSBAM9vLXgcVeh3iEPkXpw==",
+      "version": "0.33.0",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/mongodb-constants/-/mongodb-constants-0.33.0.tgz",
+      "integrity": "sha512-eCglRNhukKReQTv8BfHP2wne+rBbmF4M4s5hexfJM4/oRTk7IF5tuvfP0qEDxbNps9arGwYGuFCd3hPxZfp52Q==",
       "license": "Apache-2.0",
       "dependencies": {
-        "semver": "^7.7.1"
+        "semver": "^7.7.4"
       },
       "peerDependencies": {
         "bson": "^4.6.3 || ^5 || ^6.10.3 || ^7.0.0"
+      }
+    },
+    "node_modules/@mongodb-js/mongodb-constants/node_modules/semver": {
+      "version": "7.8.5",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.8.5.tgz",
+      "integrity": "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA==",
+      "license": "ISC",
+      "bin": {
+        "semver": "bin/semver.js"
+      },
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/@mongodb-js/mongodb-downloader": {
@@ -7137,6 +7149,7 @@
       "version": "0.6.17",
       "resolved": "https://registry.npmjs.org/@mongodb-js/mongodb-ts-autocomplete/-/mongodb-ts-autocomplete-0.6.17.tgz",
       "integrity": "sha512-Vze1NhvefTxfMUtM7aMswWhRKXHghXTNUO4iqIOAPm5zh3AVEM9e5FqClGm+Sa4HTTF//roxfLArtrAtZCemjQ==",
+      "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
         "@mongodb-js/ts-autocomplete": "^0.5.12",
@@ -7152,6 +7165,7 @@
       "version": "4.4.1",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.1.tgz",
       "integrity": "sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -7169,6 +7183,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/@mongodb-js/monorepo-tools": {
@@ -34607,8 +34622,8 @@
       "version": "5.3.2",
       "license": "Apache-2.0",
       "dependencies": {
-        "@mongodb-js/mongodb-constants": "^0.20.1",
-        "@mongodb-js/mongodb-ts-autocomplete": "^0.6.17",
+        "@mongodb-js/mongodb-constants": "^0.33.0",
+        "@mongodb-js/mongodb-ts-autocomplete": "^0.7.3",
         "@mongosh/shell-api": "^5.3.2",
         "semver": "^7.5.4"
       },
@@ -34623,6 +34638,44 @@
       "engines": {
         "node": ">=14.15.1"
       }
+    },
+    "packages/autocomplete/node_modules/@mongodb-js/mongodb-ts-autocomplete": {
+      "version": "0.7.3",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/mongodb-ts-autocomplete/-/mongodb-ts-autocomplete-0.7.3.tgz",
+      "integrity": "sha512-lVRnJTLm3KarjJHAVKMdK0kIVrORmcsMAOfSgTMN4m2tgWTrObhisngKcWvky8yVhBgnQp2nwm/ykKdbv/XTTg==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mongodb-js/ts-autocomplete": "^0.5.12",
+        "@mongosh/shell-api": "^5.1.6",
+        "debug": "^4.4.0",
+        "lodash": "^4.17.21",
+        "mongodb-schema": "^12.6.2",
+        "node-cache": "^5.1.2",
+        "typescript": "^5.9.3"
+      }
+    },
+    "packages/autocomplete/node_modules/debug": {
+      "version": "4.4.3",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
+      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "packages/autocomplete/node_modules/ms": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
+      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
+      "license": "MIT"
     },
     "packages/browser-repl": {
       "name": "@mongosh/browser-repl",

--- a/packages/autocomplete/package.json
+++ b/packages/autocomplete/package.json
@@ -41,9 +41,9 @@
     "prettier": "^2.8.8"
   },
   "dependencies": {
-    "@mongodb-js/mongodb-constants": "^0.20.1",
+    "@mongodb-js/mongodb-constants": "^0.33.0",
+    "@mongodb-js/mongodb-ts-autocomplete": "^0.7.3",
     "@mongosh/shell-api": "^5.3.2",
-    "@mongodb-js/mongodb-ts-autocomplete": "^0.6.17",
     "semver": "^7.5.4"
   }
 }

--- a/packages/browser-runtime-core/package.json
+++ b/packages/browser-runtime-core/package.json
@@ -40,7 +40,7 @@
     "@mongodb-js/eslint-config-mongosh": "^1.0.0",
     "@mongodb-js/prettier-config-devtools": "^1.0.1",
     "@mongodb-js/tsconfig-mongosh": "^1.0.0",
-    "@mongodb-js/mongodb-ts-autocomplete": "^0.6.17",
+    "@mongodb-js/mongodb-ts-autocomplete": "^0.7.3",
     "@mongosh/types": "^5.0.5",
     "bson": "^7.3.0",
     "eslint": "^7.25.0",

--- a/packages/shell-api/package.json
+++ b/packages/shell-api/package.json
@@ -62,7 +62,7 @@
     "@microsoft/api-extractor": "^7.39.3",
     "@mongosh/testing": "2.0.14",
     "@mongodb-js/eslint-config-mongosh": "^1.0.0",
-    "@mongodb-js/mongodb-ts-autocomplete": "^0.6.17",
+    "@mongodb-js/mongodb-ts-autocomplete": "^0.7.3",
     "@mongodb-js/prettier-config-devtools": "^1.0.1",
     "@mongodb-js/tsconfig-mongosh": "^1.0.0",
     "@mongosh/types": "^5.0.5",


### PR DESCRIPTION
## Summary

- Bumps `@mongodb-js/mongodb-constants` to `^0.33.0`, which adds the `$$IDX` system variable gated to MongoDB 8.3+
- Bumps `@mongodb-js/mongodb-ts-autocomplete` to `^0.7.3`, which adds `arrayIndexAs` autocomplete for `$filter`, `$map`, and `$reduce` operators introduced in MongoDB 8.3

These changes implement autocomplete support for the new array index exposure feature from [MONGOSH-3244](https://jira.mongodb.org/browse/MONGOSH-3244). Unfortunately, `$$IDX` being used inside a string quotes is not an autocomplete feature supported.


### Upstream PRs
- `mongodb-js/devtools-shared#815` — schema.d.ts updated with `arrayIndexAs`, `as`, `valueAs` for `$filter`/`$map`/`$reduce` (merged)
- `mongodb-js/devtools-shared#817` — `$$IDX` system variable added to `mongodb-constants` (merged)

## Test plan

- [x] `npm test --workspace=packages/autocomplete` passes
- [x] In mongosh connected to MongoDB 8.3+, typing `$filter: { arrayIn` suggests `arrayIndexAs`

   <img width="1489" height="72" alt="Screenshot 2026-07-08 at 08 39 57" src="https://github.com/user-attachments/assets/463cb0f7-f970-49f3-be2b-7dfa61c542b5" />