### PR TITLE
feat(shell-api): support filter arg in sh.listShards() MONGOSH-2500

### DIFF
--- a/packages/i18n/src/locales/en_US.ts
+++ b/packages/i18n/src/locales/en_US.ts
@@ -2238,8 +2238,8 @@ const translations: Catalog = {
             listShards: {
               link: 'https://mongodb.com/docs/manual/reference/method/sh.listShards',
               description:
-                'Returns a list of the configured shards in a sharded cluster',
-              example: 'sh.listShards()',
+                'Returns a list of the configured shards in a sharded cluster, optionally filtered (e.g. by draining state)',
+              example: 'sh.listShards({ draining: true })',
             },
             isConfigShardEnabled: {
               link: 'https://mongodb.com/docs/manual/reference/method/sh.isConfigShardEnabled',

--- a/packages/shell-api/src/shard.spec.ts
+++ b/packages/shell-api/src/shard.spec.ts
@@ -2200,6 +2200,27 @@ describe('Shard', function () {
         );
       });
 
+      it('passes a filter through to runCommandWithCheck when provided', async function () {
+        await shard.listShards({ draining: true });
+
+        expect(serviceProvider.runCommandWithCheck).to.have.been.calledWith(
+          ADMIN_DB,
+          {
+            listShards: 1,
+            filter: { draining: true },
+          }
+        );
+      });
+
+      it('does not send an empty filter when called with no arguments', async function () {
+        await shard.listShards();
+
+        const call = serviceProvider.runCommandWithCheck
+          .getCalls()
+          .find((c) => (c.args[1] as Document).listShards === 1);
+        expect(call?.args[1]).to.not.have.property('filter');
+      });
+
       it('returns the shards returned by runCommandWithCheck', async function () {
         serviceProvider.runCommandWithCheck.resolves({
           ok: 1,

--- a/packages/shell-api/src/shard.spec.ts
+++ b/packages/shell-api/src/shard.spec.ts
@@ -2212,13 +2212,25 @@ describe('Shard', function () {
         );
       });
 
-      it('does not send an empty filter when called with no arguments', async function () {
+      it('does not send a filter when called with no arguments', async function () {
         await shard.listShards();
 
         const call = serviceProvider.runCommandWithCheck
           .getCalls()
           .find((c) => (c.args[1] as Document).listShards === 1);
         expect(call?.args[1]).to.not.have.property('filter');
+      });
+
+      it('sends an empty filter when one is given explicitly', async function () {
+        await shard.listShards({});
+
+        expect(serviceProvider.runCommandWithCheck).to.have.been.calledWith(
+          ADMIN_DB,
+          {
+            listShards: 1,
+            filter: {},
+          }
+        );
       });
 
       it('returns the shards returned by runCommandWithCheck', async function () {

--- a/packages/shell-api/src/shard.ts
+++ b/packages/shell-api/src/shard.ts
@@ -856,7 +856,7 @@ export default class Shard<
 
   @apiVersions([])
   @returnsPromise
-  async listShards(filter: Document = {}): Promise<ShardInfo[]> {
+  async listShards(filter?: Document): Promise<ShardInfo[]> {
     assertArgsDefinedType(
       [filter],
       [[undefined, 'object']],
@@ -866,7 +866,7 @@ export default class Shard<
     await getConfigDB(this._database);
 
     const command: Document = { listShards: 1 };
-    if (Object.keys(filter).length > 0) {
+    if (filter) {
       command.filter = filter;
     }
 

--- a/packages/shell-api/src/shard.ts
+++ b/packages/shell-api/src/shard.ts
@@ -856,11 +856,21 @@ export default class Shard<
 
   @apiVersions([])
   @returnsPromise
-  async listShards(): Promise<ShardInfo[]> {
-    this._emitShardApiCall('listShards', {});
+  async listShards(filter: Document = {}): Promise<ShardInfo[]> {
+    assertArgsDefinedType(
+      [filter],
+      [[undefined, 'object']],
+      'Shard.listShards'
+    );
+    this._emitShardApiCall('listShards', { filter });
     await getConfigDB(this._database);
 
-    return (await this._database.adminCommand({ listShards: 1 })).shards ?? [];
+    const command: Document = { listShards: 1 };
+    if (Object.keys(filter).length > 0) {
+      command.filter = filter;
+    }
+
+    return (await this._database.adminCommand(command)).shards ?? [];
   }
 
   @serverVersions(['8.0.0', ServerVersions.latest])


### PR DESCRIPTION
Server epic [SPM-4275](https://jira.mongodb.org/browse/SPM-4275) ("RemoveShard Interface Improvements", debuting in MongoDB 9.0) extends the `listShards` command to accept an optional `filter` sub-document so callers can, for example, list only the shards that are actively draining:

```js
db.adminCommand({ listShards: 1, filter: { draining: true } })
```

Per the design, only the `draining` flag is respected in the filter.

This PR surfaces that capability in the `sh.listShards()` shell helper, which previously always issued a bare `{ listShards: 1 }`.

## Changes

- `sh.listShards(filter?)` now accepts an optional filter document. The filter is validated as an object and passed through to the server as `{ listShards: 1, filter }`.
- A filter is only added to the command when it is non-empty, so existing no-arg calls remain byte-for-byte `{ listShards: 1 }` and behave exactly as before on all server versions.
- Updated the `en_US` i18n help text and example for `sh.listShards`.
- Added unit tests covering filter pass-through and the empty-filter case.

## Notes

- The helper is intentionally left ungated (no `@serverVersions`) so `sh.listShards()` keeps working everywhere; the `filter` field is only sent when a caller explicitly passes one. On < 9.0 servers a supplied filter should be rejected server-side rather than guarded on the client.