### PR TITLE
feat(ci): build shared-OpenSSL binaries for ppc64le and s390x MONGOSH-1681

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -6355,6 +6355,42 @@ tasks:
           node_js_version: ${node_js_version}
           mongosh_server_test_version: ${mongosh_server_test_version}
           mongosh_test_e2e_force_fips: ${mongosh_test_e2e_force_fips}
+  - name: e2e_tests_linux_ppc64le_openssl11
+    tags: ["e2e-test", "assigned_to_jira_team_mongosh_mongosh"]
+    depends_on:
+      - name: compile_artifact
+        variant: build_linux_ppc64le_openssl11
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: ${node_js_version}
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-ppc64le-openssl11
+      - func: run_e2e_tests
+        vars:
+          node_js_version: ${node_js_version}
+          mongosh_server_test_version: ${mongosh_server_test_version}
+          mongosh_test_e2e_force_fips: ${mongosh_test_e2e_force_fips}
+  - name: e2e_tests_linux_ppc64le_openssl3
+    tags: ["e2e-test", "assigned_to_jira_team_mongosh_mongosh"]
+    depends_on:
+      - name: compile_artifact
+        variant: build_linux_ppc64le_openssl3
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: ${node_js_version}
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-ppc64le-openssl3
+      - func: run_e2e_tests
+        vars:
+          node_js_version: ${node_js_version}
+          mongosh_server_test_version: ${mongosh_server_test_version}
+          mongosh_test_e2e_force_fips: ${mongosh_test_e2e_force_fips}
   - name: e2e_tests_linux_s390x
     tags: ["e2e-test", "assigned_to_jira_team_mongosh_mongosh"]
     depends_on:
@@ -6368,6 +6404,42 @@ tasks:
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-s390x
+      - func: run_e2e_tests
+        vars:
+          node_js_version: ${node_js_version}
+          mongosh_server_test_version: ${mongosh_server_test_version}
+          mongosh_test_e2e_force_fips: ${mongosh_test_e2e_force_fips}
+  - name: e2e_tests_linux_s390x_openssl11
+    tags: ["e2e-test", "assigned_to_jira_team_mongosh_mongosh"]
+    depends_on:
+      - name: compile_artifact
+        variant: build_linux_s390x_openssl11
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: ${node_js_version}
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-s390x-openssl11
+      - func: run_e2e_tests
+        vars:
+          node_js_version: ${node_js_version}
+          mongosh_server_test_version: ${mongosh_server_test_version}
+          mongosh_test_e2e_force_fips: ${mongosh_test_e2e_force_fips}
+  - name: e2e_tests_linux_s390x_openssl3
+    tags: ["e2e-test", "assigned_to_jira_team_mongosh_mongosh"]
+    depends_on:
+      - name: compile_artifact
+        variant: build_linux_s390x_openssl3
+    commands:
+      - func: checkout
+      - func: install
+        vars:
+          node_js_version: ${node_js_version}
+      - func: download_compiled_artifact
+        vars:
+          executable_os_id: linux-s390x-openssl3
       - func: run_e2e_tests
         vars:
           node_js_version: ${node_js_version}
@@ -12126,12 +12198,48 @@ buildvariants:
       node_js_version: "24.18.0"
     tasks:
       - name: compile_artifact
+  - name: build_linux_ppc64le_openssl11
+    display_name: "RHEL 8 PPC openssl11 (Build)"
+    run_on: rhel8-power-small
+    expansions:
+      executable_os_id: "linux-ppc64le-openssl11"
+      node_js_version: "24.18.0"
+      mongosh_shared_openssl: "openssl11"
+    tasks:
+      - name: compile_artifact
+  - name: build_linux_ppc64le_openssl3
+    display_name: "RHEL 8 PPC openssl3 (Build)"
+    run_on: rhel8-power-small
+    expansions:
+      executable_os_id: "linux-ppc64le-openssl3"
+      node_js_version: "24.18.0"
+      mongosh_shared_openssl: "openssl3"
+    tasks:
+      - name: compile_artifact
   - name: build_linux_s390x
     display_name: "RHEL 7 s390x (Build)"
     run_on: rhel7-zseries-large
     expansions:
       executable_os_id: "linux-s390x"
       node_js_version: "24.18.0"
+    tasks:
+      - name: compile_artifact
+  - name: build_linux_s390x_openssl11
+    display_name: "RHEL 7 s390x openssl11 (Build)"
+    run_on: rhel7-zseries-large
+    expansions:
+      executable_os_id: "linux-s390x-openssl11"
+      node_js_version: "24.18.0"
+      mongosh_shared_openssl: "openssl11"
+    tasks:
+      - name: compile_artifact
+  - name: build_linux_s390x_openssl3
+    display_name: "RHEL 7 s390x openssl3 (Build)"
+    run_on: rhel7-zseries-large
+    expansions:
+      executable_os_id: "linux-s390x-openssl3"
+      node_js_version: "24.18.0"
+      mongosh_shared_openssl: "openssl3"
     tasks:
       - name: compile_artifact
   - name: build_darwin
@@ -12653,6 +12761,28 @@ buildvariants:
       mongosh_test_e2e_force_fips: ""
     tasks:
       - name: e2e_tests_linux_ppc64le
+  - name: e2e_tests_rhel9_power_small_openssl11
+    display_name: "RHEL 9 PPC openssl11 (E2E tests)"
+    run_on: rhel9-power-small
+    tags: []
+    expansions:
+      executable_os_id: "linux-ppc64le-openssl11"
+      node_js_version: "24.18.0"
+      mongosh_server_test_version: "stable-enterprise"
+      mongosh_test_e2e_force_fips: ""
+    tasks:
+      - name: e2e_tests_linux_ppc64le_openssl11
+  - name: e2e_tests_rhel9_power_small_openssl3
+    display_name: "RHEL 9 PPC openssl3 (E2E tests)"
+    run_on: rhel9-power-small
+    tags: []
+    expansions:
+      executable_os_id: "linux-ppc64le-openssl3"
+      node_js_version: "24.18.0"
+      mongosh_server_test_version: "stable-enterprise"
+      mongosh_test_e2e_force_fips: ""
+    tasks:
+      - name: e2e_tests_linux_ppc64le_openssl3
   - name: e2e_tests_rhel7_zseries_small_m60x
     display_name: "RHEL 7 s390x 60x (E2E tests)"
     run_on: rhel7-zseries-small
@@ -12697,6 +12827,28 @@ buildvariants:
       mongosh_test_e2e_force_fips: ""
     tasks:
       - name: e2e_tests_linux_s390x
+  - name: e2e_tests_rhel9_zseries_small_openssl11
+    display_name: "RHEL 9 s390x openssl11 (E2E tests)"
+    run_on: rhel9-zseries-small
+    tags: []
+    expansions:
+      executable_os_id: "linux-s390x-openssl11"
+      node_js_version: "24.18.0"
+      mongosh_server_test_version: "stable-enterprise"
+      mongosh_test_e2e_force_fips: ""
+    tasks:
+      - name: e2e_tests_linux_s390x_openssl11
+  - name: e2e_tests_rhel9_zseries_small_openssl3
+    display_name: "RHEL 9 s390x openssl3 (E2E tests)"
+    run_on: rhel9-zseries-small
+    tags: []
+    expansions:
+      executable_os_id: "linux-s390x-openssl3"
+      node_js_version: "24.18.0"
+      mongosh_server_test_version: "stable-enterprise"
+      mongosh_test_e2e_force_fips: ""
+    tasks:
+      - name: e2e_tests_linux_s390x_openssl3
   - name: e2e_tests_macos_15_amd64_gui
     display_name: "MacOS 15 Sequoia (amd64) (E2E tests)"
     run_on: macos-15-amd64-gui

--- a/.evergreen/compile-artifact.sh
+++ b/.evergreen/compile-artifact.sh
@@ -59,7 +59,10 @@ elif [ -n "$MONGOSH_SHARED_OPENSSL" ]; then
   pushd openssl-*
   ./config --prefix=/tmp/m/opt --libdir=lib shared
   make -j12
-  make -j12 install install_ssldirs
+  # install_sw (not install) skips building/installing HTML man pages via
+  # mkpod2html.pl, which can fail if the host's Perl lacks required modules;
+  # we only need the libs/headers here.
+  make -j12 install_sw install_ssldirs
 
   popd # openssl-*
   popd # /tmp/m

--- a/packages/build/src/compile/signable-compiler.ts
+++ b/packages/build/src/compile/signable-compiler.ts
@@ -15,6 +15,13 @@ async function preCompileHook(nodeSourceTree: string) {
     ),
     'package.json'
   )).version;
+  // LD_LIBRARY_PATH may point at a custom-built shared OpenSSL used for the
+  // Node.js compile step (see .evergreen/compile-artifact.sh); this script
+  // only clones a git repo and builds the FLE addon, and git subprocesses
+  // (git-remote-https) can fail to resolve symbols against that OpenSSL on
+  // some platforms, so we don't want it inherited here.
+  const envWithoutLdLibraryPath = { ...process.env };
+  delete envWithoutLdLibraryPath.LD_LIBRARY_PATH;
   const proc = childProcess.spawn(
     'bash',
     [
@@ -30,7 +37,7 @@ async function preCompileHook(nodeSourceTree: string) {
     ],
     {
       env: {
-        ...process.env,
+        ...envWithoutLdLibraryPath,
         FLE_NODE_SOURCE_PATH: nodeSourceTree,
         MONGODB_CLIENT_ENCRYPTION_VERSION: `v${fleAddonVersion}`,
       },


### PR DESCRIPTION
Adds build_linux_ppc64le/s390x_openssl11/openssl3 build variants and matching e2e test tasks, mirroring the existing x64/arm64 setup, so shared-OpenSSL mongosh binaries exist on these architectures too.

Also fixes two issues surfaced only when compiling on the ppc64le host: `LD_LIBRARY_PATH` leaking from the shared-OpenSSL build into the FLE addon's git-clone subprocess (breaking git's Kerberos auth), and OpenSSL 3.0.5's `make install` failing to build HTML docs due to a missing Perl module (fixed by using `install_sw` instead, which only installs the libs/headers we actually need).

Verified with Evergreen patches covering the new variants individually, then the full build matrix (all existing + new variants) to confirm no regressions: https://spruce.corp.mongodb.com/version/6a5f83268ce8f70007bf1346