### PR TITLE
test: fix connectivity tests fail MONGOSH-3642

### DIFF
--- a/packages/connectivity-tests/test/all.sh
+++ b/packages/connectivity-tests/test/all.sh
@@ -20,7 +20,7 @@ fi
 git clone https://github.com/mongodb-js/devtools-docker-test-envs.git test-envs
 cd test-envs
 
-git checkout cbec3a65efe9def50638994ae6b36ffa3b4708ee
+git checkout b01126de0fb76ba41813d8ed9f761e3a02d735a6
 
 "$CONNECTIVITY_TEST_SOURCE_DIR/ldap.sh"
 "$CONNECTIVITY_TEST_SOURCE_DIR/localhost.sh"

--- a/packages/connectivity-tests/test/kerberos.sh
+++ b/packages/connectivity-tests/test/kerberos.sh
@@ -8,13 +8,13 @@ FAILED=no
 docker compose \
   -f "$TEST_TMPDIR/test-envs/docker/kerberos/docker-compose.yaml" \
   -f "$CONNECTIVITY_TEST_SOURCE_DIR/kerberos/docker-compose.kerberos.yaml" \
-  --no-ansi \
+  --ansi never \
   up --build --exit-code-from kerberos_jumphost --abort-on-container-exit || FAILED=yes
 
 docker compose \
   -f "$TEST_TMPDIR/test-envs/docker/kerberos/docker-compose.yaml" \
   -f "$CONNECTIVITY_TEST_SOURCE_DIR/kerberos/docker-compose.kerberos.yaml" \
-  --no-ansi \
+  --ansi never \
   down -v
 
 if [ $FAILED = yes ]; then

--- a/packages/connectivity-tests/test/ldap.sh
+++ b/packages/connectivity-tests/test/ldap.sh
@@ -26,6 +26,12 @@ function test_for_version() {
   FAILED_EXPLICIT=$(try_connect_explicit 'writer@EXAMPLE.COM' 'Password1!')
   FAILED_CONNECTION_STRING=$(try_connect_connection_string 'mongodb://writer%40EXAMPLE.COM:Password1!@localhost:30017/$external?authMechanism=PLAIN' 'writer@EXAMPLE.COM')
 
+  # Dump the container logs before tearing the stack down, so that a failure
+  # here is diagnosable (e.g. mongod not having started up in time).
+  if [ $FAILED_EXPLICIT = yes ] || [ $FAILED_CONNECTION_STRING = yes ]; then
+    MONGODB_VERSION="$1" docker compose -f docker/ldap/docker-compose.yaml logs
+  fi
+
   MONGODB_VERSION="$1" docker compose -f docker/ldap/docker-compose.yaml down
 
   if [ $FAILED_EXPLICIT = yes ]; then

--- a/packages/connectivity-tests/test/ldap.sh
+++ b/packages/connectivity-tests/test/ldap.sh
@@ -27,12 +27,18 @@ function test_for_version() {
   FAILED_CONNECTION_STRING=$(try_connect_connection_string 'mongodb://writer%40EXAMPLE.COM:Password1!@localhost:30017/$external?authMechanism=PLAIN' 'writer@EXAMPLE.COM')
 
   # Dump the container logs before tearing the stack down, so that a failure
-  # here is diagnosable (e.g. mongod not having started up in time).
+  # here is diagnosable (e.g. mongod not having started up in time). The
+  # resolved compose config and the image list tell us whether the host was
+  # running what we expect, e.g. a stale image rather than a fresh build.
   if [ $FAILED_EXPLICIT = yes ] || [ $FAILED_CONNECTION_STRING = yes ]; then
     MONGODB_VERSION="$1" docker compose -f docker/ldap/docker-compose.yaml logs
+    MONGODB_VERSION="$1" docker compose -f docker/ldap/docker-compose.yaml config
+    docker images
   fi
 
-  MONGODB_VERSION="$1" docker compose -f docker/ldap/docker-compose.yaml down
+  # -v so that the data volume does not survive into the next version: an
+  # older mongod cannot open a data directory written by a newer one.
+  MONGODB_VERSION="$1" docker compose -f docker/ldap/docker-compose.yaml down -v
 
   if [ $FAILED_EXPLICIT = yes ]; then
     ANY_FAILED=yes


### PR DESCRIPTION
- Bump the pinned `devtools-docker-test-envs` to pick up [#38](https://github.com/mongodb-js/devtools-docker-test-envs/pull/38), which moves the KDC image to `debian:bookworm-slim`.
- Dump `docker compose logs` when the LDAP test fails.
- Replace the deprecated `--no-ansi` flag with `--ansi never`.
