### PR TITLE
feat(shell-api): support sh.shardDrainingStatus() and sh.getTransitionToDedicatedConfigServerStatus() MONGOSH-2501

### DIFF
--- a/packages/i18n/src/locales/en_US.ts
+++ b/packages/i18n/src/locales/en_US.ts
@@ -2247,6 +2247,18 @@ const translations: Catalog = {
                 'Returns a document with an `enabled: <boolean>` field indicating whether the cluster is configured as embedded config server cluster. If it is, then the config shard host and tags are also returned.',
               example: 'sh.isConfigShardEnabled()',
             },
+            shardDrainingStatus: {
+              link: 'https://mongodb.com/docs/manual/reference/method/sh.shardDrainingStatus',
+              description:
+                'Returns the draining status of the given shard, or of all draining shards if no shard is specified. Uses the shardDrainingStatus admin command.',
+              example: 'sh.shardDrainingStatus(shardId?)',
+            },
+            getTransitionToDedicatedConfigServerStatus: {
+              link: 'https://mongodb.com/docs/manual/reference/method/sh.getTransitionToDedicatedConfigServerStatus',
+              description:
+                'Returns the draining status of the config shard while transitioning to a dedicated config server. Uses the getTransitionToDedicatedConfigServerStatus admin command.',
+              example: 'sh.getTransitionToDedicatedConfigServerStatus()',
+            },
           },
         },
       },

--- a/packages/shell-api/src/shard.spec.ts
+++ b/packages/shell-api/src/shard.spec.ts
@@ -2359,6 +2359,119 @@ describe('Shard', function () {
         expect(warnSpy.calledOnce).to.be.true;
       });
     });
+
+    describe('shardDrainingStatus', function () {
+      this.beforeEach(function () {
+        serviceProvider.runCommandWithCheck.resolves({
+          ok: 1,
+          msg: 'isdbgrid',
+        });
+      });
+
+      it('calls serviceProvider.runCommandWithCheck without a shardId', async function () {
+        await shard.shardDrainingStatus();
+
+        expect(serviceProvider.runCommandWithCheck).to.have.been.calledWith(
+          ADMIN_DB,
+          {
+            shardDrainingStatus: 1,
+          }
+        );
+      });
+
+      it('calls serviceProvider.runCommandWithCheck with a shardId', async function () {
+        await shard.shardDrainingStatus('shard1');
+
+        expect(serviceProvider.runCommandWithCheck).to.have.been.calledWith(
+          ADMIN_DB,
+          {
+            shardDrainingStatus: 'shard1',
+          }
+        );
+      });
+
+      it('returns whatever serviceProvider.runCommandWithCheck returns', async function () {
+        serviceProvider.runCommandWithCheck
+          .onCall(0)
+          .resolves({ ok: 1, msg: 'isdbgrid' });
+        const expectedResult = { ok: 1, state: 'started' };
+        serviceProvider.runCommandWithCheck.onCall(1).resolves(expectedResult);
+        const result = await shard.shardDrainingStatus('shard1');
+        expect(result).to.deep.equal(expectedResult);
+      });
+
+      it('throws if serviceProvider.runCommandWithCheck rejects', async function () {
+        serviceProvider.runCommandWithCheck
+          .onCall(0)
+          .resolves({ ok: 1, msg: 'isdbgrid' });
+        const expectedError = new Error('unreachable');
+        serviceProvider.runCommandWithCheck.onCall(1).rejects(expectedError);
+        const caughtError = await shard
+          .shardDrainingStatus('shard1')
+          .catch((e) => e);
+        expect(caughtError).to.equal(expectedError);
+      });
+
+      it('throws if not mongos', async function () {
+        serviceProvider.runCommandWithCheck.resolves({
+          ok: 1,
+          msg: 'not dbgrid',
+        });
+        await shard.shardDrainingStatus();
+        expect(warnSpy.calledOnce).to.be.true;
+      });
+    });
+
+    describe('getTransitionToDedicatedConfigServerStatus', function () {
+      this.beforeEach(function () {
+        serviceProvider.runCommandWithCheck.resolves({
+          ok: 1,
+          msg: 'isdbgrid',
+        });
+      });
+
+      it('calls serviceProvider.runCommandWithCheck', async function () {
+        await shard.getTransitionToDedicatedConfigServerStatus();
+
+        expect(serviceProvider.runCommandWithCheck).to.have.been.calledWith(
+          ADMIN_DB,
+          {
+            getTransitionToDedicatedConfigServerStatus: 1,
+          }
+        );
+      });
+
+      it('returns whatever serviceProvider.runCommandWithCheck returns', async function () {
+        serviceProvider.runCommandWithCheck
+          .onCall(0)
+          .resolves({ ok: 1, msg: 'isdbgrid' });
+        const expectedResult = { ok: 1, state: 'started' };
+        serviceProvider.runCommandWithCheck.onCall(1).resolves(expectedResult);
+        const result = await shard.getTransitionToDedicatedConfigServerStatus();
+        expect(result).to.deep.equal(expectedResult);
+      });
+
+      it('throws if serviceProvider.runCommandWithCheck rejects', async function () {
+        serviceProvider.runCommandWithCheck
+          .onCall(0)
+          .resolves({ ok: 1, msg: 'isdbgrid' });
+        const expectedError = new Error('unreachable');
+        serviceProvider.runCommandWithCheck.onCall(1).rejects(expectedError);
+        const caughtError = await shard
+          .getTransitionToDedicatedConfigServerStatus()
+          .catch((e) => e);
+        expect(caughtError).to.equal(expectedError);
+      });
+
+      it('throws if not mongos', async function () {
+        serviceProvider.runCommandWithCheck.resolves({
+          ok: 1,
+          msg: 'not dbgrid',
+        });
+        await shard.getTransitionToDedicatedConfigServerStatus();
+        expect(warnSpy.calledOnce).to.be.true;
+      });
+    });
   });
 
   describe('integration', function () {

--- a/packages/shell-api/src/shard.ts
+++ b/packages/shell-api/src/shard.ts
@@ -883,4 +883,33 @@ export default class Shard<
       ...(configShard.tags && { tags: configShard.tags }),
     };
   }
+
+  @serverVersions(['8.2.0', ServerVersions.latest])
+  @apiVersions([])
+  @returnsPromise
+  async shardDrainingStatus(shardId?: string): Promise<Document> {
+    assertArgsDefinedType(
+      [shardId],
+      [[undefined, 'string']],
+      'Shard.shardDrainingStatus'
+    );
+    this._emitShardApiCall('shardDrainingStatus', { shardId });
+    await getConfigDB(this._database);
+
+    return this._database._runAdminReadCommand({
+      shardDrainingStatus: shardId ?? 1,
+    });
+  }
+
+  @serverVersions(['8.3.0', ServerVersions.latest])
+  @apiVersions([])
+  @returnsPromise
+  async getTransitionToDedicatedConfigServerStatus(): Promise<Document> {
+    this._emitShardApiCall('getTransitionToDedicatedConfigServerStatus', {});
+    await getConfigDB(this._database);
+
+    return this._database._runAdminReadCommand({
+      getTransitionToDedicatedConfigServerStatus: 1,
+    });
+  }
 }


### PR DESCRIPTION
Server epic [SPM-4275](https://jira.mongodb.org/browse/SPM-4275) ("RemoveShard Interface Improvements") introduced a decomposed shard-removal workflow on mongod/mongos, including a `shardDrainingStatus` admin command that reports draining progress for a given shard (or all draining shards if none is specified). A related change, [SERVER-110790](https://jira.mongodb.org/browse/SERVER-110790), exposes the same status information for the config-shard-to-dedicated-config-server transition under its own command name, `getTransitionToDedicatedConfigServerStatus`, so that the public naming stays conceptually separate from generic shard removal.

This PR surfaces both as `sh.*` shell helpers:

```js
db.adminCommand({ shardDrainingStatus: "shard1" }) // or shardDrainingStatus: 1 for all shards
db.adminCommand({ getTransitionToDedicatedConfigServerStatus: 1 })
```

## Changes

- `sh.shardDrainingStatus(shardId?)` — returns the draining status of the given shard, or of all currently draining shards if no `shardId` is passed. Gated to server versions `>= 8.2.0` (first release containing `SERVER-107016`/`SERVER-106558`).
- `sh.getTransitionToDedicatedConfigServerStatus()` — takes no arguments, returns the config shard's draining status. Gated to server versions `>= 8.3.0` (first release containing `SERVER-110790`).
- Both call `getConfigDB()` first (to confirm the client is connected to mongos, matching the existing `isBalancerRunning`/`isConfigShardEnabled` pattern) and use `_runAdminReadCommand` since these are read-only status queries.
- Added `en_US` i18n help text and examples for both new attributes.
- Added unit tests covering the with/without-`shardId` cases, result pass-through, error pass-through, and the not-connected-to-mongos warning.

## Notes

- Version gates were determined by walking the `mongodb/mongo` commit history between release branch cuts, since the Jira tickets only stated the docs "debut in 9.0" rather than the actual command availability.
- `sh.listShards()`'s new `draining` filter (a related but separate change) is tracked in [MONGOSH-2500](https://jira.mongodb.org/browse/MONGOSH-2500) / #2776 and is not part of this PR.