### PR TITLE
chore: updating mongodb-schema to new devtools shared package COMPASS-10911

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7077,17 +7077,233 @@
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
       "license": "MIT"
     },
-    "node_modules/@mongodb-js/mongodb-ts-autocomplete": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/mongodb-ts-autocomplete/-/mongodb-ts-autocomplete-0.7.3.tgz",
-      "integrity": "sha512-lVRnJTLm3KarjJHAVKMdK0kIVrORmcsMAOfSgTMN4m2tgWTrObhisngKcWvky8yVhBgnQp2nwm/ykKdbv/XTTg==",
+    "node_modules/@mongodb-js/mongodb-schema": {
+      "version": "12.7.2",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/mongodb-schema/-/mongodb-schema-12.7.2.tgz",
+      "integrity": "sha512-+LC21SF05XYVmlkP0d3llaJ1OCkC7VdD1ozLbRKCmwltFyObtFMEFEarZURRL6wjBEuqxBkLurhq+HsC6U6bOA==",
       "license": "Apache-2.0",
       "dependencies": {
-        "@mongodb-js/ts-autocomplete": "^0.5.12",
+        "reservoir": "^0.1.2"
+      },
+      "bin": {
+        "mongodb-schema": "bin/mongodb-schema"
+      },
+      "optionalDependencies": {
+        "bson": "^4.6.3 || ^5 || ^6.10.3 || ^7.0.0",
+        "cli-table": "^0.3.4",
+        "js-yaml": "^5.2.2",
+        "mongodb": "^6.9.0 || ^7.0.0",
+        "mongodb-ns": "^3.2.1",
+        "numeral": "^2.0.6",
+        "progress": "^2.0.3",
+        "stats-lite": "^2.0.0",
+        "yargs": "^18.0.0"
+      }
+    },
+    "node_modules/@mongodb-js/mongodb-schema/node_modules/ansi-regex": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-6.2.2.tgz",
+      "integrity": "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-regex?sponsor=1"
+      }
+    },
+    "node_modules/@mongodb-js/mongodb-schema/node_modules/ansi-styles": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-6.2.3.tgz",
+      "integrity": "sha512-4Dj6M28JB+oAH8kFkTLUo+a2jwOFkuqb3yucU0CANcRRUbxS0cP0nZYCGjcc3BNXwRIsUVmDGgzawme7zvJHvg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@mongodb-js/mongodb-schema/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0",
+      "optional": true
+    },
+    "node_modules/@mongodb-js/mongodb-schema/node_modules/cliui": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
+      "integrity": "sha512-k7ndgKhwoQveBL+/1tqGJYNz097I7WOvwbmmU2AR5+magtbjPWQTS1C5vzGkBC8Ym8UWRzfKUzUUqFLypY4Q+w==",
+      "license": "ISC",
+      "optional": true,
+      "dependencies": {
+        "string-width": "^7.2.0",
+        "strip-ansi": "^7.1.0",
+        "wrap-ansi": "^9.0.0"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/@mongodb-js/mongodb-schema/node_modules/cliui/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@mongodb-js/mongodb-schema/node_modules/emoji-regex": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-10.6.0.tgz",
+      "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
+      "license": "MIT",
+      "optional": true
+    },
+    "node_modules/@mongodb-js/mongodb-schema/node_modules/js-yaml": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.2.tgz",
+      "integrity": "sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.mjs"
+      }
+    },
+    "node_modules/@mongodb-js/mongodb-schema/node_modules/string-width": {
+      "version": "8.2.2",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-8.2.2.tgz",
+      "integrity": "sha512-GaPUh5gfdrYzqeVNZvUfT23vYYxXzKYidUcnMtJg/3rxRV63EFZy3k6xfKlmfeJD0176lnUV/Usr3XcwSvFzpg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "get-east-asian-width": "^1.5.0",
+        "strip-ansi": "^7.1.2"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@mongodb-js/mongodb-schema/node_modules/strip-ansi": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-7.2.0.tgz",
+      "integrity": "sha512-yDPMNjp4WyfYBkHnjIRLfca1i6KMyGCtsVgoKe/z1+6vukgaENdgGBZt+ZmKPc4gavvEZ5OgHfHdrazhgNyG7w==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ansi-regex": "^6.2.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/strip-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@mongodb-js/mongodb-schema/node_modules/wrap-ansi": {
+      "version": "9.0.2",
+      "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-9.0.2.tgz",
+      "integrity": "sha512-42AtmgqjV+X1VpdOfyTGOYRi0/zsoLqtXQckTmqTeybT+BDIbM/Guxo7x3pE2vtpr1ok6xRqM9OpBe+Jyoqyww==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "ansi-styles": "^6.2.1",
+        "string-width": "^7.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
+      }
+    },
+    "node_modules/@mongodb-js/mongodb-schema/node_modules/wrap-ansi/node_modules/string-width": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-7.2.0.tgz",
+      "integrity": "sha512-tsaTIkKW9b4N+AEj+SVA+WhJzV7/zMhcSu78mLKWSk7cXMOSHsBKFWUs0fWwq8QyK3MgJBQRX6Gbi4kYbdvGkQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "emoji-regex": "^10.3.0",
+        "get-east-asian-width": "^1.0.0",
+        "strip-ansi": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@mongodb-js/mongodb-schema/node_modules/yargs": {
+      "version": "18.1.0",
+      "resolved": "https://registry.npmjs.org/yargs/-/yargs-18.1.0.tgz",
+      "integrity": "sha512-2rAgRKu54VsHkqI0/tYkmluGXHD4KW7yZoycuqDQ15QOTnc2VVfy0nN/1eMhnQLO00A+dwtK20xuCnc1YGeUyg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "cliui": "^9.0.1",
+        "escalade": "^3.1.1",
+        "get-caller-file": "^2.0.5",
+        "string-width": "^8.2.1",
+        "y18n": "^5.0.5",
+        "yargs-parser": "^22.0.0"
+      },
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/@mongodb-js/mongodb-schema/node_modules/yargs-parser": {
+      "version": "22.0.0",
+      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-22.0.0.tgz",
+      "integrity": "sha512-rwu/ClNdSMpkSrUb+d6BRsSkLUq1fmfsY6TOpYzTwvwkg1/NRG85KBy3kq++A8LKQwX6lsu+aWad+2khvuXrqw==",
+      "license": "ISC",
+      "optional": true,
+      "engines": {
+        "node": "^20.19.0 || ^22.12.0 || >=23"
+      }
+    },
+    "node_modules/@mongodb-js/mongodb-ts-autocomplete": {
+      "version": "0.9.2",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/mongodb-ts-autocomplete/-/mongodb-ts-autocomplete-0.9.2.tgz",
+      "integrity": "sha512-Fue4ccUiBpAhGLrhQwGtRcyQh/3WVwCBkY9YZAK1wBiLKpGFiVZWrJ9Bf3WIA52KVeq606VlXd3XI4zQJOtSJw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@mongodb-js/mongodb-schema": "^12.7.2",
+        "@mongodb-js/ts-autocomplete": "^0.5.13",
         "@mongosh/shell-api": "^5.1.6",
         "debug": "^4.4.0",
         "lodash": "^4.17.21",
-        "mongodb-schema": "^12.6.2",
         "node-cache": "^5.1.2",
         "typescript": "^5.9.3"
       }
@@ -7643,9 +7859,9 @@
       }
     },
     "node_modules/@mongodb-js/ts-autocomplete": {
-      "version": "0.5.12",
-      "resolved": "https://registry.npmjs.org/@mongodb-js/ts-autocomplete/-/ts-autocomplete-0.5.12.tgz",
-      "integrity": "sha512-5tSGDhK87ArvyL5cUXYqZSVpycYn6/NjHIFUiKk5awDfChHCnaAsiiESkL3LAps+41bxXTSa3O/HguwAu9zNTA==",
+      "version": "0.5.13",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/ts-autocomplete/-/ts-autocomplete-0.5.13.tgz",
+      "integrity": "sha512-MP+Z1VuE6XzKhsgwI2o7A2uEPnNssqm/P+3GKbX3Du+CzMzAjYONWw7ppb4f40rYJbFTev7NKFTxN8ifo7hmnQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "debug": "^4.4.0",
@@ -25637,9 +25853,9 @@
       }
     },
     "node_modules/mongodb-ns": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/mongodb-ns/-/mongodb-ns-3.1.5.tgz",
-      "integrity": "sha512-eRxYlnYR7Tq1FjlQLYbqvOcGwkvaZb2rATAdVACCRjLHqe8EbExmFuiAk3n6o8Velz144pnAS0tI62tR9vHiGw==",
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/mongodb-ns/-/mongodb-ns-3.2.1.tgz",
+      "integrity": "sha512-PhuRl7oAzHbILnn+DoJkHnfduh7VRKMYnkzOv/x32GC8YvnhYXr42rhzxIK/UQvyZcnG968yVvCvjF2xSUP1OQ==",
       "license": "Apache-2.0",
       "optional": true
     },
@@ -25732,73 +25948,6 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
       "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
       "license": "ISC",
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/mongodb-schema": {
-      "version": "12.7.0",
-      "resolved": "https://registry.npmjs.org/mongodb-schema/-/mongodb-schema-12.7.0.tgz",
-      "integrity": "sha512-TPfop6c2AAQJP1QhQwi/uJnuPEeLhMvN9ouJAZ6M9mouH6fCr0WOHLJWx5Z0dSeXJIVy//WTXxZB6yiol1bGEA==",
-      "license": "Apache-2.0",
-      "dependencies": {
-        "reservoir": "^0.1.2"
-      },
-      "bin": {
-        "mongodb-schema": "bin/mongodb-schema"
-      },
-      "optionalDependencies": {
-        "bson": "^6.7.0 || ^7.1.1",
-        "cli-table": "^0.3.4",
-        "js-yaml": "^4.0.0",
-        "mongodb": "^6.6.1 || ^7.0.0",
-        "mongodb-ns": "^3.0.1",
-        "numeral": "^2.0.6",
-        "progress": "^2.0.3",
-        "stats-lite": "^2.0.0",
-        "yargs": "^17.6.2"
-      }
-    },
-    "node_modules/mongodb-schema/node_modules/cliui": {
-      "version": "8.0.1",
-      "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
-      "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "string-width": "^4.2.0",
-        "strip-ansi": "^6.0.1",
-        "wrap-ansi": "^7.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/mongodb-schema/node_modules/yargs": {
-      "version": "17.7.2",
-      "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.2.tgz",
-      "integrity": "sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "cliui": "^8.0.1",
-        "escalade": "^3.1.1",
-        "get-caller-file": "^2.0.5",
-        "require-directory": "^2.1.1",
-        "string-width": "^4.2.3",
-        "y18n": "^5.0.5",
-        "yargs-parser": "^21.1.1"
-      },
-      "engines": {
-        "node": ">=12"
-      }
-    },
-    "node_modules/mongodb-schema/node_modules/yargs-parser": {
-      "version": "21.1.1",
-      "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
-      "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
-      "license": "ISC",
-      "optional": true,
       "engines": {
         "node": ">=12"
       }
@@ -34494,7 +34643,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@mongodb-js/mongodb-constants": "^0.33.0",
-        "@mongodb-js/mongodb-ts-autocomplete": "^0.7.3",
+        "@mongodb-js/mongodb-ts-autocomplete": "^0.9.2",
         "@mongosh/shell-api": "^5.3.2",
         "semver": "^7.5.4"
       },
@@ -35857,7 +36006,7 @@
       },
       "devDependencies": {
         "@mongodb-js/eslint-config-mongosh": "^1.0.0",
-        "@mongodb-js/mongodb-ts-autocomplete": "^0.7.3",
+        "@mongodb-js/mongodb-ts-autocomplete": "^0.9.2",
         "@mongodb-js/prettier-config-devtools": "^1.0.1",
         "@mongodb-js/tsconfig-mongosh": "^1.0.0",
         "@mongosh/types": "^5.0.5",
@@ -36494,20 +36643,20 @@
       "version": "5.3.2",
       "license": "Apache-2.0",
       "dependencies": {
+        "@mongodb-js/mongodb-schema": "^12.7.1",
         "@mongosh/arg-parser": "^5.2.0",
         "@mongosh/errors": "2.4.7",
         "@mongosh/i18n": "^2.22.0",
         "@mongosh/service-provider-core": "5.0.6",
         "@mongosh/shell-bson": "3.0.6",
-        "mongodb-redact": "^1.3.0",
-        "mongodb-schema": "^12.7.0"
+        "mongodb-redact": "^1.3.0"
       },
       "devDependencies": {
         "@babel/core": "^7.26.10",
         "@babel/types": "^7.26.10",
         "@microsoft/api-extractor": "^7.39.3",
         "@mongodb-js/eslint-config-mongosh": "^1.0.0",
-        "@mongodb-js/mongodb-ts-autocomplete": "^0.7.3",
+        "@mongodb-js/mongodb-ts-autocomplete": "^0.9.2",
         "@mongodb-js/prettier-config-devtools": "^1.0.1",
         "@mongodb-js/tsconfig-mongosh": "^1.0.0",
         "@mongosh/testing": "2.0.14",

--- a/packages/autocomplete/package.json
+++ b/packages/autocomplete/package.json
@@ -42,7 +42,7 @@
   },
   "dependencies": {
     "@mongodb-js/mongodb-constants": "^0.33.0",
-    "@mongodb-js/mongodb-ts-autocomplete": "^0.7.3",
+    "@mongodb-js/mongodb-ts-autocomplete": "^0.9.2",
     "@mongosh/shell-api": "^5.3.2",
     "semver": "^7.5.4"
   }

--- a/packages/browser-runtime-core/package.json
+++ b/packages/browser-runtime-core/package.json
@@ -40,7 +40,7 @@
     "@mongodb-js/eslint-config-mongosh": "^1.0.0",
     "@mongodb-js/prettier-config-devtools": "^1.0.1",
     "@mongodb-js/tsconfig-mongosh": "^1.0.0",
-    "@mongodb-js/mongodb-ts-autocomplete": "^0.7.3",
+    "@mongodb-js/mongodb-ts-autocomplete": "^0.9.2",
     "@mongosh/types": "^5.0.5",
     "bson": "^7.3.1",
     "eslint": "^7.25.0",

--- a/packages/shell-api/api-extractor.json
+++ b/packages/shell-api/api-extractor.json
@@ -16,7 +16,7 @@
     "@mongosh/service-provider-core",
     "@mongosh/types",
     "mongodb",
-    "mongodb-schema",
+    "@mongodb-js/mongodb-schema",
     "@types/json-schema"
   ],
   "dtsRollup": {

--- a/packages/shell-api/package.json
+++ b/packages/shell-api/package.json
@@ -56,13 +56,13 @@
     "@mongosh/service-provider-core": "5.0.6",
     "@mongosh/shell-bson": "3.0.6",
     "mongodb-redact": "^1.3.0",
-    "mongodb-schema": "^12.7.0"
+    "@mongodb-js/mongodb-schema": "^12.7.1"
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.39.3",
     "@mongosh/testing": "2.0.14",
     "@mongodb-js/eslint-config-mongosh": "^1.0.0",
-    "@mongodb-js/mongodb-ts-autocomplete": "^0.7.3",
+    "@mongodb-js/mongodb-ts-autocomplete": "^0.9.2",
     "@mongodb-js/prettier-config-devtools": "^1.0.1",
     "@mongodb-js/tsconfig-mongosh": "^1.0.0",
     "@mongosh/types": "^5.0.5",

--- a/packages/shell-api/src/shell-instance-state.ts
+++ b/packages/shell-api/src/shell-instance-state.ts
@@ -50,8 +50,8 @@ import { Streams } from './streams';
 import { ShellLog } from './shell-log';
 
 import type { AutocompletionContext } from '@mongodb-js/mongodb-ts-autocomplete';
-import type { JSONSchema } from 'mongodb-schema';
-import { analyzeDocuments } from 'mongodb-schema';
+import type { JSONSchema } from '@mongodb-js/mongodb-schema';
+import { analyzeDocuments } from '@mongodb-js/mongodb-schema';
 import type { BaseCursor } from './abstract-cursor';
 import { deepInspectServiceProviderWrapper } from './deep-inspect/service-provider-wrapper';
 


### PR DESCRIPTION
We have a new package being published from shared devtools repo, this PR is updating the usage of mongodb-schema to remove all the old references. 

@mongodb-js/mongodb-ts-autocomplete depends on mongodb-schema and it was also updated to remove the old reference of the non-existing package.