### PR TITLE
chore(ci): bump pinned 9.0 version to rc4 MONGOSH-3590

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -11053,7 +11053,7 @@ buildvariants:
     disable: false
     expansions:
       executable_os_id: darwin-arm64
-      mongosh_server_test_version: "9.0.0-rc3"
+      mongosh_server_test_version: "9.0.0-rc4"
       mongosh_server_test_version_list_url: "https://downloads.mongodb.org/cloud.json"
       node_js_version: "24.18.1"
       mongosh_skip_node_version_check: ""
@@ -11088,7 +11088,7 @@ buildvariants:
     disable: false
     expansions:
       executable_os_id: darwin-arm64
-      mongosh_server_test_version: "9.0.0-rc3-enterprise"
+      mongosh_server_test_version: "9.0.0-rc4-enterprise"
       mongosh_server_test_version_list_url: "https://downloads.mongodb.org/cloud.json"
       node_js_version: "24.18.1"
       mongosh_skip_node_version_check: ""
@@ -11599,7 +11599,7 @@ buildvariants:
     disable: false
     expansions:
       executable_os_id: darwin-arm64
-      mongosh_server_test_version: "9.0.0-rc3"
+      mongosh_server_test_version: "9.0.0-rc4"
       mongosh_server_test_version_list_url: "https://downloads.mongodb.org/cloud.json"
       node_js_version: "24.18.1"
       mongosh_skip_node_version_check: ""
@@ -11634,7 +11634,7 @@ buildvariants:
     disable: false
     expansions:
       executable_os_id: darwin-arm64
-      mongosh_server_test_version: "9.0.0-rc3-enterprise"
+      mongosh_server_test_version: "9.0.0-rc4-enterprise"
       mongosh_server_test_version_list_url: "https://downloads.mongodb.org/cloud.json"
       node_js_version: "24.18.1"
       mongosh_skip_node_version_check: ""
@@ -12132,7 +12132,7 @@ buildvariants:
     disable: false
     expansions:
       executable_os_id: win32
-      mongosh_server_test_version: "9.0.0-rc3"
+      mongosh_server_test_version: "9.0.0-rc4"
       mongosh_server_test_version_list_url: "https://downloads.mongodb.org/cloud.json"
       node_js_version: "24.18.1"
       mongosh_skip_node_version_check: ""
@@ -12166,7 +12166,7 @@ buildvariants:
     disable: false
     expansions:
       executable_os_id: win32
-      mongosh_server_test_version: "9.0.0-rc3-enterprise"
+      mongosh_server_test_version: "9.0.0-rc4-enterprise"
       mongosh_server_test_version_list_url: "https://downloads.mongodb.org/cloud.json"
       node_js_version: "24.18.1"
       mongosh_skip_node_version_check: ""

--- a/.evergreen/constants.js
+++ b/.evergreen/constants.js
@@ -39,14 +39,14 @@ exports.MONGODB_VERSIONS = [
   { shortName: '83xe', versionSpec: '8.3.x-enterprise' },
   {
     shortName: '90xc',
-    versionSpec: '9.0.0-rc3',
+    versionSpec: '9.0.0-rc4',
     // 9.0 release candidates are only published to cloud.json, not the
     // default full.json feed that mongodb-download-url resolves against.
     versionListUrl: 'https://downloads.mongodb.org/cloud.json',
   },
   {
     shortName: '90xe',
-    versionSpec: '9.0.0-rc3-enterprise',
+    versionSpec: '9.0.0-rc4-enterprise',
     versionListUrl: 'https://downloads.mongodb.org/cloud.json',
   },
   { shortName: 'latest', versionSpec: 'latest-alpha-enterprise' },

--- a/packages/build/src/packaging/download-crypt-library.ts
+++ b/packages/build/src/packaging/download-crypt-library.ts
@@ -38,7 +38,7 @@ export async function downloadCryptLibrary(
     // A 9.0 library is required to analyze the GA Queryable Encryption query
     // type names. Switch back to 'continuous' and drop the overrides below once
     // 9.0 is GA and lands in the default feed.
-    versionSpec = '9.0.0-rc3';
+    versionSpec = '9.0.0-rc4';
 
     // Release candidates past rc0 only exist in cloud.json, and the version list
     // cache is keyed by cache path rather than by feed URL, so a list already


### PR DESCRIPTION
Tests against 9.0-rc4 to match latest RC version available.