### PR TITLE
chore: default draft tag message to version name MONGOSH-3554

### DIFF
--- a/packages/build/src/local/trigger-release-draft.spec.ts
+++ b/packages/build/src/local/trigger-release-draft.spec.ts
@@ -60,7 +60,7 @@ describe('local trigger-release-draft', function () {
       expect(spawnSync).to.have.been.calledTwice;
       expect(spawnSync.getCall(0)).calledWith(
         'git',
-        ['tag', 'v0.8.0-draft.8'],
+        ['tag', '-m', 'v0.8.0-draft.8', 'v0.8.0-draft.8'],
         sinon.match.any
       );
       expect(spawnSync.getCall(1)).calledWith(
@@ -99,7 +99,7 @@ describe('local trigger-release-draft', function () {
       expect(spawnSync).to.have.been.calledTwice;
       expect(spawnSync.getCall(0)).calledWith(
         'git',
-        ['tag', 'v0.9.0-draft.0'],
+        ['tag', '-m', 'v0.9.0-draft.0', 'v0.9.0-draft.0'],
         sinon.match.any
       );
       expect(spawnSync.getCall(1)).calledWith(
@@ -147,7 +147,7 @@ describe('local trigger-release-draft', function () {
       expect(spawnSync).to.have.been.calledTwice;
       expect(spawnSync.getCall(0)).calledWith(
         'git',
-        ['tag', 'v0.8.3-draft.0'],
+        ['tag', '-m', 'v0.8.3-draft.0', 'v0.8.3-draft.0'],
         sinon.match.any
       );
       expect(spawnSync.getCall(1)).calledWith(

--- a/packages/build/src/local/trigger-release-draft.ts
+++ b/packages/build/src/local/trigger-release-draft.ts
@@ -85,7 +85,7 @@ export async function triggerReleaseDraft(
   }
 
   console.info('... creating and pushing tag ...');
-  spawnSync('git', ['tag', nextTagName], {
+  spawnSync('git', ['tag', '-m', nextTagName, nextTagName], {
     cwd: repositoryRoot,
     encoding: 'utf-8',
   });


### PR DESCRIPTION
If the tag creation is signed in, the process was hanging locally because git was waiting for a message confirmation.
This change defaults the message to be the tag name, if necessary.