### PR TITLE
fix(build): resolve shrinkwrap versions from the lockfile MONGOSH-3641

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4069,9 +4069,9 @@
       }
     },
     "node_modules/@eslint/eslintrc/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+      "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -4728,9 +4728,9 @@
       }
     },
     "node_modules/@istanbuljs/load-nyc-config/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+      "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -7847,9 +7847,9 @@
       "optional": true
     },
     "node_modules/@mongodb-js/mongodb-schema/node_modules/js-yaml": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.2.tgz",
-      "integrity": "sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.4.1.tgz",
+      "integrity": "sha512-28R/k+NAjeuf7+CKlTxWZVExJGwVVLwY06DgEnOMz2gEpfNkDcD7QvyiVPT0xy0XXhU8vHsd4Ot42OOPdJG7dQ==",
       "funding": [
         {
           "type": "github",
@@ -13888,9 +13888,9 @@
       }
     },
     "node_modules/@yarnpkg/parsers/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+      "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -19231,9 +19231,9 @@
       }
     },
     "node_modules/eslint/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+      "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
       "license": "MIT",
       "dependencies": {
         "argparse": "^1.0.7",
@@ -20512,9 +20512,9 @@
       }
     },
     "node_modules/front-matter/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+      "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -23424,9 +23424,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.0.tgz",
-      "integrity": "sha512-1td788aAnnZ5qs7V2QIRl1owjtYpbKt749Y3xauqQgwIIGF/xXWz1wMTEBx5O3LK3lXLVuqXPdPxj2BoFHaW9Q==",
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+      "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
       "devOptional": true,
       "funding": [
         {
@@ -32006,9 +32006,9 @@
       }
     },
     "node_modules/snyk-policy/node_modules/js-yaml": {
-      "version": "3.15.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.0.tgz",
-      "integrity": "sha512-ttBQIIQPDeLjpPOohtUdXuXUVoA2uIB6fEH9HyJ7234s5mBJ5wTx20njxplLZQgLaOfpmPQA7X2t5AX6tIPbog==",
+      "version": "3.15.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.15.2.tgz",
+      "integrity": "sha512-6EuL879VkRA+1Cz578mKMiKvjPNEuk6+r1JaFzoSWejZmtf7xWbIyw1e3KkxlkzTIt9Taw6JBhEppG7utc1P+w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -36969,7 +36969,7 @@
         "bson": "^7.3.1",
         "escape-string-regexp": "^4.0.0",
         "is-recoverable-error": "^1.0.3",
-        "js-yaml": "^5.2.2",
+        "js-yaml": "^5.4.1",
         "mongodb-connection-string-url": "^7.0.1",
         "mongodb-log-writer": "^2.5.6",
         "mongodb-redact": "^1.4.6",
@@ -37029,9 +37029,9 @@
       "license": "Python-2.0"
     },
     "packages/cli-repl/node_modules/js-yaml": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.2.tgz",
-      "integrity": "sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.4.1.tgz",
+      "integrity": "sha512-28R/k+NAjeuf7+CKlTxWZVExJGwVVLwY06DgEnOMz2gEpfNkDcD7QvyiVPT0xy0XXhU8vHsd4Ot42OOPdJG7dQ==",
       "funding": [
         {
           "type": "github",

--- a/packages/build/src/npm-packages/generate-shrinkwrap.ts
+++ b/packages/build/src/npm-packages/generate-shrinkwrap.ts
@@ -83,21 +83,21 @@ export async function generateShrinkwrap(
     lockfile.version = packageJson.version;
     lockfile.packages[''] = { ...prodPkg };
 
-    // When a workspace needs a different version of a dependency than the one
-    // npm hoisted to the monorepo root, the lockfile nests it under
-    // `packages/<name>/node_modules/...`. Those paths are unreachable from the
-    // root entry we just swapped in, so npm would resolve those ranges against
-    // the registry instead of the lockfile. Re-key them onto the new root's
-    // node_modules, overriding the hoisted versions.
-    const workspacePrefix = `${path
-      .relative(projectRoot, packageDir)
-      .split(path.sep)
-      .join('/')}/node_modules/`;
-    for (const [key, entry] of Object.entries(lockfile.packages)) {
-      if (!key.startsWith(workspacePrefix)) continue;
-      lockfile.packages[`node_modules/${key.slice(workspacePrefix.length)}`] =
-        entry;
-      delete lockfile.packages[key];
+    // Move the workspace's nested dependencies onto the new root, so their
+    // versions resolve from the lockfile rather than from the registry.
+    const workspaceLocation = (
+      lockfile.packages[`node_modules/${packageJson.name}`] as
+        | LockfilePackageEntry
+        | undefined
+    )?.resolved;
+    if (workspaceLocation) {
+      const workspacePrefix = `${workspaceLocation}/node_modules/`;
+      for (const [key, entry] of Object.entries(lockfile.packages)) {
+        if (!key.startsWith(workspacePrefix)) continue;
+        lockfile.packages[`node_modules/${key.slice(workspacePrefix.length)}`] =
+          entry;
+        delete lockfile.packages[key];
+      }
     }
 
     await fs.writeFile(
@@ -106,10 +106,9 @@ export async function generateShrinkwrap(
     );
 
     // Let npm prune the lockfile to only the reachable dependencies.
-    // --no-audit/--no-fund keep npm from making network calls we do not need
-    // here: we only want the lockfile rewritten, and the audit endpoint in
-    // particular has been slow enough to time this out in CI.
-    const result = spawnSync(
+    // --offline keeps this free of network calls and fails loudly if a version
+    // cannot be resolved from the lockfile.
+    spawnSync(
       'npm',
       [
         'install',
@@ -125,14 +124,6 @@ export async function generateShrinkwrap(
         encoding: 'utf8',
       }
     );
-    if (result.error) throw result.error;
-    if (result.status !== 0) {
-      throw new Error(
-        `npm install --package-lock-only failed with status ${result.status}: ${
-          result.stderr || result.stdout
-        }`
-      );
-    }
 
     // Read the pruned lockfile and post-process it
     const prunedContent = await fs.readFile(

--- a/packages/build/src/npm-packages/generate-shrinkwrap.ts
+++ b/packages/build/src/npm-packages/generate-shrinkwrap.ts
@@ -87,12 +87,33 @@ export async function generateShrinkwrap(
       JSON.stringify(lockfile, null, 2)
     );
 
-    // Let npm prune the lockfile to only the reachable dependencies
-    spawnSync('npm', ['install', '--package-lock-only', '--ignore-scripts'], {
-      cwd: tmpDir,
-      stdio: 'pipe',
-      encoding: 'utf8',
-    });
+    // Let npm prune the lockfile to only the reachable dependencies.
+    // --no-audit/--no-fund keep npm from making network calls we do not need
+    // here: we only want the lockfile rewritten, and the audit endpoint in
+    // particular has been slow enough to time this out in CI.
+    const result = spawnSync(
+      'npm',
+      [
+        'install',
+        '--package-lock-only',
+        '--ignore-scripts',
+        '--no-audit',
+        '--no-fund',
+      ],
+      {
+        cwd: tmpDir,
+        stdio: 'pipe',
+        encoding: 'utf8',
+      }
+    );
+    if (result.error) throw result.error;
+    if (result.status !== 0) {
+      throw new Error(
+        `npm install --package-lock-only failed with status ${result.status}: ${
+          result.stderr || result.stdout
+        }`
+      );
+    }
 
     // Read the pruned lockfile and post-process it
     const prunedContent = await fs.readFile(

--- a/packages/build/src/npm-packages/generate-shrinkwrap.ts
+++ b/packages/build/src/npm-packages/generate-shrinkwrap.ts
@@ -82,6 +82,24 @@ export async function generateShrinkwrap(
     lockfile.name = packageJson.name;
     lockfile.version = packageJson.version;
     lockfile.packages[''] = { ...prodPkg };
+
+    // When a workspace needs a different version of a dependency than the one
+    // npm hoisted to the monorepo root, the lockfile nests it under
+    // `packages/<name>/node_modules/...`. Those paths are unreachable from the
+    // root entry we just swapped in, so npm would resolve those ranges against
+    // the registry instead of the lockfile. Re-key them onto the new root's
+    // node_modules, overriding the hoisted versions.
+    const workspacePrefix = `${path
+      .relative(projectRoot, packageDir)
+      .split(path.sep)
+      .join('/')}/node_modules/`;
+    for (const [key, entry] of Object.entries(lockfile.packages)) {
+      if (!key.startsWith(workspacePrefix)) continue;
+      lockfile.packages[`node_modules/${key.slice(workspacePrefix.length)}`] =
+        entry;
+      delete lockfile.packages[key];
+    }
+
     await fs.writeFile(
       path.join(tmpDir, 'package-lock.json'),
       JSON.stringify(lockfile, null, 2)
@@ -99,6 +117,7 @@ export async function generateShrinkwrap(
         '--ignore-scripts',
         '--no-audit',
         '--no-fund',
+        '--offline',
       ],
       {
         cwd: tmpDir,

--- a/packages/cli-repl/npm-shrinkwrap.json
+++ b/packages/cli-repl/npm-shrinkwrap.json
@@ -1540,6 +1540,13 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/@mongodb-js/mongodb-schema/node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0",
+      "optional": true
+    },
     "node_modules/@mongodb-js/mongodb-schema/node_modules/cliui": {
       "version": "9.0.1",
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-9.0.1.tgz",
@@ -1579,6 +1586,29 @@
       "integrity": "sha512-toUI84YS5YmxW219erniWD0CIVOo46xGKColeNQRgOzDorgBi1v4D71/OFzgD9GO2UGKIv1C3Sp8DAn0+j5w7A==",
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/@mongodb-js/mongodb-schema/node_modules/js-yaml": {
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.2.tgz",
+      "integrity": "sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/nodeca"
+        }
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "argparse": "^2.0.1"
+      },
+      "bin": {
+        "js-yaml": "bin/js-yaml.mjs"
+      }
     },
     "node_modules/@mongodb-js/mongodb-schema/node_modules/string-width": {
       "version": "8.2.2",
@@ -5817,9 +5847,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "5.4.1",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.4.1.tgz",
-      "integrity": "sha512-28R/k+NAjeuf7+CKlTxWZVExJGwVVLwY06DgEnOMz2gEpfNkDcD7QvyiVPT0xy0XXhU8vHsd4Ot42OOPdJG7dQ==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.2.tgz",
+      "integrity": "sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==",
       "funding": [
         {
           "type": "github",

--- a/packages/cli-repl/npm-shrinkwrap.json
+++ b/packages/cli-repl/npm-shrinkwrap.json
@@ -32,7 +32,7 @@
         "bson": "^7.3.1",
         "escape-string-regexp": "^4.0.0",
         "is-recoverable-error": "^1.0.3",
-        "js-yaml": "^5.2.2",
+        "js-yaml": "^5.4.1",
         "mongodb-connection-string-url": "^7.0.1",
         "mongodb-log-writer": "^2.5.6",
         "mongodb-redact": "^1.4.6",
@@ -1588,9 +1588,9 @@
       "optional": true
     },
     "node_modules/@mongodb-js/mongodb-schema/node_modules/js-yaml": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.2.tgz",
-      "integrity": "sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.4.1.tgz",
+      "integrity": "sha512-28R/k+NAjeuf7+CKlTxWZVExJGwVVLwY06DgEnOMz2gEpfNkDcD7QvyiVPT0xy0XXhU8vHsd4Ot42OOPdJG7dQ==",
       "funding": [
         {
           "type": "github",
@@ -5847,9 +5847,9 @@
       "license": "MIT"
     },
     "node_modules/js-yaml": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.2.tgz",
-      "integrity": "sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.4.1.tgz",
+      "integrity": "sha512-28R/k+NAjeuf7+CKlTxWZVExJGwVVLwY06DgEnOMz2gEpfNkDcD7QvyiVPT0xy0XXhU8vHsd4Ot42OOPdJG7dQ==",
       "funding": [
         {
           "type": "github",

--- a/packages/cli-repl/package.json
+++ b/packages/cli-repl/package.json
@@ -90,7 +90,7 @@
     "bson": "^7.3.1",
     "escape-string-regexp": "^4.0.0",
     "is-recoverable-error": "^1.0.3",
-    "js-yaml": "^5.2.2",
+    "js-yaml": "^5.4.1",
     "mongodb-connection-string-url": "^7.0.1",
     "mongodb-log-writer": "^2.5.6",
     "mongodb-redact": "^1.4.6",

--- a/packages/mongosh/npm-shrinkwrap.json
+++ b/packages/mongosh/npm-shrinkwrap.json
@@ -1549,9 +1549,9 @@
       "optional": true
     },
     "node_modules/@mongodb-js/mongodb-schema/node_modules/js-yaml": {
-      "version": "5.2.2",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.2.2.tgz",
-      "integrity": "sha512-dayzUzKkJ1MkuUtZglSebU43utNXH0OWQByK9rKOOuYIO8M5TV1y+n8ALMdG0rdzBnfNkOmZEqrURepb0ejqBw==",
+      "version": "5.4.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-5.4.1.tgz",
+      "integrity": "sha512-28R/k+NAjeuf7+CKlTxWZVExJGwVVLwY06DgEnOMz2gEpfNkDcD7QvyiVPT0xy0XXhU8vHsd4Ot42OOPdJG7dQ==",
       "funding": [
         {
           "type": "github",
@@ -1967,7 +1967,7 @@
         "bson": "^7.3.1",
         "escape-string-regexp": "^4.0.0",
         "is-recoverable-error": "^1.0.3",
-        "js-yaml": "^5.2.2",
+        "js-yaml": "^5.4.1",
         "mongodb-connection-string-url": "^7.0.1",
         "mongodb-log-writer": "^2.5.6",
         "mongodb-redact": "^1.4.6",


### PR DESCRIPTION
- Re-key workspace-nested entries onto the new root so every version comes from the lockfile.
- Add `--offline`, so any future gap fails loudly instead of silently pinning whatever the registry serves. With the remap in place the command makes no network calls at all.
- Add `--no-audit`: the audit request were timing out `test_build` on `main` as well as in patches.
- Bump `js-yaml` to `^5.4.1`.

CI on this PR will still show unrelated failures. See https://github.com/mongodb-js/mongosh/pull/2831 that combines all fixes to demonstrate that CI actually reaches green.
