### PR TITLE
chore(deps): native-machine-id -> @mongodb-js/native-machine-id

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8081,6 +8081,30 @@
         "node": ">=8"
       }
     },
+    "node_modules/@mongodb-js/native-machine-id": {
+      "version": "0.3.14",
+      "resolved": "https://registry.npmjs.org/@mongodb-js/native-machine-id/-/native-machine-id-0.3.14.tgz",
+      "integrity": "sha512-Ux6AVCaRYeVCmagAxeRm6uoCe3hxj8lzywPFccFeRaIu4UHRtk1dS7tw1fpCax56PhhCoimKCBVUepD5Wf4ayg==",
+      "hasInstallScript": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "dependencies": {
+        "node-addon-api": "^8.0.0"
+      },
+      "bin": {
+        "native-machine-id": "dist/bin/machine-id.js"
+      }
+    },
+    "node_modules/@mongodb-js/native-machine-id/node_modules/node-addon-api": {
+      "version": "8.9.2",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.9.2.tgz",
+      "integrity": "sha512-VijLXbi3UACN69I0JVXJsX4tjACjNoQDgv2gTF6sx2wWEi8tkSg2eX8p5gSIFi8z2+DL3oHmY6OyKce38SDolg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": "^18 || ^20 || >= 21"
+      }
+    },
     "node_modules/@mongodb-js/oidc-http-server-pages": {
       "version": "1.2.6",
       "resolved": "https://registry.npmjs.org/@mongodb-js/oidc-http-server-pages/-/oidc-http-server-pages-1.2.6.tgz",
@@ -27024,30 +27048,6 @@
         "nanoscheduler": "^1.0.2"
       }
     },
-    "node_modules/native-machine-id": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/native-machine-id/-/native-machine-id-0.3.6.tgz",
-      "integrity": "sha512-Lbe1k9WudZFQxzIbAM5IeUQNzJnEVwMDGz2q0K5irw4Zb+XgsbUWxqudp3rY/6UymF2PEAvAqVysOBqrTe+f3Q==",
-      "hasInstallScript": true,
-      "license": "Apache-2.0",
-      "optional": true,
-      "dependencies": {
-        "node-addon-api": "^8.0.0"
-      },
-      "bin": {
-        "native-machine-id": "dist/bin/machine-id.js"
-      }
-    },
-    "node_modules/native-machine-id/node_modules/node-addon-api": {
-      "version": "8.3.1",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-8.3.1.tgz",
-      "integrity": "sha512-lytcDEdxKjGJPTLEfW4mYMigRezMlyJY8W4wxJK8zE533Jlb8L8dRuObJFWg2P+AuOIxoCgKF+2Oq4d4Zd0OUA==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": "^18 || ^20 || >= 21"
-      }
-    },
     "node_modules/natural-compare": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/natural-compare/-/natural-compare-1.4.0.tgz",
@@ -37004,11 +37004,11 @@
         "node": ">=18.19.0"
       },
       "optionalDependencies": {
+        "@mongodb-js/native-machine-id": "^0.3.6",
         "get-console-process-list": "^1.0.5",
         "glibc-version": "^1.0.1",
         "macos-export-certificate-and-key": "^2.0.1",
         "mongodb-crypt-library-version": "^2.0.1",
-        "native-machine-id": "^0.3.6",
         "win-export-certificate-and-key": "^3.0.2"
       }
     },

--- a/packages/build/src/compile/signable-compiler.ts
+++ b/packages/build/src/compile/signable-compiler.ts
@@ -159,7 +159,7 @@ export class SignableCompiler {
       requireRegexp: /\bglibc_version\.node$/,
     };
     const nativeMachineIdAddon = {
-      path: await findModulePath('cli-repl', 'native-machine-id'),
+      path: await findModulePath('cli-repl', '@mongodb-js/native-machine-id'),
       requireRegexp: /\bnative_machine_id\.node$/,
     };
     // Warning! Until https://jira.mongodb.org/browse/MONGOSH-990,

--- a/packages/cli-repl/package.json
+++ b/packages/cli-repl/package.json
@@ -58,7 +58,7 @@
       "glibc-version": [
         "linux"
       ],
-      "native-machine-id": [
+      "@mongodb-js/native-machine-id": [
         "linux",
         "darwin",
         "win32"
@@ -69,6 +69,7 @@
     "@mongodb-js/device-id": "^0.4.13",
     "@mongodb-js/devtools-proxy-support": "^0.7.5",
     "@mongodb-js/get-os-info": "^0.7.0",
+    "@mongodb-js/native-machine-id": "^0.3.6",
     "@mongosh/arg-parser": "^5.4.0",
     "@mongosh/autocomplete": "^5.5.0",
     "@mongosh/editor": "^5.5.0",
@@ -98,8 +99,7 @@
     "semver": "^7.5.4",
     "strip-ansi": "^6.0.0",
     "text-table": "^0.2.0",
-    "glibc-version": "^1.0.1",
-    "native-machine-id": "^0.3.6"
+    "glibc-version": "^1.0.1"
   },
   "devDependencies": {
     "@mongodb-js/eslint-config-mongosh": "^1.0.0",
@@ -120,11 +120,11 @@
     "webpack-merge": "^5.8.0"
   },
   "optionalDependencies": {
+    "@mongodb-js/native-machine-id": "^0.3.6",
     "get-console-process-list": "^1.0.5",
     "glibc-version": "^1.0.1",
     "macos-export-certificate-and-key": "^2.0.1",
     "mongodb-crypt-library-version": "^2.0.1",
-    "native-machine-id": "^0.3.6",
     "win-export-certificate-and-key": "^3.0.2"
   }
 }

--- a/packages/cli-repl/src/device-id.ts
+++ b/packages/cli-repl/src/device-id.ts
@@ -10,7 +10,7 @@ export async function getDeviceIdForMongosh({
 }): Promise<string> {
   try {
     // eslint-disable-next-line @typescript-eslint/no-var-requires
-    const getMachineId = require('native-machine-id').getMachineId;
+    const getMachineId = require('@mongodb-js/native-machine-id').getMachineId;
     return await getDeviceId({
       getMachineId: () => getMachineId({ raw: true }),
       onError: (reason, error) => {

--- a/packages/e2e-tests/test/e2e-snapshot.spec.ts
+++ b/packages/e2e-tests/test/e2e-snapshot.spec.ts
@@ -142,7 +142,7 @@ describe('e2e snapshot support', function () {
       );
       verifyAllInCategoryMatch(
         'nodb-eval',
-        /^node_modules\/(kerberos|native-machine-id|mongodb-client-encryption|glibc-version|@mongodb-js\/devtools-proxy-support|@mongodb-js\/socksv5|agent-base|(win|macos)-export-certificate-and-key|@tootallnate\/quickjs-emscripten)\//
+        /^node_modules\/(kerberos|@mongodb-js\/native-machine-id|mongodb-client-encryption|glibc-version|@mongodb-js\/devtools-proxy-support|@mongodb-js\/socksv5|agent-base|(win|macos)-export-certificate-and-key|@tootallnate\/quickjs-emscripten)\//
       );
       if (process.arch !== 's390x') {
         // quickjs is in the list above but should be exlucded anywhere but on s390x


### PR DESCRIPTION
We namespaced this package some time ago, but didn't follow-up by changing the dependency, this patch fixes that