### PR TITLE
feat(shell-api): allow empty pipeline in stream processor creation functions STREAMS-2592

### DIFF
--- a/packages/shell-api/src/streams.spec.ts
+++ b/packages/shell-api/src/streams.spec.ts
@@ -17,7 +17,7 @@ describe('Streams', function () {
     mongo = {
       _instanceState: {
         interrupted: new InterruptFlag(),
-        shellApi: { printjson: identity },
+        shellApi: { printjson: identity, sleep: identity },
         transformError: identity,
       },
       _serviceProvider: {

--- a/packages/shell-api/src/streams.spec.ts
+++ b/packages/shell-api/src/streams.spec.ts
@@ -77,14 +77,22 @@ describe('Streams', function () {
 
   describe('process', function () {
     it('allows empty pipeline', async function () {
-      const response = { ok: 1, name: 'proc', cursorId: 1 };
-      const runCmdStub = sinon
-        .stub(mongo._serviceProvider, 'runCommand')
-        .resolves(response);
+      const runCmdStub = sinon.stub(mongo._serviceProvider, 'runCommand');
+      runCmdStub
+        .withArgs('admin', { processStreamProcessor: [] }, {})
+        .resolves({ ok: 1, name: 'proc', cursorId: 1 });
+      runCmdStub
+        .withArgs(
+          'admin',
+          { getMoreSampleStreamProcessor: 'proc', cursorId: 1 },
+          {}
+        )
+        .resolves({ ok: 1, messages: [], cursorId: 0 });
+      runCmdStub.resolves({ ok: 1 });
 
-      streams.process([]);
+      await streams.process([]);
       expect(
-        runCmdStub.calledOnceWithExactly(
+        runCmdStub.calledWithExactly(
           'admin',
           { processStreamProcessor: [] },
           {}

--- a/packages/shell-api/src/streams.spec.ts
+++ b/packages/shell-api/src/streams.spec.ts
@@ -38,11 +38,12 @@ describe('Streams', function () {
       );
     });
 
-    it('throws when pipeline is empty', async function () {
-      const caught = await streams
-        .createStreamProcessor('spm', [])
-        .catch((e) => e);
-      expect(caught.message).to.contain('[COMMON-10001] Invalid pipeline');
+    it('allows empty pipeline', async function () {
+      const response = { ok: 1, name: 'spm' };
+      sinon.stub(mongo._serviceProvider, 'runCommand').resolves(response);
+
+      const result = await streams.createStreamProcessor('spm', []);
+      expect(result._name).to.equal('spm');
     });
 
     it('returns error when creation fails', async function () {
@@ -69,9 +70,20 @@ describe('Streams', function () {
   });
 
   describe('process', function () {
-    it('throws when pipeline is empty', async function () {
-      const caught = await streams.process([]).catch((e) => e);
-      expect(caught.message).to.contain('[COMMON-10001] Invalid pipeline');
+    it('allows empty pipeline', async function () {
+      const response = { ok: 1, name: 'proc', cursorId: 1 };
+      const runCmdStub = sinon
+        .stub(mongo._serviceProvider, 'runCommand')
+        .resolves(response);
+
+      streams.process([]);
+      expect(
+        runCmdStub.calledOnceWithExactly(
+          'admin',
+          { processStreamProcessor: [] },
+          {}
+        )
+      ).to.be.true;
     });
 
     it('returns if process cmd errors', async function () {

--- a/packages/shell-api/src/streams.spec.ts
+++ b/packages/shell-api/src/streams.spec.ts
@@ -39,11 +39,17 @@ describe('Streams', function () {
     });
 
     it('allows empty pipeline', async function () {
-      const response = { ok: 1, name: 'spm' };
-      sinon.stub(mongo._serviceProvider, 'runCommand').resolves(response);
+      const runCmdStub = sinon
+        .stub(mongo._serviceProvider, 'runCommand')
+        .resolves({ ok: 1 });
 
       const result = await streams.createStreamProcessor('spm', []);
-      expect(result._name).to.equal('spm');
+      expect(result).to.eql(
+        streams.getProcessor({ name: 'spm', pipeline: [] })
+      );
+
+      const cmd = { createStreamProcessor: 'spm', pipeline: [] };
+      expect(runCmdStub.calledOnceWithExactly('admin', cmd, {})).to.be.true;
     });
 
     it('returns error when creation fails', async function () {

--- a/packages/shell-api/src/streams.ts
+++ b/packages/shell-api/src/streams.ts
@@ -62,7 +62,7 @@ export class Streams<
 
   @returnsPromise
   async process(pipeline: MQLPipeline, options?: Document) {
-    if (!Array.isArray(pipeline) || !pipeline.length) {
+    if (!Array.isArray(pipeline)) {
       throw new MongoshInvalidInputError(
         'Invalid pipeline',
         CommonErrors.InvalidArgument,
@@ -114,7 +114,7 @@ export class Streams<
         CommonErrors.InvalidArgument
       );
     }
-    if (!Array.isArray(pipeline) || !pipeline.length) {
+    if (!Array.isArray(pipeline)) {
       throw new MongoshInvalidInputError(
         'Invalid pipeline',
         CommonErrors.InvalidArgument,


### PR DESCRIPTION
for materialized views, an empty pipeline is a valid use case- it means materializing a source onto a sink without any transformations. we should allow this use case and let the server do the validation