### PR TITLE
test(cli-repl): remove the redundant GC test MONGOSH-3505

### DIFF
--- a/packages/cli-repl/src/cli-repl-gc.spec.ts
+++ b/packages/cli-repl/src/cli-repl-gc.spec.ts
@@ -125,18 +125,4 @@ describe('CliRepl GC', function () {
     await new Promise(setImmediate);
     expect(finalizersCalled).to.equal(1);
   });
-
-  it('the retry loop detects a genuine leak', async function () {
-    // A strong reference, unlike the benign weak-handle timing artifact in the
-    // test above: the retry loop must keep reporting this on every attempt.
-    const leakSink: any[] = [await createTaggedObjectFromInsideRepl()];
-
-    let leaked: { index: number }[] = [];
-    for (let attempt = 0; attempt < 2; attempt++) {
-      await new Promise(setImmediate);
-      leaked = [...taggedObjectsInHeap(await takeHeapSnapshot())];
-    }
-    expect(leaked).to.have.lengthOf(1);
-    expect(leakSink).to.have.lengthOf(1); // keep leakSink alive until here
-  });
 });


### PR DESCRIPTION
Follow-up to https://github.com/mongodb-js/mongosh/pull/2835.

The intent was to make sure the retry loop couldn't swallow a real leak. But a real leak stays visible on every attempt, the loop only breaks when nothing is found, so the assertion fails anyway.