### PR TITLE
chore(build): defer Ubuntu 26.04 PPA publishing out of 9.0.0 MONGOSH-3582

### DIFF
--- a/packages/build/src/barque.spec.ts
+++ b/packages/build/src/barque.spec.ts
@@ -75,8 +75,6 @@ describe('Barque', function () {
                 'https://repo.mongodb.com/apt/ubuntu/dists/noble/mongodb-enterprise/8.3/multiverse/binary-amd64/mongodb-mongosh_0.1.0_amd64.deb',
                 'https://repo.mongodb.org/apt/ubuntu/dists/noble/mongodb-org/9.0/multiverse/binary-amd64/mongodb-mongosh_0.1.0_amd64.deb',
                 'https://repo.mongodb.com/apt/ubuntu/dists/noble/mongodb-enterprise/9.0/multiverse/binary-amd64/mongodb-mongosh_0.1.0_amd64.deb',
-                'https://repo.mongodb.org/apt/ubuntu/dists/resolute/mongodb-org/9.0/multiverse/binary-amd64/mongodb-mongosh_0.1.0_amd64.deb',
-                'https://repo.mongodb.com/apt/ubuntu/dists/resolute/mongodb-enterprise/9.0/multiverse/binary-amd64/mongodb-mongosh_0.1.0_amd64.deb',
                 'https://repo.mongodb.org/apt/debian/dists/buster/mongodb-org/4.4/main/binary-amd64/mongodb-mongosh_0.1.0_amd64.deb',
                 'https://repo.mongodb.com/apt/debian/dists/buster/mongodb-enterprise/4.4/main/binary-amd64/mongodb-mongosh_0.1.0_amd64.deb',
                 'https://repo.mongodb.org/apt/debian/dists/buster/mongodb-org/5.0/main/binary-amd64/mongodb-mongosh_0.1.0_amd64.deb',

--- a/packages/build/src/config/server-with-ppa.ts
+++ b/packages/build/src/config/server-with-ppa.ts
@@ -154,7 +154,6 @@ export const SERVER_WITH_PPAS: Record<
     'suse16',
     'ubuntu2204',
     'ubuntu2404',
-    'ubuntu2604',
   ],
 };
 


### PR DESCRIPTION
## Description

Drops `ubuntu2604` from the `'9.0.0'` entry of `SERVER_WITH_PPAS`, so mongosh does not publish to the Ubuntu 26.04 (`resolute`) org and enterprise repos for the 9.0 release.

The server team currently cannot build 9.0.0 on Ubuntu 26.04 — it is blocked on [SERVER-131155](https://jira.mongodb.org/browse/SERVER-131155) and is expected to be pushed out to 9.0.1. Publishing there for 9.0 would point at repositories the server itself does not ship into.