### PR TITLE
test: fix flaky requests password when user is redirecting output MONGOSH-3663

### DIFF
--- a/packages/cli-repl/src/run.spec.ts
+++ b/packages/cli-repl/src/run.spec.ts
@@ -109,11 +109,13 @@ describe('CLI entry point', function () {
       });
       let stdout = '';
       let promptedForPassword = false;
+      // The write can race the child exiting, so handle EPIPE in
+      // the callback rather than letting it be thrown asynchronously.
       proc.stdout?.setEncoding('utf8').on('data', (chunk) => {
         stdout += chunk;
         if (stdout.includes('Enter password')) {
           promptedForPassword = true;
-          proc.stdin?.write('\n');
+          proc.stdin?.write('\n', () => {});
         }
       });
 
@@ -130,11 +132,13 @@ describe('CLI entry point', function () {
       });
       let stderr = '';
       let promptedForPassword = false;
+      // The write can race the child exiting, so handle EPIPE in
+      // the callback rather than letting it be thrown asynchronously.
       proc.stderr?.setEncoding('utf8').on('data', (chunk) => {
         stderr += chunk;
         if (stderr.includes('Enter password')) {
           promptedForPassword = true;
-          proc.stdin?.write('\n');
+          proc.stdin?.write('\n', () => {});
         }
       });
 

--- a/packages/cli-repl/src/run.spec.ts
+++ b/packages/cli-repl/src/run.spec.ts
@@ -109,13 +109,12 @@ describe('CLI entry point', function () {
       });
       let stdout = '';
       let promptedForPassword = false;
-      // The write can race the child exiting, so handle EPIPE in
-      // the callback rather than letting it be thrown asynchronously.
       proc.stdout?.setEncoding('utf8').on('data', (chunk) => {
         stdout += chunk;
-        if (stdout.includes('Enter password')) {
+        // Answer the prompt exactly once to handle EPIPE.
+        if (!promptedForPassword && stdout.includes('Enter password')) {
           promptedForPassword = true;
-          proc.stdin?.write('\n', () => {});
+          proc.stdin?.write('\n');
         }
       });
 
@@ -132,13 +131,12 @@ describe('CLI entry point', function () {
       });
       let stderr = '';
       let promptedForPassword = false;
-      // The write can race the child exiting, so handle EPIPE in
-      // the callback rather than letting it be thrown asynchronously.
       proc.stderr?.setEncoding('utf8').on('data', (chunk) => {
         stderr += chunk;
-        if (stderr.includes('Enter password')) {
+        // Answer the prompt exactly once to handle EPIPE.
+        if (!promptedForPassword && stderr.includes('Enter password')) {
           promptedForPassword = true;
-          proc.stdin?.write('\n', () => {});
+          proc.stdin?.write('\n');
         }
       });
 


### PR DESCRIPTION
Pass a callback to write() so the error is reported there instead of being thrown.