### PR TITLE
feat(browser-repl): update background color on dark mode

### DIFF
--- a/packages/browser-repl/src/components/shell.tsx
+++ b/packages/browser-repl/src/components/shell.tsx
@@ -63,7 +63,7 @@ const shellContainerLightModeStyles = css({
 });
 
 const shellContainerDarkModeStyles = css({
-  backgroundColor: palette.gray.dark4,
+  backgroundColor: palette.black,
   color: palette.gray.light3,
 });
 


### PR DESCRIPTION
Match the rest of editors in Compass.

| before | after |
| - | - |
| <img width="374" height="69" alt="Screenshot 2026-08-31 at 12 49 39" src="https://github.com/user-attachments/assets/a8dba2f2-cc4b-4d99-98c7-fa115f994356" /> | <img width="256" height="81" alt="Screenshot 2026-08-31 at 12 49 32" src="https://github.com/user-attachments/assets/959a787f-b26f-485b-a6c2-ec2b3096df7f" /> |

We updated the background styles in Compass, so with the current mongosh we're seeing some issues without this:
<img width="1860" height="278" alt="image" src="https://github.com/user-attachments/assets/0a68403b-f321-4464-b63e-495e7717806b" />
