### PR TITLE
chore: update node.js to 24.21.0 and bump shared OpenSSL 3 to 3.0.12 MONGOSH-3676

### DIFF
--- a/.evergreen.yml
+++ b/.evergreen.yml
@@ -5214,7 +5214,7 @@ tasks:
       - func: checkout
       - func: compile_ts
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
 
   - name: check
     depends_on:
@@ -5224,10 +5224,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: check
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
 
   - name: check_coverage
     depends_on:
@@ -5811,10 +5811,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: check_coverage
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
 
   ###
   # UNIT TESTS
@@ -6312,7 +6312,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_vscode
         vars:
           task_name: ${task_name}
@@ -6325,10 +6325,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_connectivity
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           task_name: ${task_name}
   - name: test_apistrict
     tags: ["extra-integration-test", "assigned_to_jira_team_mongosh_mongosh"]
@@ -6339,10 +6339,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_apistrict
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           mongosh_server_test_version: "latest-alpha-enterprise"
           mongosh_test_force_api_strict: "1"
           task_name: ${task_name}
@@ -6384,16 +6384,16 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: compile_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: upload_compiled_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: upload_first_party_deps_list
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
 
   - name: generate_license_and_vulnerability_report
     tags: ["extra-integration-test"]
@@ -6404,10 +6404,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: generate_license_and_vulnerability_report
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
 
   ###
   # E2E TESTS
@@ -6692,7 +6692,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: "linux-x64"
@@ -6708,7 +6708,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: "linux-x64"
@@ -6728,13 +6728,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64
       - func: test_connectivity
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           test_mongosh_executable: dist/mongosh
           kerberos_jumphost_dockerfile: "Dockerfile.rocky8"
           task_name: ${task_name}
@@ -6747,13 +6747,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64
       - func: test_connectivity
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           test_mongosh_executable: dist/mongosh
           kerberos_jumphost_dockerfile: "Dockerfile.ubuntu2004"
           task_name: ${task_name}
@@ -6766,13 +6766,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64
       - func: test_connectivity
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           test_mongosh_executable: dist/mongosh
           kerberos_jumphost_dockerfile: "Dockerfile.node20"
           task_name: ${task_name}
@@ -6785,13 +6785,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64
       - func: test_connectivity
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           test_mongosh_executable: dist/mongosh
           kerberos_jumphost_dockerfile: "Dockerfile.rocky9"
           task_name: ${task_name}
@@ -6804,13 +6804,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64
       - func: test_connectivity
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           test_mongosh_executable: dist/mongosh
           kerberos_jumphost_dockerfile: "Dockerfile.rocky10"
           task_name: ${task_name}
@@ -6823,13 +6823,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64
       - func: test_connectivity
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           test_mongosh_executable: dist/mongosh
           kerberos_jumphost_dockerfile: "Dockerfile.ubuntu2204"
           task_name: ${task_name}
@@ -6842,13 +6842,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64-openssl11
       - func: test_connectivity
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           test_mongosh_executable: dist/mongosh
           kerberos_jumphost_dockerfile: "Dockerfile.rocky8"
           task_name: ${task_name}
@@ -6861,13 +6861,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64-openssl11
       - func: test_connectivity
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           test_mongosh_executable: dist/mongosh
           kerberos_jumphost_dockerfile: "Dockerfile.ubuntu2004"
           task_name: ${task_name}
@@ -6880,13 +6880,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64-openssl3
       - func: test_connectivity
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           test_mongosh_executable: dist/mongosh
           kerberos_jumphost_dockerfile: "Dockerfile.node20"
           task_name: ${task_name}
@@ -6899,13 +6899,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64-openssl3
       - func: test_connectivity
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           test_mongosh_executable: dist/mongosh
           kerberos_jumphost_dockerfile: "Dockerfile.rocky9"
           task_name: ${task_name}
@@ -6918,13 +6918,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64-openssl3
       - func: test_connectivity
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           test_mongosh_executable: dist/mongosh
           kerberos_jumphost_dockerfile: "Dockerfile.rocky10"
           task_name: ${task_name}
@@ -6937,13 +6937,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64-openssl3
       - func: test_connectivity
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           test_mongosh_executable: dist/mongosh
           kerberos_jumphost_dockerfile: "Dockerfile.ubuntu2204"
           task_name: ${task_name}
@@ -6956,13 +6956,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64
       - func: test_connectivity
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           test_mongosh_executable: dist/mongosh
           kerberos_jumphost_dockerfile: "Dockerfile.rocky8"
           task_name: ${task_name}
@@ -6975,13 +6975,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64
       - func: test_connectivity
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           test_mongosh_executable: dist/mongosh
           kerberos_jumphost_dockerfile: "Dockerfile.ubuntu2004"
           task_name: ${task_name}
@@ -6994,13 +6994,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64
       - func: test_connectivity
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           test_mongosh_executable: dist/mongosh
           kerberos_jumphost_dockerfile: "Dockerfile.node20"
           task_name: ${task_name}
@@ -7013,13 +7013,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64
       - func: test_connectivity
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           test_mongosh_executable: dist/mongosh
           kerberos_jumphost_dockerfile: "Dockerfile.rocky9"
           task_name: ${task_name}
@@ -7032,13 +7032,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64
       - func: test_connectivity
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           test_mongosh_executable: dist/mongosh
           kerberos_jumphost_dockerfile: "Dockerfile.rocky10"
           task_name: ${task_name}
@@ -7051,13 +7051,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64
       - func: test_connectivity
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           test_mongosh_executable: dist/mongosh
           kerberos_jumphost_dockerfile: "Dockerfile.ubuntu2204"
           task_name: ${task_name}
@@ -7070,13 +7070,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64-openssl11
       - func: test_connectivity
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           test_mongosh_executable: dist/mongosh
           kerberos_jumphost_dockerfile: "Dockerfile.rocky8"
           task_name: ${task_name}
@@ -7089,13 +7089,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64-openssl11
       - func: test_connectivity
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           test_mongosh_executable: dist/mongosh
           kerberos_jumphost_dockerfile: "Dockerfile.ubuntu2004"
           task_name: ${task_name}
@@ -7108,13 +7108,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64-openssl3
       - func: test_connectivity
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           test_mongosh_executable: dist/mongosh
           kerberos_jumphost_dockerfile: "Dockerfile.node20"
           task_name: ${task_name}
@@ -7127,13 +7127,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64-openssl3
       - func: test_connectivity
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           test_mongosh_executable: dist/mongosh
           kerberos_jumphost_dockerfile: "Dockerfile.rocky9"
           task_name: ${task_name}
@@ -7146,13 +7146,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64-openssl3
       - func: test_connectivity
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           test_mongosh_executable: dist/mongosh
           kerberos_jumphost_dockerfile: "Dockerfile.rocky10"
           task_name: ${task_name}
@@ -7165,13 +7165,13 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64-openssl3
       - func: test_connectivity
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           test_mongosh_executable: dist/mongosh
           kerberos_jumphost_dockerfile: "Dockerfile.ubuntu2204"
           task_name: ${task_name}
@@ -7188,7 +7188,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: darwin-x64
@@ -7212,14 +7212,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: darwin-x64
           extra_upload_tag: -darwin-x64-complete
       - func: package_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           package_variant: darwin-x64
           executable_os_id: darwin-x64
       - func: put_artifact_url
@@ -7234,14 +7234,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: get_artifact_url
         vars:
           package_variant: darwin-x64
           signature_tag: unsigned
       - func: sign_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           package_variant: darwin-x64
       - func: papertrail_trace
         vars:
@@ -7271,7 +7271,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: darwin-arm64
@@ -7295,14 +7295,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: darwin-arm64
           extra_upload_tag: -darwin-arm64-complete
       - func: package_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           package_variant: darwin-arm64
           executable_os_id: darwin-arm64
       - func: put_artifact_url
@@ -7317,14 +7317,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: get_artifact_url
         vars:
           package_variant: darwin-arm64
           signature_tag: unsigned
       - func: sign_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           package_variant: darwin-arm64
       - func: papertrail_trace
         vars:
@@ -7354,7 +7354,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64
@@ -7378,14 +7378,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64
           extra_upload_tag: -linux-x64-complete
       - func: package_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           package_variant: linux-x64
           executable_os_id: linux-x64
       - func: put_artifact_url
@@ -7400,14 +7400,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: get_artifact_url
         vars:
           package_variant: linux-x64
           signature_tag: unsigned
       - func: sign_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           package_variant: linux-x64
       - func: papertrail_trace
         vars:
@@ -7425,7 +7425,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64
@@ -7449,14 +7449,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64
           extra_upload_tag: -deb-x64-complete
       - func: package_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           package_variant: deb-x64
           executable_os_id: linux-x64
       - func: put_artifact_url
@@ -7471,14 +7471,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: get_artifact_url
         vars:
           package_variant: deb-x64
           signature_tag: unsigned
       - func: sign_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           package_variant: deb-x64
       - func: papertrail_trace
         vars:
@@ -7508,7 +7508,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64
@@ -7532,14 +7532,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64
           extra_upload_tag: -rpm-x64-complete
       - func: package_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           package_variant: rpm-x64
           executable_os_id: linux-x64
       - func: put_artifact_url
@@ -7554,14 +7554,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: get_artifact_url
         vars:
           package_variant: rpm-x64
           signature_tag: unsigned
       - func: sign_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           package_variant: rpm-x64
       - func: papertrail_trace
         vars:
@@ -7591,7 +7591,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64-openssl11
@@ -7615,14 +7615,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64-openssl11
           extra_upload_tag: -linux-x64-openssl11-complete
       - func: package_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           package_variant: linux-x64-openssl11
           executable_os_id: linux-x64-openssl11
       - func: put_artifact_url
@@ -7637,14 +7637,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: get_artifact_url
         vars:
           package_variant: linux-x64-openssl11
           signature_tag: unsigned
       - func: sign_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           package_variant: linux-x64-openssl11
       - func: papertrail_trace
         vars:
@@ -7662,7 +7662,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64-openssl11
@@ -7686,14 +7686,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64-openssl11
           extra_upload_tag: -deb-x64-openssl11-complete
       - func: package_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           package_variant: deb-x64-openssl11
           executable_os_id: linux-x64-openssl11
       - func: put_artifact_url
@@ -7708,14 +7708,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: get_artifact_url
         vars:
           package_variant: deb-x64-openssl11
           signature_tag: unsigned
       - func: sign_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           package_variant: deb-x64-openssl11
       - func: papertrail_trace
         vars:
@@ -7745,7 +7745,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64-openssl11
@@ -7769,14 +7769,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64-openssl11
           extra_upload_tag: -rpm-x64-openssl11-complete
       - func: package_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           package_variant: rpm-x64-openssl11
           executable_os_id: linux-x64-openssl11
       - func: put_artifact_url
@@ -7791,14 +7791,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: get_artifact_url
         vars:
           package_variant: rpm-x64-openssl11
           signature_tag: unsigned
       - func: sign_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           package_variant: rpm-x64-openssl11
       - func: papertrail_trace
         vars:
@@ -7828,7 +7828,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64-openssl3
@@ -7852,14 +7852,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64-openssl3
           extra_upload_tag: -linux-x64-openssl3-complete
       - func: package_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           package_variant: linux-x64-openssl3
           executable_os_id: linux-x64-openssl3
       - func: put_artifact_url
@@ -7874,14 +7874,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: get_artifact_url
         vars:
           package_variant: linux-x64-openssl3
           signature_tag: unsigned
       - func: sign_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           package_variant: linux-x64-openssl3
       - func: papertrail_trace
         vars:
@@ -7899,7 +7899,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64-openssl3
@@ -7923,14 +7923,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64-openssl3
           extra_upload_tag: -deb-x64-openssl3-complete
       - func: package_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           package_variant: deb-x64-openssl3
           executable_os_id: linux-x64-openssl3
       - func: put_artifact_url
@@ -7945,14 +7945,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: get_artifact_url
         vars:
           package_variant: deb-x64-openssl3
           signature_tag: unsigned
       - func: sign_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           package_variant: deb-x64-openssl3
       - func: papertrail_trace
         vars:
@@ -7982,7 +7982,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64-openssl3
@@ -8006,14 +8006,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-x64-openssl3
           extra_upload_tag: -rpm-x64-openssl3-complete
       - func: package_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           package_variant: rpm-x64-openssl3
           executable_os_id: linux-x64-openssl3
       - func: put_artifact_url
@@ -8028,14 +8028,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: get_artifact_url
         vars:
           package_variant: rpm-x64-openssl3
           signature_tag: unsigned
       - func: sign_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           package_variant: rpm-x64-openssl3
       - func: papertrail_trace
         vars:
@@ -8065,7 +8065,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64
@@ -8089,14 +8089,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64
           extra_upload_tag: -linux-arm64-complete
       - func: package_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           package_variant: linux-arm64
           executable_os_id: linux-arm64
       - func: put_artifact_url
@@ -8111,14 +8111,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: get_artifact_url
         vars:
           package_variant: linux-arm64
           signature_tag: unsigned
       - func: sign_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           package_variant: linux-arm64
       - func: papertrail_trace
         vars:
@@ -8136,7 +8136,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64
@@ -8160,14 +8160,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64
           extra_upload_tag: -deb-arm64-complete
       - func: package_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           package_variant: deb-arm64
           executable_os_id: linux-arm64
       - func: put_artifact_url
@@ -8182,14 +8182,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: get_artifact_url
         vars:
           package_variant: deb-arm64
           signature_tag: unsigned
       - func: sign_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           package_variant: deb-arm64
       - func: papertrail_trace
         vars:
@@ -8219,7 +8219,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64
@@ -8243,14 +8243,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64
           extra_upload_tag: -rpm-arm64-complete
       - func: package_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           package_variant: rpm-arm64
           executable_os_id: linux-arm64
       - func: put_artifact_url
@@ -8265,14 +8265,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: get_artifact_url
         vars:
           package_variant: rpm-arm64
           signature_tag: unsigned
       - func: sign_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           package_variant: rpm-arm64
       - func: papertrail_trace
         vars:
@@ -8302,7 +8302,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64-openssl11
@@ -8326,14 +8326,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64-openssl11
           extra_upload_tag: -linux-arm64-openssl11-complete
       - func: package_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           package_variant: linux-arm64-openssl11
           executable_os_id: linux-arm64-openssl11
       - func: put_artifact_url
@@ -8348,14 +8348,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: get_artifact_url
         vars:
           package_variant: linux-arm64-openssl11
           signature_tag: unsigned
       - func: sign_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           package_variant: linux-arm64-openssl11
       - func: papertrail_trace
         vars:
@@ -8373,7 +8373,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64-openssl11
@@ -8397,14 +8397,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64-openssl11
           extra_upload_tag: -deb-arm64-openssl11-complete
       - func: package_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           package_variant: deb-arm64-openssl11
           executable_os_id: linux-arm64-openssl11
       - func: put_artifact_url
@@ -8419,14 +8419,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: get_artifact_url
         vars:
           package_variant: deb-arm64-openssl11
           signature_tag: unsigned
       - func: sign_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           package_variant: deb-arm64-openssl11
       - func: papertrail_trace
         vars:
@@ -8456,7 +8456,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64-openssl11
@@ -8480,14 +8480,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64-openssl11
           extra_upload_tag: -rpm-arm64-openssl11-complete
       - func: package_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           package_variant: rpm-arm64-openssl11
           executable_os_id: linux-arm64-openssl11
       - func: put_artifact_url
@@ -8502,14 +8502,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: get_artifact_url
         vars:
           package_variant: rpm-arm64-openssl11
           signature_tag: unsigned
       - func: sign_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           package_variant: rpm-arm64-openssl11
       - func: papertrail_trace
         vars:
@@ -8539,7 +8539,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64-openssl3
@@ -8563,14 +8563,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64-openssl3
           extra_upload_tag: -linux-arm64-openssl3-complete
       - func: package_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           package_variant: linux-arm64-openssl3
           executable_os_id: linux-arm64-openssl3
       - func: put_artifact_url
@@ -8585,14 +8585,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: get_artifact_url
         vars:
           package_variant: linux-arm64-openssl3
           signature_tag: unsigned
       - func: sign_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           package_variant: linux-arm64-openssl3
       - func: papertrail_trace
         vars:
@@ -8610,7 +8610,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64-openssl3
@@ -8634,14 +8634,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64-openssl3
           extra_upload_tag: -deb-arm64-openssl3-complete
       - func: package_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           package_variant: deb-arm64-openssl3
           executable_os_id: linux-arm64-openssl3
       - func: put_artifact_url
@@ -8656,14 +8656,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: get_artifact_url
         vars:
           package_variant: deb-arm64-openssl3
           signature_tag: unsigned
       - func: sign_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           package_variant: deb-arm64-openssl3
       - func: papertrail_trace
         vars:
@@ -8693,7 +8693,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64-openssl3
@@ -8717,14 +8717,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-arm64-openssl3
           extra_upload_tag: -rpm-arm64-openssl3-complete
       - func: package_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           package_variant: rpm-arm64-openssl3
           executable_os_id: linux-arm64-openssl3
       - func: put_artifact_url
@@ -8739,14 +8739,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: get_artifact_url
         vars:
           package_variant: rpm-arm64-openssl3
           signature_tag: unsigned
       - func: sign_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           package_variant: rpm-arm64-openssl3
       - func: papertrail_trace
         vars:
@@ -8776,7 +8776,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-ppc64le
@@ -8800,14 +8800,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-ppc64le
           extra_upload_tag: -linux-ppc64le-complete
       - func: package_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           package_variant: linux-ppc64le
           executable_os_id: linux-ppc64le
       - func: put_artifact_url
@@ -8822,14 +8822,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: get_artifact_url
         vars:
           package_variant: linux-ppc64le
           signature_tag: unsigned
       - func: sign_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           package_variant: linux-ppc64le
       - func: papertrail_trace
         vars:
@@ -8847,7 +8847,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-ppc64le
@@ -8871,14 +8871,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-ppc64le
           extra_upload_tag: -rpm-ppc64le-complete
       - func: package_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           package_variant: rpm-ppc64le
           executable_os_id: linux-ppc64le
       - func: put_artifact_url
@@ -8893,14 +8893,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: get_artifact_url
         vars:
           package_variant: rpm-ppc64le
           signature_tag: unsigned
       - func: sign_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           package_variant: rpm-ppc64le
       - func: papertrail_trace
         vars:
@@ -8930,7 +8930,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-ppc64le-openssl11
@@ -8954,14 +8954,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-ppc64le-openssl11
           extra_upload_tag: -linux-ppc64le-openssl11-complete
       - func: package_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           package_variant: linux-ppc64le-openssl11
           executable_os_id: linux-ppc64le-openssl11
       - func: put_artifact_url
@@ -8976,14 +8976,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: get_artifact_url
         vars:
           package_variant: linux-ppc64le-openssl11
           signature_tag: unsigned
       - func: sign_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           package_variant: linux-ppc64le-openssl11
       - func: papertrail_trace
         vars:
@@ -9001,7 +9001,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-ppc64le-openssl11
@@ -9025,14 +9025,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-ppc64le-openssl11
           extra_upload_tag: -rpm-ppc64le-openssl11-complete
       - func: package_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           package_variant: rpm-ppc64le-openssl11
           executable_os_id: linux-ppc64le-openssl11
       - func: put_artifact_url
@@ -9047,14 +9047,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: get_artifact_url
         vars:
           package_variant: rpm-ppc64le-openssl11
           signature_tag: unsigned
       - func: sign_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           package_variant: rpm-ppc64le-openssl11
       - func: papertrail_trace
         vars:
@@ -9084,7 +9084,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-ppc64le-openssl3
@@ -9108,14 +9108,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-ppc64le-openssl3
           extra_upload_tag: -linux-ppc64le-openssl3-complete
       - func: package_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           package_variant: linux-ppc64le-openssl3
           executable_os_id: linux-ppc64le-openssl3
       - func: put_artifact_url
@@ -9130,14 +9130,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: get_artifact_url
         vars:
           package_variant: linux-ppc64le-openssl3
           signature_tag: unsigned
       - func: sign_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           package_variant: linux-ppc64le-openssl3
       - func: papertrail_trace
         vars:
@@ -9155,7 +9155,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-ppc64le-openssl3
@@ -9179,14 +9179,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-ppc64le-openssl3
           extra_upload_tag: -rpm-ppc64le-openssl3-complete
       - func: package_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           package_variant: rpm-ppc64le-openssl3
           executable_os_id: linux-ppc64le-openssl3
       - func: put_artifact_url
@@ -9201,14 +9201,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: get_artifact_url
         vars:
           package_variant: rpm-ppc64le-openssl3
           signature_tag: unsigned
       - func: sign_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           package_variant: rpm-ppc64le-openssl3
       - func: papertrail_trace
         vars:
@@ -9238,7 +9238,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-s390x
@@ -9262,14 +9262,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-s390x
           extra_upload_tag: -linux-s390x-complete
       - func: package_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           package_variant: linux-s390x
           executable_os_id: linux-s390x
       - func: put_artifact_url
@@ -9284,14 +9284,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: get_artifact_url
         vars:
           package_variant: linux-s390x
           signature_tag: unsigned
       - func: sign_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           package_variant: linux-s390x
       - func: papertrail_trace
         vars:
@@ -9309,7 +9309,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-s390x
@@ -9333,14 +9333,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-s390x
           extra_upload_tag: -rpm-s390x-complete
       - func: package_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           package_variant: rpm-s390x
           executable_os_id: linux-s390x
       - func: put_artifact_url
@@ -9355,14 +9355,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: get_artifact_url
         vars:
           package_variant: rpm-s390x
           signature_tag: unsigned
       - func: sign_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           package_variant: rpm-s390x
       - func: papertrail_trace
         vars:
@@ -9392,7 +9392,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-s390x-openssl11
@@ -9416,14 +9416,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-s390x-openssl11
           extra_upload_tag: -linux-s390x-openssl11-complete
       - func: package_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           package_variant: linux-s390x-openssl11
           executable_os_id: linux-s390x-openssl11
       - func: put_artifact_url
@@ -9438,14 +9438,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: get_artifact_url
         vars:
           package_variant: linux-s390x-openssl11
           signature_tag: unsigned
       - func: sign_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           package_variant: linux-s390x-openssl11
       - func: papertrail_trace
         vars:
@@ -9463,7 +9463,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-s390x-openssl11
@@ -9487,14 +9487,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-s390x-openssl11
           extra_upload_tag: -rpm-s390x-openssl11-complete
       - func: package_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           package_variant: rpm-s390x-openssl11
           executable_os_id: linux-s390x-openssl11
       - func: put_artifact_url
@@ -9509,14 +9509,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: get_artifact_url
         vars:
           package_variant: rpm-s390x-openssl11
           signature_tag: unsigned
       - func: sign_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           package_variant: rpm-s390x-openssl11
       - func: papertrail_trace
         vars:
@@ -9546,7 +9546,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-s390x-openssl3
@@ -9570,14 +9570,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-s390x-openssl3
           extra_upload_tag: -linux-s390x-openssl3-complete
       - func: package_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           package_variant: linux-s390x-openssl3
           executable_os_id: linux-s390x-openssl3
       - func: put_artifact_url
@@ -9592,14 +9592,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: get_artifact_url
         vars:
           package_variant: linux-s390x-openssl3
           signature_tag: unsigned
       - func: sign_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           package_variant: linux-s390x-openssl3
       - func: papertrail_trace
         vars:
@@ -9617,7 +9617,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-s390x-openssl3
@@ -9641,14 +9641,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: linux-s390x-openssl3
           extra_upload_tag: -rpm-s390x-openssl3-complete
       - func: package_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           package_variant: rpm-s390x-openssl3
           executable_os_id: linux-s390x-openssl3
       - func: put_artifact_url
@@ -9663,14 +9663,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: get_artifact_url
         vars:
           package_variant: rpm-s390x-openssl3
           signature_tag: unsigned
       - func: sign_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           package_variant: rpm-s390x-openssl3
       - func: papertrail_trace
         vars:
@@ -9700,7 +9700,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: win32
@@ -9724,14 +9724,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: win32
           extra_upload_tag: -win32-x64-complete
       - func: package_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           package_variant: win32-x64
           executable_os_id: win32
       - func: put_artifact_url
@@ -9746,14 +9746,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: get_artifact_url
         vars:
           package_variant: win32-x64
           signature_tag: unsigned
       - func: sign_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           package_variant: win32-x64
       - func: papertrail_trace
         vars:
@@ -9783,7 +9783,7 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: win32
@@ -9807,14 +9807,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: download_compiled_artifact
         vars:
           executable_os_id: win32
           extra_upload_tag: -win32msi-x64-complete
       - func: package_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           package_variant: win32msi-x64
           executable_os_id: win32
       - func: put_artifact_url
@@ -9829,14 +9829,14 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: get_artifact_url
         vars:
           package_variant: win32msi-x64
           signature_tag: unsigned
       - func: sign_artifact
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           package_variant: win32msi-x64
       - func: papertrail_trace
         vars:
@@ -9901,10 +9901,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: ubuntu20.04-tgz
           task_name: ${task_name}
   - name: pkg_test_docker_deb_x64_ubuntu18_04_deb
@@ -9921,10 +9921,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: ubuntu18.04-deb
           task_name: ${task_name}
   - name: pkg_test_docker_deb_x64_ubuntu20_04_deb
@@ -9941,10 +9941,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: ubuntu20.04-deb
           task_name: ${task_name}
   - name: pkg_test_docker_deb_x64_ubuntu22_04_deb
@@ -9961,10 +9961,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: ubuntu22.04-deb
           task_name: ${task_name}
   - name: pkg_test_docker_deb_x64_ubuntu22_04_nohome_deb
@@ -9981,10 +9981,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: ubuntu22.04-nohome-deb
           task_name: ${task_name}
   - name: pkg_test_docker_deb_x64_ubuntu22_04_qemu_deb
@@ -10001,10 +10001,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: ubuntu22.04-qemu-deb
           task_name: ${task_name}
   - name: pkg_test_docker_deb_x64_ubuntu24_04_deb
@@ -10021,10 +10021,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: ubuntu24.04-deb
           task_name: ${task_name}
   - name: pkg_test_docker_deb_x64_debian10_deb
@@ -10041,10 +10041,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: debian10-deb
           task_name: ${task_name}
   - name: pkg_test_docker_deb_x64_debian11_deb
@@ -10061,10 +10061,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: debian11-deb
           task_name: ${task_name}
   - name: pkg_test_docker_deb_x64_debian12_deb
@@ -10081,10 +10081,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: debian12-deb
           task_name: ${task_name}
   - name: pkg_test_docker_deb_x64_debian13_deb
@@ -10101,10 +10101,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: debian13-deb
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_x64_centos7_rpm
@@ -10121,10 +10121,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: centos7-rpm
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_x64_amazonlinux2_rpm
@@ -10141,10 +10141,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: amazonlinux2-rpm
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_x64_amazonlinux2023_rpm
@@ -10161,10 +10161,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: amazonlinux2023-rpm
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_x64_rocky8_rpm
@@ -10181,10 +10181,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: rocky8-rpm
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_x64_rocky9_rpm
@@ -10201,10 +10201,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: rocky9-rpm
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_x64_rocky10_rpm
@@ -10221,10 +10221,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: rocky10-rpm
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_x64_fedora34_rpm
@@ -10241,10 +10241,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: fedora34-rpm
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_x64_suse12_rpm
@@ -10261,10 +10261,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: suse12-rpm
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_x64_suse15_rpm
@@ -10281,10 +10281,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: suse15-rpm
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_x64_oraclelinux9_rpm
@@ -10301,10 +10301,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: oraclelinux9-rpm
           task_name: ${task_name}
   - name: pkg_test_docker_deb_x64_openssl11_ubuntu20_04_deb
@@ -10321,10 +10321,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: ubuntu20.04-deb
           task_name: ${task_name}
   - name: pkg_test_docker_deb_x64_openssl11_debian10_deb
@@ -10341,10 +10341,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: debian10-deb
           task_name: ${task_name}
   - name: pkg_test_docker_deb_x64_openssl11_debian11_deb
@@ -10361,10 +10361,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: debian11-deb
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_x64_openssl11_centos7_epel_rpm
@@ -10381,10 +10381,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: centos7-epel-rpm
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_x64_openssl11_amazonlinux2_rpm
@@ -10401,10 +10401,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: amazonlinux2-rpm
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_x64_openssl11_rocky8_rpm
@@ -10421,10 +10421,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: rocky8-rpm
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_x64_openssl11_rocky9_rpm
@@ -10441,10 +10441,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: rocky9-rpm
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_x64_openssl11_fedora34_rpm
@@ -10461,10 +10461,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: fedora34-rpm
           task_name: ${task_name}
   - name: pkg_test_docker_deb_x64_openssl3_ubuntu22_04_deb
@@ -10481,10 +10481,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: ubuntu22.04-deb
           task_name: ${task_name}
   - name: pkg_test_docker_deb_x64_openssl3_ubuntu22_04_fips_deb
@@ -10501,10 +10501,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: ubuntu22.04-fips-deb
           task_name: ${task_name}
   - name: pkg_test_docker_deb_x64_openssl3_debian12_deb
@@ -10521,10 +10521,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: debian12-deb
           task_name: ${task_name}
   - name: pkg_test_docker_deb_x64_openssl3_debian13_deb
@@ -10541,10 +10541,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: debian13-deb
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_x64_openssl3_rocky8_epel_rpm
@@ -10561,10 +10561,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: rocky8-epel-rpm
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_x64_openssl3_rocky9_rpm
@@ -10581,10 +10581,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: rocky9-rpm
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_x64_openssl3_rocky9_fips_rpm
@@ -10601,10 +10601,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: rocky9-fips-rpm
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_x64_openssl3_rocky10_rpm
@@ -10621,10 +10621,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: rocky10-rpm
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_x64_openssl3_amazonlinux2023_rpm
@@ -10641,10 +10641,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: amazonlinux2023-rpm
           task_name: ${task_name}
   - name: pkg_test_docker_linux_arm64_ubuntu20_04_tgz
@@ -10661,10 +10661,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: ubuntu20.04-tgz
           task_name: ${task_name}
   - name: pkg_test_docker_deb_arm64_ubuntu18_04_deb
@@ -10681,10 +10681,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: ubuntu18.04-deb
           task_name: ${task_name}
   - name: pkg_test_docker_deb_arm64_ubuntu20_04_deb
@@ -10701,10 +10701,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: ubuntu20.04-deb
           task_name: ${task_name}
   - name: pkg_test_docker_deb_arm64_ubuntu22_04_deb
@@ -10721,10 +10721,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: ubuntu22.04-deb
           task_name: ${task_name}
   - name: pkg_test_docker_deb_arm64_ubuntu22_04_nohome_deb
@@ -10741,10 +10741,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: ubuntu22.04-nohome-deb
           task_name: ${task_name}
   - name: pkg_test_docker_deb_arm64_ubuntu22_04_qemu_deb
@@ -10761,10 +10761,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: ubuntu22.04-qemu-deb
           task_name: ${task_name}
   - name: pkg_test_docker_deb_arm64_ubuntu24_04_deb
@@ -10781,10 +10781,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: ubuntu24.04-deb
           task_name: ${task_name}
   - name: pkg_test_docker_deb_arm64_debian10_deb
@@ -10801,10 +10801,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: debian10-deb
           task_name: ${task_name}
   - name: pkg_test_docker_deb_arm64_debian11_deb
@@ -10821,10 +10821,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: debian11-deb
           task_name: ${task_name}
   - name: pkg_test_docker_deb_arm64_debian12_deb
@@ -10841,10 +10841,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: debian12-deb
           task_name: ${task_name}
   - name: pkg_test_docker_deb_arm64_debian13_deb
@@ -10861,10 +10861,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: debian13-deb
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_arm64_rocky8_rpm
@@ -10881,10 +10881,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: rocky8-rpm
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_arm64_rocky9_rpm
@@ -10901,10 +10901,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: rocky9-rpm
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_arm64_rocky10_rpm
@@ -10921,10 +10921,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: rocky10-rpm
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_arm64_fedora34_rpm
@@ -10941,10 +10941,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: fedora34-rpm
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_arm64_amazonlinux2_rpm
@@ -10961,10 +10961,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: amazonlinux2-rpm
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_arm64_amazonlinux2023_rpm
@@ -10981,10 +10981,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: amazonlinux2023-rpm
           task_name: ${task_name}
   - name: pkg_test_docker_deb_arm64_openssl11_ubuntu20_04_deb
@@ -11001,10 +11001,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: ubuntu20.04-deb
           task_name: ${task_name}
   - name: pkg_test_docker_deb_arm64_openssl11_debian10_deb
@@ -11021,10 +11021,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: debian10-deb
           task_name: ${task_name}
   - name: pkg_test_docker_deb_arm64_openssl11_debian11_deb
@@ -11041,10 +11041,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: debian11-deb
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_arm64_openssl11_rocky8_rpm
@@ -11061,10 +11061,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: rocky8-rpm
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_arm64_openssl11_rocky9_rpm
@@ -11081,10 +11081,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: rocky9-rpm
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_arm64_openssl11_fedora34_rpm
@@ -11101,10 +11101,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: fedora34-rpm
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_arm64_openssl11_amazonlinux2_rpm
@@ -11121,10 +11121,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: amazonlinux2-rpm
           task_name: ${task_name}
   - name: pkg_test_docker_deb_arm64_openssl3_ubuntu22_04_deb
@@ -11141,10 +11141,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: ubuntu22.04-deb
           task_name: ${task_name}
   - name: pkg_test_docker_deb_arm64_openssl3_ubuntu22_04_fips_deb
@@ -11161,10 +11161,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: ubuntu22.04-fips-deb
           task_name: ${task_name}
   - name: pkg_test_docker_deb_arm64_openssl3_debian12_deb
@@ -11181,10 +11181,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: debian12-deb
           task_name: ${task_name}
   - name: pkg_test_docker_deb_arm64_openssl3_debian13_deb
@@ -11201,10 +11201,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: debian13-deb
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_arm64_openssl3_rocky8_epel_rpm
@@ -11221,10 +11221,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: rocky8-epel-rpm
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_arm64_openssl3_rocky9_rpm
@@ -11241,10 +11241,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: rocky9-rpm
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_arm64_openssl3_rocky9_fips_rpm
@@ -11261,10 +11261,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: rocky9-fips-rpm
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_arm64_openssl3_rocky10_rpm
@@ -11281,10 +11281,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: rocky10-rpm
           task_name: ${task_name}
   - name: pkg_test_docker_rpm_arm64_openssl3_amazonlinux2023_rpm
@@ -11301,10 +11301,10 @@ tasks:
       - func: write_preload_script
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: test_artifact_docker
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
           dockerfile: amazonlinux2023-rpm
           task_name: ${task_name}
   - name: pkg_test_rpmextract_rpm_ppc64le
@@ -11434,10 +11434,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: create_static_analysis_report
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
 
   ###
   # RELEASE TASKS
@@ -11461,10 +11461,10 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: release_draft
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
   - name: release_publish_dry_run
     git_tag_only: true
     exec_timeout_secs: 86400
@@ -11474,16 +11474,16 @@ tasks:
       - func: checkout
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: release_publish_download_and_list_artifacts
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: papertrail_trace
         vars:
           product: "mongosh-draft"
       - func: release_publish_dry_run
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
   - name: release_publish
     tags: ["publish"]
     git_tag_only: true
@@ -11495,16 +11495,16 @@ tasks:
       - func: checkout_writeable
       - func: install
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: release_publish_download_and_list_artifacts
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
       - func: papertrail_trace
         vars:
           product: "mongosh"
       - func: release_publish
         vars:
-          node_js_version: "24.18.1"
+          node_js_version: "24.21.0"
 
 # Need to run builds for every possible build variant.
 buildvariants:
@@ -11516,7 +11516,7 @@ buildvariants:
     expansions:
       executable_os_id: darwin-arm64
       mongosh_server_test_version: ""
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -11550,7 +11550,7 @@ buildvariants:
     expansions:
       executable_os_id: darwin-arm64
       mongosh_server_test_version: "6.0.x"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -11584,7 +11584,7 @@ buildvariants:
     expansions:
       executable_os_id: darwin-arm64
       mongosh_server_test_version: "6.0.x-enterprise"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -11618,7 +11618,7 @@ buildvariants:
     expansions:
       executable_os_id: darwin-arm64
       mongosh_server_test_version: "7.0.x"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -11652,7 +11652,7 @@ buildvariants:
     expansions:
       executable_os_id: darwin-arm64
       mongosh_server_test_version: "7.0.x-enterprise"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -11686,7 +11686,7 @@ buildvariants:
     expansions:
       executable_os_id: darwin-arm64
       mongosh_server_test_version: "8.0.x"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -11720,7 +11720,7 @@ buildvariants:
     expansions:
       executable_os_id: darwin-arm64
       mongosh_server_test_version: "8.0.x-enterprise"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -11754,7 +11754,7 @@ buildvariants:
     expansions:
       executable_os_id: darwin-arm64
       mongosh_server_test_version: "8.3.x"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -11788,7 +11788,7 @@ buildvariants:
     expansions:
       executable_os_id: darwin-arm64
       mongosh_server_test_version: "8.3.x-enterprise"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -11823,7 +11823,7 @@ buildvariants:
       executable_os_id: darwin-arm64
       mongosh_server_test_version: "9.0.0-rc4"
       mongosh_server_test_version_list_url: "https://downloads.mongodb.org/cloud.json"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -11858,7 +11858,7 @@ buildvariants:
       executable_os_id: darwin-arm64
       mongosh_server_test_version: "9.0.0-rc4-enterprise"
       mongosh_server_test_version_list_url: "https://downloads.mongodb.org/cloud.json"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -11892,7 +11892,7 @@ buildvariants:
     expansions:
       executable_os_id: darwin-arm64
       mongosh_server_test_version: "latest-alpha-enterprise"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -11926,7 +11926,7 @@ buildvariants:
     expansions:
       executable_os_id: darwin-arm64
       mongosh_server_test_version: ""
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -11960,7 +11960,7 @@ buildvariants:
     expansions:
       executable_os_id: darwin-arm64
       mongosh_server_test_version: "4.4.x"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -11994,7 +11994,7 @@ buildvariants:
     expansions:
       executable_os_id: darwin-arm64
       mongosh_server_test_version: "4.4.x-enterprise"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -12028,7 +12028,7 @@ buildvariants:
     expansions:
       executable_os_id: darwin-arm64
       mongosh_server_test_version: "5.0.x"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -12062,7 +12062,7 @@ buildvariants:
     expansions:
       executable_os_id: darwin-arm64
       mongosh_server_test_version: "5.0.x-enterprise"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -12096,7 +12096,7 @@ buildvariants:
     expansions:
       executable_os_id: darwin-arm64
       mongosh_server_test_version: "6.0.x"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -12130,7 +12130,7 @@ buildvariants:
     expansions:
       executable_os_id: darwin-arm64
       mongosh_server_test_version: "6.0.x-enterprise"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -12164,7 +12164,7 @@ buildvariants:
     expansions:
       executable_os_id: darwin-arm64
       mongosh_server_test_version: "7.0.x"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -12198,7 +12198,7 @@ buildvariants:
     expansions:
       executable_os_id: darwin-arm64
       mongosh_server_test_version: "7.0.x-enterprise"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -12232,7 +12232,7 @@ buildvariants:
     expansions:
       executable_os_id: darwin-arm64
       mongosh_server_test_version: "8.0.x"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -12266,7 +12266,7 @@ buildvariants:
     expansions:
       executable_os_id: darwin-arm64
       mongosh_server_test_version: "8.0.x-enterprise"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -12300,7 +12300,7 @@ buildvariants:
     expansions:
       executable_os_id: darwin-arm64
       mongosh_server_test_version: "8.3.x"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -12334,7 +12334,7 @@ buildvariants:
     expansions:
       executable_os_id: darwin-arm64
       mongosh_server_test_version: "8.3.x-enterprise"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -12369,7 +12369,7 @@ buildvariants:
       executable_os_id: darwin-arm64
       mongosh_server_test_version: "9.0.0-rc4"
       mongosh_server_test_version_list_url: "https://downloads.mongodb.org/cloud.json"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -12404,7 +12404,7 @@ buildvariants:
       executable_os_id: darwin-arm64
       mongosh_server_test_version: "9.0.0-rc4-enterprise"
       mongosh_server_test_version_list_url: "https://downloads.mongodb.org/cloud.json"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -12438,7 +12438,7 @@ buildvariants:
     expansions:
       executable_os_id: darwin-arm64
       mongosh_server_test_version: "latest-alpha-enterprise"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -12472,7 +12472,7 @@ buildvariants:
     expansions:
       executable_os_id: win32
       mongosh_server_test_version: ""
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -12505,7 +12505,7 @@ buildvariants:
     expansions:
       executable_os_id: win32
       mongosh_server_test_version: "4.4.x"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -12538,7 +12538,7 @@ buildvariants:
     expansions:
       executable_os_id: win32
       mongosh_server_test_version: "4.4.x-enterprise"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -12571,7 +12571,7 @@ buildvariants:
     expansions:
       executable_os_id: win32
       mongosh_server_test_version: "5.0.x"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -12604,7 +12604,7 @@ buildvariants:
     expansions:
       executable_os_id: win32
       mongosh_server_test_version: "5.0.x-enterprise"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -12637,7 +12637,7 @@ buildvariants:
     expansions:
       executable_os_id: win32
       mongosh_server_test_version: "6.0.x"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -12670,7 +12670,7 @@ buildvariants:
     expansions:
       executable_os_id: win32
       mongosh_server_test_version: "6.0.x-enterprise"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -12703,7 +12703,7 @@ buildvariants:
     expansions:
       executable_os_id: win32
       mongosh_server_test_version: "7.0.x"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -12736,7 +12736,7 @@ buildvariants:
     expansions:
       executable_os_id: win32
       mongosh_server_test_version: "7.0.x-enterprise"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -12769,7 +12769,7 @@ buildvariants:
     expansions:
       executable_os_id: win32
       mongosh_server_test_version: "8.0.x"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -12802,7 +12802,7 @@ buildvariants:
     expansions:
       executable_os_id: win32
       mongosh_server_test_version: "8.0.x-enterprise"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -12835,7 +12835,7 @@ buildvariants:
     expansions:
       executable_os_id: win32
       mongosh_server_test_version: "8.3.x"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -12868,7 +12868,7 @@ buildvariants:
     expansions:
       executable_os_id: win32
       mongosh_server_test_version: "8.3.x-enterprise"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -12902,7 +12902,7 @@ buildvariants:
       executable_os_id: win32
       mongosh_server_test_version: "9.0.0-rc4"
       mongosh_server_test_version_list_url: "https://downloads.mongodb.org/cloud.json"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -12936,7 +12936,7 @@ buildvariants:
       executable_os_id: win32
       mongosh_server_test_version: "9.0.0-rc4-enterprise"
       mongosh_server_test_version_list_url: "https://downloads.mongodb.org/cloud.json"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -12969,7 +12969,7 @@ buildvariants:
     expansions:
       executable_os_id: win32
       mongosh_server_test_version: "latest-alpha-enterprise"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_skip_node_version_check: ""
     tasks:
       - name: test_arg_parser
@@ -12999,7 +12999,7 @@ buildvariants:
     run_on: rhel70-build
     expansions:
       executable_os_id: "linux-x64"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
     tasks:
       - name: compile_artifact
   - name: build_linux_x64_rhel8
@@ -13007,7 +13007,7 @@ buildvariants:
     run_on: rhel80-build
     expansions:
       executable_os_id: "linux-x64"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
     tasks:
       - name: compile_artifact
   - name: build_linux_x64_openssl11
@@ -13015,7 +13015,7 @@ buildvariants:
     run_on: rhel70-build
     expansions:
       executable_os_id: "linux-x64-openssl11"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_shared_openssl: "openssl11"
     tasks:
       - name: compile_artifact
@@ -13024,7 +13024,7 @@ buildvariants:
     run_on: rhel80-build
     expansions:
       executable_os_id: "linux-x64-openssl11"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_shared_openssl: "openssl11"
     tasks:
       - name: compile_artifact
@@ -13033,7 +13033,7 @@ buildvariants:
     run_on: rhel70-build
     expansions:
       executable_os_id: "linux-x64-openssl3"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_shared_openssl: "openssl3"
     tasks:
       - name: compile_artifact
@@ -13042,7 +13042,7 @@ buildvariants:
     run_on: rhel80-build
     expansions:
       executable_os_id: "linux-x64-openssl3"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_shared_openssl: "openssl3"
     tasks:
       - name: compile_artifact
@@ -13051,7 +13051,7 @@ buildvariants:
     run_on: amazon2-arm64-large
     expansions:
       executable_os_id: "linux-arm64"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
     tasks:
       - name: compile_artifact
   - name: build_linux_arm64_openssl11
@@ -13059,7 +13059,7 @@ buildvariants:
     run_on: amazon2-arm64-large
     expansions:
       executable_os_id: "linux-arm64-openssl11"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_shared_openssl: "openssl11"
     tasks:
       - name: compile_artifact
@@ -13068,7 +13068,7 @@ buildvariants:
     run_on: amazon2-arm64-large
     expansions:
       executable_os_id: "linux-arm64-openssl3"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_shared_openssl: "openssl3"
     tasks:
       - name: compile_artifact
@@ -13077,7 +13077,7 @@ buildvariants:
     run_on: rhel8-power-small
     expansions:
       executable_os_id: "linux-ppc64le"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
     tasks:
       - name: compile_artifact
   - name: build_linux_ppc64le_openssl11
@@ -13085,7 +13085,7 @@ buildvariants:
     run_on: rhel8-power-small
     expansions:
       executable_os_id: "linux-ppc64le-openssl11"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_shared_openssl: "openssl11"
     tasks:
       - name: compile_artifact
@@ -13094,7 +13094,7 @@ buildvariants:
     run_on: rhel8-power-small
     expansions:
       executable_os_id: "linux-ppc64le-openssl3"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_shared_openssl: "openssl3"
     tasks:
       - name: compile_artifact
@@ -13103,7 +13103,7 @@ buildvariants:
     run_on: rhel7-zseries-large
     expansions:
       executable_os_id: "linux-s390x"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
     tasks:
       - name: compile_artifact
   - name: build_linux_s390x_openssl11
@@ -13111,7 +13111,7 @@ buildvariants:
     run_on: rhel7-zseries-large
     expansions:
       executable_os_id: "linux-s390x-openssl11"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_shared_openssl: "openssl11"
     tasks:
       - name: compile_artifact
@@ -13120,7 +13120,7 @@ buildvariants:
     run_on: rhel7-zseries-large
     expansions:
       executable_os_id: "linux-s390x-openssl3"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_shared_openssl: "openssl3"
     tasks:
       - name: compile_artifact
@@ -13129,7 +13129,7 @@ buildvariants:
     run_on: macos-15-amd64-gui
     expansions:
       executable_os_id: "darwin-x64"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
     tasks:
       - name: compile_artifact
   - name: build_darwin_arm64
@@ -13137,7 +13137,7 @@ buildvariants:
     run_on: macos-15-arm64-gui
     expansions:
       executable_os_id: "darwin-arm64"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
     tasks:
       - name: compile_artifact
   - name: build_win32
@@ -13145,7 +13145,7 @@ buildvariants:
     run_on: windows-2022-latest-small
     expansions:
       executable_os_id: "win32"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
     tasks:
       - name: compile_artifact
   - name: e2e_tests_rhel70_small_m70x
@@ -13154,7 +13154,7 @@ buildvariants:
     tags: ["nightly-driver"]
     expansions:
       executable_os_id: "linux-x64"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_server_test_version: "7.0.x-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13165,7 +13165,7 @@ buildvariants:
     tags: ["nightly-driver"]
     expansions:
       executable_os_id: "linux-x64"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_server_test_version: "7.0.x-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13176,7 +13176,7 @@ buildvariants:
     tags: ["nightly-driver"]
     expansions:
       executable_os_id: "linux-x64"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13187,7 +13187,7 @@ buildvariants:
     tags: ["nightly-driver"]
     expansions:
       executable_os_id: "linux-x64"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_server_test_version: "7.0.x-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13198,7 +13198,7 @@ buildvariants:
     tags: ["nightly-driver"]
     expansions:
       executable_os_id: "linux-x64"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13209,7 +13209,7 @@ buildvariants:
     tags: ["nightly-driver"]
     expansions:
       executable_os_id: "linux-x64"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13220,7 +13220,7 @@ buildvariants:
     tags: ["nightly-driver"]
     expansions:
       executable_os_id: "linux-x64-openssl11"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13231,7 +13231,7 @@ buildvariants:
     tags: ["nightly-driver"]
     expansions:
       executable_os_id: "linux-x64-openssl11"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: "1"
     tasks:
@@ -13242,7 +13242,7 @@ buildvariants:
     tags: ["nightly-driver"]
     expansions:
       executable_os_id: "linux-x64"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13253,7 +13253,7 @@ buildvariants:
     tags: ["nightly-driver"]
     expansions:
       executable_os_id: "linux-x64-openssl3"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13264,7 +13264,7 @@ buildvariants:
     tags: ["nightly-driver"]
     expansions:
       executable_os_id: "linux-x64-openssl3"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: "1"
     tasks:
@@ -13275,7 +13275,7 @@ buildvariants:
     tags: ["nightly-driver"]
     expansions:
       executable_os_id: "linux-x64"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_server_test_version: "6.0.x-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13286,7 +13286,7 @@ buildvariants:
     tags: ["nightly-driver"]
     expansions:
       executable_os_id: "linux-x64"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13297,7 +13297,7 @@ buildvariants:
     tags: ["nightly-driver"]
     expansions:
       executable_os_id: "linux-x64-openssl11"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13308,7 +13308,7 @@ buildvariants:
     tags: ["nightly-driver"]
     expansions:
       executable_os_id: "linux-x64"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13319,7 +13319,7 @@ buildvariants:
     tags: ["nightly-driver"]
     expansions:
       executable_os_id: "linux-x64-openssl3"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13330,7 +13330,7 @@ buildvariants:
     tags: ["nightly-driver"]
     expansions:
       executable_os_id: "linux-x64"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13341,7 +13341,7 @@ buildvariants:
     tags: ["nightly-driver"]
     expansions:
       executable_os_id: "linux-x64-openssl3"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13352,7 +13352,7 @@ buildvariants:
     tags: ["nightly-driver"]
     expansions:
       executable_os_id: "linux-x64"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_server_test_version: "6.0.x-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13363,7 +13363,7 @@ buildvariants:
     tags: ["nightly-driver"]
     expansions:
       executable_os_id: "linux-x64-openssl11"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_server_test_version: "6.0.x-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13374,7 +13374,7 @@ buildvariants:
     tags: ["nightly-driver"]
     expansions:
       executable_os_id: "linux-x64"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_server_test_version: "7.0.x-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13385,7 +13385,7 @@ buildvariants:
     tags: ["nightly-driver"]
     expansions:
       executable_os_id: "linux-x64-openssl11"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_server_test_version: "7.0.x-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13396,7 +13396,7 @@ buildvariants:
     tags: ["nightly-driver"]
     expansions:
       executable_os_id: "linux-x64"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_server_test_version: "7.0.x-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13407,7 +13407,7 @@ buildvariants:
     tags: ["nightly-driver"]
     expansions:
       executable_os_id: "linux-x64"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13418,7 +13418,7 @@ buildvariants:
     tags: ["nightly-driver"]
     expansions:
       executable_os_id: "linux-x64"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_server_test_version: "7.0.x-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13429,7 +13429,7 @@ buildvariants:
     tags: ["nightly-driver"]
     expansions:
       executable_os_id: "linux-x64"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13440,7 +13440,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "linux-arm64"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_server_test_version: "6.0.x-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13451,7 +13451,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "linux-arm64"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13462,7 +13462,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "linux-arm64-openssl11"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13473,7 +13473,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "linux-arm64"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13484,7 +13484,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "linux-arm64-openssl3"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13495,7 +13495,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "linux-arm64"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13506,7 +13506,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "linux-arm64-openssl3"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13517,7 +13517,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "linux-arm64-openssl3"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_server_test_version: "8.3.x-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13528,7 +13528,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "linux-arm64"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_server_test_version: "7.0.x-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13539,7 +13539,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "linux-arm64"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13550,7 +13550,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "linux-arm64"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_server_test_version: "8.3.x-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13561,7 +13561,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "linux-arm64"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13572,7 +13572,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "linux-arm64"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_server_test_version: "7.0.x-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13583,7 +13583,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "linux-arm64-openssl3"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_server_test_version: "7.0.x-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13594,7 +13594,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "linux-arm64"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13605,7 +13605,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "linux-arm64-openssl3"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13616,7 +13616,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "linux-ppc64le"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13627,7 +13627,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "linux-ppc64le"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13638,7 +13638,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "linux-ppc64le-openssl11"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13649,7 +13649,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "linux-ppc64le-openssl3"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13660,7 +13660,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "linux-ppc64le"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_server_test_version: "8.3.x-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13671,7 +13671,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "linux-s390x"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_server_test_version: "6.0.x-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13682,7 +13682,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "linux-s390x"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13693,7 +13693,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "linux-s390x"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13704,7 +13704,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "linux-s390x-openssl11"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13715,7 +13715,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "linux-s390x-openssl3"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13726,7 +13726,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "linux-s390x"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_server_test_version: "8.3.x-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13737,7 +13737,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "darwin-x64"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13748,7 +13748,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "darwin-arm64"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13759,7 +13759,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "darwin-arm64"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_server_test_version: "8.2.x-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13770,7 +13770,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "darwin-x64"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13781,7 +13781,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "darwin-arm64"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13792,7 +13792,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "darwin-arm64"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_server_test_version: "8.3.x-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13803,7 +13803,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "darwin-x64"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_server_test_version: "8.0.5-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13814,7 +13814,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "darwin-arm64"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_server_test_version: "8.0.5-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13829,7 +13829,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "win32"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_server_test_version: "8.0.x-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13840,7 +13840,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "win32"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_server_test_version: "8.2.x-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13851,7 +13851,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "win32"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_server_test_version: "stable-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13864,7 +13864,7 @@ buildvariants:
     tags: []
     expansions:
       executable_os_id: "win32"
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
       mongosh_server_test_version: "8.3.x-enterprise"
       mongosh_test_e2e_force_fips: ""
     tasks:
@@ -13882,7 +13882,7 @@ buildvariants:
     run_on: ubuntu2204-small
     tags: ["nightly-driver"]
     expansions:
-      node_js_version: "24.18.1"
+      node_js_version: "24.21.0"
     tasks:
       # TODO(MONGOSH-3496): re-enable once VSCODE-788 is fixed.
       - name: test_vscode

--- a/.evergreen/compile-artifact.sh
+++ b/.evergreen/compile-artifact.sh
@@ -42,7 +42,10 @@ elif [ -n "$MONGOSH_SHARED_OPENSSL" ]; then
     curl -sSfLO https://github.com/openssl/openssl/releases/download/OpenSSL_1_1_1o/openssl-1.1.1o.tar.gz
     MONGOSH_OPENSSL_LIBNAME=:libcrypto.so.1.1,:libssl.so.1.1
   elif [ "$MONGOSH_SHARED_OPENSSL" == "openssl3" ]; then
-    curl -sSfLO https://www.openssl.org/source/old/3.0/openssl-3.0.5.tar.gz
+    # Node.js 24.21 needs EVP_PKEY_PRIVATE_KEY and
+    # OPENSSL_DH_CHECK_MAX_MODULUS_BITS, which were backported to the 3.0
+    # branch in 3.0.13, so anything older fails to compile deps/ncrypto.
+    curl -sSfLO https://www.openssl.org/source/old/3.0/openssl-3.0.22.tar.gz
     MONGOSH_OPENSSL_LIBNAME=:libcrypto.so.3,:libssl.so.3
   else
     echo "Unknown MONGOSH_SHARED_OPENSSL value: $MONGOSH_SHARED_OPENSSL"

--- a/.evergreen/compile-artifact.sh
+++ b/.evergreen/compile-artifact.sh
@@ -42,10 +42,11 @@ elif [ -n "$MONGOSH_SHARED_OPENSSL" ]; then
     curl -sSfLO https://github.com/openssl/openssl/releases/download/OpenSSL_1_1_1o/openssl-1.1.1o.tar.gz
     MONGOSH_OPENSSL_LIBNAME=:libcrypto.so.1.1,:libssl.so.1.1
   elif [ "$MONGOSH_SHARED_OPENSSL" == "openssl3" ]; then
+    # The OpenSSL here is the minimum version that users need installed.
+    # Keep it at the oldest one we can build against:
     # Node.js 24.21 needs EVP_PKEY_PRIVATE_KEY and
-    # OPENSSL_DH_CHECK_MAX_MODULUS_BITS, which were backported to the 3.0
-    # branch in 3.0.13, so anything older fails to compile deps/ncrypto.
-    curl -sSfLO https://www.openssl.org/source/old/3.0/openssl-3.0.22.tar.gz
+    # OPENSSL_DH_CHECK_MAX_MODULUS_BITS, first available together in 3.0.12.
+    curl -sSfLO https://www.openssl.org/source/old/3.0/openssl-3.0.12.tar.gz
     MONGOSH_OPENSSL_LIBNAME=:libcrypto.so.3,:libssl.so.3
   else
     echo "Unknown MONGOSH_SHARED_OPENSSL value: $MONGOSH_SHARED_OPENSSL"

--- a/.evergreen/node-24-latest.json
+++ b/.evergreen/node-24-latest.json
@@ -1,8 +1,8 @@
 {
-  "version": "24.18.1",
+  "version": "24.21.0",
   "major": 24,
-  "minor": 18,
-  "patch": 1,
+  "minor": 21,
+  "patch": 0,
   "tag": "",
   "codename": "krypton",
   "versionName": "v24",
@@ -10,11 +10,11 @@
   "lts": "2025-10-28T00:00:00.000Z",
   "maintenance": "2026-10-20T00:00:00.000Z",
   "end": "2028-04-30T00:00:00.000Z",
-  "releaseDate": "2026-07-28T00:00:00.000Z",
+  "releaseDate": "2026-09-07T00:00:00.000Z",
   "isLts": true,
   "isSupported": true,
   "isMaintenance": false,
-  "isSecurity": true,
+  "isSecurity": false,
   "modules": "137",
   "files": [
     "aix-ppc64",
@@ -23,6 +23,7 @@
     "linux-ppc64le",
     "linux-s390x",
     "linux-x64",
+    "linux-x64-musl",
     "osx-arm64-tar",
     "osx-x64-pkg",
     "osx-x64-tar",
@@ -35,10 +36,10 @@
     "win-x64-zip"
   ],
   "dependencies": {
-    "npm": "11.16.0",
+    "npm": "11.19.0",
     "v8": "13.6.233.17",
     "uv": "1.52.1",
-    "zlib": "1.3.1",
-    "openssl": "3.5.7"
+    "zlib": "1.3.2.1-motley",
+    "openssl": "3.5.8"
   }
 }


### PR DESCRIPTION
Doing the Node.js bump manually because the automation PR https://github.com/mongodb-js/mongosh/pull/2814 can't succeed on its own, because Node 24.21.0 fails to compile against the OpenSSL 3.0.5 we pin for the shared-openssl builds.

```
ncrypto.cc:1906: error: 'OPENSSL_DH_CHECK_MAX_MODULUS_BITS' was not declared in this scope
ncrypto.cc:3276: error: 'EVP_PKEY_PRIVATE_KEY' was not declared in this scope
make: *** [node] Error 2
```