### PR TITLE
chore: fix generated files workflow by using newer node but pinning npm 10

### DIFF
--- a/.github/workflows/cron-tasks.yml
+++ b/.github/workflows/cron-tasks.yml
@@ -39,7 +39,10 @@ jobs:
       - uses: actions/setup-node@v6
         with:
           check-latest: true
-          node-version: 20.x
+          node-version: 24.x
+
+      - name: Pin npm
+        run: npm install -g npm@10
 
       - name: Install Dependencies and Compile
         run: |


### PR DESCRIPTION
https://github.com/mongodb-js/mongosh/pull/2604

The gyp bump causes an issue on node 20, in the PR above is when Kevin had to downgrade this flow to 20 to avoid issues but the real problem is with npm@11, we should be able to unblock for now on just a node upgrade.