### PR TITLE
chore(ci): fix windows e2e with server pin, upgrade OS for nightlies and add skips, skip vscode tests, fix evergreen warnings

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -12601,14 +12601,14 @@ buildvariants:
       - name: sign_artifact_darwin_x64
       - name: package_artifact_darwin_arm64
       - name: sign_artifact_darwin_arm64
-  - name: e2e_tests_windows_vsCurrent_small
-    display_name: "Windows VS pre-2022 (E2E tests)"
+  - name: e2e_tests_windows_vsCurrent_small_m80x
+    display_name: "Windows VS pre-2022 80x (E2E tests)"
     run_on: windows-vsCurrent-small
     tags: []
     expansions:
       executable_os_id: "win32"
       node_js_version: "24.18.0"
-      mongosh_server_test_version: "stable-enterprise"
+      mongosh_server_test_version: "8.0.x-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
       - name: e2e_tests_win32

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -5704,26 +5704,6 @@ tasks:
           mongosh_test_id: "cli_repl"
           mongosh_run_only_in_package: "cli-repl"
           task_name: ${task_name}
-  - name: test_connectivity_tests
-    tags: ["assigned_to_jira_team_mongosh_mongosh","unit-test"]
-    depends_on:
-      - name: compile_ts
-        variant: linux_compile
-    commands:
-      - func: checkout
-      - func: install
-        vars:
-          node_js_version: ${node_js_version}
-          puppeteer_skip_download: "true"
-          mongosh_install_workspace: "@mongosh/connectivity-tests"
-      - func: test
-        vars:
-          mongosh_server_test_version: ${mongosh_server_test_version}
-          node_js_version: ${node_js_version}
-          mongosh_skip_node_version_check: ${mongosh_skip_node_version_check}
-          mongosh_test_id: "connectivity_tests"
-          mongosh_run_only_in_package: "connectivity-tests"
-          task_name: ${task_name}
   - name: test_e2e_tests
     tags: ["assigned_to_jira_team_mongosh_mongosh","unit-test"]
     depends_on:
@@ -5882,26 +5862,6 @@ tasks:
           mongosh_skip_node_version_check: ${mongosh_skip_node_version_check}
           mongosh_test_id: "logging"
           mongosh_run_only_in_package: "logging"
-          task_name: ${task_name}
-  - name: test_mongosh
-    tags: ["assigned_to_jira_team_mongosh_mongosh","unit-test"]
-    depends_on:
-      - name: compile_ts
-        variant: linux_compile
-    commands:
-      - func: checkout
-      - func: install
-        vars:
-          node_js_version: ${node_js_version}
-          puppeteer_skip_download: "true"
-          mongosh_install_workspace: "@mongosh/mongosh"
-      - func: test
-        vars:
-          mongosh_server_test_version: ${mongosh_server_test_version}
-          node_js_version: ${node_js_version}
-          mongosh_skip_node_version_check: ${mongosh_skip_node_version_check}
-          mongosh_test_id: "mongosh"
-          mongosh_run_only_in_package: "mongosh"
           task_name: ${task_name}
   - name: test_node_runtime_worker_thread
     tags: ["assigned_to_jira_team_mongosh_mongosh","unit-test"]
@@ -6067,6 +6027,8 @@ tasks:
   # INTEGRATION TESTS
   ###
   - name: test_vscode
+    # TODO(MONGOSH-3496): re-enable once VSCODE-788 is fixed.
+    disable: true
     depends_on:
       - name: compile_ts
         variant: linux_compile
@@ -6193,24 +6155,6 @@ tasks:
           node_js_version: ${node_js_version}
           mongosh_server_test_version: ${mongosh_server_test_version}
           mongosh_test_e2e_force_fips: ${mongosh_test_e2e_force_fips}
-  - name: e2e_tests_linux_x64_rhel8
-    tags: ["e2e-test", "assigned_to_jira_team_mongosh_mongosh"]
-    depends_on:
-      - name: compile_artifact
-        variant: build_linux_x64_rhel8
-    commands:
-      - func: checkout
-      - func: install
-        vars:
-          node_js_version: ${node_js_version}
-      - func: download_compiled_artifact
-        vars:
-          executable_os_id: linux-x64-rhel8
-      - func: run_e2e_tests
-        vars:
-          node_js_version: ${node_js_version}
-          mongosh_server_test_version: ${mongosh_server_test_version}
-          mongosh_test_e2e_force_fips: ${mongosh_test_e2e_force_fips}
   - name: e2e_tests_linux_x64_openssl11
     tags: ["e2e-test", "assigned_to_jira_team_mongosh_mongosh"]
     depends_on:
@@ -6229,24 +6173,6 @@ tasks:
           node_js_version: ${node_js_version}
           mongosh_server_test_version: ${mongosh_server_test_version}
           mongosh_test_e2e_force_fips: ${mongosh_test_e2e_force_fips}
-  - name: e2e_tests_linux_x64_openssl11_rhel8
-    tags: ["e2e-test", "assigned_to_jira_team_mongosh_mongosh"]
-    depends_on:
-      - name: compile_artifact
-        variant: build_linux_x64_openssl11_rhel8
-    commands:
-      - func: checkout
-      - func: install
-        vars:
-          node_js_version: ${node_js_version}
-      - func: download_compiled_artifact
-        vars:
-          executable_os_id: linux-x64-openssl11-rhel8
-      - func: run_e2e_tests
-        vars:
-          node_js_version: ${node_js_version}
-          mongosh_server_test_version: ${mongosh_server_test_version}
-          mongosh_test_e2e_force_fips: ${mongosh_test_e2e_force_fips}
   - name: e2e_tests_linux_x64_openssl3
     tags: ["e2e-test", "assigned_to_jira_team_mongosh_mongosh"]
     depends_on:
@@ -6260,24 +6186,6 @@ tasks:
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64-openssl3
-      - func: run_e2e_tests
-        vars:
-          node_js_version: ${node_js_version}
-          mongosh_server_test_version: ${mongosh_server_test_version}
-          mongosh_test_e2e_force_fips: ${mongosh_test_e2e_force_fips}
-  - name: e2e_tests_linux_x64_openssl3_rhel8
-    tags: ["e2e-test", "assigned_to_jira_team_mongosh_mongosh"]
-    depends_on:
-      - name: compile_artifact
-        variant: build_linux_x64_openssl3_rhel8
-    commands:
-      - func: checkout
-      - func: install
-        vars:
-          node_js_version: ${node_js_version}
-      - func: download_compiled_artifact
-        vars:
-          executable_os_id: linux-x64-openssl3-rhel8
       - func: run_e2e_tests
         vars:
           node_js_version: ${node_js_version}
@@ -7142,18 +7050,6 @@ tasks:
         vars:
           package_variant: linux-x64
           signature_tag: signed
-  - name: verify_artifact_linux_x64
-    tags: ["smoke-test"]
-    depends_on:
-      - name: sign_artifact_linux_x64
-        variant: "*"
-    commands:
-      - func: checkout
-      - func: get_artifact_url
-        vars:
-          package_variant: linux-x64
-          signature_tag: signed
-      - func: verify_artifact
   - name: add_crypt_shared_and_sbom_deb_x64
     tags: ["add-sbom-task"]
     depends_on:
@@ -7391,18 +7287,6 @@ tasks:
         vars:
           package_variant: linux-x64-openssl11
           signature_tag: signed
-  - name: verify_artifact_linux_x64_openssl11
-    tags: ["smoke-test"]
-    depends_on:
-      - name: sign_artifact_linux_x64_openssl11
-        variant: "*"
-    commands:
-      - func: checkout
-      - func: get_artifact_url
-        vars:
-          package_variant: linux-x64-openssl11
-          signature_tag: signed
-      - func: verify_artifact
   - name: add_crypt_shared_and_sbom_deb_x64_openssl11
     tags: ["add-sbom-task"]
     depends_on:
@@ -7640,18 +7524,6 @@ tasks:
         vars:
           package_variant: linux-x64-openssl3
           signature_tag: signed
-  - name: verify_artifact_linux_x64_openssl3
-    tags: ["smoke-test"]
-    depends_on:
-      - name: sign_artifact_linux_x64_openssl3
-        variant: "*"
-    commands:
-      - func: checkout
-      - func: get_artifact_url
-        vars:
-          package_variant: linux-x64-openssl3
-          signature_tag: signed
-      - func: verify_artifact
   - name: add_crypt_shared_and_sbom_deb_x64_openssl3
     tags: ["add-sbom-task"]
     depends_on:
@@ -7889,18 +7761,6 @@ tasks:
         vars:
           package_variant: linux-arm64
           signature_tag: signed
-  - name: verify_artifact_linux_arm64
-    tags: ["smoke-test"]
-    depends_on:
-      - name: sign_artifact_linux_arm64
-        variant: "*"
-    commands:
-      - func: checkout
-      - func: get_artifact_url
-        vars:
-          package_variant: linux-arm64
-          signature_tag: signed
-      - func: verify_artifact
   - name: add_crypt_shared_and_sbom_deb_arm64
     tags: ["add-sbom-task"]
     depends_on:
@@ -8138,18 +7998,6 @@ tasks:
         vars:
           package_variant: linux-arm64-openssl11
           signature_tag: signed
-  - name: verify_artifact_linux_arm64_openssl11
-    tags: ["smoke-test"]
-    depends_on:
-      - name: sign_artifact_linux_arm64_openssl11
-        variant: "*"
-    commands:
-      - func: checkout
-      - func: get_artifact_url
-        vars:
-          package_variant: linux-arm64-openssl11
-          signature_tag: signed
-      - func: verify_artifact
   - name: add_crypt_shared_and_sbom_deb_arm64_openssl11
     tags: ["add-sbom-task"]
     depends_on:
@@ -8387,18 +8235,6 @@ tasks:
         vars:
           package_variant: linux-arm64-openssl3
           signature_tag: signed
-  - name: verify_artifact_linux_arm64_openssl3
-    tags: ["smoke-test"]
-    depends_on:
-      - name: sign_artifact_linux_arm64_openssl3
-        variant: "*"
-    commands:
-      - func: checkout
-      - func: get_artifact_url
-        vars:
-          package_variant: linux-arm64-openssl3
-          signature_tag: signed
-      - func: verify_artifact
   - name: add_crypt_shared_and_sbom_deb_arm64_openssl3
     tags: ["add-sbom-task"]
     depends_on:
@@ -8636,18 +8472,6 @@ tasks:
         vars:
           package_variant: linux-ppc64le
           signature_tag: signed
-  - name: verify_artifact_linux_ppc64le
-    tags: ["smoke-test"]
-    depends_on:
-      - name: sign_artifact_linux_ppc64le
-        variant: "*"
-    commands:
-      - func: checkout
-      - func: get_artifact_url
-        vars:
-          package_variant: linux-ppc64le
-          signature_tag: signed
-      - func: verify_artifact
   - name: add_crypt_shared_and_sbom_rpm_ppc64le
     tags: ["add-sbom-task"]
     depends_on:
@@ -8802,18 +8626,6 @@ tasks:
         vars:
           package_variant: linux-s390x
           signature_tag: signed
-  - name: verify_artifact_linux_s390x
-    tags: ["smoke-test"]
-    depends_on:
-      - name: sign_artifact_linux_s390x
-        variant: "*"
-    commands:
-      - func: checkout
-      - func: get_artifact_url
-        vars:
-          package_variant: linux-s390x
-          signature_tag: signed
-      - func: verify_artifact
   - name: add_crypt_shared_and_sbom_rpm_s390x
     tags: ["add-sbom-task"]
     depends_on:
@@ -12247,7 +12059,7 @@ buildvariants:
     tasks:
       - name: e2e_tests_linux_x64_openssl11
   - name: e2e_tests_rhel93_fips
-    display_name: "RHEL 9.3 x64 (E2E tests)"
+    display_name: "RHEL 9.3 x64 (fips host) (E2E tests)"
     run_on: rhel93-fips
     tags: ["nightly-driver"]
     expansions:
@@ -12850,10 +12662,8 @@ buildvariants:
     expansions:
       node_js_version: "24.18.0"
     tasks:
-      # TODO(MONGOSH-3496): re-enable once VSCODE-788 is fixed. The vscode
-      # extension currently requires two different compass-components versions
-      # at once, which our single-version override in test-vscode.sh can't satisfy.
-      # - name: test_vscode
+      # TODO(MONGOSH-3496): re-enable once VSCODE-788 is fixed.
+      - name: test_vscode
       - name: test_connectivity
       - name: test_apistrict
   - name: linux_node_nightly

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -4945,7 +4945,7 @@ functions:
 
           echo "Response Body: $response_body"
           echo "HTTP Status: $http_status"
-          
+
 # Tasks will show up as the individual blocks in the Evergreen UI that can
 # pass or fail.
 #
@@ -12854,8 +12854,8 @@ buildvariants:
       - name: test_connectivity
       - name: test_apistrict
   - name: linux_node_nightly
-    display_name: "Ubuntu 20.04 x64 (Node.js nightly e2e)"
-    run_on: ubuntu2004-small
+    display_name: "Ubuntu 26.04 arm (Node.js nightly e2e)"
+    run_on: ubuntu2604-arm64-m7g-xlarge
     tags: ["node-nightly-test"]
     expansions:
       node_js_version: "nightly"

--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -12850,7 +12850,10 @@ buildvariants:
     expansions:
       node_js_version: "24.18.0"
     tasks:
-      - name: test_vscode
+      # TODO(MONGOSH-3496): re-enable once VSCODE-788 is fixed. The vscode
+      # extension currently requires two different compass-components versions
+      # at once, which our single-version override in test-vscode.sh can't satisfy.
+      # - name: test_vscode
       - name: test_connectivity
       - name: test_apistrict
   - name: linux_node_nightly

--- a/.evergreen/build-variants/e2e-tests-build-variants.js
+++ b/.evergreen/build-variants/e2e-tests-build-variants.js
@@ -63,7 +63,7 @@ exports.E2E_TESTS_BUILD_VARIANTS = [
     mVersion: 'stable',
   },
   {
-    displayName: 'RHEL 9.3 x64',
+    displayName: 'RHEL 9.3 x64 (fips host)',
     runOn: 'rhel93-fips',
     tags: ['nightly-driver'],
     executableOsId: 'linux-x64',

--- a/.evergreen/build-variants/e2e-tests-build-variants.js
+++ b/.evergreen/build-variants/e2e-tests-build-variants.js
@@ -431,10 +431,15 @@ exports.E2E_TESTS_BUILD_VARIANTS = [
     ],
   },
   {
+    // Server 8.3+ binaries are built with Windows SDK 10.0.26100.0 and fail to
+    // load on Windows Server 2019 (missing GetProcessWorkingSetSize in the
+    // api-ms-win-core-memory-l1-1-1 API set; see SERVER-116018, closed as
+    // Works as Designed). Pin pre-2022 Windows to the newest server versions
+    // that still run there instead of `stable`.
     displayName: 'Windows VS pre-2022',
     runOn: 'windows-vsCurrent-small',
     executableOsId: 'win32',
-    mVersion: 'stable',
+    mVersion: '8.0.x',
   },
   {
     displayName: 'Windows VS pre-2022',

--- a/.evergreen/evergreen.yml.in
+++ b/.evergreen/evergreen.yml.in
@@ -1654,7 +1654,10 @@ buildvariants:
     expansions:
       node_js_version: "<% out(NODE_JS_VERSION_TARGET) %>"
     tasks:
-      - name: test_vscode
+      # TODO(MONGOSH-3496): re-enable once VSCODE-788 is fixed. The vscode
+      # extension currently requires two different compass-components versions
+      # at once, which our single-version override in test-vscode.sh can't satisfy.
+      # - name: test_vscode
       - name: test_connectivity
       - name: test_apistrict
   - name: linux_node_nightly

--- a/.evergreen/evergreen.yml.in
+++ b/.evergreen/evergreen.yml.in
@@ -1161,7 +1161,12 @@ tasks:
   # UNIT TESTS
   # E.g. test_m60xc_n20 stands for mongod 6.0.x, community edition, Node.js 20
   ###
-  <% for (const { id, packageName, usePuppeteer } of UNIT_TESTS) { %>
+  <% const USED_UNIT_TEST_IDS = new Set(UNIT_TESTS_WITH_BUILD_VARIANTS.map(([test]) => test.id));
+     for (const { id, packageName, usePuppeteer } of UNIT_TESTS) {
+       // Skip unit tests not placed in any build variant (e.g. packages with
+       // mongosh.variants: []) so we don't emit orphan task definitions that
+       // the .unit-test release gate would reference but never run.
+       if (!USED_UNIT_TEST_IDS.has(id)) continue; %>
   - name: test_<% out(id) %>
     tags: ["assigned_to_jira_team_mongosh_mongosh","unit-test"]
     depends_on:
@@ -1190,6 +1195,8 @@ tasks:
   # INTEGRATION TESTS
   ###
   - name: test_vscode
+    # TODO(MONGOSH-3496): re-enable once VSCODE-788 is fixed.
+    disable: true
     depends_on:
       - name: compile_ts
         variant: linux_compile
@@ -1298,9 +1305,13 @@ tasks:
   # E2E TESTS
   ###
   # Tests reuse the same compilation build variant, so we create those variations based on this.
-  <% for (const compileBuildVariant of COMPILE_BUILD_VARIANTS) {
+  <% const E2E_USED_COMPILE_VARIANTS = new Set(E2E_TESTS_BUILD_VARIANTS.map((v) => v.compileBuildVariant));
+     for (const compileBuildVariant of COMPILE_BUILD_VARIANTS) {
     const platformName = compileBuildVariant.name.replace('build_', '');
     const executableOsId = platformName == 'darwin' ? 'darwin-x64' : platformName.replaceAll('_', '-');
+    // Skip build-only compile variants (e.g. the rhel8 artifact builds) that no
+    // e2e build variant runs, so we don't emit orphan e2e task definitions.
+    if (!E2E_USED_COMPILE_VARIANTS.has(compileBuildVariant.name)) continue;
     %>
   - name: e2e_tests_<% out(platformName) %>
     tags: ["e2e-test", "assigned_to_jira_team_mongosh_mongosh"]
@@ -1442,6 +1453,10 @@ tasks:
         vars:
           package_variant: <% out(packageVariant) %>
           signature_tag: signed
+  <% /* verify_artifact is only wired into a variant for deb/rpm/win32/darwin
+        packages (see the *_package / verify_*_artifact variants); skip the rest
+        so we don't emit orphan smoke-test task definitions. */
+     if (/^(deb|rpm|win32|darwin)/.test(packageVariant)) { %>
   - name: verify_artifact_<% out(packageVariant.replace(/-/g, '_')) %>
     tags: ["smoke-test"]
     depends_on:
@@ -1454,6 +1469,7 @@ tasks:
           package_variant: <% out(packageVariant) %>
           signature_tag: signed
       - func: verify_artifact
+  <% } %>
   <% } } %>
 
   ###
@@ -1654,10 +1670,8 @@ buildvariants:
     expansions:
       node_js_version: "<% out(NODE_JS_VERSION_TARGET) %>"
     tasks:
-      # TODO(MONGOSH-3496): re-enable once VSCODE-788 is fixed. The vscode
-      # extension currently requires two different compass-components versions
-      # at once, which our single-version override in test-vscode.sh can't satisfy.
-      # - name: test_vscode
+      # TODO(MONGOSH-3496): re-enable once VSCODE-788 is fixed.
+      - name: test_vscode
       - name: test_connectivity
       - name: test_apistrict
   - name: linux_node_nightly

--- a/.evergreen/evergreen.yml.in
+++ b/.evergreen/evergreen.yml.in
@@ -1101,7 +1101,7 @@ functions:
 
           echo "Response Body: $response_body"
           echo "HTTP Status: $http_status"
-          
+
 # Tasks will show up as the individual blocks in the Evergreen UI that can
 # pass or fail.
 #
@@ -1658,8 +1658,8 @@ buildvariants:
       - name: test_connectivity
       - name: test_apistrict
   - name: linux_node_nightly
-    display_name: "Ubuntu 20.04 x64 (Node.js nightly e2e)"
-    run_on: ubuntu2004-small
+    display_name: "Ubuntu 26.04 arm (Node.js nightly e2e)"
+    run_on: ubuntu2604-arm64-m7g-xlarge
     tags: ["node-nightly-test"]
     expansions:
       node_js_version: "nightly"

--- a/.evergreen/install-npm-deps.sh
+++ b/.evergreen/install-npm-deps.sh
@@ -6,7 +6,7 @@ export BASEDIR="$PWD/.evergreen"
 . "$BASEDIR/setup-env.sh"
 
 if [ "${PUPPETEER_SKIP_DOWNLOAD:-true}" != "true" ]; then
-  node "$BASEDIR/purge-incomplete-puppeteer-cache.js" || true
+  node "$BASEDIR/purge-incomplete-puppeteer-cache.mts" || true
 fi
 
 # Install root directories used by scripts. We should consider moving scripts to separate packages.

--- a/.evergreen/install-npm-deps.sh
+++ b/.evergreen/install-npm-deps.sh
@@ -5,6 +5,10 @@ export BASEDIR="$PWD/.evergreen"
 
 . "$BASEDIR/setup-env.sh"
 
+if [ "${PUPPETEER_SKIP_DOWNLOAD:-true}" != "true" ]; then
+  node "$BASEDIR/purge-incomplete-puppeteer-cache.js" || true
+fi
+
 # Install root directories used by scripts. We should consider moving scripts to separate packages.
 # Also install config workspaces since they're referenced by tsconfig.json files but not automatically linked when workspaces=false is used
 npm ci -w configs/tsconfig-mongosh -w configs/eslint-config-mongosh --include-workspace-root

--- a/.evergreen/purge-incomplete-puppeteer-cache.js
+++ b/.evergreen/purge-incomplete-puppeteer-cache.js
@@ -1,0 +1,92 @@
+'use strict';
+// Persistent CI hosts (notably the macOS builders) keep ~/.cache/puppeteer
+// across runs. If a browser download/extraction is interrupted it leaves a
+// partial version folder behind, and puppeteer neither repairs nor
+// re-downloads it -- its installer errors with "the browser folder exists but
+// the executable is missing", and a half-extracted Chrome later dies at dlopen
+// ("... Framework: no such file"). Because the folder exists, every subsequent
+// run on that host reuses the broken browser forever.
+//
+// This script removes any cached browser version whose executable is missing or
+// won't even run `--version`, so puppeteer re-downloads a complete copy on the
+// next install. Complete caches are left untouched (fast path preserved). It is
+// intentionally dependency-free (runs before `npm ci`) and never fails the
+// build -- the worst case is a redundant re-download.
+const fs = require('fs');
+const os = require('os');
+const path = require('path');
+const { execFileSync } = require('child_process');
+
+const cacheDir =
+  process.env.PUPPETEER_CACHE_DIR ||
+  path.join(os.homedir(), '.cache', 'puppeteer');
+
+// Basename of the launchable binary for each browser puppeteer may install.
+const EXECUTABLE_NAMES = {
+  chrome: [
+    'Google Chrome for Testing', // macOS (inside .app/Contents/MacOS)
+    'chrome', // linux
+    'chrome.exe', // win32
+  ],
+  'chrome-headless-shell': ['chrome-headless-shell', 'chrome-headless-shell.exe'],
+  chromium: ['Chromium', 'chrome', 'chrome.exe'],
+  firefox: ['firefox', 'firefox.exe'],
+};
+
+function walk(dir, onFile) {
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) walk(full, onFile);
+    else if (entry.isFile()) onFile(full);
+  }
+}
+
+function findExecutable(versionDir, browser) {
+  const names = EXECUTABLE_NAMES[browser] || [];
+  let found;
+  walk(versionDir, (file) => {
+    if (!found && names.includes(path.basename(file))) found = file;
+  });
+  return found;
+}
+
+function runsOk(exe) {
+  try {
+    execFileSync(exe, ['--version'], { stdio: 'ignore', timeout: 30000 });
+    return true;
+  } catch {
+    return false;
+  }
+}
+
+function main() {
+  if (!fs.existsSync(cacheDir)) {
+    console.log(`[puppeteer-cache] nothing to check at ${cacheDir}`);
+    return;
+  }
+  for (const browser of fs.readdirSync(cacheDir)) {
+    const browserDir = path.join(cacheDir, browser);
+    if (!fs.statSync(browserDir).isDirectory()) continue;
+    for (const version of fs.readdirSync(browserDir)) {
+      const versionDir = path.join(browserDir, version);
+      if (!fs.statSync(versionDir).isDirectory()) continue;
+      const exe = findExecutable(versionDir, browser);
+      if (exe && runsOk(exe)) {
+        console.log(`[puppeteer-cache] ok: ${browser} ${version}`);
+        continue;
+      }
+      console.log(
+        `[puppeteer-cache] purging incomplete ${browser} ${version} ` +
+          `(${exe ? 'executable will not run' : 'executable missing'})`
+      );
+      fs.rmSync(versionDir, { recursive: true, force: true });
+    }
+  }
+}
+
+try {
+  main();
+} catch (err) {
+  // Never block the build on a cache-hygiene best-effort step.
+  console.warn(`[puppeteer-cache] skipped: ${err && err.message}`);
+}

--- a/.evergreen/purge-incomplete-puppeteer-cache.mts
+++ b/.evergreen/purge-incomplete-puppeteer-cache.mts
@@ -1,39 +1,33 @@
-'use strict';
-// Persistent CI hosts (notably the macOS builders) keep ~/.cache/puppeteer
-// across runs. If a browser download/extraction is interrupted it leaves a
-// partial version folder behind, and puppeteer neither repairs nor
-// re-downloads it -- its installer errors with "the browser folder exists but
-// the executable is missing", and a half-extracted Chrome later dies at dlopen
-// ("... Framework: no such file"). Because the folder exists, every subsequent
-// run on that host reuses the broken browser forever.
-//
 // This script removes any cached browser version whose executable is missing or
 // won't even run `--version`, so puppeteer re-downloads a complete copy on the
 // next install. Complete caches are left untouched (fast path preserved). It is
 // intentionally dependency-free (runs before `npm ci`) and never fails the
 // build -- the worst case is a redundant re-download.
-const fs = require('fs');
-const os = require('os');
-const path = require('path');
-const { execFileSync } = require('child_process');
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+import { execFileSync } from 'node:child_process';
 
 const cacheDir =
   process.env.PUPPETEER_CACHE_DIR ||
   path.join(os.homedir(), '.cache', 'puppeteer');
 
 // Basename of the launchable binary for each browser puppeteer may install.
-const EXECUTABLE_NAMES = {
+const EXECUTABLE_NAMES: Record<string, string[]> = {
   chrome: [
     'Google Chrome for Testing', // macOS (inside .app/Contents/MacOS)
     'chrome', // linux
     'chrome.exe', // win32
   ],
-  'chrome-headless-shell': ['chrome-headless-shell', 'chrome-headless-shell.exe'],
+  'chrome-headless-shell': [
+    'chrome-headless-shell',
+    'chrome-headless-shell.exe',
+  ],
   chromium: ['Chromium', 'chrome', 'chrome.exe'],
   firefox: ['firefox', 'firefox.exe'],
 };
 
-function walk(dir, onFile) {
+function walk(dir: string, onFile: (file: string) => void): void {
   for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
     const full = path.join(dir, entry.name);
     if (entry.isDirectory()) walk(full, onFile);
@@ -41,16 +35,19 @@ function walk(dir, onFile) {
   }
 }
 
-function findExecutable(versionDir, browser) {
+function findExecutable(
+  versionDir: string,
+  browser: string
+): string | undefined {
   const names = EXECUTABLE_NAMES[browser] || [];
-  let found;
+  let found: string | undefined;
   walk(versionDir, (file) => {
     if (!found && names.includes(path.basename(file))) found = file;
   });
   return found;
 }
 
-function runsOk(exe) {
+function runsOk(exe: string): boolean {
   try {
     execFileSync(exe, ['--version'], { stdio: 'ignore', timeout: 30000 });
     return true;
@@ -59,17 +56,26 @@ function runsOk(exe) {
   }
 }
 
-function main() {
+function main(): void {
   if (!fs.existsSync(cacheDir)) {
     console.log(`[puppeteer-cache] nothing to check at ${cacheDir}`);
     return;
   }
-  for (const browser of fs.readdirSync(cacheDir)) {
+  // Dirent.isDirectory() does not follow symlinks (unlike statSync), so a
+  // symlink placed in the cache can neither redirect the walk/executable
+  // probe outside the cache tree nor abort the script by dangling.
+  for (const browserEntry of fs.readdirSync(cacheDir, {
+    withFileTypes: true,
+  })) {
+    if (!browserEntry.isDirectory()) continue;
+    const browser = browserEntry.name;
     const browserDir = path.join(cacheDir, browser);
-    if (!fs.statSync(browserDir).isDirectory()) continue;
-    for (const version of fs.readdirSync(browserDir)) {
+    for (const versionEntry of fs.readdirSync(browserDir, {
+      withFileTypes: true,
+    })) {
+      if (!versionEntry.isDirectory()) continue;
+      const version = versionEntry.name;
       const versionDir = path.join(browserDir, version);
-      if (!fs.statSync(versionDir).isDirectory()) continue;
       const exe = findExecutable(versionDir, browser);
       if (exe && runsOk(exe)) {
         console.log(`[puppeteer-cache] ok: ${browser} ${version}`);
@@ -88,5 +94,7 @@ try {
   main();
 } catch (err) {
   // Never block the build on a cache-hygiene best-effort step.
-  console.warn(`[puppeteer-cache] skipped: ${err && err.message}`);
+  console.warn(
+    `[puppeteer-cache] skipped: ${err instanceof Error ? err.message : err}`
+  );
 }

--- a/.evergreen/setup-env.sh
+++ b/.evergreen/setup-env.sh
@@ -27,7 +27,14 @@ if [ "$NODE_JS_VERSION" = "nightly" ]; then
   fi
   if [ ! -x "$NIGHTLY_NODE_DIR/bin/node" ]; then
     mkdir -p "$NIGHTLY_NODE_DIR"
-    curl -sSfL "https://nodejs.org/download/nightly/v$NODE_JS_VERSION/node-v$NODE_JS_VERSION-linux-x64.tar.xz" \
+    # Map the host architecture to the Node.js download naming so the nightly
+    # variant can run on either x64 or arm64 Linux distros.
+    case "$(uname -m)" in
+      x86_64) NIGHTLY_NODE_ARCH=x64 ;;
+      aarch64 | arm64) NIGHTLY_NODE_ARCH=arm64 ;;
+      *) echo "Unsupported architecture for Node.js nightly: $(uname -m)" >&2; exit 1 ;;
+    esac
+    curl -sSfL "https://nodejs.org/download/nightly/v$NODE_JS_VERSION/node-v$NODE_JS_VERSION-linux-$NIGHTLY_NODE_ARCH.tar.xz" \
       | tar -xJ --strip-components=1 -C "$NIGHTLY_NODE_DIR"
   fi
   export PATH="$NIGHTLY_NODE_DIR/bin:$PATH"

--- a/package-lock.json
+++ b/package-lock.json
@@ -36266,7 +36266,6 @@
         "@mongosh/testing": "2.0.14",
         "@types/chai-as-promised": "^8.0.2",
         "@types/node": "^22.15.30",
-        "@types/rimraf": "^3.0.0",
         "bson": "^7.3.1",
         "chai-as-promised": "^8.0.2",
         "eslint": "^7.25.0",
@@ -36276,7 +36275,6 @@
         "mongodb-log-writer": "^2.5.6",
         "node-fetch": "^3.3.2",
         "prettier": "^2.8.8",
-        "rimraf": "^3.0.2",
         "strip-ansi": "^6.0.0"
       },
       "engines": {

--- a/packages/cli-repl/src/mongosh-repl.ts
+++ b/packages/cli-repl/src/mongosh-repl.ts
@@ -49,7 +49,10 @@ import type { Context } from 'vm';
 import { Script, createContext, runInContext } from 'vm';
 import { fixNode60446, installPasteSupport } from './repl-paste-support';
 import util from 'util';
-import { fixNodeReplCompleterSideEffectHandling } from './node-repl-fix-completer-side-effects';
+import {
+  fixNodeReplCompleterSideEffectHandling,
+  promisifyCompleter,
+} from './node-repl-fix-completer-side-effects';
 import { fixNodeReplHistoryHandler } from './node-repl-fix-history-rewrite-on-error';
 
 declare const __non_webpack_require__: any;
@@ -448,8 +451,8 @@ class MongoshNodeRepl implements EvaluationListener {
     this.outputFinishString += installPasteSupport(repl);
 
     const origReplCompleter = await fixNodeReplCompleterSideEffectHandling(
-      promisify(repl.completer.bind(repl))
-    ); // repl.completer is callback-style
+      promisifyCompleter(repl.completer.bind(repl))
+    ); // repl.completer is callback-style on older Node, Promise-returning on newer
 
     await fixNodeReplHistoryHandler(repl);
     let newMongoshCompleter: (line: string) => Promise<CompletionResults>;

--- a/packages/cli-repl/src/node-repl-fix-completer-side-effects.ts
+++ b/packages/cli-repl/src/node-repl-fix-completer-side-effects.ts
@@ -4,7 +4,7 @@ import { PassThrough } from 'stream';
 function isThenable<T>(value: unknown): value is PromiseLike<T> {
   return !!(
     value &&
-    typeof value === 'object' &&
+    (typeof value === 'object' || typeof value === 'function') &&
     'then' in value &&
     typeof value.then === 'function'
   );

--- a/packages/cli-repl/src/node-repl-fix-completer-side-effects.ts
+++ b/packages/cli-repl/src/node-repl-fix-completer-side-effects.ts
@@ -1,6 +1,31 @@
 import type { CompleterResult } from 'readline';
 import { PassThrough } from 'stream';
-import { promisify } from 'util';
+
+function isThenable<T>(value: unknown): value is PromiseLike<T> {
+  return !!(
+    value &&
+    typeof value === 'object' &&
+    'then' in value &&
+    typeof value.then === 'function'
+  );
+}
+
+export function promisifyCompleter(
+  completer: (
+    line: string,
+    callback: (err?: Error | null, result?: CompleterResult) => void
+  ) => unknown
+): (line: string) => Promise<CompleterResult> {
+  return (line: string) =>
+    new Promise<CompleterResult>((resolve, reject) => {
+      const maybePromise = completer(line, (err, result) =>
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        err ? reject(err) : resolve(result!)
+      );
+      if (isThenable<CompleterResult>(maybePromise))
+        maybePromise.then(resolve, reject);
+    });
+}
 
 // Detect whether the issue described in https://github.com/nodejs/node/pull/59774
 // occurs in this version of Node.js or not.
@@ -21,7 +46,7 @@ async function detectReplNodeBug59774(): Promise<boolean> {
   try {
     // Try to autocomplete a random property access on the result of calling
     // causeSideEffect(). If the function is actually called, then the bug is present.
-    await promisify(repl.completer)('causeSideEffect().x');
+    await promisifyCompleter(repl.completer)('causeSideEffect().x');
   } finally {
     repl.close();
   }

--- a/packages/e2e-tests/package.json
+++ b/packages/e2e-tests/package.json
@@ -36,7 +36,6 @@
     "@mongosh/testing": "2.0.14",
     "@types/chai-as-promised": "^8.0.2",
     "@types/node": "^22.15.30",
-    "@types/rimraf": "^3.0.0",
     "bson": "^7.3.1",
     "chai-as-promised": "^8.0.2",
     "eslint": "^7.25.0",
@@ -46,7 +45,6 @@
     "mongodb-log-writer": "^2.5.6",
     "node-fetch": "^3.3.2",
     "prettier": "^2.8.8",
-    "rimraf": "^3.0.2",
     "strip-ansi": "^6.0.0"
   }
 }

--- a/packages/e2e-tests/test/e2e-direct.spec.ts
+++ b/packages/e2e-tests/test/e2e-direct.spec.ts
@@ -42,7 +42,10 @@ describe('e2e direct connection', function () {
       });
     });
 
-    context('after rs.initiate()', function () {
+    // TODO(MONGOSH-3498): after() cleanup uses exit which hangs on Node nightly
+    (process.version.includes('-nightly')
+      ? context.skip
+      : context)('after rs.initiate()', function () {
       let dbname: string;
 
       before(async function () {

--- a/packages/e2e-tests/test/e2e-direct.spec.ts
+++ b/packages/e2e-tests/test/e2e-direct.spec.ts
@@ -1,5 +1,7 @@
 import {
   eventually,
+  isNightly,
+  skipOnNightly,
   startTestCluster,
   skipIfServerVersion,
   skipIfApiStrict,
@@ -42,11 +44,10 @@ describe('e2e direct connection', function () {
       });
     });
 
-    // TODO(MONGOSH-3498): after() cleanup uses exit which hangs on Node nightly
-    (process.version.includes('-nightly')
-      ? context.skip
-      : context)('after rs.initiate()', function () {
+    context('after rs.initiate()', function () {
       let dbname: string;
+
+      skipOnNightly(); // TODO(MONGOSH-3498): shell termination broken on Node nightly
 
       before(async function () {
         this.timeout(60_000);
@@ -86,7 +87,9 @@ describe('e2e direct connection', function () {
         await shell.executeLine('db.testcollection.insertOne({})');
         shell.writeInputLine('exit');
       });
+
       after(async function () {
+        if (isNightly) return; // TODO(MONGOSH-3498): cleanup uses exit which hangs on Node nightly
         const shell = startTestShell(this, {
           args: [await rs0.connectionString()],
         });

--- a/packages/e2e-tests/test/e2e-snippet.spec.ts
+++ b/packages/e2e-tests/test/e2e-snippet.spec.ts
@@ -85,6 +85,7 @@ describe('snippet integration tests', function () {
   });
 
   it('works when an index file is inaccessible', async function () {
+    if (process.version.includes('-nightly')) return this.skip(); // TODO(MONGOSH-3498): shell termination broken on Node nightly
     await shell.executeLine(
       'config.set("snippetIndexSourceURLs", "http://localhost:1/")'
     );

--- a/packages/e2e-tests/test/e2e-snippet.spec.ts
+++ b/packages/e2e-tests/test/e2e-snippet.spec.ts
@@ -3,7 +3,7 @@ import path from 'path';
 import { expect } from 'chai';
 import type { TestShell } from './test-shell';
 import { useTmpdir } from './repl-helpers';
-import { eventually } from '@mongosh/testing';
+import { eventually, isNightly } from '@mongosh/testing';
 import { startTestShell } from './test-shell-context';
 
 describe('snippet integration tests', function () {
@@ -85,7 +85,7 @@ describe('snippet integration tests', function () {
   });
 
   it('works when an index file is inaccessible', async function () {
-    if (process.version.includes('-nightly')) return this.skip(); // TODO(MONGOSH-3498): shell termination broken on Node nightly
+    if (isNightly) return this.skip(); // TODO(MONGOSH-3498): shell termination broken on Node nightly
     await shell.executeLine(
       'config.set("snippetIndexSourceURLs", "http://localhost:1/")'
     );

--- a/packages/e2e-tests/test/e2e-tls.spec.ts
+++ b/packages/e2e-tests/test/e2e-tls.spec.ts
@@ -3,6 +3,8 @@ import { promises as fs } from 'fs';
 import path from 'path';
 import {
   getTestCertificatePath as getCertPath,
+  isNightly,
+  skipOnNightly,
   startTestServer,
 } from '@mongosh/testing';
 import {
@@ -77,11 +79,12 @@ describe('e2e TLS', function () {
     }
   });
 
-  // TODO(MONGOSH-3498): after() cleanup uses exit which hangs on Node nightly
-  (process.version.includes('-nightly') ? context.skip : context)(
+  context(
     'connecting without client cert to server with valid cert',
     function () {
+      skipOnNightly(); // TODO(MONGOSH-3498): shell termination broken on Node nightly
       after(async function () {
+        if (isNightly) return; // cleanup uses exit which hangs on Node nightly
         // mlaunch has some trouble interpreting all the server options correctly,
         // and subsequently can't connect to the server to find out if it's up,
         // then thinks it isn't and doesn't shut it down cleanly. We shut it down
@@ -391,344 +394,343 @@ describe('e2e TLS', function () {
     }
   );
 
-  // TODO(MONGOSH-3498): after() cleanup uses exit which hangs on Node nightly
-  (process.version.includes('-nightly') ? context.skip : context)(
-    'connecting with client cert to server with valid cert',
-    function () {
-      after(async function () {
-        const shell = startTestShell(this, {
-          args: [
-            await connectionStringWithLocalhost(server),
-            '--tls',
-            '--tlsCAFile',
-            CA_CERT,
-            '--tlsCertificateKeyFile',
-            CLIENT_CERT,
-          ],
-        });
-        await shell.waitForPrompt();
-        await shell.executeLine('db.shutdownServer({ force: true })');
-        shell.writeInputLine('exit');
-        await shell.waitForAnyExit(); // closing the server may lead to an error being displayed
-      });
+  context('connecting with client cert to server with valid cert', function () {
+    skipOnNightly(); // TODO(MONGOSH-3498): shell termination broken on Node nightly
 
-      const server = startTestServer('e2e-tls-valid-cli-valid-srv', {
+    after(async function () {
+      if (isNightly) return; // cleanup uses exit which hangs on Node nightly
+      const shell = startTestShell(this, {
         args: [
-          '--tlsMode',
-          'requireTLS',
-          '--tlsCertificateKeyFile',
-          SERVER_KEY,
+          await connectionStringWithLocalhost(server),
+          '--tls',
           '--tlsCAFile',
           CA_CERT,
+          '--tlsCertificateKeyFile',
+          CLIENT_CERT,
         ],
-        tlsAddClientKey: false,
       });
-      const certUser =
-        'emailAddress=tester@example.com,CN=Wonderwoman,OU=DevTools Testers,O=MongoDB';
+      await shell.waitForPrompt();
+      await shell.executeLine('db.shutdownServer({ force: true })');
+      shell.writeInputLine('exit');
+      await shell.waitForAnyExit(); // closing the server may lead to an error being displayed
+    });
 
-      before(async function () {
-        if (process.env.MONGOSH_TEST_FORCE_API_STRICT) {
-          return this.skip(); // createUser is unversioned
-        }
-        /* connect with cert to create user */
-        const shell = startTestShell(this, {
-          args: [
-            await connectionStringWithLocalhost(server, {
-              serverSelectionTimeoutMS: '1500',
-            }),
-            '--tls',
-            '--tlsCAFile',
-            CA_CERT,
-            '--tlsCertificateKeyFile',
-            CLIENT_CERT,
-          ],
-        });
-        const prompt = await shell.waitForPromptOrExit();
-        expect(prompt.state).to.equal('prompt');
-        await shell.executeLine(`db=db.getSiblingDB('$external');db.runCommand({
+    const server = startTestServer('e2e-tls-valid-cli-valid-srv', {
+      args: [
+        '--tlsMode',
+        'requireTLS',
+        '--tlsCertificateKeyFile',
+        SERVER_KEY,
+        '--tlsCAFile',
+        CA_CERT,
+      ],
+      tlsAddClientKey: false,
+    });
+    const certUser =
+      'emailAddress=tester@example.com,CN=Wonderwoman,OU=DevTools Testers,O=MongoDB';
+
+    before(async function () {
+      if (process.env.MONGOSH_TEST_FORCE_API_STRICT) {
+        return this.skip(); // createUser is unversioned
+      }
+      /* connect with cert to create user */
+      const shell = startTestShell(this, {
+        args: [
+          await connectionStringWithLocalhost(server, {
+            serverSelectionTimeoutMS: '1500',
+          }),
+          '--tls',
+          '--tlsCAFile',
+          CA_CERT,
+          '--tlsCertificateKeyFile',
+          CLIENT_CERT,
+        ],
+      });
+      const prompt = await shell.waitForPromptOrExit();
+      expect(prompt.state).to.equal('prompt');
+      await shell.executeLine(`db=db.getSiblingDB('$external');db.runCommand({
         createUser: '${certUser}',
         roles: [
           {role: 'userAdminAnyDatabase', db: 'admin'}
         ]
       })`);
-        shell.assertContainsOutput('{ ok: 1 }');
+      shell.assertContainsOutput('{ ok: 1 }');
+    });
+
+    it('works with valid cert (args)', async function () {
+      const shell = startTestShell(this, {
+        args: [
+          await connectionStringWithLocalhost(server, {
+            serverSelectionTimeoutMS: '1500',
+          }),
+          '--authenticationMechanism',
+          'MONGODB-X509',
+          '--tls',
+          '--tlsCAFile',
+          CA_CERT,
+          '--tlsCertificateKeyFile',
+          CLIENT_CERT,
+        ],
+      });
+      const prompt = await shell.waitForPromptOrExit();
+      expect(prompt.state).to.equal('prompt');
+      expect(
+        await shell.executeLine('db.runCommand({ connectionStatus: 1 })')
+      ).to.include(`user: '${certUser}'`);
+
+      expect(
+        await shell.executeLine(
+          'db.getSiblingDB("$external").auth({mechanism: "MONGODB-X509"})'
+        )
+      ).to.include('ok: 1');
+      expect(
+        await shell.executeLine('db.runCommand({ connectionStatus: 1 })')
+      ).to.include(`user: '${certUser}'`);
+    });
+
+    it('works with valid cert (args, encrypted)', async function () {
+      const shell = startTestShell(this, {
+        args: [
+          await connectionStringWithLocalhost(server, {
+            serverSelectionTimeoutMS: '1500',
+          }),
+          '--authenticationMechanism',
+          'MONGODB-X509',
+          '--tls',
+          '--tlsCAFile',
+          CA_CERT,
+          '--tlsCertificateKeyFile',
+          CLIENT_CERT_ENCRYPTED,
+          '--tlsCertificateKeyFilePassword',
+          CLIENT_CERT_PASSWORD,
+        ],
+        env,
+      });
+      const prompt = await shell.waitForPromptOrExit();
+      expect(prompt.state).to.equal('prompt');
+      expect(
+        await shell.executeLine('db.runCommand({ connectionStatus: 1 })')
+      ).to.include(`user: '${certUser}'`);
+
+      expect(
+        await shell.executeLine(
+          'db.getSiblingDB("$external").auth({mechanism: "MONGODB-X509"})'
+        )
+      ).to.include('ok: 1');
+      expect(
+        await shell.executeLine('db.runCommand({ connectionStatus: 1 })')
+      ).to.include(`user: '${certUser}'`);
+
+      const logPath = path.join(logBasePath, `${shell.logId}_log`);
+      const logFileContents = await fs.readFile(logPath, 'utf8');
+      expect(logFileContents).not.to.include(CLIENT_CERT_PASSWORD);
+    });
+
+    it('works with valid cert (connection string)', async function () {
+      const shell = startTestShell(this, {
+        args: [
+          await connectionStringWithLocalhost(server, {
+            serverSelectionTimeoutMS: '1500',
+            authMechanism: 'MONGODB-X509',
+            tls: 'true',
+            tlsCAFile: CA_CERT,
+            tlsCertificateKeyFile: CLIENT_CERT,
+          }),
+        ],
+      });
+      const prompt = await shell.waitForPromptOrExit();
+      expect(prompt.state).to.equal('prompt');
+      expect(
+        await shell.executeLine('db.runCommand({ connectionStatus: 1 })')
+      ).to.include(`user: '${certUser}'`);
+
+      expect(
+        await shell.executeLine(
+          'db.getSiblingDB("$external").auth({mechanism: "MONGODB-X509"})'
+        )
+      ).to.include('ok: 1');
+      expect(
+        await shell.executeLine('db.runCommand({ connectionStatus: 1 })')
+      ).to.include(`user: '${certUser}'`);
+    });
+
+    it('works with valid cert (connection string, encrypted)', async function () {
+      const shell = startTestShell(this, {
+        args: [
+          await connectionStringWithLocalhost(server, {
+            serverSelectionTimeoutMS: '1500',
+            authMechanism: 'MONGODB-X509',
+            tls: 'true',
+            tlsCAFile: CA_CERT,
+            tlsCertificateKeyFile: CLIENT_CERT_ENCRYPTED,
+            tlsCertificateKeyFilePassword: CLIENT_CERT_PASSWORD,
+          }),
+        ],
+        env,
+      });
+      const prompt = await shell.waitForPromptOrExit();
+      expect(prompt.state).to.equal('prompt');
+      expect(
+        await shell.executeLine('db.runCommand({ connectionStatus: 1 })')
+      ).to.include(`user: '${certUser}'`);
+
+      expect(
+        await shell.executeLine(
+          'db.getSiblingDB("$external").auth({mechanism: "MONGODB-X509"})'
+        )
+      ).to.include('ok: 1');
+      expect(
+        await shell.executeLine('db.runCommand({ connectionStatus: 1 })')
+      ).to.include(`user: '${certUser}'`);
+
+      const logPath = path.join(logBasePath, `${shell.logId}_log`);
+      const logFileContents = await fs.readFile(logPath, 'utf8');
+      expect(logFileContents).not.to.include(CLIENT_CERT_PASSWORD);
+    });
+
+    it('asks for tlsCertificateKeyFilePassword when it is needed (connection string, encrypted)', async function () {
+      const shell = startTestShell(this, {
+        args: [
+          await connectionStringWithLocalhost(server, {
+            serverSelectionTimeoutMS: '1500',
+            authMechanism: 'MONGODB-X509',
+            tls: 'true',
+            tlsCAFile: CA_CERT,
+            tlsCertificateKeyFile: CLIENT_CERT_ENCRYPTED,
+          }),
+        ],
+        env,
       });
 
-      it('works with valid cert (args)', async function () {
-        const shell = startTestShell(this, {
-          args: [
-            await connectionStringWithLocalhost(server, {
-              serverSelectionTimeoutMS: '1500',
-            }),
-            '--authenticationMechanism',
-            'MONGODB-X509',
-            '--tls',
-            '--tlsCAFile',
-            CA_CERT,
-            '--tlsCertificateKeyFile',
-            CLIENT_CERT,
-          ],
-        });
-        const prompt = await shell.waitForPromptOrExit();
-        expect(prompt.state).to.equal('prompt');
-        expect(
-          await shell.executeLine('db.runCommand({ connectionStatus: 1 })')
-        ).to.include(`user: '${certUser}'`);
+      await shell.waitForLine(/Enter TLS key file password:/);
+      await shell.executeLine(CLIENT_CERT_PASSWORD);
 
-        expect(
-          await shell.executeLine(
-            'db.getSiblingDB("$external").auth({mechanism: "MONGODB-X509"})'
-          )
-        ).to.include('ok: 1');
-        expect(
-          await shell.executeLine('db.runCommand({ connectionStatus: 1 })')
-        ).to.include(`user: '${certUser}'`);
+      expect(
+        await shell.executeLine('db.runCommand({ connectionStatus: 1 })')
+      ).to.include(`user: '${certUser}'`);
+
+      expect(
+        await shell.executeLine(
+          'db.getSiblingDB("$external").auth({mechanism: "MONGODB-X509"})'
+        )
+      ).to.include('ok: 1');
+      expect(
+        await shell.executeLine('db.runCommand({ connectionStatus: 1 })')
+      ).to.include(`user: '${certUser}'`);
+
+      const logPath = path.join(logBasePath, `${shell.logId}_log`);
+      const logFileContents = await fs.readFile(logPath, 'utf8');
+      expect(logFileContents).not.to.include(CLIENT_CERT_PASSWORD);
+    });
+
+    it('fails with invalid cert (args)', async function () {
+      const shell = startTestShell(this, {
+        args: [
+          await connectionStringWithLocalhost(server, {
+            serverSelectionTimeoutMS: '1500',
+          }),
+          '--authenticationMechanism',
+          'MONGODB-X509',
+          '--tls',
+          '--tlsCAFile',
+          CA_CERT,
+          '--tlsCertificateKeyFile',
+          INVALID_CLIENT_CERT,
+        ],
       });
+      const exit = await shell.waitForPromptOrExit();
+      expect(exit.state).to.equal('exit');
+      shell.assertContainsOutput('MongoServerSelectionError');
+    });
 
-      it('works with valid cert (args, encrypted)', async function () {
-        const shell = startTestShell(this, {
-          args: [
-            await connectionStringWithLocalhost(server, {
-              serverSelectionTimeoutMS: '1500',
-            }),
-            '--authenticationMechanism',
-            'MONGODB-X509',
-            '--tls',
-            '--tlsCAFile',
-            CA_CERT,
-            '--tlsCertificateKeyFile',
-            CLIENT_CERT_ENCRYPTED,
-            '--tlsCertificateKeyFilePassword',
-            CLIENT_CERT_PASSWORD,
-          ],
-          env,
-        });
-        const prompt = await shell.waitForPromptOrExit();
-        expect(prompt.state).to.equal('prompt');
-        expect(
-          await shell.executeLine('db.runCommand({ connectionStatus: 1 })')
-        ).to.include(`user: '${certUser}'`);
-
-        expect(
-          await shell.executeLine(
-            'db.getSiblingDB("$external").auth({mechanism: "MONGODB-X509"})'
-          )
-        ).to.include('ok: 1');
-        expect(
-          await shell.executeLine('db.runCommand({ connectionStatus: 1 })')
-        ).to.include(`user: '${certUser}'`);
-
-        const logPath = path.join(logBasePath, `${shell.logId}_log`);
-        const logFileContents = await fs.readFile(logPath, 'utf8');
-        expect(logFileContents).not.to.include(CLIENT_CERT_PASSWORD);
+    it('fails with invalid cert (connection string)', async function () {
+      const shell = startTestShell(this, {
+        args: [
+          await connectionStringWithLocalhost(server, {
+            serverSelectionTimeoutMS: '1500',
+            authMechanism: 'MONGODB-X509',
+            tls: 'true',
+            tlsCAFile: CA_CERT,
+            tlsCertificateKeyFile: INVALID_CLIENT_CERT,
+          }),
+        ],
       });
+      const exit = await shell.waitForPromptOrExit();
+      expect(exit.state).to.equal('exit');
+      shell.assertContainsOutput('MongoServerSelectionError');
+    });
 
-      it('works with valid cert (connection string)', async function () {
-        const shell = startTestShell(this, {
-          args: [
-            await connectionStringWithLocalhost(server, {
-              serverSelectionTimeoutMS: '1500',
-              authMechanism: 'MONGODB-X509',
-              tls: 'true',
-              tlsCAFile: CA_CERT,
-              tlsCertificateKeyFile: CLIENT_CERT,
-            }),
-          ],
-        });
-        const prompt = await shell.waitForPromptOrExit();
-        expect(prompt.state).to.equal('prompt');
-        expect(
-          await shell.executeLine('db.runCommand({ connectionStatus: 1 })')
-        ).to.include(`user: '${certUser}'`);
-
-        expect(
-          await shell.executeLine(
-            'db.getSiblingDB("$external").auth({mechanism: "MONGODB-X509"})'
-          )
-        ).to.include('ok: 1');
-        expect(
-          await shell.executeLine('db.runCommand({ connectionStatus: 1 })')
-        ).to.include(`user: '${certUser}'`);
-      });
-
-      it('works with valid cert (connection string, encrypted)', async function () {
-        const shell = startTestShell(this, {
-          args: [
-            await connectionStringWithLocalhost(server, {
-              serverSelectionTimeoutMS: '1500',
-              authMechanism: 'MONGODB-X509',
-              tls: 'true',
-              tlsCAFile: CA_CERT,
-              tlsCertificateKeyFile: CLIENT_CERT_ENCRYPTED,
-              tlsCertificateKeyFilePassword: CLIENT_CERT_PASSWORD,
-            }),
-          ],
-          env,
-        });
-        const prompt = await shell.waitForPromptOrExit();
-        expect(prompt.state).to.equal('prompt');
-        expect(
-          await shell.executeLine('db.runCommand({ connectionStatus: 1 })')
-        ).to.include(`user: '${certUser}'`);
-
-        expect(
-          await shell.executeLine(
-            'db.getSiblingDB("$external").auth({mechanism: "MONGODB-X509"})'
-          )
-        ).to.include('ok: 1');
-        expect(
-          await shell.executeLine('db.runCommand({ connectionStatus: 1 })')
-        ).to.include(`user: '${certUser}'`);
-
-        const logPath = path.join(logBasePath, `${shell.logId}_log`);
-        const logFileContents = await fs.readFile(logPath, 'utf8');
-        expect(logFileContents).not.to.include(CLIENT_CERT_PASSWORD);
-      });
-
-      it('asks for tlsCertificateKeyFilePassword when it is needed (connection string, encrypted)', async function () {
-        const shell = startTestShell(this, {
-          args: [
-            await connectionStringWithLocalhost(server, {
-              serverSelectionTimeoutMS: '1500',
-              authMechanism: 'MONGODB-X509',
-              tls: 'true',
-              tlsCAFile: CA_CERT,
-              tlsCertificateKeyFile: CLIENT_CERT_ENCRYPTED,
-            }),
-          ],
-          env,
-        });
-
-        await shell.waitForLine(/Enter TLS key file password:/);
-        await shell.executeLine(CLIENT_CERT_PASSWORD);
-
-        expect(
-          await shell.executeLine('db.runCommand({ connectionStatus: 1 })')
-        ).to.include(`user: '${certUser}'`);
-
-        expect(
-          await shell.executeLine(
-            'db.getSiblingDB("$external").auth({mechanism: "MONGODB-X509"})'
-          )
-        ).to.include('ok: 1');
-        expect(
-          await shell.executeLine('db.runCommand({ connectionStatus: 1 })')
-        ).to.include(`user: '${certUser}'`);
-
-        const logPath = path.join(logBasePath, `${shell.logId}_log`);
-        const logFileContents = await fs.readFile(logPath, 'utf8');
-        expect(logFileContents).not.to.include(CLIENT_CERT_PASSWORD);
-      });
-
-      it('fails with invalid cert (args)', async function () {
-        const shell = startTestShell(this, {
-          args: [
-            await connectionStringWithLocalhost(server, {
-              serverSelectionTimeoutMS: '1500',
-            }),
-            '--authenticationMechanism',
-            'MONGODB-X509',
-            '--tls',
-            '--tlsCAFile',
-            CA_CERT,
-            '--tlsCertificateKeyFile',
-            INVALID_CLIENT_CERT,
-          ],
-        });
-        const exit = await shell.waitForPromptOrExit();
-        expect(exit.state).to.equal('exit');
-        shell.assertContainsOutput('MongoServerSelectionError');
-      });
-
-      it('fails with invalid cert (connection string)', async function () {
-        const shell = startTestShell(this, {
-          args: [
-            await connectionStringWithLocalhost(server, {
-              serverSelectionTimeoutMS: '1500',
-              authMechanism: 'MONGODB-X509',
-              tls: 'true',
-              tlsCAFile: CA_CERT,
-              tlsCertificateKeyFile: INVALID_CLIENT_CERT,
-            }),
-          ],
-        });
-        const exit = await shell.waitForPromptOrExit();
-        expect(exit.state).to.equal('exit');
-        shell.assertContainsOutput('MongoServerSelectionError');
-      });
-
-      it('works with valid cert (with tlsCertificateSelector)', async function () {
-        if (process.env.MONGOSH_TEST_E2E_FORCE_FIPS) {
-          return this.skip(); // No tlsCertificateSelector support in FIPS mode
-        }
-        const fakeOsCaModule = path.resolve(tmpdir.path, 'fake-ca.js');
-        await fs.writeFile(
-          fakeOsCaModule,
-          `
+    it('works with valid cert (with tlsCertificateSelector)', async function () {
+      if (process.env.MONGOSH_TEST_E2E_FORCE_FIPS) {
+        return this.skip(); // No tlsCertificateSelector support in FIPS mode
+      }
+      const fakeOsCaModule = path.resolve(tmpdir.path, 'fake-ca.js');
+      await fs.writeFile(
+        fakeOsCaModule,
+        `
       const fs = require('fs');
       module.exports = () => ({
         passphrase: 'passw0rd',
         pfx: fs.readFileSync(${JSON.stringify(CLIENT_CERT_PFX)})
       });
       `
-        );
-        const shell = startTestShell(this, {
-          args: [
-            await connectionStringWithLocalhost(server, {
-              serverSelectionTimeoutMS: '1500',
-            }),
-            '--authenticationMechanism',
-            'MONGODB-X509',
-            '--tls',
-            '--tlsCAFile',
-            CA_CERT,
-            '--tlsCertificateSelector',
-            'subject=tester@example.com',
-          ],
-          env: {
-            ...process.env,
-            TEST_OS_EXPORT_CERTIFICATE_AND_KEY_PATH: fakeOsCaModule,
-          },
-        });
-        const prompt = await shell.waitForPromptOrExit();
-        expect(prompt.state).to.equal('prompt');
-        await shell.executeLine('db.runCommand({ connectionStatus: 1 })');
-        shell.assertContainsOutput(`user: '${certUser}'`);
+      );
+      const shell = startTestShell(this, {
+        args: [
+          await connectionStringWithLocalhost(server, {
+            serverSelectionTimeoutMS: '1500',
+          }),
+          '--authenticationMechanism',
+          'MONGODB-X509',
+          '--tls',
+          '--tlsCAFile',
+          CA_CERT,
+          '--tlsCertificateSelector',
+          'subject=tester@example.com',
+        ],
+        env: {
+          ...process.env,
+          TEST_OS_EXPORT_CERTIFICATE_AND_KEY_PATH: fakeOsCaModule,
+        },
       });
+      const prompt = await shell.waitForPromptOrExit();
+      expect(prompt.state).to.equal('prompt');
+      await shell.executeLine('db.runCommand({ connectionStatus: 1 })');
+      shell.assertContainsOutput(`user: '${certUser}'`);
+    });
 
-      it('fails with an invalid tlsCertificateSelector', async function () {
-        const shell = startTestShell(this, {
-          args: [
-            await connectionStringWithLocalhost(server, {
-              serverSelectionTimeoutMS: '1500',
-            }),
-            '--authenticationMechanism',
-            'MONGODB-X509',
-            '--tls',
-            '--tlsCAFile',
-            CA_CERT,
-            '--tlsCertificateSelector',
-            'subject=tester@example.com',
-          ],
-        });
-        const prompt = await shell.waitForPromptOrExit();
-        expect(prompt.state).to.equal('exit');
-        if (process.platform === 'win32') {
-          shell.assertContainsOutput(
-            'Could not resolve certificate specification'
-          );
-        } else if (process.platform === 'darwin') {
-          shell.assertContainsOutput(
-            /Could not find a matching certificate|The specified item could not be found in the keychain/
-          );
-        } else {
-          shell.assertContainsOutput(
-            'tlsCertificateSelector is not supported on this platform'
-          );
-        }
+    it('fails with an invalid tlsCertificateSelector', async function () {
+      const shell = startTestShell(this, {
+        args: [
+          await connectionStringWithLocalhost(server, {
+            serverSelectionTimeoutMS: '1500',
+          }),
+          '--authenticationMechanism',
+          'MONGODB-X509',
+          '--tls',
+          '--tlsCAFile',
+          CA_CERT,
+          '--tlsCertificateSelector',
+          'subject=tester@example.com',
+        ],
       });
-    }
-  );
+      const prompt = await shell.waitForPromptOrExit();
+      expect(prompt.state).to.equal('exit');
+      if (process.platform === 'win32') {
+        shell.assertContainsOutput(
+          'Could not resolve certificate specification'
+        );
+      } else if (process.platform === 'darwin') {
+        shell.assertContainsOutput(
+          /Could not find a matching certificate|The specified item could not be found in the keychain/
+        );
+      } else {
+        shell.assertContainsOutput(
+          'tlsCertificateSelector is not supported on this platform'
+        );
+      }
+    });
+  });
 
   context('connecting to server with invalid cert', function () {
     after(async function () {

--- a/packages/e2e-tests/test/e2e-tls.spec.ts
+++ b/packages/e2e-tests/test/e2e-tls.spec.ts
@@ -77,7 +77,8 @@ describe('e2e TLS', function () {
     }
   });
 
-  context(
+  // TODO(MONGOSH-3498): after() cleanup uses exit which hangs on Node nightly
+  (process.version.includes('-nightly') ? context.skip : context)(
     'connecting without client cert to server with valid cert',
     function () {
       after(async function () {
@@ -390,340 +391,344 @@ describe('e2e TLS', function () {
     }
   );
 
-  context('connecting with client cert to server with valid cert', function () {
-    after(async function () {
-      const shell = startTestShell(this, {
+  // TODO(MONGOSH-3498): after() cleanup uses exit which hangs on Node nightly
+  (process.version.includes('-nightly') ? context.skip : context)(
+    'connecting with client cert to server with valid cert',
+    function () {
+      after(async function () {
+        const shell = startTestShell(this, {
+          args: [
+            await connectionStringWithLocalhost(server),
+            '--tls',
+            '--tlsCAFile',
+            CA_CERT,
+            '--tlsCertificateKeyFile',
+            CLIENT_CERT,
+          ],
+        });
+        await shell.waitForPrompt();
+        await shell.executeLine('db.shutdownServer({ force: true })');
+        shell.writeInputLine('exit');
+        await shell.waitForAnyExit(); // closing the server may lead to an error being displayed
+      });
+
+      const server = startTestServer('e2e-tls-valid-cli-valid-srv', {
         args: [
-          await connectionStringWithLocalhost(server),
-          '--tls',
+          '--tlsMode',
+          'requireTLS',
+          '--tlsCertificateKeyFile',
+          SERVER_KEY,
           '--tlsCAFile',
           CA_CERT,
-          '--tlsCertificateKeyFile',
-          CLIENT_CERT,
         ],
+        tlsAddClientKey: false,
       });
-      await shell.waitForPrompt();
-      await shell.executeLine('db.shutdownServer({ force: true })');
-      shell.writeInputLine('exit');
-      await shell.waitForAnyExit(); // closing the server may lead to an error being displayed
-    });
+      const certUser =
+        'emailAddress=tester@example.com,CN=Wonderwoman,OU=DevTools Testers,O=MongoDB';
 
-    const server = startTestServer('e2e-tls-valid-cli-valid-srv', {
-      args: [
-        '--tlsMode',
-        'requireTLS',
-        '--tlsCertificateKeyFile',
-        SERVER_KEY,
-        '--tlsCAFile',
-        CA_CERT,
-      ],
-      tlsAddClientKey: false,
-    });
-    const certUser =
-      'emailAddress=tester@example.com,CN=Wonderwoman,OU=DevTools Testers,O=MongoDB';
-
-    before(async function () {
-      if (process.env.MONGOSH_TEST_FORCE_API_STRICT) {
-        return this.skip(); // createUser is unversioned
-      }
-      /* connect with cert to create user */
-      const shell = startTestShell(this, {
-        args: [
-          await connectionStringWithLocalhost(server, {
-            serverSelectionTimeoutMS: '1500',
-          }),
-          '--tls',
-          '--tlsCAFile',
-          CA_CERT,
-          '--tlsCertificateKeyFile',
-          CLIENT_CERT,
-        ],
-      });
-      const prompt = await shell.waitForPromptOrExit();
-      expect(prompt.state).to.equal('prompt');
-      await shell.executeLine(`db=db.getSiblingDB('$external');db.runCommand({
+      before(async function () {
+        if (process.env.MONGOSH_TEST_FORCE_API_STRICT) {
+          return this.skip(); // createUser is unversioned
+        }
+        /* connect with cert to create user */
+        const shell = startTestShell(this, {
+          args: [
+            await connectionStringWithLocalhost(server, {
+              serverSelectionTimeoutMS: '1500',
+            }),
+            '--tls',
+            '--tlsCAFile',
+            CA_CERT,
+            '--tlsCertificateKeyFile',
+            CLIENT_CERT,
+          ],
+        });
+        const prompt = await shell.waitForPromptOrExit();
+        expect(prompt.state).to.equal('prompt');
+        await shell.executeLine(`db=db.getSiblingDB('$external');db.runCommand({
         createUser: '${certUser}',
         roles: [
           {role: 'userAdminAnyDatabase', db: 'admin'}
         ]
       })`);
-      shell.assertContainsOutput('{ ok: 1 }');
-    });
-
-    it('works with valid cert (args)', async function () {
-      const shell = startTestShell(this, {
-        args: [
-          await connectionStringWithLocalhost(server, {
-            serverSelectionTimeoutMS: '1500',
-          }),
-          '--authenticationMechanism',
-          'MONGODB-X509',
-          '--tls',
-          '--tlsCAFile',
-          CA_CERT,
-          '--tlsCertificateKeyFile',
-          CLIENT_CERT,
-        ],
-      });
-      const prompt = await shell.waitForPromptOrExit();
-      expect(prompt.state).to.equal('prompt');
-      expect(
-        await shell.executeLine('db.runCommand({ connectionStatus: 1 })')
-      ).to.include(`user: '${certUser}'`);
-
-      expect(
-        await shell.executeLine(
-          'db.getSiblingDB("$external").auth({mechanism: "MONGODB-X509"})'
-        )
-      ).to.include('ok: 1');
-      expect(
-        await shell.executeLine('db.runCommand({ connectionStatus: 1 })')
-      ).to.include(`user: '${certUser}'`);
-    });
-
-    it('works with valid cert (args, encrypted)', async function () {
-      const shell = startTestShell(this, {
-        args: [
-          await connectionStringWithLocalhost(server, {
-            serverSelectionTimeoutMS: '1500',
-          }),
-          '--authenticationMechanism',
-          'MONGODB-X509',
-          '--tls',
-          '--tlsCAFile',
-          CA_CERT,
-          '--tlsCertificateKeyFile',
-          CLIENT_CERT_ENCRYPTED,
-          '--tlsCertificateKeyFilePassword',
-          CLIENT_CERT_PASSWORD,
-        ],
-        env,
-      });
-      const prompt = await shell.waitForPromptOrExit();
-      expect(prompt.state).to.equal('prompt');
-      expect(
-        await shell.executeLine('db.runCommand({ connectionStatus: 1 })')
-      ).to.include(`user: '${certUser}'`);
-
-      expect(
-        await shell.executeLine(
-          'db.getSiblingDB("$external").auth({mechanism: "MONGODB-X509"})'
-        )
-      ).to.include('ok: 1');
-      expect(
-        await shell.executeLine('db.runCommand({ connectionStatus: 1 })')
-      ).to.include(`user: '${certUser}'`);
-
-      const logPath = path.join(logBasePath, `${shell.logId}_log`);
-      const logFileContents = await fs.readFile(logPath, 'utf8');
-      expect(logFileContents).not.to.include(CLIENT_CERT_PASSWORD);
-    });
-
-    it('works with valid cert (connection string)', async function () {
-      const shell = startTestShell(this, {
-        args: [
-          await connectionStringWithLocalhost(server, {
-            serverSelectionTimeoutMS: '1500',
-            authMechanism: 'MONGODB-X509',
-            tls: 'true',
-            tlsCAFile: CA_CERT,
-            tlsCertificateKeyFile: CLIENT_CERT,
-          }),
-        ],
-      });
-      const prompt = await shell.waitForPromptOrExit();
-      expect(prompt.state).to.equal('prompt');
-      expect(
-        await shell.executeLine('db.runCommand({ connectionStatus: 1 })')
-      ).to.include(`user: '${certUser}'`);
-
-      expect(
-        await shell.executeLine(
-          'db.getSiblingDB("$external").auth({mechanism: "MONGODB-X509"})'
-        )
-      ).to.include('ok: 1');
-      expect(
-        await shell.executeLine('db.runCommand({ connectionStatus: 1 })')
-      ).to.include(`user: '${certUser}'`);
-    });
-
-    it('works with valid cert (connection string, encrypted)', async function () {
-      const shell = startTestShell(this, {
-        args: [
-          await connectionStringWithLocalhost(server, {
-            serverSelectionTimeoutMS: '1500',
-            authMechanism: 'MONGODB-X509',
-            tls: 'true',
-            tlsCAFile: CA_CERT,
-            tlsCertificateKeyFile: CLIENT_CERT_ENCRYPTED,
-            tlsCertificateKeyFilePassword: CLIENT_CERT_PASSWORD,
-          }),
-        ],
-        env,
-      });
-      const prompt = await shell.waitForPromptOrExit();
-      expect(prompt.state).to.equal('prompt');
-      expect(
-        await shell.executeLine('db.runCommand({ connectionStatus: 1 })')
-      ).to.include(`user: '${certUser}'`);
-
-      expect(
-        await shell.executeLine(
-          'db.getSiblingDB("$external").auth({mechanism: "MONGODB-X509"})'
-        )
-      ).to.include('ok: 1');
-      expect(
-        await shell.executeLine('db.runCommand({ connectionStatus: 1 })')
-      ).to.include(`user: '${certUser}'`);
-
-      const logPath = path.join(logBasePath, `${shell.logId}_log`);
-      const logFileContents = await fs.readFile(logPath, 'utf8');
-      expect(logFileContents).not.to.include(CLIENT_CERT_PASSWORD);
-    });
-
-    it('asks for tlsCertificateKeyFilePassword when it is needed (connection string, encrypted)', async function () {
-      const shell = startTestShell(this, {
-        args: [
-          await connectionStringWithLocalhost(server, {
-            serverSelectionTimeoutMS: '1500',
-            authMechanism: 'MONGODB-X509',
-            tls: 'true',
-            tlsCAFile: CA_CERT,
-            tlsCertificateKeyFile: CLIENT_CERT_ENCRYPTED,
-          }),
-        ],
-        env,
+        shell.assertContainsOutput('{ ok: 1 }');
       });
 
-      await shell.waitForLine(/Enter TLS key file password:/);
-      await shell.executeLine(CLIENT_CERT_PASSWORD);
+      it('works with valid cert (args)', async function () {
+        const shell = startTestShell(this, {
+          args: [
+            await connectionStringWithLocalhost(server, {
+              serverSelectionTimeoutMS: '1500',
+            }),
+            '--authenticationMechanism',
+            'MONGODB-X509',
+            '--tls',
+            '--tlsCAFile',
+            CA_CERT,
+            '--tlsCertificateKeyFile',
+            CLIENT_CERT,
+          ],
+        });
+        const prompt = await shell.waitForPromptOrExit();
+        expect(prompt.state).to.equal('prompt');
+        expect(
+          await shell.executeLine('db.runCommand({ connectionStatus: 1 })')
+        ).to.include(`user: '${certUser}'`);
 
-      expect(
-        await shell.executeLine('db.runCommand({ connectionStatus: 1 })')
-      ).to.include(`user: '${certUser}'`);
-
-      expect(
-        await shell.executeLine(
-          'db.getSiblingDB("$external").auth({mechanism: "MONGODB-X509"})'
-        )
-      ).to.include('ok: 1');
-      expect(
-        await shell.executeLine('db.runCommand({ connectionStatus: 1 })')
-      ).to.include(`user: '${certUser}'`);
-
-      const logPath = path.join(logBasePath, `${shell.logId}_log`);
-      const logFileContents = await fs.readFile(logPath, 'utf8');
-      expect(logFileContents).not.to.include(CLIENT_CERT_PASSWORD);
-    });
-
-    it('fails with invalid cert (args)', async function () {
-      const shell = startTestShell(this, {
-        args: [
-          await connectionStringWithLocalhost(server, {
-            serverSelectionTimeoutMS: '1500',
-          }),
-          '--authenticationMechanism',
-          'MONGODB-X509',
-          '--tls',
-          '--tlsCAFile',
-          CA_CERT,
-          '--tlsCertificateKeyFile',
-          INVALID_CLIENT_CERT,
-        ],
+        expect(
+          await shell.executeLine(
+            'db.getSiblingDB("$external").auth({mechanism: "MONGODB-X509"})'
+          )
+        ).to.include('ok: 1');
+        expect(
+          await shell.executeLine('db.runCommand({ connectionStatus: 1 })')
+        ).to.include(`user: '${certUser}'`);
       });
-      const exit = await shell.waitForPromptOrExit();
-      expect(exit.state).to.equal('exit');
-      shell.assertContainsOutput('MongoServerSelectionError');
-    });
 
-    it('fails with invalid cert (connection string)', async function () {
-      const shell = startTestShell(this, {
-        args: [
-          await connectionStringWithLocalhost(server, {
-            serverSelectionTimeoutMS: '1500',
-            authMechanism: 'MONGODB-X509',
-            tls: 'true',
-            tlsCAFile: CA_CERT,
-            tlsCertificateKeyFile: INVALID_CLIENT_CERT,
-          }),
-        ],
+      it('works with valid cert (args, encrypted)', async function () {
+        const shell = startTestShell(this, {
+          args: [
+            await connectionStringWithLocalhost(server, {
+              serverSelectionTimeoutMS: '1500',
+            }),
+            '--authenticationMechanism',
+            'MONGODB-X509',
+            '--tls',
+            '--tlsCAFile',
+            CA_CERT,
+            '--tlsCertificateKeyFile',
+            CLIENT_CERT_ENCRYPTED,
+            '--tlsCertificateKeyFilePassword',
+            CLIENT_CERT_PASSWORD,
+          ],
+          env,
+        });
+        const prompt = await shell.waitForPromptOrExit();
+        expect(prompt.state).to.equal('prompt');
+        expect(
+          await shell.executeLine('db.runCommand({ connectionStatus: 1 })')
+        ).to.include(`user: '${certUser}'`);
+
+        expect(
+          await shell.executeLine(
+            'db.getSiblingDB("$external").auth({mechanism: "MONGODB-X509"})'
+          )
+        ).to.include('ok: 1');
+        expect(
+          await shell.executeLine('db.runCommand({ connectionStatus: 1 })')
+        ).to.include(`user: '${certUser}'`);
+
+        const logPath = path.join(logBasePath, `${shell.logId}_log`);
+        const logFileContents = await fs.readFile(logPath, 'utf8');
+        expect(logFileContents).not.to.include(CLIENT_CERT_PASSWORD);
       });
-      const exit = await shell.waitForPromptOrExit();
-      expect(exit.state).to.equal('exit');
-      shell.assertContainsOutput('MongoServerSelectionError');
-    });
 
-    it('works with valid cert (with tlsCertificateSelector)', async function () {
-      if (process.env.MONGOSH_TEST_E2E_FORCE_FIPS) {
-        return this.skip(); // No tlsCertificateSelector support in FIPS mode
-      }
-      const fakeOsCaModule = path.resolve(tmpdir.path, 'fake-ca.js');
-      await fs.writeFile(
-        fakeOsCaModule,
-        `
+      it('works with valid cert (connection string)', async function () {
+        const shell = startTestShell(this, {
+          args: [
+            await connectionStringWithLocalhost(server, {
+              serverSelectionTimeoutMS: '1500',
+              authMechanism: 'MONGODB-X509',
+              tls: 'true',
+              tlsCAFile: CA_CERT,
+              tlsCertificateKeyFile: CLIENT_CERT,
+            }),
+          ],
+        });
+        const prompt = await shell.waitForPromptOrExit();
+        expect(prompt.state).to.equal('prompt');
+        expect(
+          await shell.executeLine('db.runCommand({ connectionStatus: 1 })')
+        ).to.include(`user: '${certUser}'`);
+
+        expect(
+          await shell.executeLine(
+            'db.getSiblingDB("$external").auth({mechanism: "MONGODB-X509"})'
+          )
+        ).to.include('ok: 1');
+        expect(
+          await shell.executeLine('db.runCommand({ connectionStatus: 1 })')
+        ).to.include(`user: '${certUser}'`);
+      });
+
+      it('works with valid cert (connection string, encrypted)', async function () {
+        const shell = startTestShell(this, {
+          args: [
+            await connectionStringWithLocalhost(server, {
+              serverSelectionTimeoutMS: '1500',
+              authMechanism: 'MONGODB-X509',
+              tls: 'true',
+              tlsCAFile: CA_CERT,
+              tlsCertificateKeyFile: CLIENT_CERT_ENCRYPTED,
+              tlsCertificateKeyFilePassword: CLIENT_CERT_PASSWORD,
+            }),
+          ],
+          env,
+        });
+        const prompt = await shell.waitForPromptOrExit();
+        expect(prompt.state).to.equal('prompt');
+        expect(
+          await shell.executeLine('db.runCommand({ connectionStatus: 1 })')
+        ).to.include(`user: '${certUser}'`);
+
+        expect(
+          await shell.executeLine(
+            'db.getSiblingDB("$external").auth({mechanism: "MONGODB-X509"})'
+          )
+        ).to.include('ok: 1');
+        expect(
+          await shell.executeLine('db.runCommand({ connectionStatus: 1 })')
+        ).to.include(`user: '${certUser}'`);
+
+        const logPath = path.join(logBasePath, `${shell.logId}_log`);
+        const logFileContents = await fs.readFile(logPath, 'utf8');
+        expect(logFileContents).not.to.include(CLIENT_CERT_PASSWORD);
+      });
+
+      it('asks for tlsCertificateKeyFilePassword when it is needed (connection string, encrypted)', async function () {
+        const shell = startTestShell(this, {
+          args: [
+            await connectionStringWithLocalhost(server, {
+              serverSelectionTimeoutMS: '1500',
+              authMechanism: 'MONGODB-X509',
+              tls: 'true',
+              tlsCAFile: CA_CERT,
+              tlsCertificateKeyFile: CLIENT_CERT_ENCRYPTED,
+            }),
+          ],
+          env,
+        });
+
+        await shell.waitForLine(/Enter TLS key file password:/);
+        await shell.executeLine(CLIENT_CERT_PASSWORD);
+
+        expect(
+          await shell.executeLine('db.runCommand({ connectionStatus: 1 })')
+        ).to.include(`user: '${certUser}'`);
+
+        expect(
+          await shell.executeLine(
+            'db.getSiblingDB("$external").auth({mechanism: "MONGODB-X509"})'
+          )
+        ).to.include('ok: 1');
+        expect(
+          await shell.executeLine('db.runCommand({ connectionStatus: 1 })')
+        ).to.include(`user: '${certUser}'`);
+
+        const logPath = path.join(logBasePath, `${shell.logId}_log`);
+        const logFileContents = await fs.readFile(logPath, 'utf8');
+        expect(logFileContents).not.to.include(CLIENT_CERT_PASSWORD);
+      });
+
+      it('fails with invalid cert (args)', async function () {
+        const shell = startTestShell(this, {
+          args: [
+            await connectionStringWithLocalhost(server, {
+              serverSelectionTimeoutMS: '1500',
+            }),
+            '--authenticationMechanism',
+            'MONGODB-X509',
+            '--tls',
+            '--tlsCAFile',
+            CA_CERT,
+            '--tlsCertificateKeyFile',
+            INVALID_CLIENT_CERT,
+          ],
+        });
+        const exit = await shell.waitForPromptOrExit();
+        expect(exit.state).to.equal('exit');
+        shell.assertContainsOutput('MongoServerSelectionError');
+      });
+
+      it('fails with invalid cert (connection string)', async function () {
+        const shell = startTestShell(this, {
+          args: [
+            await connectionStringWithLocalhost(server, {
+              serverSelectionTimeoutMS: '1500',
+              authMechanism: 'MONGODB-X509',
+              tls: 'true',
+              tlsCAFile: CA_CERT,
+              tlsCertificateKeyFile: INVALID_CLIENT_CERT,
+            }),
+          ],
+        });
+        const exit = await shell.waitForPromptOrExit();
+        expect(exit.state).to.equal('exit');
+        shell.assertContainsOutput('MongoServerSelectionError');
+      });
+
+      it('works with valid cert (with tlsCertificateSelector)', async function () {
+        if (process.env.MONGOSH_TEST_E2E_FORCE_FIPS) {
+          return this.skip(); // No tlsCertificateSelector support in FIPS mode
+        }
+        const fakeOsCaModule = path.resolve(tmpdir.path, 'fake-ca.js');
+        await fs.writeFile(
+          fakeOsCaModule,
+          `
       const fs = require('fs');
       module.exports = () => ({
         passphrase: 'passw0rd',
         pfx: fs.readFileSync(${JSON.stringify(CLIENT_CERT_PFX)})
       });
       `
-      );
-      const shell = startTestShell(this, {
-        args: [
-          await connectionStringWithLocalhost(server, {
-            serverSelectionTimeoutMS: '1500',
-          }),
-          '--authenticationMechanism',
-          'MONGODB-X509',
-          '--tls',
-          '--tlsCAFile',
-          CA_CERT,
-          '--tlsCertificateSelector',
-          'subject=tester@example.com',
-        ],
-        env: {
-          ...process.env,
-          TEST_OS_EXPORT_CERTIFICATE_AND_KEY_PATH: fakeOsCaModule,
-        },
+        );
+        const shell = startTestShell(this, {
+          args: [
+            await connectionStringWithLocalhost(server, {
+              serverSelectionTimeoutMS: '1500',
+            }),
+            '--authenticationMechanism',
+            'MONGODB-X509',
+            '--tls',
+            '--tlsCAFile',
+            CA_CERT,
+            '--tlsCertificateSelector',
+            'subject=tester@example.com',
+          ],
+          env: {
+            ...process.env,
+            TEST_OS_EXPORT_CERTIFICATE_AND_KEY_PATH: fakeOsCaModule,
+          },
+        });
+        const prompt = await shell.waitForPromptOrExit();
+        expect(prompt.state).to.equal('prompt');
+        await shell.executeLine('db.runCommand({ connectionStatus: 1 })');
+        shell.assertContainsOutput(`user: '${certUser}'`);
       });
-      const prompt = await shell.waitForPromptOrExit();
-      expect(prompt.state).to.equal('prompt');
-      await shell.executeLine('db.runCommand({ connectionStatus: 1 })');
-      shell.assertContainsOutput(`user: '${certUser}'`);
-    });
 
-    it('fails with an invalid tlsCertificateSelector', async function () {
-      const shell = startTestShell(this, {
-        args: [
-          await connectionStringWithLocalhost(server, {
-            serverSelectionTimeoutMS: '1500',
-          }),
-          '--authenticationMechanism',
-          'MONGODB-X509',
-          '--tls',
-          '--tlsCAFile',
-          CA_CERT,
-          '--tlsCertificateSelector',
-          'subject=tester@example.com',
-        ],
+      it('fails with an invalid tlsCertificateSelector', async function () {
+        const shell = startTestShell(this, {
+          args: [
+            await connectionStringWithLocalhost(server, {
+              serverSelectionTimeoutMS: '1500',
+            }),
+            '--authenticationMechanism',
+            'MONGODB-X509',
+            '--tls',
+            '--tlsCAFile',
+            CA_CERT,
+            '--tlsCertificateSelector',
+            'subject=tester@example.com',
+          ],
+        });
+        const prompt = await shell.waitForPromptOrExit();
+        expect(prompt.state).to.equal('exit');
+        if (process.platform === 'win32') {
+          shell.assertContainsOutput(
+            'Could not resolve certificate specification'
+          );
+        } else if (process.platform === 'darwin') {
+          shell.assertContainsOutput(
+            /Could not find a matching certificate|The specified item could not be found in the keychain/
+          );
+        } else {
+          shell.assertContainsOutput(
+            'tlsCertificateSelector is not supported on this platform'
+          );
+        }
       });
-      const prompt = await shell.waitForPromptOrExit();
-      expect(prompt.state).to.equal('exit');
-      if (process.platform === 'win32') {
-        shell.assertContainsOutput(
-          'Could not resolve certificate specification'
-        );
-      } else if (process.platform === 'darwin') {
-        shell.assertContainsOutput(
-          /Could not find a matching certificate|The specified item could not be found in the keychain/
-        );
-      } else {
-        shell.assertContainsOutput(
-          'tlsCertificateSelector is not supported on this platform'
-        );
-      }
-    });
-  });
+    }
+  );
 
   context('connecting to server with invalid cert', function () {
     after(async function () {

--- a/packages/e2e-tests/test/e2e.spec.ts
+++ b/packages/e2e-tests/test/e2e.spec.ts
@@ -7,7 +7,9 @@ import { TestShell } from './test-shell';
 import { ensureTestShellAfterHook, startTestShell } from './test-shell-context';
 import {
   eventually,
+  isNightly,
   skipIfServerVersion,
+  skipOnNightly,
   startSharedTestServer,
 } from '@mongosh/testing';
 import { promises as fs, createReadStream } from 'fs';
@@ -69,7 +71,7 @@ describe('e2e', function () {
       // runtimeGlibcVersion = "N/A" while Node.js's process.report still
       // sees the host's glibc. Investigate the addon's loader behavior
       // under the nightly's prebuilt binary and re-enable.
-      if (process.version.includes('-nightly')) {
+      if (isNightly) {
         return this.skip();
       }
       const shell = startTestShell(this, { args: ['--build-info'] });
@@ -203,13 +205,7 @@ describe('e2e', function () {
       });
     });
     describe('shell termination via exit/quit', function () {
-      beforeEach(function () {
-        // MONGOSH-3498: on Node.js nightly builds the shell process does not
-        // terminate on exit/quit (nor on SIGTERM). Skip until that is fixed.
-        if (process.version.includes('-nightly')) {
-          return this.skip();
-        }
-      });
+      skipOnNightly(); // TODO(MONGOSH-3498): shell does not exit on Node nightly
       it('closes the shell when "exit" is entered', async function () {
         shell.writeInputLine('exit');
         await shell.waitForSuccessfulExit();
@@ -795,7 +791,7 @@ describe('e2e', function () {
       // telemetry deviceId falls back to the literal string "unknown".
       // Pairs with the glibc-version skip in --build-info above; both
       // point at the same loader/dlsym behavior under the nightly binary.
-      if (process.version.includes('-nightly')) {
+      if (isNightly) {
         return this.skip();
       }
       const deviceId = (
@@ -1002,8 +998,8 @@ describe('e2e', function () {
       describe(`non-interactive (${JSON.stringify(
         jsContextFlags
       )})`, function () {
+        skipOnNightly(); // TODO(MONGOSH-3498): SIGINT/termination broken on Node nightly
         it('interrupts file execution', async function () {
-          if (process.version.includes('-nightly')) return this.skip(); // TODO(MONGOSH-3498): SIGINT/termination broken on Node nightly
           const filename = path.resolve(
             __dirname,
             'fixtures',
@@ -1054,7 +1050,7 @@ describe('e2e', function () {
         shell.assertContainsError('interrupted');
       });
       it('interrupts async awaiting', async function () {
-        if (process.version.includes('-nightly')) return this.skip(); // TODO(MONGOSH-3498): SIGINT/termination broken on Node nightly
+        if (isNightly) return this.skip(); // TODO(MONGOSH-3498): SIGINT/termination broken on Node nightly
         const result = shell.executeLine('new Promise(() => {});');
         setTimeout(() => shell.kill('SIGINT'), 3000);
         await result;
@@ -2345,7 +2341,7 @@ describe('e2e', function () {
           // the captured shell output on Node.js nightlies — needs a closer
           // look at how the update-fetch interacts with the local httpServer
           // fixture under the nightly's HTTP/fetch implementation.
-          if (process.version.includes('-nightly')) {
+          if (isNightly) {
             return this.skip();
           }
           {
@@ -2637,6 +2633,8 @@ describe('e2e', function () {
   describe('ask-for-connection-string mode', function () {
     let shell: TestShell;
 
+    skipOnNightly(); // TODO(MONGOSH-3498): shell termination broken on Node nightly
+
     beforeEach(function () {
       shell = startTestShell(this, {
         args: [],
@@ -2646,7 +2644,6 @@ describe('e2e', function () {
     });
 
     it('allows connecting to a host and running commands against it', async function () {
-      if (process.version.includes('-nightly')) return this.skip(); // TODO(MONGOSH-3498): shell termination broken on Node nightly
       const connectionString = await testServer.connectionString();
       await shell.waitForLine(/Please enter a MongoDB connection string/);
       shell.writeInputLine(connectionString);

--- a/packages/e2e-tests/test/e2e.spec.ts
+++ b/packages/e2e-tests/test/e2e.spec.ts
@@ -202,29 +202,38 @@ describe('e2e', function () {
         );
       });
     });
-    it('closes the shell when "exit" is entered', async function () {
-      shell.writeInputLine('exit');
-      await shell.waitForSuccessfulExit();
-    });
-    it('closes the shell when "quit" is entered', async function () {
-      shell.writeInputLine('quit');
-      await shell.waitForSuccessfulExit();
-    });
-    it('closes the shell with the specified exit code when "exit(n)" is entered', async function () {
-      shell.writeInputLine('exit(42)');
-      expect(await shell.waitForAnyExit()).to.equal(42);
-    });
-    it('closes the shell with the specified exit code when "quit(n)" is entered', async function () {
-      shell.writeInputLine('quit(42)');
-      expect(await shell.waitForAnyExit()).to.equal(42);
-    });
-    it('closes the shell with the pre-specified exit code when "exit" is entered', async function () {
-      shell.writeInputLine('process.exitCode = 42; exit()');
-      expect(await shell.waitForAnyExit()).to.equal(42);
-    });
-    it('closes the shell with the pre-specified exit code when "quit" is entered', async function () {
-      shell.writeInputLine('process.exitCode = 42; quit()');
-      expect(await shell.waitForAnyExit()).to.equal(42);
+    describe('shell termination via exit/quit', function () {
+      beforeEach(function () {
+        // MONGOSH-3498: on Node.js nightly builds the shell process does not
+        // terminate on exit/quit (nor on SIGTERM). Skip until that is fixed.
+        if (process.version.includes('-nightly')) {
+          return this.skip();
+        }
+      });
+      it('closes the shell when "exit" is entered', async function () {
+        shell.writeInputLine('exit');
+        await shell.waitForSuccessfulExit();
+      });
+      it('closes the shell when "quit" is entered', async function () {
+        shell.writeInputLine('quit');
+        await shell.waitForSuccessfulExit();
+      });
+      it('closes the shell with the specified exit code when "exit(n)" is entered', async function () {
+        shell.writeInputLine('exit(42)');
+        expect(await shell.waitForAnyExit()).to.equal(42);
+      });
+      it('closes the shell with the specified exit code when "quit(n)" is entered', async function () {
+        shell.writeInputLine('quit(42)');
+        expect(await shell.waitForAnyExit()).to.equal(42);
+      });
+      it('closes the shell with the pre-specified exit code when "exit" is entered', async function () {
+        shell.writeInputLine('process.exitCode = 42; exit()');
+        expect(await shell.waitForAnyExit()).to.equal(42);
+      });
+      it('closes the shell with the pre-specified exit code when "quit" is entered', async function () {
+        shell.writeInputLine('process.exitCode = 42; quit()');
+        expect(await shell.waitForAnyExit()).to.equal(42);
+      });
     });
     it('decorates internal errors with bug reporting information', async function () {
       const err = await shell.executeLine(

--- a/packages/e2e-tests/test/e2e.spec.ts
+++ b/packages/e2e-tests/test/e2e.spec.ts
@@ -1003,6 +1003,7 @@ describe('e2e', function () {
         jsContextFlags
       )})`, function () {
         it('interrupts file execution', async function () {
+          if (process.version.includes('-nightly')) return this.skip(); // TODO(MONGOSH-3498): SIGINT/termination broken on Node nightly
           const filename = path.resolve(
             __dirname,
             'fixtures',
@@ -1053,6 +1054,7 @@ describe('e2e', function () {
         shell.assertContainsError('interrupted');
       });
       it('interrupts async awaiting', async function () {
+        if (process.version.includes('-nightly')) return this.skip(); // TODO(MONGOSH-3498): SIGINT/termination broken on Node nightly
         const result = shell.executeLine('new Promise(() => {});');
         setTimeout(() => shell.kill('SIGINT'), 3000);
         await result;
@@ -2644,6 +2646,7 @@ describe('e2e', function () {
     });
 
     it('allows connecting to a host and running commands against it', async function () {
+      if (process.version.includes('-nightly')) return this.skip(); // TODO(MONGOSH-3498): shell termination broken on Node nightly
       const connectionString = await testServer.connectionString();
       await shell.waitForLine(/Please enter a MongoDB connection string/);
       shell.writeInputLine(connectionString);

--- a/packages/e2e-tests/test/repl-helpers.ts
+++ b/packages/e2e-tests/test/repl-helpers.ts
@@ -1,7 +1,5 @@
 import { promises as fs } from 'fs';
-import { promisify } from 'util';
 import path from 'path';
-import rimraf from 'rimraf';
 import * as chai from 'chai';
 import sinonChai from 'sinon-chai';
 import chaiAsPromised from 'chai-as-promised';
@@ -33,10 +31,17 @@ function useTmpdir(): { readonly path: string } {
 
   afterEach(async () => {
     try {
-      await promisify(rimraf)(tmpdir);
+      // On Windows a just-exited mongosh may still hold a handle in the fake
+      // home dir when we remove it, causing EBUSY/EPERM. fs.rm retries those
+      // (and ENOTEMPTY) internally, giving the OS time to release the handle.
+      await fs.rm(tmpdir, {
+        recursive: true,
+        force: true,
+        maxRetries: 30,
+        retryDelay: 100,
+      });
     } catch (err: any) {
-      // On Windows in CI, this can fail with EPERM for some reason.
-      // If it does, just log the error instead of failing all tests.
+      // If it still fails, just log the error instead of failing all tests.
       console.error('Could not remove fake home directory:', err);
     }
   });

--- a/packages/e2e-tests/test/test-shell-context.ts
+++ b/packages/e2e-tests/test/test-shell-context.ts
@@ -50,6 +50,12 @@ export function ensureTestShellAfterHook(
         shellsToKill.map((shell) => {
           if (shell.process.exitCode === null) {
             shell.kill();
+            // MONGOSH-3498: on Node.js nightly builds the shell does not
+            // terminate on SIGTERM, which would hang this teardown (and every
+            // suite that relies on it). Force-kill so cleanup completes.
+            if (process.version.includes('-nightly')) {
+              shell.kill('SIGKILL');
+            }
           }
           return shell.waitForAnyExit();
         })

--- a/packages/e2e-tests/test/test-shell-context.ts
+++ b/packages/e2e-tests/test/test-shell-context.ts
@@ -1,5 +1,6 @@
 import assert from 'assert';
 import Mocha from 'mocha';
+import { isNightly } from '@mongosh/testing';
 import { TestShell, type TestShellOptions } from './test-shell';
 
 const TEST_SHELLS_AFTER_ALL = Symbol('test-shells-after-all');
@@ -53,7 +54,7 @@ export function ensureTestShellAfterHook(
             // MONGOSH-3498: on Node.js nightly builds the shell does not
             // terminate on SIGTERM, which would hang this teardown (and every
             // suite that relies on it). Force-kill so cleanup completes.
-            if (process.version.includes('-nightly')) {
+            if (isNightly) {
               shell.kill('SIGKILL');
             }
           }

--- a/packages/e2e-tests/test/test-shell.ts
+++ b/packages/e2e-tests/test/test-shell.ts
@@ -143,7 +143,18 @@ export class TestShell {
   }
 
   static assertNoOpenShells() {
-    const debugInformation = [...TestShell._openShells].map((shell) =>
+    const openShells = [...TestShell._openShells];
+    if (process.version.includes('-nightly') && openShells.length > 0) {
+      // MONGOSH-3498: on Node.js nightly builds a mongosh process does not
+      // terminate on exit/quit or SIGTERM, so the "no open shells" invariant
+      // that every e2e spec relies on cannot hold. Force-kill the leftovers so
+      // they don't accumulate across suites, and skip the assertion.
+      for (const shell of openShells) {
+        shell.kill('SIGKILL');
+      }
+      return;
+    }
+    const debugInformation = openShells.map((shell) =>
       shell.debugInformation()
     );
     assert.strictEqual(

--- a/packages/e2e-tests/test/test-shell.ts
+++ b/packages/e2e-tests/test/test-shell.ts
@@ -9,7 +9,7 @@ import { inspect } from 'util';
 import path from 'path';
 import stripAnsi from 'strip-ansi';
 import { EJSON } from 'bson';
-import { eventually } from '@mongosh/testing';
+import { eventually, isNightly } from '@mongosh/testing';
 
 /* eslint-disable mocha/no-exports -- This file export hooks wrapping Mocha's Hooks APIs */
 
@@ -144,7 +144,7 @@ export class TestShell {
 
   static assertNoOpenShells() {
     const openShells = [...TestShell._openShells];
-    if (process.version.includes('-nightly') && openShells.length > 0) {
+    if (isNightly && openShells.length > 0) {
       // MONGOSH-3498: on Node.js nightly builds a mongosh process does not
       // terminate on exit/quit or SIGTERM, so the "no open shells" invariant
       // that every e2e spec relies on cannot hold. Force-kill the leftovers so

--- a/packages/testing/src/integration-testing-hooks.ts
+++ b/packages/testing/src/integration-testing-hooks.ts
@@ -343,6 +343,37 @@ export function skipIfCommunityServer(server: MongodSetup): void {
 }
 
 /**
+ * Whether the current process is running on a Node.js nightly build.
+ *
+ * mongosh currently does not terminate correctly on nightly builds
+ * (exit/quit/SIGINT, see MONGOSH-3498), which breaks tests that depend on
+ * shell lifecycle. Use this for inline `it`-body skips or static
+ * `(isNightly ? describe.skip : describe)(...)` skips of suites whose `after`
+ * hooks would otherwise hang (a `before`-hook skip does not skip `after` hooks).
+ */
+export const isNightly = process.version.includes('-nightly');
+
+/**
+ * Skip tests in the suite if running on a Node.js nightly build (MONGOSH-3498).
+ *
+ * NOTE: like the other skip* hooks this installs a `before` hook, so it does
+ * not skip `after`/`afterEach` hooks. For a suite whose `after` hook itself
+ * hangs on nightly, skip the whole suite statically with
+ * `(isNightly ? describe.skip : describe)(...)` instead.
+ *
+ * describe('...', () => {
+ *   skipOnNightly();
+ * });
+ */
+export function skipOnNightly(): void {
+  before(function () {
+    if (isNightly) {
+      this.skip();
+    }
+  });
+}
+
+/**
  * Skip tests if environment variables signal that every test runs with
  * --apiStrict.
  */


### PR DESCRIPTION
- fix all the evergreen warnings: removed unused tasks, and ensured all variants have unique names
- Skipped vscode testing: MONGOSH-3496, VSCODE-788
- added a script that will test cached browsers on the host and if they are corrupted it deletes them MONGOSH-3502
- upgrade linux for node nightlies to ubuntu 26 and migrated them to arm (only hardware available for that linux version)
- Node.js nightly has reimplemented repl completer to be an async function, using util.promisfy emits a warning when you use it on an async function so basically wrote our own for this one case. We'll be able to clean it up when we upgrade.
- A number of nightly skips that have been ticketed: MONGOSH-3498 and put in the node 26 epic. This will help us estimate the size of that effort
- Replaces rimraf with the native nodejs rm method, it has built in retries for windows EBUSY errors
- Windows server 2019 (or "pre-2022") was fixed by pinning to server 8.0, 8.3 dropped support for vs2019