### PR TITLE
chore(shell-api): accept viewless timeseries bucketsNs in sharded stats test MONGOSH-2680

### DIFF
--- a/packages/shell-api/src/shard.spec.ts
+++ b/packages/shell-api/src/shard.spec.ts
@@ -3413,15 +3413,21 @@ describe('Shard', function () {
           for (const shard of Object.values(result.shards) as any) {
             expect(shard.totalSize).to.be.a('number');
             expect(shard.indexDetails).to.equal(undefined);
-            expect(shard.timeseries.bucketsNs).to.equal(
-              `${dbName}.system.buckets.${timeseriesCollectionName}`
-            );
+            // Newer servers no longer expose the explicit buckets namespace
+            // for timeseries collections (viewless timeseries), so accept both
+            // the legacy `system.buckets.` namespace and the user namespace.
+            // See MONGOSH-1967 for the non-sharded equivalent.
+            expect(shard.timeseries.bucketsNs).to.be.oneOf([
+              `${dbName}.system.buckets.${timeseriesCollectionName}`,
+              `${dbName}.${timeseriesCollectionName}`,
+            ]);
             expect(shard.timeseries.numBucketUpdates).to.equal(0);
             expect(typeof result.timeseries.bucketCount).to.equal('number');
           }
-          expect(result.timeseries.bucketsNs).to.equal(
-            `${dbName}.system.buckets.${timeseriesCollectionName}`
-          );
+          expect(result.timeseries.bucketsNs).to.be.oneOf([
+            `${dbName}.system.buckets.${timeseriesCollectionName}`,
+            `${dbName}.${timeseriesCollectionName}`,
+          ]);
           expect(result.timeseries.bucketCount).to.equal(1);
           expect(result.timeseries.numBucketInserts).to.equal(1);
         });

--- a/packages/shell-api/src/shard.spec.ts
+++ b/packages/shell-api/src/shard.spec.ts
@@ -3416,7 +3416,6 @@ describe('Shard', function () {
             // Newer servers no longer expose the explicit buckets namespace
             // for timeseries collections (viewless timeseries), so accept both
             // the legacy `system.buckets.` namespace and the user namespace.
-            // See MONGOSH-1967 for the non-sharded equivalent.
             expect(shard.timeseries.bucketsNs).to.be.oneOf([
               `${dbName}.system.buckets.${timeseriesCollectionName}`,
               `${dbName}.${timeseriesCollectionName}`,


### PR DESCRIPTION
MONGOSH-2680

The sharded timeseries `collection.stats()` test hard-coded the legacy `<db>.system.buckets.<coll>` namespace for `timeseries.bucketsNs`. Newer (viewless timeseries) servers no longer expose the explicit buckets namespace and report `<db>.<coll>`, so the assertion fails on the `tests_win32-mlatest` variant.

Accept both namespace forms via `oneOf`, mirroring the non-sharded fix from MONGOSH-1967 (#2635) which missed this sharded case. Product code already passes `bucketsNs` through from the server, so this is a test-only fix.

## Verification

The previously-failing task passes on this PR's patch (live latest-alpha server): [`test_shell_api` / `tests_win32-mlatest_n24`](https://spruce.mongodb.com/task/mongosh_tests_win32_mlatest_n24_test_shell_api_patch_d95cb21007017abcf004428cbdbb1a6db1f72f3a_6a4fa54719c4dc0007aff9da_26_07_09_13_42_37) — success, 2078 passing / 0 failing (was 2077 / 1 failing on mainline).