### PR TITLE
feat: fall back to the seed host instead of uri MONGOSH-3620

### DIFF
--- a/packages/service-provider-core/src/connect-info.spec.ts
+++ b/packages/service-provider-core/src/connect-info.spec.ts
@@ -191,6 +191,84 @@ describe('getConnectInfo', function () {
     ).to.deep.equal(output);
   });
 
+  describe('host information', function () {
+    const hostInfo = ({
+      resolvedHostname,
+      uri,
+    }: {
+      resolvedHostname?: string;
+      uri?: string;
+    }) => {
+      const { is_localhost, is_atlas_url, is_do_url } = getConnectExtraInfo({
+        connectionString: uri ? new ConnectionString(uri) : undefined,
+        buildInfo: BUILD_INFO,
+        atlasVersion: null,
+        resolvedHostname,
+        isLocalAtlas: false,
+        serverName: 'mongodb',
+      });
+      return { is_localhost, is_atlas_url, is_do_url };
+    };
+
+    const LOCALHOST = {
+      is_localhost: true,
+      is_atlas_url: false,
+      is_do_url: false,
+    };
+
+    it('falls back to the seed host, not the credential-bearing uri', function () {
+      expect(
+        hostInfo({ uri: 'mongodb://admin:hunter2@localhost:27017' })
+      ).to.deep.equal(LOCALHOST);
+    });
+
+    it('ignores an empty resolved hostname', function () {
+      expect(
+        hostInfo({ resolvedHostname: '', uri: 'mongodb://localhost:27017' })
+      ).to.deep.equal(LOCALHOST);
+    });
+
+    it('strips the port from the resolved hostname', function () {
+      expect(hostInfo({ resolvedHostname: 'localhost:27017' })).to.deep.equal(
+        LOCALHOST
+      );
+    });
+
+    it('handles a bracketed IPv6 resolved hostname', function () {
+      expect(hostInfo({ resolvedHostname: '[::1]:27017' })).to.deep.equal(
+        LOCALHOST
+      );
+    });
+
+    // The driver reports `hostAddress.host` without brackets, but
+    // `mongodb-build-info` only recognises the bracketed form.
+    it('brackets a bare IPv6 resolved hostname', function () {
+      expect(hostInfo({ resolvedHostname: '::1' })).to.deep.equal(LOCALHOST);
+    });
+
+    it('handles an IPv6 seed host', function () {
+      expect(hostInfo({ uri: 'mongodb://[::1]:27017' })).to.deep.equal(
+        LOCALHOST
+      );
+    });
+
+    it('returns the defaults when there is no host at all', function () {
+      expect(hostInfo({})).to.deep.equal({
+        is_localhost: false,
+        is_atlas_url: false,
+        is_do_url: false,
+      });
+    });
+
+    it('detects an atlas seed host', function () {
+      expect(hostInfo({ uri: ATLAS_URI })).to.deep.equal({
+        is_localhost: false,
+        is_atlas_url: true,
+        is_do_url: false,
+      });
+    });
+  });
+
   it('does not fail when buildInfo is unavailable', function () {
     const output = {
       is_atlas: false,

--- a/packages/service-provider-core/src/connect-info.ts
+++ b/packages/service-provider-core/src/connect-info.ts
@@ -33,6 +33,40 @@ export type HostInformation = {
   is_do_url?: boolean; // Is digital ocean url.
 };
 
+// Strips the port from a `host:port` address. IPv6 hosts are returned in
+// bracketed form, which is what `mongodb-build-info` matches against, and which
+// the driver's `hostAddress.host` does not use.
+function extractHostname(address?: string): string | undefined {
+  if (!address) {
+    return undefined;
+  }
+
+  if (address.startsWith('[')) {
+    const host = address.slice(1).split(']')[0];
+    return host ? `[${host}]` : undefined;
+  }
+
+  // A bare IPv6 address has more than one colon, so it has no port to strip.
+  if (address.indexOf(':') !== address.lastIndexOf(':')) {
+    return `[${address}]`;
+  }
+
+  return address.split(':')[0] || undefined;
+}
+
+// Prefers the address of the server we actually talked to, falling back to the
+// seed host from the connection string when the topology has not been populated.
+// Both sources are credential-free, unlike the connection string itself.
+function getResolvedHostname(
+  resolvedHostname?: string,
+  connectionString?: ConnectionString
+): string | undefined {
+  return (
+    extractHostname(resolvedHostname) ??
+    extractHostname(connectionString?.hosts[0])
+  );
+}
+
 function getHostInformation(host?: string): HostInformation {
   if (!host) {
     return {
@@ -93,7 +127,9 @@ export default function getConnectExtraInfo({
   const isAtlas = !!atlasVersion?.atlasVersion || getBuildInfo.isAtlas(uri);
 
   return {
-    ...getHostInformation(resolvedHostname || uri),
+    ...getHostInformation(
+      getResolvedHostname(resolvedHostname, connectionString)
+    ),
     is_atlas: isAtlas,
     is_srv: connectionString?.isSRV,
     server_version: buildInfo.version,


### PR DESCRIPTION
MONGOSH-3620

Strip the port from `resolvedHostname` (unwrapping IPv6), and fall back to `connectionString.hosts[0]` instead of the URI.