### PR TITLE
build: ignore the expired bullseye release file in the smoke test image MONGOSH-3664

### DIFF
--- a/scripts/docker/debian11-deb.Dockerfile
+++ b/scripts/docker/debian11-deb.Dockerfile
@@ -3,6 +3,11 @@ FROM debian:11
 ARG artifact_url=""
 ADD ${artifact_url} /tmp
 ADD node_modules /usr/share/mongodb-crypt-library-version/node_modules
+
+# Debian 11 (bullseye) LTS ended 2026-08-31 (https://wiki.debian.org/LTS).
+# TODO(MONGOSH-3476): Ignore the expiry until we drop Debian 11 support.
+RUN echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99no-check-valid-until
+
 RUN apt-get update
 RUN apt-get install -y man-db
 RUN apt-get install -y /tmp/*mongosh*.deb

--- a/scripts/docker/debian11-deb.Dockerfile
+++ b/scripts/docker/debian11-deb.Dockerfile
@@ -5,7 +5,7 @@ ADD ${artifact_url} /tmp
 ADD node_modules /usr/share/mongodb-crypt-library-version/node_modules
 
 # Debian 11 (bullseye) LTS ended 2026-08-31 (https://wiki.debian.org/LTS).
-# TODO(MONGOSH-3476): Ignore the expiry until we drop Debian 11 support.
+# TODO(MONGOSH-3476): Ignore the expiry field in apt repository metadata until we drop Debian 11 support.
 RUN echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99no-check-valid-until
 
 RUN apt-get update


### PR DESCRIPTION
[Debian 11 LTS ended 2026-08-31](https://wiki.debian.org/LTS), so its release files are no longer refreshed and apt-get update fails with exit 100. Silence until [MONGOSH-3476](https://jira.mongodb.org/browse/MONGOSH-3476) drops old platform support (mongosh 3.0).