### PR TITLE
test: extend zip test coverage MONGOSH-3646

### DIFF
--- a/packages/build/src/packaging/package/zip.spec.ts
+++ b/packages/build/src/packaging/package/zip.spec.ts
@@ -53,8 +53,31 @@ describe('package zip', function () {
       path.join(tmpPkg.tarballDir, 'outfile.zip'),
       execFileStub
     );
-    expect(execFileStub).to.have.been.calledTwice;
+    const outFile = path.join(tmpPkg.tarballDir, 'outfile.zip');
+    expect(execFileStub.callCount).to.equal(2);
     expect(execFileStub.getCalls()[1].args[0]).to.equal('7z');
+    expect(execFileStub.getCalls()[1].args[1]).to.deep.equal([
+      'a',
+      outFile,
+      '.',
+    ]);
+  });
+
+  it('does not swallow ENOENT when no archiver is available', async function () {
+    const execFileStub = sinon.stub().rejects(new FakeNOENTError());
+
+    try {
+      await createZipPackage(
+        tmpPkg.pkgConfig,
+        path.join(tmpPkg.tarballDir, 'outfile.zip'),
+        execFileStub
+      );
+    } catch (e: any) {
+      expect(e.code).to.equal('ENOENT');
+      expect(execFileStub.lastCall.args[0]).to.equal('7z');
+      return;
+    }
+    expect.fail('Expected error');
   });
 
   it('rethrows errors', async function () {


### PR DESCRIPTION
Windows packaging (package_artifact_win32_x64) was failing with spawn 7z ENOENT after the 7zip package was deleted from the windows-2022-latest AMI.

Was temporarily fixed by a workaround:

https://github.com/mongodb-js/mongosh/pull/2831/changes/5b858a55b383d5f26ed03441fc9911ccc06112c9#diff-00ac6468ccdd2b562c9d9ea8e18f1c47fb9829af3a867956bcfa64745eb2761a

https://github.com/mongodb-js/mongosh/pull/2831/changes/6e370ae3aef061a2c554a7ba4e919cb277a081df#diff-00ac6468ccdd2b562c9d9ea8e18f1c47fb9829af3a867956bcfa64745eb2761a

DevProd restored the package under [DEVPROD-42642](https://jira.mongodb.org/browse/DEVPROD-42642).

Extend test coverage from what we learned from it.

CI on this PR will still show unrelated failures. See https://github.com/mongodb-js/mongosh/pull/2831 that combines all fixes to demonstrate that CI actually reaches green.